### PR TITLE
feat(cluster): make TP and pipeline serving request-safe

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -14,8 +14,10 @@ import json
 import logging
 import os
 import re
+import shlex
 import shutil
 import signal
+import subprocess
 import sys
 import time
 from collections import deque
@@ -61,6 +63,80 @@ from .auth import (
 logger = logging.getLogger(__name__)
 
 PRESET_REMOTE_URL = "https://omlx.ai/assets/omlx_preset.json"
+
+
+def _clear_cold_remote_cluster_cache_roots(
+    roots: tuple[Path, ...],
+    *,
+    runner: Any = subprocess.run,
+) -> tuple[int, int]:
+    """Remove unloaded cluster snapshots from every configured peer Mac.
+
+    Loaded ranks clear through their live cache managers. With no resident
+    engine, the normal SSD-clear action still has to reach peer-local snapshot
+    trees; deleting only the coordinator root makes the next load silently
+    restore data the user explicitly cleared.
+    """
+
+    from ..cluster.launch import _run_cluster_ssh
+    from ..cluster.registry import get_cluster_registry
+
+    try:
+        deployments = get_cluster_registry().list()
+    except RuntimeError:
+        return 0, 0
+    if not deployments:
+        return 0, 0
+
+    normalized = tuple(str(path.expanduser()) for path in roots)
+    allowed = {"cluster-prompt-snapshots", "prompt-cache-ssd"}
+    if any(Path(path).name not in allowed for path in normalized):
+        raise RuntimeError("refusing to clear an unexpected cluster cache root")
+
+    node_ids: set[str] = set()
+    remote_targets: set[str] = set()
+    for deployment in deployments:
+        for rank, host in enumerate(deployment.hosts):
+            node_ids.add(host.node_id)
+            if rank > 0:
+                remote_targets.add(host.ssh)
+
+    script = r"""
+import json, shutil, sys
+from pathlib import Path
+roots = [Path(value).expanduser() for value in json.loads(sys.argv[1])]
+allowed = {'cluster-prompt-snapshots', 'prompt-cache-ssd'}
+if any(root.name not in allowed for root in roots):
+    raise SystemExit(3)
+deleted = 0
+for root in roots:
+    if not root.exists():
+        continue
+    deleted += sum(1 for item in root.rglob('*') if item.is_file())
+    shutil.rmtree(root)
+print(deleted)
+""".strip()
+    command = shlex.join(["python3", "-c", script, json.dumps(normalized)])
+    deleted = 0
+    for target in sorted(remote_targets):
+        completed = _run_cluster_ssh(
+            target,
+            command,
+            timeout=45.0,
+            runner=runner,
+        )
+        if completed.returncode != 0:
+            detail = completed.stderr.strip() or completed.stdout.strip()
+            raise RuntimeError(
+                f"cold cluster SSD clear failed on {target}: {detail[:300]}"
+            )
+        try:
+            deleted += max(0, int(completed.stdout.strip() or "0"))
+        except ValueError as exc:
+            raise RuntimeError(
+                f"cold cluster SSD clear returned invalid output on {target}"
+            ) from exc
+    return deleted, len(node_ids)
 
 
 # =============================================================================

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -5604,8 +5604,8 @@ async def clear_alltime_stats(is_admin: bool = Depends(require_admin)):
     return {"status": "ok"}
 
 
-def _iter_loaded_scheduler_records():
-    """Yield (model_id, scheduler, core) for each loaded model.
+def _iter_loaded_engine_records():
+    """Yield (model_id, scheduler-or-None, core) for each loaded model.
 
     Traverses the internal engine hierarchy: pool entry → async engine →
     core engine → scheduler.
@@ -5623,6 +5623,14 @@ def _iter_loaded_scheduler_records():
         async_core = getattr(entry.engine, "_engine", None)
         core = getattr(async_core, "engine", None) if async_core is not None else None
         scheduler = getattr(core, "scheduler", None) if core is not None else None
+        if core is not None:
+            yield model_id, scheduler, core
+
+
+def _iter_loaded_scheduler_records():
+    """Yield local scheduler records, excluding distributed proxy engines."""
+
+    for model_id, scheduler, core in _iter_loaded_engine_records():
         if scheduler is not None:
             yield model_id, scheduler, core
 
@@ -5645,8 +5653,24 @@ async def clear_ssd_cache(is_admin: bool = Depends(require_admin)):
     is loaded.
     """
     total_deleted = 0
+    distributed_ranks = 0
+    distributed_failures = []
 
-    for model_id, scheduler in _iter_loaded_schedulers():
+    for model_id, scheduler, core in _iter_loaded_engine_records():
+        distributed_clear = getattr(core, "clear_prompt_caches", None)
+        if callable(distributed_clear):
+            try:
+                report = await distributed_clear(ssd=True)
+                total_deleted += int(report.get("ssd_deleted", 0))
+                distributed_ranks += len(report.get("ranks", ()))
+            except Exception as exc:
+                logger.warning(
+                    "Failed to clear distributed SSD cache for model '%s': %s",
+                    model_id,
+                    exc,
+                )
+                distributed_failures.append(f"{model_id}: {exc}")
+            continue
         ssd_manager = getattr(scheduler, "paged_ssd_cache_manager", None)
         if ssd_manager is not None:
             try:
@@ -5679,7 +5703,16 @@ async def clear_ssd_cache(is_admin: bool = Depends(require_admin)):
             except Exception as exc:
                 logger.warning("Failed to clean SSD cache directory: %s", exc)
 
-    return {"status": "ok", "total_deleted": total_deleted}
+    if distributed_failures:
+        raise HTTPException(
+            status_code=503,
+            detail="; ".join(distributed_failures)[:1000],
+        )
+    return {
+        "status": "ok",
+        "total_deleted": total_deleted,
+        "distributed_ranks": distributed_ranks,
+    }
 
 
 @router.post("/api/hot-cache/clear")
@@ -5699,7 +5732,24 @@ async def clear_hot_cache(is_admin: bool = Depends(require_admin)):
 
     footprint_before = get_phys_footprint()
     total_cleared = 0
+    distributed_ranks = 0
+    distributed_failures = []
     reclaim_targets = []
+    for model_id, scheduler, core in _iter_loaded_engine_records():
+        distributed_clear = getattr(core, "clear_prompt_caches", None)
+        if not callable(distributed_clear):
+            continue
+        try:
+            report = await distributed_clear(hot=True)
+            total_cleared += int(report.get("hot_cleared", 0))
+            distributed_ranks += len(report.get("ranks", ()))
+        except Exception as exc:
+            logger.warning(
+                "Failed to clear distributed hot cache for model '%s': %s",
+                model_id,
+                exc,
+            )
+            distributed_failures.append(f"{model_id}: {exc}")
     for model_id, scheduler, core in _iter_loaded_scheduler_records():
         ssd_manager = getattr(scheduler, "paged_ssd_cache_manager", None)
         if ssd_manager is not None and hasattr(ssd_manager, "clear_hot_cache"):
@@ -5756,10 +5806,16 @@ async def clear_hot_cache(is_admin: bool = Depends(require_admin)):
         await loop.run_in_executor(get_mlx_executor(), _sync_and_clear_cache)
     bytes_reclaimed = max(0, footprint_before - get_phys_footprint())
 
+    if distributed_failures:
+        raise HTTPException(
+            status_code=503,
+            detail="; ".join(distributed_failures)[:1000],
+        )
     return {
         "status": "ok",
         "total_cleared": total_cleared,
         "bytes_reclaimed": bytes_reclaimed,
+        "distributed_ranks": distributed_ranks,
     }
 
 

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -88,9 +88,8 @@ def _clear_cold_remote_cluster_cache_roots(
     if not deployments:
         return 0, 0
 
-    normalized = tuple(str(path.expanduser()) for path in roots)
     allowed = {"cluster-prompt-snapshots", "prompt-cache-ssd"}
-    if any(Path(path).name not in allowed for path in normalized):
+    if any(path.expanduser().name not in allowed for path in roots):
         raise RuntimeError("refusing to clear an unexpected cluster cache root")
 
     node_ids: set[str] = set()
@@ -101,10 +100,18 @@ def _clear_cold_remote_cluster_cache_roots(
             if rank > 0:
                 remote_targets.add(host.ssh)
 
+    # Resolve settings on the peer. Sending the coordinator's expanded
+    # /Users/<name>/... roots breaks as soon as the Macs use different login
+    # names, data roots, or SSD-cache locations.
     script = r"""
-import json, shutil, sys
+import shutil
 from pathlib import Path
-roots = [Path(value).expanduser() for value in json.loads(sys.argv[1])]
+from omlx.settings import GlobalSettings
+settings = GlobalSettings.load()
+roots = [
+    settings.cache.get_ssd_cache_dir(settings.base_path) / 'cluster-prompt-snapshots',
+    Path(settings.base_path) / 'cluster/runtime/prompt-cache-ssd',
+]
 allowed = {'cluster-prompt-snapshots', 'prompt-cache-ssd'}
 if any(root.name not in allowed for root in roots):
     raise SystemExit(3)
@@ -116,7 +123,7 @@ for root in roots:
     shutil.rmtree(root)
 print(deleted)
 """.strip()
-    command = shlex.join(["python3", "-c", script, json.dumps(normalized)])
+    command = shlex.join(["python3", "-c", script])
     deleted = 0
     for target in sorted(remote_targets):
         completed = _run_cluster_ssh(
@@ -5787,6 +5794,40 @@ async def clear_ssd_cache(is_admin: bool = Depends(require_admin)):
                             pass
             except Exception as exc:
                 logger.warning("Failed to clean SSD cache directory: %s", exc)
+
+        # When no distributed engine is resident, no rank-local maintenance
+        # endpoint exists. Clear the coordinator's cold cluster trees directly
+        # and ask every configured peer to resolve and clear its own paths.
+        if distributed_ranks == 0:
+            cluster_roots = (
+                cache_dir / "cluster-prompt-snapshots",
+                Path(global_settings.base_path)
+                / "cluster/runtime/prompt-cache-ssd",
+            )
+            for cluster_root in cluster_roots:
+                if not cluster_root.exists():
+                    continue
+                try:
+                    total_deleted += sum(
+                        1 for item in cluster_root.rglob("*") if item.is_file()
+                    )
+                    shutil.rmtree(cluster_root)
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to clean distributed SSD cache directory %s: %s",
+                        cluster_root,
+                        exc,
+                    )
+            try:
+                remote_deleted, configured_ranks = await asyncio.to_thread(
+                    _clear_cold_remote_cluster_cache_roots,
+                    cluster_roots,
+                )
+                total_deleted += remote_deleted
+                distributed_ranks = configured_ranks
+            except Exception as exc:
+                logger.warning("Failed to clean cold peer SSD cache: %s", exc)
+                distributed_failures.append(f"cold cluster peers: {exc}")
 
     if distributed_failures:
         raise HTTPException(

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -5620,8 +5620,17 @@ def _iter_loaded_engine_records():
         entry = engine_pool._entries.get(model_id)
         if entry is None or entry.engine is None:
             continue
-        async_core = getattr(entry.engine, "_engine", None)
-        core = getattr(async_core, "engine", None) if async_core is not None else None
+        # DistributedBatchedEngine is stored directly in the pool; local
+        # batched engines retain the historical async-wrapper chain.
+        direct = entry.engine
+        async_core = getattr(direct, "_engine", None)
+        core = (
+            direct
+            if callable(getattr(direct, "clear_prompt_caches", None))
+            else getattr(async_core, "engine", None)
+            if async_core is not None
+            else None
+        )
         scheduler = getattr(core, "scheduler", None) if core is not None else None
         if core is not None:
             yield model_id, scheduler, core

--- a/omlx/cluster/control_plane.py
+++ b/omlx/cluster/control_plane.py
@@ -9,6 +9,7 @@ import pickle
 import secrets
 import socket
 import struct
+import threading
 import time
 import zlib
 from contextlib import AbstractContextManager, suppress
@@ -24,16 +25,24 @@ _HANDSHAKE_MAGIC = b"OC2H"
 _HANDSHAKE_CHALLENGE_MAGIC = b"OC2C"
 _HANDSHAKE_ACK_MAGIC = b"OC2A"
 _MESSAGE_MAGIC = b"OC2M"
+_OWNED_BYTES_MAGIC = b"OC2B"
+_BARRIER_MAGIC = b"OC2R"
 _VERSION = 1
 _HANDSHAKE_CHALLENGE = struct.Struct("!4sI32s")
 _HANDSHAKE = struct.Struct("!4sII32s")
 _HANDSHAKE_ACK = struct.Struct("!4sI32s")
 _HEADER_PREFIX = struct.Struct("!4sIIII")
 _HEADER = struct.Struct("!4sIIII32s")
+_OWNED_BYTES_PREFIX = struct.Struct("!4sIIIII")
+_OWNED_BYTES_HEADER = struct.Struct("!4sIIIII32s")
+_BARRIER_PREFIX = struct.Struct("!4sIII")
+_BARRIER_PACKET = struct.Struct("!4sIII32s")
 _MAX_OBJECT_BYTES = 256 * 1024 * 1024
 _WORKER_AUTH_DOMAIN = b"omlx-rank-control-worker-v1"
 _COORDINATOR_AUTH_DOMAIN = b"omlx-rank-control-coordinator-v1"
 _MESSAGE_AUTH_DOMAIN = b"omlx-rank-control-message-v1"
+_OWNED_BYTES_AUTH_DOMAIN = b"omlx-rank-control-owned-bytes-v1"
+_BARRIER_AUTH_DOMAIN = b"omlx-rank-control-barrier-v1"
 
 
 def _recv_exact(stream: socket.socket, size: int) -> bytes:
@@ -86,6 +95,10 @@ class RankControlPlane(AbstractContextManager["RankControlPlane"]):
         self._stream: socket.socket | None = None
         self._stream_proxy: SystemSocketProxy | None = None
         self._sequence = 0
+        # Model decisions and cancellation normally share one generation
+        # thread. Serialize defensively so a future second caller cannot
+        # interleave frames or consume the ordered sequence twice.
+        self._operation_lock = threading.RLock()
 
     def __enter__(self) -> RankControlPlane:
         try:
@@ -247,64 +260,258 @@ class RankControlPlane(AbstractContextManager["RankControlPlane"]):
     def broadcast_object(self, obj: Any) -> Any:
         """Broadcast one rank-zero-owned Python object in strict sequence."""
 
-        self._sequence += 1
-        if self.rank == 0:
-            payload = pickle.dumps(obj) if obj is not None else b""
-            if len(payload) > _MAX_OBJECT_BYTES:
-                raise RuntimeError("rank-control object exceeds 256 MiB")
-            checksum = zlib.crc32(payload)
-            prefix = _HEADER_PREFIX.pack(
-                _MESSAGE_MAGIC,
-                _VERSION,
-                self._sequence,
-                len(payload),
-                checksum,
+        with self._operation_lock:
+            self._sequence += 1
+            if self.rank == 0:
+                payload = pickle.dumps(obj) if obj is not None else b""
+                if len(payload) > _MAX_OBJECT_BYTES:
+                    raise RuntimeError("rank-control object exceeds 256 MiB")
+                checksum = zlib.crc32(payload)
+                prefix = _HEADER_PREFIX.pack(
+                    _MESSAGE_MAGIC,
+                    _VERSION,
+                    self._sequence,
+                    len(payload),
+                    checksum,
+                )
+                tag = hmac.new(
+                    self._token,
+                    _MESSAGE_AUTH_DOMAIN + prefix + payload,
+                    hashlib.sha256,
+                ).digest()
+                header = _HEADER.pack(
+                    _MESSAGE_MAGIC,
+                    _VERSION,
+                    self._sequence,
+                    len(payload),
+                    checksum,
+                    tag,
+                )
+                packet = header + payload
+                for rank in range(1, self.world_size):
+                    self._peers[rank].sendall(packet)
+                return obj
+
+            stream = self._stream
+            if stream is None:
+                raise RuntimeError("rank-control worker is not connected")
+            magic, version, sequence, size, checksum, observed_tag = _HEADER.unpack(
+                _recv_exact(stream, _HEADER.size)
             )
-            tag = hmac.new(
+            if magic != _MESSAGE_MAGIC or version != _VERSION:
+                raise RuntimeError("rank-control message header is invalid")
+            if sequence != self._sequence:
+                raise RuntimeError(
+                    f"rank-control sequence diverged: expected {self._sequence}, "
+                    f"received {sequence}"
+                )
+            if size > _MAX_OBJECT_BYTES:
+                raise RuntimeError("rank-control object has an invalid size")
+            payload = _recv_exact(stream, size) if size else b""
+            if zlib.crc32(payload) != checksum:
+                raise RuntimeError("rank-control object failed CRC32")
+            prefix = _HEADER_PREFIX.pack(magic, version, sequence, size, checksum)
+            expected_tag = hmac.new(
                 self._token,
                 _MESSAGE_AUTH_DOMAIN + prefix + payload,
                 hashlib.sha256,
             ).digest()
-            header = _HEADER.pack(
-                _MESSAGE_MAGIC,
-                _VERSION,
-                self._sequence,
-                len(payload),
-                checksum,
-                tag,
-            )
-            packet = header + payload
-            for rank in range(1, self.world_size):
-                self._peers[rank].sendall(packet)
-            return obj
+            if not hmac.compare_digest(observed_tag, expected_tag):
+                raise RuntimeError("rank-control object failed authentication")
+            return pickle.loads(payload) if payload else None
 
-        stream = self._stream
-        if stream is None:
-            raise RuntimeError("rank-control worker is not connected")
-        magic, version, sequence, size, checksum, observed_tag = _HEADER.unpack(
-            _recv_exact(stream, _HEADER.size)
+    def _owned_bytes_packet(
+        self,
+        stream: socket.socket,
+        *,
+        sequence: int,
+        source_rank: int,
+        expected_size: int,
+    ) -> tuple[bytes, bytes]:
+        header = _recv_exact(stream, _OWNED_BYTES_HEADER.size)
+        magic, version, received_sequence, source, size, checksum, observed_tag = (
+            _OWNED_BYTES_HEADER.unpack(header)
         )
-        if magic != _MESSAGE_MAGIC or version != _VERSION:
-            raise RuntimeError("rank-control message header is invalid")
-        if sequence != self._sequence:
+        if magic != _OWNED_BYTES_MAGIC or version != _VERSION:
+            raise RuntimeError("rank-control owned-bytes header is invalid")
+        if received_sequence != sequence:
             raise RuntimeError(
-                f"rank-control sequence diverged: expected {self._sequence}, "
-                f"received {sequence}"
+                f"rank-control sequence diverged: expected {sequence}, "
+                f"received {received_sequence}"
             )
-        if size > _MAX_OBJECT_BYTES:
-            raise RuntimeError("rank-control object has an invalid size")
+        if source != source_rank:
+            raise RuntimeError(
+                f"rank-control owned-bytes source diverged: expected {source_rank}, "
+                f"received {source}"
+            )
+        if size != expected_size or size > _MAX_OBJECT_BYTES:
+            raise RuntimeError(
+                f"rank-control owned-bytes size diverged: expected {expected_size}, "
+                f"received {size}"
+            )
         payload = _recv_exact(stream, size) if size else b""
         if zlib.crc32(payload) != checksum:
-            raise RuntimeError("rank-control object failed CRC32")
-        prefix = _HEADER_PREFIX.pack(magic, version, sequence, size, checksum)
+            raise RuntimeError("rank-control owned bytes failed CRC32")
+        prefix = _OWNED_BYTES_PREFIX.pack(
+            magic, version, received_sequence, source, size, checksum
+        )
         expected_tag = hmac.new(
             self._token,
-            _MESSAGE_AUTH_DOMAIN + prefix + payload,
+            _OWNED_BYTES_AUTH_DOMAIN + prefix + payload,
             hashlib.sha256,
         ).digest()
         if not hmac.compare_digest(observed_tag, expected_tag):
-            raise RuntimeError("rank-control object failed authentication")
-        return pickle.loads(payload) if payload else None
+            raise RuntimeError("rank-control owned bytes failed authentication")
+        return header + payload, payload
+
+    def broadcast_owned_bytes(
+        self,
+        payload: bytes | None,
+        *,
+        source_rank: int,
+        expected_size: int,
+    ) -> bytes:
+        """Broadcast fixed-size bytes owned by any rank in strict sequence."""
+
+        if not 0 <= int(source_rank) < self.world_size:
+            raise ValueError("rank-control owned-bytes source is invalid")
+        if not 0 <= int(expected_size) <= _MAX_OBJECT_BYTES:
+            raise ValueError("rank-control owned-bytes size is invalid")
+        if payload is not None and not isinstance(payload, bytes):
+            raise TypeError("rank-control owned payload must be bytes")
+        if self.rank == source_rank:
+            if payload is None or len(payload) != expected_size:
+                raise RuntimeError(
+                    "rank-control owned source produced an invalid payload"
+                )
+        elif payload is not None:
+            raise RuntimeError("rank-control non-source supplied owned bytes")
+
+        with self._operation_lock:
+            self._sequence += 1
+            sequence = self._sequence
+            if self.rank == source_rank:
+                checksum = zlib.crc32(payload)
+                prefix = _OWNED_BYTES_PREFIX.pack(
+                    _OWNED_BYTES_MAGIC,
+                    _VERSION,
+                    sequence,
+                    source_rank,
+                    expected_size,
+                    checksum,
+                )
+                tag = hmac.new(
+                    self._token,
+                    _OWNED_BYTES_AUTH_DOMAIN + prefix + payload,
+                    hashlib.sha256,
+                ).digest()
+                packet = (
+                    _OWNED_BYTES_HEADER.pack(
+                        _OWNED_BYTES_MAGIC,
+                        _VERSION,
+                        sequence,
+                        source_rank,
+                        expected_size,
+                        checksum,
+                        tag,
+                    )
+                    + payload
+                )
+            else:
+                packet = b""
+
+            if self.rank == 0:
+                if source_rank == 0:
+                    owned = payload
+                else:
+                    source = self._peers.get(source_rank)
+                    if source is None:
+                        raise RuntimeError("rank-control owned source is not connected")
+                    packet, owned = self._owned_bytes_packet(
+                        source,
+                        sequence=sequence,
+                        source_rank=source_rank,
+                        expected_size=expected_size,
+                    )
+                for rank in range(1, self.world_size):
+                    if rank != source_rank:
+                        self._peers[rank].sendall(packet)
+                return owned
+
+            stream = self._stream
+            if stream is None:
+                raise RuntimeError("rank-control worker is not connected")
+            if self.rank == source_rank:
+                stream.sendall(packet)
+                return payload
+            _packet, owned = self._owned_bytes_packet(
+                stream,
+                sequence=sequence,
+                source_rank=source_rank,
+                expected_size=expected_size,
+            )
+            return owned
+
+    def _barrier_packet(self, *, sequence: int, rank: int) -> bytes:
+        prefix = _BARRIER_PREFIX.pack(_BARRIER_MAGIC, _VERSION, sequence, rank)
+        tag = hmac.new(
+            self._token,
+            _BARRIER_AUTH_DOMAIN + prefix,
+            hashlib.sha256,
+        ).digest()
+        return _BARRIER_PACKET.pack(_BARRIER_MAGIC, _VERSION, sequence, rank, tag)
+
+    def _recv_barrier_packet(
+        self,
+        stream: socket.socket,
+        *,
+        sequence: int,
+        rank: int,
+    ) -> None:
+        magic, version, received_sequence, received_rank, observed_tag = (
+            _BARRIER_PACKET.unpack(_recv_exact(stream, _BARRIER_PACKET.size))
+        )
+        prefix = _BARRIER_PREFIX.pack(magic, version, received_sequence, received_rank)
+        expected_tag = hmac.new(
+            self._token,
+            _BARRIER_AUTH_DOMAIN + prefix,
+            hashlib.sha256,
+        ).digest()
+        if (
+            magic != _BARRIER_MAGIC
+            or version != _VERSION
+            or received_sequence != sequence
+            or received_rank != rank
+            or not hmac.compare_digest(observed_tag, expected_tag)
+        ):
+            raise RuntimeError("rank-control barrier packet is invalid")
+
+    def barrier(self) -> None:
+        """Wait until every rank reaches one ordered control boundary."""
+
+        with self._operation_lock:
+            self._sequence += 1
+            sequence = self._sequence
+            if self.rank == 0:
+                for rank in range(1, self.world_size):
+                    stream = self._peers.get(rank)
+                    if stream is None:
+                        raise RuntimeError("rank-control barrier peer is not connected")
+                    self._recv_barrier_packet(
+                        stream,
+                        sequence=sequence,
+                        rank=rank,
+                    )
+                release = self._barrier_packet(sequence=sequence, rank=0)
+                for rank in range(1, self.world_size):
+                    self._peers[rank].sendall(release)
+                return
+
+            stream = self._stream
+            if stream is None:
+                raise RuntimeError("rank-control worker is not connected")
+            stream.sendall(self._barrier_packet(sequence=sequence, rank=self.rank))
+            self._recv_barrier_packet(stream, sequence=sequence, rank=0)
 
     def close(self) -> None:
         for stream in self._peers.values():

--- a/omlx/cluster/inference_worker.py
+++ b/omlx/cluster/inference_worker.py
@@ -520,15 +520,15 @@ def _execution_settings(args: argparse.Namespace) -> ExecutionSettings:
 def _prompt_cache_ssd_dir(args: argparse.Namespace, rank: int) -> str | None:
     """Per-rank SSD directory for prompt-cache snapshots, or None when off.
 
-    Kept beside the runtime markers and scoped by deployment and rank, so two
-    deployments never read each other's snapshots and a rank only ever loads its
-    own layer slice.
+    Kept beside the runtime markers and scoped by deployment, signed plan and
+    rank, so a changed tensor split can never restore another shard layout.
     """
 
     if not args.prompt_cache_ssd:
         return None
     root = Path(args.state_dir).expanduser() / "prompt-cache-ssd"
-    return str(root / f"{args.deployment_id}-rank-{rank}")
+    plan_hash = str(getattr(args, "plan_hash", "") or "unplanned")
+    return str(root / args.deployment_id / plan_hash / f"rank-{rank}")
 
 
 def _release_metal_memory(reason: str) -> None:
@@ -1474,6 +1474,7 @@ def run_worker(args: argparse.Namespace) -> int:
                         execution=execution,
                         assignment=assignment,
                         ssd_cache_dir=_prompt_cache_ssd_dir(args, rank),
+                        ssd_cache_persistent=bool(args.prompt_cache_ssd),
                         prefill_step_size=args.prefill_step_size,
                         prefill_guard=build_guard(
                             provider.model,

--- a/omlx/cluster/inference_worker.py
+++ b/omlx/cluster/inference_worker.py
@@ -611,19 +611,30 @@ def _write_cancel_request(
     mid-collective.
     """
 
-    payload: dict[str, Any] = {
-        "schema_version": 1,
-        "deployment_id": deployment_id,
-        "epoch": int(time.time() * 1000),
-        "scope": "all",
-        "reason": reason,
-    }
-    if plan_hash:
-        payload["plan_hash"] = plan_hash
     try:
         root = Path(state_dir).expanduser()
         root.mkdir(parents=True, exist_ok=True)
         path = root / f"{deployment_id}-cancel.json"
+        epoch = int(time.time() * 1000)
+        # A reused deployment ID can leave a marker from a future-skewed
+        # clock. Keep the edge monotonically newer so the live worker cannot
+        # mistake a watchdog request for its startup watermark.
+        try:
+            existing = json.loads(path.read_text(encoding="utf-8"))
+            previous_epoch = existing.get("epoch") if isinstance(existing, dict) else 0
+            if isinstance(previous_epoch, int) and not isinstance(previous_epoch, bool):
+                epoch = max(epoch, previous_epoch + 1)
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            pass
+        payload: dict[str, Any] = {
+            "schema_version": 1,
+            "deployment_id": deployment_id,
+            "epoch": epoch,
+            "scope": "all",
+            "reason": reason,
+        }
+        if plan_hash:
+            payload["plan_hash"] = plan_hash
         temporary = path.with_name(path.name + ".tmp")
         descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
         with os.fdopen(descriptor, "w", encoding="utf-8") as stream:

--- a/omlx/cluster/launch.py
+++ b/omlx/cluster/launch.py
@@ -52,6 +52,13 @@ _LOG_HISTORY = 200
 _REMOTE_OUTPUT_LIMIT = 64 * 1024
 _FABRIC_INTERFACE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,63}$")
 _DEFAULT_CONNECTX_MIN_BYTES_PER_SECOND = 2 * 1024**3
+_LAUNCHER_RANK_EXIT_RE = re.compile(
+    r"Node with rank\s+(?P<rank>\d+)\s+exited with code\s+(?P<code>-?\d+)"
+)
+_JACCL_NO_PROGRESS_RE = re.compile(
+    r"\[jaccl\]\s+(?P<reason>[^\r\n]*made no progress[^\r\n]*)",
+    re.IGNORECASE,
+)
 _REBOOT_REQUIRED_GUIDANCE = (
     "A distributed rank survived SIGKILL and may be stuck in the macOS "
     "Metal driver. Reboot this Mac before starting another distributed launch."

--- a/omlx/cluster/launch.py
+++ b/omlx/cluster/launch.py
@@ -2773,6 +2773,33 @@ class DistributedJobSupervisor:
                                 self.rank_ready_events[rank] = event
                         elif event.get("reason") or event.get("error"):
                             self.failure_event = event
+                # mlx.launch does not emit a structured event when a native
+                # JACCL watchdog terminates a rank.  Worse, its SSH cleanup
+                # thread can raise after that and leave the launcher itself
+                # exiting with code zero.  Promote the exact native terminal
+                # lines into the same failure surface used by peer_lost so a
+                # dead rank can never remain phase=ready.
+                no_progress = _JACCL_NO_PROGRESS_RE.search(line)
+                if no_progress is not None:
+                    self.failure_event = {
+                        "type": "collective_stall",
+                        "reason": "JACCL " + no_progress.group("reason").strip(),
+                    }
+                rank_exit = _LAUNCHER_RANK_EXIT_RE.search(line)
+                if rank_exit is not None and int(rank_exit.group("code")) != 0:
+                    reason = (
+                        f"rank {rank_exit.group('rank')} exited with code "
+                        f"{rank_exit.group('code')}"
+                    )
+                    prior = self._failure_reason()
+                    if prior and prior not in reason:
+                        reason += f" after {prior}"
+                    self.failure_event = {
+                        "type": "rank_exit",
+                        "rank": int(rank_exit.group("rank")),
+                        "returncode": int(rank_exit.group("code")),
+                        "reason": reason,
+                    }
                 self._condition.notify_all()
 
     def _wait_for_ready(self) -> dict[str, Any]:
@@ -3243,12 +3270,28 @@ class DistributedJobSupervisor:
 
     def status(self) -> DistributedJobStatus:
         process = self.process
+        returncode = process.poll() if process is not None else None
+        phase = self._phase
+        failure_reason = self._failure_reason()
+        if phase != "stopped" and (failure_reason or returncode is not None):
+            phase = "failed"
+            if failure_reason is None:
+                failure_reason = self._runtime_failure_reason()
+            if failure_reason is None:
+                # A serving launcher ending is terminal even when mlx.launch
+                # accidentally reports success after a worker's cleanup thread
+                # failed.  Stop/unload clears ``process`` and phase afterwards;
+                # while it remains registered this is always unexpected.
+                failure_reason = (
+                    "distributed launcher exited unexpectedly with code "
+                    f"{returncode}"
+                )
         return DistributedJobStatus(
             deployment_id=self.deployment.deployment_id,
-            phase=self._phase,
+            phase=phase,
             endpoint=self.endpoint,
             pid=process.pid if process is not None else None,
-            returncode=process.poll() if process is not None else None,
+            returncode=returncode,
             world_size=self.deployment.world_size,
             plan_hash=self.deployment.plan_hash,
             stderr_tail=tuple(self._stderr)[-20:],

--- a/omlx/cluster/launch.py
+++ b/omlx/cluster/launch.py
@@ -3290,8 +3290,7 @@ class DistributedJobSupervisor:
                 # failed.  Stop/unload clears ``process`` and phase afterwards;
                 # while it remains registered this is always unexpected.
                 failure_reason = (
-                    "distributed launcher exited unexpectedly with code "
-                    f"{returncode}"
+                    f"distributed launcher exited unexpectedly with code {returncode}"
                 )
         return DistributedJobStatus(
             deployment_id=self.deployment.deployment_id,

--- a/omlx/cluster/prompt_snapshot_cache.py
+++ b/omlx/cluster/prompt_snapshot_cache.py
@@ -29,16 +29,19 @@ write that failed on one rank cannot desync the pipeline) is the caller's job
 and lives in the telemetry integration, which has the collective; this module
 stays pure and unit-testable.
 
-Snapshots are process-lifetime. The digest filenames cannot be re-indexed
-without their token tuples, and a file that is not in the index is invisible to
-hits yet still holds disk, so a new store starts by clearing its directory and
-the telemetry teardown removes it. A rank that restarts simply begins empty,
-which the boundary vote already handles.
+When persistence is enabled, a compact atomic manifest records the digest,
+boundary and byte size of every chain segment. The digest already commits to
+the model identity and exact prefix tokens, so the manifest does not duplicate
+the token arrays (which would grow quadratically at long context). Directories
+are scoped by plan hash and rank by the worker, preventing a changed tensor
+split from ever reading another shard layout. A missing or invalid manifest
+fails closed by clearing otherwise-unindexable files.
 """
 
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import os
 import struct
@@ -315,6 +318,7 @@ class _Entry:
     tokens: tuple[int, ...]
     filename: str
     nbytes: int
+    boundary: int
 
 
 def candidate_boundaries(prompt_len: int, step: int) -> tuple[int, ...]:
@@ -377,11 +381,13 @@ class SSDPromptSnapshotStore:
         step: int = 2048,
         max_entries: int = _MAX_ENTRIES_DEFAULT,
         max_bytes: int | None = None,
+        persistent: bool = False,
     ) -> None:
         self.directory = Path(directory)
         self.step = max(1, int(step))
         self.max_entries = max(1, int(max_entries))
         self.max_bytes = max_bytes
+        self.persistent = bool(persistent)
         self._lock = threading.RLock()
         # Access-ordered: most-recently-used at the end. The order is advanced
         # only by put/load, both driven by the identical request stream every
@@ -396,13 +402,10 @@ class SSDPromptSnapshotStore:
         self._serialisable = True
         _register_snapshot_classes()
         self.directory.mkdir(parents=True, exist_ok=True)
-        # Snapshots are process-lifetime (see the module docstring): whatever a
-        # dead process left behind is unreachable, so reclaim it up front and
-        # keep the directory exactly as large as the live index says it is.
-        for stale in self.directory.iterdir():
-            if stale.is_file():
-                with suppress(OSError):
-                    stale.unlink()
+        if self.persistent:
+            self._load_manifest_or_reset()
+        else:
+            self._clear_directory()
 
     def __len__(self) -> int:
         with self._lock:
@@ -415,6 +418,108 @@ class SSDPromptSnapshotStore:
 
     def _path(self, key: str) -> Path:
         return self.directory / f"{key}.safetensors"
+
+    @property
+    def _manifest_path(self) -> Path:
+        return self.directory / "index.json"
+
+    def _clear_directory(self) -> None:
+        self._index.clear()
+        self._nbytes = 0
+        for stale in self.directory.iterdir():
+            if stale.is_file():
+                with suppress(OSError):
+                    stale.unlink()
+
+    @staticmethod
+    def _valid_key(value: object) -> bool:
+        return bool(
+            isinstance(value, str)
+            and len(value) == 64
+            and all(ch in "0123456789abcdef" for ch in value)
+        )
+
+    def _load_manifest_or_reset(self) -> None:
+        """Restore the durable LRU, or fail closed on any malformed state."""
+
+        manifest = self._manifest_path
+        if not manifest.is_file():
+            self._clear_directory()
+            self._persist_index_locked()
+            return
+        try:
+            payload = json.loads(manifest.read_text(encoding="utf-8"))
+            if payload.get("version") != 1 or int(payload.get("step")) != self.step:
+                raise ValueError("snapshot manifest contract changed")
+            rows = payload.get("entries")
+            if not isinstance(rows, list):
+                raise ValueError("snapshot manifest entries are invalid")
+            indexed_files = {manifest.name}
+            for row in rows:
+                if not isinstance(row, dict):
+                    raise ValueError("snapshot manifest entry is invalid")
+                key = row.get("key")
+                filename = row.get("filename")
+                boundary = int(row.get("boundary"))
+                nbytes = int(row.get("nbytes"))
+                if (
+                    not self._valid_key(key)
+                    or filename != f"{key}.safetensors"
+                    or boundary <= 0
+                    or boundary % self.step != 0
+                    or nbytes <= 0
+                ):
+                    raise ValueError("snapshot manifest entry is unsafe")
+                path = self.directory / filename
+                if key in self._index:
+                    raise ValueError("snapshot manifest contains a duplicate key")
+                if not path.is_file() or path.stat().st_size != nbytes:
+                    raise ValueError("snapshot manifest file is missing or changed")
+                self._index[key] = _Entry((), filename, nbytes, boundary)
+                self._nbytes += nbytes
+                indexed_files.add(filename)
+            for stale in self.directory.iterdir():
+                if stale.is_file() and stale.name not in indexed_files:
+                    with suppress(OSError):
+                        stale.unlink()
+            self._evict_locked()
+            self._persist_index_locked()
+        except Exception as error:
+            logger.warning("resetting invalid prompt snapshot manifest: %s", error)
+            self._clear_directory()
+            self._persist_index_locked()
+
+    def _persist_index_locked(self) -> None:
+        if not self.persistent:
+            return
+        payload = {
+            "version": 1,
+            "step": self.step,
+            "entries": [
+                {
+                    "key": key,
+                    "filename": entry.filename,
+                    "nbytes": entry.nbytes,
+                    "boundary": entry.boundary,
+                }
+                for key, entry in self._index.items()
+            ],
+        }
+        descriptor, temporary = tempfile.mkstemp(
+            prefix=".index.", suffix=".json", dir=self.directory
+        )
+        try:
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                json.dump(payload, handle, separators=(",", ":"), sort_keys=True)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, self._manifest_path)
+        except OSError as error:
+            with suppress(OSError):
+                os.close(descriptor)
+            with suppress(OSError):
+                os.unlink(temporary)
+            logger.warning("could not persist prompt snapshot manifest: %s", error)
 
     def _chain_keys(self, model: Any, tokens: tuple[int, ...]) -> list[str]:
         """Digest per chain boundary, shortest first, sharing one hash walk."""
@@ -450,8 +555,12 @@ class SSDPromptSnapshotStore:
         key = self._chain_keys(model, token_tuple)[-1]
         with self._lock:
             entry = self._index.get(key)
-            if entry is not None and entry.tokens == token_tuple:
+            if entry is not None and (
+                entry.tokens == token_tuple
+                or (not entry.tokens and entry.boundary == boundary)
+            ):
                 self._index.move_to_end(key)
+                self._persist_index_locked()
                 return True
         wrapped = _wrap_for_save(
             cache, boundary=boundary, segment_start=boundary - self.step
@@ -491,10 +600,11 @@ class SSDPromptSnapshotStore:
             previous = self._index.pop(key, None)
             if previous is not None:
                 self._nbytes -= previous.nbytes
-            self._index[key] = _Entry(token_tuple, target.name, size)
+            self._index[key] = _Entry(token_tuple, target.name, size, boundary)
             self._nbytes += size
             self._index.move_to_end(key)
             self._evict_locked()
+            self._persist_index_locked()
         return True
 
     def present_boundaries(self, model: Any, tokens: list[int]) -> tuple[int, ...]:
@@ -512,7 +622,12 @@ class SSDPromptSnapshotStore:
                 entry = self._index.get(key)
                 if (
                     entry is None
-                    or entry.tokens != token_tuple[:boundary]
+                    or (
+                        entry.tokens != token_tuple[:boundary]
+                        and not (
+                            not entry.tokens and entry.boundary == boundary
+                        )
+                    )
                     or not self._path(key).is_file()
                 ):
                     break
@@ -532,11 +647,18 @@ class SSDPromptSnapshotStore:
             for position, key in enumerate(chain):
                 entry = self._index.get(key)
                 prefix = token_tuple[: (position + 1) * self.step]
-                if entry is None or entry.tokens != prefix:
+                expected_boundary = (position + 1) * self.step
+                if entry is None or (
+                    entry.tokens != prefix
+                    and not (
+                        not entry.tokens and entry.boundary == expected_boundary
+                    )
+                ):
                     return None
                 if not self._path(key).is_file():
                     self._index.pop(key, None)
                     self._nbytes -= entry.nbytes
+                    self._persist_index_locked()
                     return None
         try:
             files = [load_prompt_cache(str(self._path(key))) for key in chain]
@@ -549,6 +671,7 @@ class SSDPromptSnapshotStore:
             for key in chain:
                 if key in self._index:
                     self._index.move_to_end(key)
+            self._persist_index_locked()
         return assembled
 
     def _evict_locked(self) -> None:

--- a/omlx/cluster/prompt_snapshot_cache.py
+++ b/omlx/cluster/prompt_snapshot_cache.py
@@ -624,9 +624,7 @@ class SSDPromptSnapshotStore:
                     entry is None
                     or (
                         entry.tokens != token_tuple[:boundary]
-                        and not (
-                            not entry.tokens and entry.boundary == boundary
-                        )
+                        and not (not entry.tokens and entry.boundary == boundary)
                     )
                     or not self._path(key).is_file()
                 ):
@@ -650,9 +648,7 @@ class SSDPromptSnapshotStore:
                 expected_boundary = (position + 1) * self.step
                 if entry is None or (
                     entry.tokens != prefix
-                    and not (
-                        not entry.tokens and entry.boundary == expected_boundary
-                    )
+                    and not (not entry.tokens and entry.boundary == expected_boundary)
                 ):
                     return None
                 if not self._path(key).is_file():

--- a/omlx/cluster/prompt_snapshot_cache.py
+++ b/omlx/cluster/prompt_snapshot_cache.py
@@ -411,6 +411,22 @@ class SSDPromptSnapshotStore:
         with self._lock:
             return len(self._index)
 
+    def clear(self, timeout: float = 30.0) -> int:
+        """Atomically forget every live snapshot and reset its manifest.
+
+        This split writes snapshots synchronously, so there is no write-behind
+        queue to flush. ``timeout`` is accepted for parity with the rank cache
+        maintenance hook and with the later asynchronous store.
+        """
+
+        del timeout
+        with self._lock:
+            count = len(self._index)
+            self._clear_directory()
+            self._serialisable = True
+            self._persist_index_locked()
+            return count
+
     @property
     def nbytes(self) -> int:
         with self._lock:

--- a/omlx/cluster/telemetry.py
+++ b/omlx/cluster/telemetry.py
@@ -308,6 +308,12 @@ class RuntimeTelemetry:
                 for sample in self._requests.values()
             )
 
+    def active_request_count(self) -> int:
+        """Current rank-local requests, for quiescence-gated maintenance."""
+
+        with self._lock:
+            return len(self._requests)
+
     def make_cancel_vote(self, uids: Any) -> dict[str, Any]:
         """Create the next rank-zero-owned, monotonically ordered cancel vote."""
 
@@ -1044,6 +1050,7 @@ def install_server_telemetry(
     original_generation_context = mlx_server.GenerationContext
     original_time_budget = mlx_server.TimeBudget
     original_handle_completion = mlx_server.APIHandler.handle_completion
+    original_do_post = mlx_server.APIHandler.do_POST
     cancellation_state = threading.local()
     marker_path = getattr(marker, "path", None)
     marker_payload = getattr(marker, "payload", None)
@@ -1066,6 +1073,7 @@ def install_server_telemetry(
     )
 
     snapshot_ctx = threading.local()
+    prompt_cache_instances: list[Any] = []
     snapshot_step = max(1, int(prefill_step_size))
     ssd_store = None
     if ssd_cache_dir:
@@ -1471,6 +1479,80 @@ def install_server_telemetry(
             request._omlx_transport_request_id = request_id
         return original_handle_completion(handler, request, stop_words)
 
+    def maintenance_do_post(handler: Any) -> Any:
+        """Private rank-local cache maintenance endpoint.
+
+        The public coordinator invokes this on every rank. It is bound to
+        loopback by the worker, authenticated with the signed plan hash, and
+        refuses to race a live request. Keeping the store clear in-process is
+        essential: deleting only coordinator files leaves peer manifests and
+        write-behind queues able to resurrect stale snapshots.
+        """
+
+        modes = {
+            "/omlx/internal/cache/ssd/clear": (True, False),
+            "/omlx/internal/cache/hot/clear": (False, True),
+            "/omlx/internal/cache/all/clear": (True, True),
+        }
+        selected = modes.get(handler.path)
+        if selected is None:
+            return original_do_post(handler)
+        if handler.headers.get("X-oMLX-Plan-Hash") != marker_plan_hash:
+            handler._set_completion_headers(403)
+            handler.end_headers()
+            handler.wfile.write(b'{"error":"invalid maintenance token"}')
+            return None
+        active = telemetry.active_request_count()
+        if active:
+            handler._set_completion_headers(409)
+            handler.end_headers()
+            handler.wfile.write(
+                json.dumps({"error": "requests are active", "active": active}).encode()
+            )
+            return None
+        clear_ssd, clear_hot = selected
+        deleted = 0
+        cleared = 0
+        try:
+            if clear_ssd and ssd_store is not None:
+                deleted = ssd_store.clear(timeout=30.0)
+            if clear_hot:
+                for cache in tuple(prompt_cache_instances):
+                    before = len(cache)
+                    cache.trim_to(n_sequences=0, n_bytes=0)
+                    cleared += before
+            memory_entries = sum(len(cache) for cache in prompt_cache_instances)
+            memory_bytes = sum(cache.nbytes for cache in prompt_cache_instances)
+            disk_entries = len(ssd_store) if ssd_store is not None else 0
+            disk_bytes = ssd_store.nbytes if ssd_store is not None else 0
+            telemetry.observe_cache_state(
+                entries=memory_entries + disk_entries,
+                nbytes=memory_bytes + disk_bytes,
+                memory_entries=memory_entries,
+                memory_bytes=memory_bytes,
+                ssd_entries=disk_entries,
+                ssd_bytes=disk_bytes,
+                **ssd_store_observability(),
+            )
+        except TimeoutError as exc:
+            handler._set_completion_headers(503)
+            handler.end_headers()
+            handler.wfile.write(json.dumps({"error": str(exc)}).encode())
+            return None
+        body = json.dumps(
+            {
+                "status": "ok",
+                "rank": rank,
+                "ssd_deleted": deleted,
+                "hot_cleared": cleared,
+            },
+            separators=(",", ":"),
+        ).encode()
+        handler._set_completion_headers(200)
+        handler.end_headers()
+        handler.wfile.write(body)
+        return None
+
     def snapshotting_stream_generate(*args: Any, **kwargs: Any) -> Any:
         """Deposit a snapshot at each prefill boundary before it is overwritten.
 
@@ -1516,6 +1598,7 @@ def install_server_telemetry(
     mlx_server.GenerationContext = CoordinatedGenerationContext
     mlx_server.TimeBudget = PrefillCancellationTimeBudget
     mlx_server.APIHandler.handle_completion = request_correlated_handle_completion
+    mlx_server.APIHandler.do_POST = maintenance_do_post
     if ssd_store is not None:
         mlx_server.stream_generate = snapshotting_stream_generate
     # Started here rather than by the caller: this block is exactly the span
@@ -1532,6 +1615,7 @@ def install_server_telemetry(
         mlx_server.GenerationContext = original_generation_context
         mlx_server.TimeBudget = original_time_budget
         mlx_server.APIHandler.handle_completion = original_handle_completion
+        mlx_server.APIHandler.do_POST = original_do_post
         mlx_server.stream_generate = original_stream_generate
         if ssd_store is not None and not ssd_cache_persistent:
             # Legacy process-lifetime mode: a hard crash skips this and the

--- a/omlx/cluster/telemetry.py
+++ b/omlx/cluster/telemetry.py
@@ -11,7 +11,7 @@ import shutil
 import threading
 import time
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
@@ -110,6 +110,7 @@ class RuntimeTelemetry:
         self._heartbeat_interval = float(heartbeat_interval)
         self._heartbeat_stop = threading.Event()
         self._heartbeat_thread: threading.Thread | None = None
+        self._maintenance_callback: Any | None = None
         self._lock = threading.Lock()
         self._started_at = float(self._clock())
         self._last_step_finished_at = self._started_at
@@ -165,8 +166,16 @@ class RuntimeTelemetry:
         # A coordinator cancel request is picked up here even when no
         # request event is driving publishes (e.g. a wedged handler).
         self.poll_cancel_requests(min_interval=0.0)
+        maintenance = self._maintenance_callback
+        if maintenance is not None:
+            maintenance()
         with self._lock:
             self._publish_locked(now, force=True)
+
+    def set_maintenance_callback(self, callback: Any | None) -> None:
+        """Install the rank-local, heartbeat-driven maintenance poll."""
+
+        self._maintenance_callback = callback
 
     def start_heartbeat(self) -> None:
         """Begin refreshing the marker on a fixed interval. Idempotent."""
@@ -1479,6 +1488,105 @@ def install_server_telemetry(
             request._omlx_transport_request_id = request_id
         return original_handle_completion(handler, request, stop_words)
 
+    def clear_rank_caches(*, clear_ssd: bool, clear_hot: bool) -> dict[str, Any]:
+        active = telemetry.active_request_count()
+        if active:
+            raise RuntimeError(f"requests are active ({active})")
+        deleted = 0
+        cleared = 0
+        if clear_ssd and ssd_store is not None:
+            deleted = ssd_store.clear(timeout=30.0)
+        if clear_hot:
+            for cache in tuple(prompt_cache_instances):
+                before = len(cache)
+                cache.trim_to(n_sequences=0, n_bytes=0)
+                cleared += before
+        memory_entries = sum(len(cache) for cache in prompt_cache_instances)
+        memory_bytes = sum(cache.nbytes for cache in prompt_cache_instances)
+        disk_entries = len(ssd_store) if ssd_store is not None else 0
+        disk_bytes = ssd_store.nbytes if ssd_store is not None else 0
+        telemetry.observe_cache_state(
+            entries=memory_entries + disk_entries,
+            nbytes=memory_bytes + disk_bytes,
+            memory_entries=memory_entries,
+            memory_bytes=memory_bytes,
+            ssd_entries=disk_entries,
+            ssd_bytes=disk_bytes,
+            **ssd_store_observability(),
+        )
+        return {
+            "status": "ok",
+            "rank": rank,
+            "ssd_deleted": deleted,
+            "hot_cleared": cleared,
+        }
+
+    def write_maintenance_ack(path: Path, payload: dict[str, Any]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = path.with_name(path.name + ".tmp")
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            0o600,
+        )
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(payload, stream, separators=(",", ":"), sort_keys=True)
+        os.replace(temporary, path)
+
+    maintenance_epoch_floor = time.time_ns()
+    maintenance_last_epoch = maintenance_epoch_floor
+    maintenance_request_path = (
+        Path(marker_path).parent / f"{marker_deployment_id}-cache-clear.json"
+        if marker_path is not None and marker_deployment_id
+        else None
+    )
+    maintenance_ack_path = (
+        Path(marker_path).parent
+        / f"{marker_deployment_id}-cache-clear-rank-{rank}.json"
+        if marker_path is not None and marker_deployment_id
+        else None
+    )
+
+    def poll_cache_maintenance() -> None:
+        nonlocal maintenance_last_epoch
+        path = maintenance_request_path
+        ack_path = maintenance_ack_path
+        if path is None or ack_path is None or not path.is_file():
+            return
+        try:
+            if path.stat().st_size > _MAX_CANCEL_FILE_BYTES:
+                return
+            request = json.loads(path.read_text(encoding="utf-8"))
+            epoch = int(request.get("epoch", 0))
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            return
+        if (
+            epoch <= maintenance_last_epoch
+            or epoch < maintenance_epoch_floor
+            or request.get("deployment_id") != marker_deployment_id
+            or request.get("plan_hash") != marker_plan_hash
+        ):
+            return
+        maintenance_last_epoch = epoch
+        try:
+            result = clear_rank_caches(
+                clear_ssd=bool(request.get("ssd")),
+                clear_hot=bool(request.get("hot")),
+            )
+            ack = result | {"epoch": epoch}
+        except Exception as exc:
+            ack = {
+                "status": "error",
+                "rank": rank,
+                "epoch": epoch,
+                "error": f"{type(exc).__name__}: {exc}"[:500],
+            }
+        write_maintenance_ack(ack_path, ack)
+        with suppress(OSError):
+            path.unlink()
+
+    telemetry.set_maintenance_callback(poll_cache_maintenance)
+
     def maintenance_do_post(handler: Any) -> Any:
         """Private rank-local cache maintenance endpoint.
 
@@ -1502,52 +1610,19 @@ def install_server_telemetry(
             handler.end_headers()
             handler.wfile.write(b'{"error":"invalid maintenance token"}')
             return None
-        active = telemetry.active_request_count()
-        if active:
-            handler._set_completion_headers(409)
-            handler.end_headers()
-            handler.wfile.write(
-                json.dumps({"error": "requests are active", "active": active}).encode()
-            )
-            return None
         clear_ssd, clear_hot = selected
-        deleted = 0
-        cleared = 0
         try:
-            if clear_ssd and ssd_store is not None:
-                deleted = ssd_store.clear(timeout=30.0)
-            if clear_hot:
-                for cache in tuple(prompt_cache_instances):
-                    before = len(cache)
-                    cache.trim_to(n_sequences=0, n_bytes=0)
-                    cleared += before
-            memory_entries = sum(len(cache) for cache in prompt_cache_instances)
-            memory_bytes = sum(cache.nbytes for cache in prompt_cache_instances)
-            disk_entries = len(ssd_store) if ssd_store is not None else 0
-            disk_bytes = ssd_store.nbytes if ssd_store is not None else 0
-            telemetry.observe_cache_state(
-                entries=memory_entries + disk_entries,
-                nbytes=memory_bytes + disk_bytes,
-                memory_entries=memory_entries,
-                memory_bytes=memory_bytes,
-                ssd_entries=disk_entries,
-                ssd_bytes=disk_bytes,
-                **ssd_store_observability(),
+            result = clear_rank_caches(
+                clear_ssd=clear_ssd,
+                clear_hot=clear_hot,
             )
-        except TimeoutError as exc:
-            handler._set_completion_headers(503)
+        except (RuntimeError, TimeoutError) as exc:
+            status = 409 if "requests are active" in str(exc) else 503
+            handler._set_completion_headers(status)
             handler.end_headers()
             handler.wfile.write(json.dumps({"error": str(exc)}).encode())
             return None
-        body = json.dumps(
-            {
-                "status": "ok",
-                "rank": rank,
-                "ssd_deleted": deleted,
-                "hot_cleared": cleared,
-            },
-            separators=(",", ":"),
-        ).encode()
+        body = json.dumps(result, separators=(",", ":")).encode()
         handler._set_completion_headers(200)
         handler.end_headers()
         handler.wfile.write(body)

--- a/omlx/cluster/telemetry.py
+++ b/omlx/cluster/telemetry.py
@@ -1013,7 +1013,8 @@ def install_server_telemetry(
     prefill_guard: Any | None = None,
     heartbeat_interval: float = _DEFAULT_HEARTBEAT_INTERVAL,
     ssd_cache_dir: str | None = None,
-    ssd_max_entries: int = 64,
+    ssd_max_entries: int = 512,
+    ssd_cache_persistent: bool = False,
     prefill_step_size: int = 2048,
     control_plane: Any | None = None,
 ) -> Iterator[RuntimeTelemetry]:
@@ -1029,9 +1030,9 @@ def install_server_telemetry(
     a chained progress callback) and restore from it on an in-memory miss, so a
     model whose per-layer state cannot be sliced still reuses a long prefix
     instead of recomputing it. The restore boundary is agreed across ranks so a
-    disk write that failed on one rank cannot desync the pipeline. The snapshot
-    directory is process-lifetime: the store starts it clean and this context's
-    teardown removes it.
+    disk write that failed on one rank cannot desync the pipeline. With
+    ``ssd_cache_persistent`` the compact plan-scoped index survives rank
+    restarts; otherwise this context retains the legacy process-lifetime tier.
     """
 
     import mlx.core as mx
@@ -1075,7 +1076,10 @@ def install_server_telemetry(
         )
 
         ssd_store = SSDPromptSnapshotStore(
-            ssd_cache_dir, step=snapshot_step, max_entries=ssd_max_entries
+            ssd_cache_dir,
+            step=snapshot_step,
+            max_entries=ssd_max_entries,
+            persistent=ssd_cache_persistent,
         )
     try:
         world_size = int(mx.distributed.init().size())
@@ -1230,15 +1234,15 @@ def install_server_telemetry(
             return prompt_responses, generation_responses
 
     class TelemetryPromptCache(original_prompt_cache):
+        def _omlx_cache_inventory(self) -> tuple[int, int]:
+            """Combined volatile LRU and durable rank-local snapshot tiers."""
+
+            disk_entries = len(ssd_store) if ssd_store is not None else 0
+            disk_bytes = ssd_store.nbytes if ssd_store is not None else 0
+            return len(self) + disk_entries, self.nbytes + disk_bytes
+
         def _fetch_observed(self, model: Any, tokens: list[int]) -> Any:
-            cache, rest = super().fetch_nearest_cache(model, tokens)
-            telemetry.observe_cache_lookup(
-                prompt_tokens=len(tokens),
-                remaining_tokens=len(rest),
-                entries=len(self),
-                nbytes=self.nbytes,
-            )
-            return cache, rest
+            return super().fetch_nearest_cache(model, tokens)
 
         def _lookup(self, model: Any, tokens: list[int]) -> Any:
             cache, rest = self._fetch_observed(model, tokens)
@@ -1302,7 +1306,8 @@ def install_server_telemetry(
 
         def insert_cache(self, *args: Any, **kwargs: Any) -> Any:
             result = super().insert_cache(*args, **kwargs)
-            telemetry.observe_cache_state(entries=len(self), nbytes=self.nbytes)
+            entries, nbytes = self._omlx_cache_inventory()
+            telemetry.observe_cache_state(entries=entries, nbytes=nbytes)
             return result
 
     class CoordinatedGenerationContext(original_generation_context):
@@ -1521,7 +1526,7 @@ def install_server_telemetry(
         mlx_server.TimeBudget = original_time_budget
         mlx_server.APIHandler.handle_completion = original_handle_completion
         mlx_server.stream_generate = original_stream_generate
-        if ssd_store is not None:
-            # Snapshots are process-lifetime; a hard crash skips this and the
-            # next store on the same directory reclaims the leftovers instead.
+        if ssd_store is not None and not ssd_cache_persistent:
+            # Legacy process-lifetime mode: a hard crash skips this and the
+            # next nonpersistent store reclaims the leftovers instead.
             shutil.rmtree(ssd_store.directory, ignore_errors=True)

--- a/omlx/cluster/telemetry.py
+++ b/omlx/cluster/telemetry.py
@@ -36,6 +36,24 @@ _MAX_CANCEL_FILE_BYTES = 64 * 1024
 # heartbeats can be missed before anything is called stale, and long enough that
 # it never competes with generation for the lock.
 _DEFAULT_HEARTBEAT_INTERVAL = 10.0
+_MAX_TRANSPORT_REQUEST_ID_BYTES = 128
+
+
+def _transport_request_id(value: Any) -> str | None:
+    """Validate the private coordinator-to-rank request correlation id."""
+
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        encoded = value.encode("ascii")
+    except UnicodeEncodeError:
+        return None
+    if len(encoded) > _MAX_TRANSPORT_REQUEST_ID_BYTES:
+        return None
+    allowed = frozenset(
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.:"
+    )
+    return value if all(character in allowed for character in value) else None
 
 
 class MarkerWriter(Protocol):
@@ -174,7 +192,7 @@ class RuntimeTelemetry:
                 # and reintroduce the self-kill it exists to prevent.
                 logger.debug("Runtime marker heartbeat failed: %s", exc)
 
-    def begin_request(self) -> int:
+    def begin_request(self, transport_request_id: str | None = None) -> int:
         now = float(self._clock())
         with self._lock:
             self._next_request_id += 1
@@ -184,6 +202,10 @@ class RuntimeTelemetry:
                 started_at=now,
                 updated_at=now,
             )
+            transport_request_id = _transport_request_id(transport_request_id)
+            if transport_request_id is not None:
+                self._transport_to_request[transport_request_id] = request_id
+                self._request_to_transport[request_id] = transport_request_id
             self._publish_locked(now, force=True)
             return request_id
 
@@ -379,6 +401,41 @@ class RuntimeTelemetry:
         )
         return len(uids)
 
+    def force_cancel_request(
+        self,
+        transport_request_id: str,
+        *,
+        reason: str = "coordinator cancel",
+    ) -> int:
+        """Stop exactly one request identified by the private HTTP transport."""
+
+        normalized = _transport_request_id(transport_request_id)
+        if normalized is None:
+            return 0
+        with self._lock:
+            request_id = self._transport_to_request.get(normalized)
+            context = self._request_contexts.get(request_id)
+            active = request_id in self._requests if request_id is not None else False
+        if not active or context is None:
+            with self._lock:
+                if len(self._pending_transport_cancels) < _MAX_TARGETED_CANCEL_REQUESTS:
+                    self._pending_transport_cancels.add(normalized)
+            return 0
+        stop = getattr(context, "stop", None)
+        if not callable(stop):
+            return 0
+        try:
+            stop()
+        except Exception as exc:
+            logger.warning("Rank-side targeted context cancel failed: %s", exc)
+            return 0
+        logger.warning(
+            "Requested synchronized cancellation for request %s: %s",
+            normalized,
+            reason,
+        )
+        return 1
+
     def _read_cancel_request(self) -> dict[str, Any] | None:
         path = self._cancel_path
         if path is None:
@@ -448,9 +505,30 @@ class RuntimeTelemetry:
         if epoch <= self._last_cancel_epoch:
             return 0
         self._last_cancel_epoch = epoch
-        cancelled = self.force_cancel_all(
-            reason=str(payload.get("reason") or "coordinator cancel")
-        )
+        reason = str(payload.get("reason") or "coordinator cancel")
+        if payload.get("scope") == "request":
+            cancelled = self.force_cancel_request(
+                payload.get("request_id"),
+                reason=reason,
+            )
+        elif payload.get("scope") == "requests":
+            request_ids = payload.get("request_ids")
+            if not isinstance(request_ids, list):
+                cancelled = 0
+            else:
+                normalized = []
+                for request_id in request_ids[:_MAX_TARGETED_CANCEL_REQUESTS]:
+                    request_id = _transport_request_id(request_id)
+                    if request_id is not None and request_id not in normalized:
+                        normalized.append(request_id)
+                cancelled = sum(
+                    self.force_cancel_request(request_id, reason=reason)
+                    for request_id in normalized
+                )
+        elif payload.get("scope") == "all":
+            cancelled = self.force_cancel_all(reason=reason)
+        else:
+            cancelled = 0
         self._write_cancel_ack(epoch=epoch, cancelled=cancelled)
         return cancelled
 
@@ -731,7 +809,12 @@ def _finite_metrics(value: Any) -> bool:
 class _TelemetryQueue:
     """Observe MLX-LM's rank-local response queue without changing its API."""
 
-    def __init__(self, queue: Any, telemetry: RuntimeTelemetry) -> None:
+    def __init__(
+        self,
+        queue: Any,
+        telemetry: RuntimeTelemetry,
+        transport_request_id: str | None = None,
+    ) -> None:
         self._queue = queue
         self._telemetry = telemetry
         self._request_id = telemetry.begin_request()
@@ -796,6 +879,7 @@ def install_server_telemetry(
     original_batch_generator = mlx_server.BatchGenerator
     original_prompt_cache = mlx_server.LRUPromptCache
     original_generation_context = mlx_server.GenerationContext
+    original_handle_completion = mlx_server.APIHandler.handle_completion
     cancellation_state = threading.local()
     marker_path = getattr(marker, "path", None)
     marker_payload = getattr(marker, "payload", None)
@@ -1080,7 +1164,21 @@ def install_server_telemetry(
             if shared is None:
                 return None
             response_queue, *rest = shared
-            return _TelemetryQueue(response_queue, telemetry), *rest
+            transport_request_id = (
+                _transport_request_id(
+                    getattr(rest[0], "_omlx_transport_request_id", None)
+                )
+                if rest
+                else None
+            )
+            return (
+                _TelemetryQueue(
+                    response_queue,
+                    telemetry,
+                    transport_request_id=transport_request_id,
+                ),
+                *rest,
+            )
 
         def _tokenize(self, tokenizer: Any, request: Any, args: Any) -> Any:
             tokenized = super()._tokenize(tokenizer, request, args)
@@ -1123,6 +1221,20 @@ def install_server_telemetry(
                 cancellation_state.sequential = previous
 
     original_stream_generate = mlx_server.stream_generate
+
+    def request_correlated_handle_completion(
+        handler: Any,
+        request: Any,
+        stop_words: Any,
+    ) -> Any:
+        """Attach the private coordinator id before ranks share the request."""
+
+        request_id = _transport_request_id(
+            handler.headers.get("X-oMLX-Request-ID")
+        )
+        if request_id is not None:
+            request._omlx_transport_request_id = request_id
+        return original_handle_completion(handler, request, stop_words)
 
     def snapshotting_stream_generate(*args: Any, **kwargs: Any) -> Any:
         """Deposit a snapshot at each prefill boundary before it is overwritten.
@@ -1167,6 +1279,7 @@ def install_server_telemetry(
     mlx_server.ResponseGenerator = TelemetryResponseGenerator
     mlx_server.LRUPromptCache = TelemetryPromptCache
     mlx_server.GenerationContext = CoordinatedGenerationContext
+    mlx_server.APIHandler.handle_completion = request_correlated_handle_completion
     if ssd_store is not None:
         mlx_server.stream_generate = snapshotting_stream_generate
     # Started here rather than by the caller: this block is exactly the span
@@ -1181,6 +1294,7 @@ def install_server_telemetry(
         mlx_server.BatchGenerator = original_batch_generator
         mlx_server.LRUPromptCache = original_prompt_cache
         mlx_server.GenerationContext = original_generation_context
+        mlx_server.APIHandler.handle_completion = original_handle_completion
         mlx_server.stream_generate = original_stream_generate
         if ssd_store is not None:
             # Snapshots are process-lifetime; a hard crash skips this and the

--- a/omlx/cluster/telemetry.py
+++ b/omlx/cluster/telemetry.py
@@ -1279,6 +1279,13 @@ def install_server_telemetry(
                     loaded = ssd_store.load(model, tokens, boundary)
                     if loaded is not None:
                         cache, rest = loaded, list(tokens[boundary:])
+            entries, nbytes = self._omlx_cache_inventory()
+            telemetry.observe_cache_lookup(
+                prompt_tokens=len(tokens),
+                remaining_tokens=len(rest) if cache is not None else len(tokens),
+                entries=entries,
+                nbytes=nbytes,
+            )
             return cache, rest
 
         def prefetch_nearest_cache(self, model: Any, tokens: list[int]) -> Any:

--- a/omlx/cluster/telemetry.py
+++ b/omlx/cluster/telemetry.py
@@ -58,6 +58,34 @@ def _transport_request_id(value: Any) -> str | None:
     return value if all(character in allowed for character in value) else None
 
 
+def _python_token_id(value: Any) -> int:
+    """Normalize a generated token to a Python signed-32-bit index.
+
+    MLX samplers may surface a uint32 scalar (or a one-element nested list
+    after ``tolist``). Those are valid model values but some MLX releases
+    reject them as ``array[index]`` objects. The private server indexes the
+    response logprob row after BatchGenerator.next(), so normalize at that
+    queue boundary without touching the device-side token graph.
+    """
+
+    while isinstance(value, (list, tuple)):
+        if len(value) != 1:
+            raise ValueError("generated token must be a scalar")
+        value = value[0]
+    item = getattr(value, "item", None)
+    if callable(item) and not isinstance(value, (int, bool)):
+        value = item()
+    if isinstance(value, bool):
+        raise ValueError("generated token must be an integer")
+    try:
+        token = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("generated token must be an integer") from exc
+    if not 0 <= token <= 2**31 - 1:
+        raise ValueError("generated token is outside signed int32 range")
+    return token
+
+
 class MarkerWriter(Protocol):
     """Small RuntimeMarker surface used by the telemetry observer."""
 
@@ -1319,6 +1347,8 @@ def install_server_telemetry(
             started = time.perf_counter()
             prompt_responses, generation_responses = super().next()
             elapsed = time.perf_counter() - started
+            for response in generation_responses:
+                response.token = _python_token_id(response.token)
             for response in prompt_responses:
                 progress = getattr(response, "progress", None)
                 uid = getattr(response, "uid", None)

--- a/omlx/cluster/telemetry.py
+++ b/omlx/cluster/telemetry.py
@@ -39,6 +39,8 @@ _MAX_CANCEL_FILE_BYTES = 64 * 1024
 _DEFAULT_HEARTBEAT_INTERVAL = 10.0
 _MAX_TRANSPORT_REQUEST_ID_BYTES = 128
 _MAX_TARGETED_CANCEL_REQUESTS = 256
+_CANCEL_VOTE_KIND = "omlx.cancel_vote"
+_CANCEL_VOTE_SCHEMA_VERSION = 1
 
 
 def _transport_request_id(value: Any) -> str | None:
@@ -555,8 +557,7 @@ class RuntimeTelemetry:
             requested = [
                 self._request_to_uid[request_id]
                 for request_id in self._cancel_requested_requests
-                if request_id in self._request_to_uid
-                and request_id in self._requests
+                if request_id in self._request_to_uid and request_id in self._requests
             ]
         for uid in requested:
             if uid not in merged:
@@ -1097,6 +1098,11 @@ def install_server_telemetry(
         if isinstance(marker_payload, dict)
         else ""
     )
+    marker_plan_hash = (
+        str(marker_payload.get("plan_hash") or "")
+        if isinstance(marker_payload, dict)
+        else ""
+    )
     telemetry = RuntimeTelemetry(
         marker,
         execution=execution,
@@ -1189,9 +1195,7 @@ def install_server_telemetry(
         plans: list[tuple[int, int, int]] = []
         if control_plane is not None:
             for source in range(world_size):
-                payload = (
-                    struct.pack("!QQQ", *local) if rank == source else None
-                )
+                payload = struct.pack("!QQQ", *local) if rank == source else None
                 packet = control_plane.broadcast_owned_bytes(
                     payload,
                     source_rank=source,
@@ -1201,9 +1205,7 @@ def install_server_telemetry(
         else:
             fields = [0] * (3 * world_size)
             fields[3 * rank : 3 * rank + 3] = local
-            agreed = mx.distributed.all_sum(
-                mx.array(fields, dtype=mx.int32)
-            )
+            agreed = mx.distributed.all_sum(mx.array(fields, dtype=mx.int32))
             mx.eval(agreed)
             values = [int(value) for value in agreed.tolist()]
             plans = [
@@ -1501,8 +1503,7 @@ def install_server_telemetry(
         @staticmethod
         def _finish_shared_cancel_vote(shared: Any) -> Any:
             if not (
-                isinstance(shared, dict)
-                and shared.get("kind") == _CANCEL_VOTE_KIND
+                isinstance(shared, dict) and shared.get("kind") == _CANCEL_VOTE_KIND
             ):
                 return shared
             epoch, uids = telemetry.accept_cancel_vote(shared)
@@ -1603,9 +1604,7 @@ def install_server_telemetry(
     ) -> Any:
         """Attach the private coordinator id before ranks share the request."""
 
-        request_id = _transport_request_id(
-            handler.headers.get("X-oMLX-Request-ID")
-        )
+        request_id = _transport_request_id(handler.headers.get("X-oMLX-Request-ID"))
         if request_id is not None:
             request._omlx_transport_request_id = request_id
         return original_handle_completion(handler, request, stop_words)
@@ -1630,11 +1629,6 @@ def install_server_telemetry(
         telemetry.observe_cache_state(
             entries=memory_entries + disk_entries,
             nbytes=memory_bytes + disk_bytes,
-            memory_entries=memory_entries,
-            memory_bytes=memory_bytes,
-            ssd_entries=disk_entries,
-            ssd_bytes=disk_bytes,
-            **ssd_store_observability(),
         )
         return {
             "status": "ok",

--- a/omlx/cluster/telemetry.py
+++ b/omlx/cluster/telemetry.py
@@ -37,6 +37,7 @@ _MAX_CANCEL_FILE_BYTES = 64 * 1024
 # it never competes with generation for the lock.
 _DEFAULT_HEARTBEAT_INTERVAL = 10.0
 _MAX_TRANSPORT_REQUEST_ID_BYTES = 128
+_MAX_TARGETED_CANCEL_REQUESTS = 256
 
 
 def _transport_request_id(value: Any) -> str | None:

--- a/omlx/cluster/telemetry.py
+++ b/omlx/cluster/telemetry.py
@@ -291,6 +291,17 @@ class RuntimeTelemetry:
             sample.updated_at = now
             self._publish_locked(now, force=True)
 
+    def has_active_prefill(self) -> bool:
+        """Whether a request still has prompt chunks left on this rank."""
+
+        with self._lock:
+            return any(
+                sample.first_token_at is None
+                and sample.prefill_total_tokens > 0
+                and sample.prefill_processed_tokens < sample.prefill_total_tokens
+                for sample in self._requests.values()
+            )
+
     def observe_token(self, request_id: int) -> None:
         now = float(self._clock())
         with self._lock:
@@ -351,6 +362,7 @@ class RuntimeTelemetry:
                 request_id = self._uid_to_request.pop(uid, None)
                 if request_id is None:
                     continue
+                self._cancel_requested_requests.discard(request_id)
                 self._request_to_uid.pop(request_id, None)
                 changed = (
                     self._finish_locked(
@@ -368,6 +380,32 @@ class RuntimeTelemetry:
 
         with self._lock:
             self._batch_generator = generator
+
+    def merge_requested_cancel_uids(self, uids: Any) -> list[Any]:
+        """Inject requested UIDs into MLX-LM's rank-zero cancellation vote.
+
+        This runs on the generation thread immediately before its existing
+        ``_share_object(uids_to_remove)`` broadcast.  It is therefore safe for
+        distributed collectives: rank zero remains the single producer and
+        every peer receives/removes the same list at the same batch boundary.
+        The heartbeat thread never calls ``BatchGenerator.remove`` directly.
+        """
+
+        try:
+            merged = list(uids)
+        except TypeError:
+            merged = []
+        with self._lock:
+            requested = [
+                self._request_to_uid[request_id]
+                for request_id in self._cancel_requested_requests
+                if request_id in self._request_to_uid
+                and request_id in self._requests
+            ]
+        for uid in requested:
+            if uid not in merged:
+                merged.append(uid)
+        return merged
 
     def force_cancel_all(self, *, reason: str = "coordinator cancel") -> int:
         """Remove every active uid through MLX-LM's own cancel path.
@@ -417,6 +455,8 @@ class RuntimeTelemetry:
             request_id = self._transport_to_request.get(normalized)
             context = self._request_contexts.get(request_id)
             active = request_id in self._requests if request_id is not None else False
+            if active and request_id is not None:
+                self._cancel_requested_requests.add(request_id)
         if not active or context is None:
             with self._lock:
                 if len(self._pending_transport_cancels) < _MAX_TARGETED_CANCEL_REQUESTS:
@@ -600,6 +640,7 @@ class RuntimeTelemetry:
         sample = self._requests.pop(request_id, None)
         if sample is None:
             return False
+        self._cancel_requested_requests.discard(request_id)
         if getattr(self._pending_uid, "request_id", None) == request_id:
             self._pending_uid.request_id = None
         uid = self._request_to_uid.pop(request_id, None)
@@ -880,6 +921,7 @@ def install_server_telemetry(
     original_batch_generator = mlx_server.BatchGenerator
     original_prompt_cache = mlx_server.LRUPromptCache
     original_generation_context = mlx_server.GenerationContext
+    original_time_budget = mlx_server.TimeBudget
     original_handle_completion = mlx_server.APIHandler.handle_completion
     cancellation_state = threading.local()
     marker_path = getattr(marker, "path", None)
@@ -1152,10 +1194,36 @@ def install_server_telemetry(
         def _should_stop(self, value: Any) -> None:
             self.__dict__["_omlx_local_should_stop"] = bool(value)
 
+    class PrefillCancellationTimeBudget(original_time_budget):
+        """Expose one synchronized cancel/admission boundary per prompt chunk.
+
+        MLX-LM's distributed TimeBudget normally batches 25 ``next()`` calls
+        before sharing ``uids_to_remove``.  With 2,048-token prompt chunks that
+        deferred a disconnect by 51,200 tokens.  Every rank observes the same
+        prompt lifecycle, so limiting only active-prefill slices to one step is
+        symmetric and lets the existing rank-zero cancellation vote run after
+        at most the in-progress chunk. Decode keeps the amortized 25-step slice.
+        """
+
+        def __next__(self) -> Any:
+            if (
+                telemetry.has_active_prefill()
+                and getattr(self, "_current_iterations", 0) >= 1
+            ):
+                raise StopIteration()
+            return super().__next__()
+
     class TelemetryResponseGenerator(original):
         def _share_object(self, obj: Any) -> Any:
             if not bool(getattr(self, "_is_distributed", False)):
                 return super()._share_object(obj)
+            # MLX-LM calls this with the rank-zero-owned ``uids_to_remove``
+            # list once per batch-loop slice. Merge heartbeat/transport aborts
+            # here, on the generation thread, so cancellation cannot depend on
+            # cross-thread mutation of GenerationContext and cannot remove a
+            # UID on only one rank.
+            if int(getattr(self, "_rank", 0)) == 0 and isinstance(obj, list):
+                obj = telemetry.merge_requested_cancel_uids(obj)
             if control_plane is not None:
                 return control_plane.broadcast_object(obj)
             return super()._share_object(obj)
@@ -1280,6 +1348,7 @@ def install_server_telemetry(
     mlx_server.ResponseGenerator = TelemetryResponseGenerator
     mlx_server.LRUPromptCache = TelemetryPromptCache
     mlx_server.GenerationContext = CoordinatedGenerationContext
+    mlx_server.TimeBudget = PrefillCancellationTimeBudget
     mlx_server.APIHandler.handle_completion = request_correlated_handle_completion
     if ssd_store is not None:
         mlx_server.stream_generate = snapshotting_stream_generate
@@ -1295,6 +1364,7 @@ def install_server_telemetry(
         mlx_server.BatchGenerator = original_batch_generator
         mlx_server.LRUPromptCache = original_prompt_cache
         mlx_server.GenerationContext = original_generation_context
+        mlx_server.TimeBudget = original_time_budget
         mlx_server.APIHandler.handle_completion = original_handle_completion
         mlx_server.stream_generate = original_stream_generate
         if ssd_store is not None:

--- a/omlx/cluster/telemetry.py
+++ b/omlx/cluster/telemetry.py
@@ -117,6 +117,12 @@ class RuntimeTelemetry:
         self._requests: dict[int, _RequestSample] = {}
         self._uid_to_request: dict[Any, int] = {}
         self._request_to_uid: dict[int, Any] = {}
+        self._request_contexts: dict[int, Any] = {}
+        self._request_queues: dict[int, Any] = {}
+        self._transport_to_request: dict[str, int] = {}
+        self._request_to_transport: dict[int, str] = {}
+        self._pending_transport_cancels: set[str] = set()
+        self._cancel_requested_requests: set[int] = set()
         self._pending_uid = threading.local()
         self._last_completed: dict[str, Any] | None = None
         self._last_publish_at = float("-inf")
@@ -408,6 +414,31 @@ class RuntimeTelemetry:
         """Remember the queue request immediately preceding batch insertion."""
 
         self._pending_uid.request_id = request_id
+
+    def register_context(self, request_id: int, context: Any) -> None:
+        """Retain the server context used by its synchronized cancel path."""
+
+        cancel_immediately = False
+        with self._lock:
+            if request_id in self._requests:
+                self._request_contexts[request_id] = context
+                transport_request_id = self._request_to_transport.get(request_id)
+                if transport_request_id in self._pending_transport_cancels:
+                    self._pending_transport_cancels.discard(transport_request_id)
+                    self._cancel_requested_requests.add(request_id)
+                    cancel_immediately = True
+        if cancel_immediately:
+            stop = getattr(context, "stop", None)
+            if callable(stop):
+                try:
+                    stop()
+                except Exception as exc:
+                    logger.warning("Rank-side pending context cancel failed: %s", exc)
+
+    def register_response_queue(self, request_id: int, queue: Any) -> None:
+        with self._lock:
+            if request_id in self._requests:
+                self._request_queues[request_id] = queue
 
     def bind_pending_uid(self, uids: Any) -> None:
         """Bind MLX-LM's generated batch UID to the observed queue request."""
@@ -725,6 +756,12 @@ class RuntimeTelemetry:
         if getattr(self._pending_uid, "request_id", None) == request_id:
             self._pending_uid.request_id = None
         uid = self._request_to_uid.pop(request_id, None)
+        self._request_contexts.pop(request_id, None)
+        self._request_queues.pop(request_id, None)
+        transport_request_id = self._request_to_transport.pop(request_id, None)
+        if transport_request_id is not None:
+            self._transport_to_request.pop(transport_request_id, None)
+            self._pending_transport_cancels.discard(transport_request_id)
         if uid is not None:
             self._uid_to_request.pop(uid, None)
         sample.updated_at = now
@@ -940,7 +977,8 @@ class _TelemetryQueue:
     ) -> None:
         self._queue = queue
         self._telemetry = telemetry
-        self._request_id = telemetry.begin_request()
+        self._request_id = telemetry.begin_request(transport_request_id)
+        telemetry.register_response_queue(self._request_id, queue)
         self._finished = False
 
     def put(self, item: Any, *args: Any, **kwargs: Any) -> Any:
@@ -960,6 +998,7 @@ class _TelemetryQueue:
                     cached_tokens=max(0, int(cache_count)),
                 )
                 self._telemetry.mark_pending_uid(self._request_id)
+                self._telemetry.register_context(self._request_id, item)
             elif hasattr(item, "token") and hasattr(item, "finish_reason"):
                 self._telemetry.observe_token(self._request_id)
         return self._queue.put(item, *args, **kwargs)

--- a/omlx/cluster/telemetry.py
+++ b/omlx/cluster/telemetry.py
@@ -8,6 +8,7 @@ import logging
 import math
 import os
 import shutil
+import struct
 import threading
 import time
 from collections.abc import Iterator
@@ -1099,9 +1100,100 @@ def install_server_telemetry(
             persistent=ssd_cache_persistent,
         )
     try:
-        world_size = int(mx.distributed.init().size())
+        group = mx.distributed.init()
+        world_size = int(group.size())
+        rank = int(group.rank())
     except Exception:
         world_size = 1
+        rank = 0
+
+    def prompt_cache_positions(cache: Any) -> tuple[int, ...]:
+        """Best-effort logical token positions for a rank-local cache copy."""
+
+        positions: list[int] = []
+        for item in cache or ():
+            nested = getattr(item, "caches", None)
+            entries = nested if isinstance(nested, (list, tuple)) else (item,)
+            for entry in entries:
+                # DS4 PoolingCache.offset counts compressed rows rather than
+                # source tokens.  Reconstruct the logical source position so
+                # a failed arbitrary trim cannot masquerade as a valid hit.
+                ratio = getattr(entry, "ratio", None)
+                remainder = getattr(entry, "remainder", None)
+                pooled = getattr(entry, "_pool_len", None)
+                if all(isinstance(value, int) for value in (ratio, remainder, pooled)):
+                    positions.append(int(pooled) * int(ratio) + int(remainder))
+                    continue
+                offset = getattr(entry, "offset", None)
+                if isinstance(offset, int):
+                    positions.append(offset)
+        return tuple(positions)
+
+    def agree_prompt_cache_plan(
+        cache: Any,
+        tokens: list[int],
+        rest: list[int],
+    ) -> tuple[Any, list[int]]:
+        """Use a cache only when every rank will prefill the same suffix.
+
+        Pipeline stages can have different cache types.  In particular, one
+        DS4 stage may be able to trim a longer cached conversation to a common
+        prefix while another stage containing a recurrent cache cannot.  The
+        stock rank-local lookup then gives the stages different input lengths;
+        JACCL reports ``IBV_WC_LOC_LEN_ERR`` when the activation send reaches a
+        receive posted for the other length.
+
+        Exchange both the reused-prefix and suffix lengths before the first
+        model call.  Any disagreement makes every rank discard its local copy
+        and perform the same full prefill.  The reliable TCP control plane is
+        preferred because these are owned scalar values, not tensor
+        reductions; the fixed-shape reduction is retained for older launchers.
+        """
+
+        if world_size <= 1:
+            return cache, rest
+
+        reused = len(tokens) - len(rest) if cache is not None else 0
+        suffix = len(rest) if cache is not None else len(tokens)
+        positions = prompt_cache_positions(cache)
+        incoherent = int(any(position != reused for position in positions))
+        local = (reused, suffix, incoherent)
+        plans: list[tuple[int, int, int]] = []
+        if control_plane is not None:
+            for source in range(world_size):
+                payload = (
+                    struct.pack("!QQQ", *local) if rank == source else None
+                )
+                packet = control_plane.broadcast_owned_bytes(
+                    payload,
+                    source_rank=source,
+                    expected_size=24,
+                )
+                plans.append(struct.unpack("!QQQ", packet))
+        else:
+            fields = [0] * (3 * world_size)
+            fields[3 * rank : 3 * rank + 3] = local
+            agreed = mx.distributed.all_sum(
+                mx.array(fields, dtype=mx.int32)
+            )
+            mx.eval(agreed)
+            values = [int(value) for value in agreed.tolist()]
+            plans = [
+                tuple(values[3 * source : 3 * source + 3])
+                for source in range(world_size)
+            ]
+
+        if not any(plan[2] for plan in plans) and all(
+            plan == plans[0] for plan in plans[1:]
+        ):
+            return cache, rest
+
+        logger.warning(
+            "Prompt-cache plan diverged across ranks (%s); rebuilding the "
+            "request with a full synchronized prefill",
+            plans,
+        )
+        return None, list(tokens)
 
     def agree_ssd_boundary(model: Any, tokens: list[int]) -> int:
         """Longest prefix boundary every rank can restore for ``tokens``, or 0.

--- a/omlx/cluster/telemetry.py
+++ b/omlx/cluster/telemetry.py
@@ -302,6 +302,87 @@ class RuntimeTelemetry:
                 for sample in self._requests.values()
             )
 
+    def make_cancel_vote(self, uids: Any) -> dict[str, Any]:
+        """Create the next rank-zero-owned, monotonically ordered cancel vote."""
+
+        try:
+            candidates = tuple(uids)
+        except TypeError as exc:
+            raise RuntimeError("distributed cancel vote UIDs are not iterable") from exc
+        normalized: list[int] = []
+        for uid in candidates:
+            if not isinstance(uid, int) or isinstance(uid, bool) or uid < 0:
+                raise RuntimeError("distributed cancel vote contains an invalid UID")
+            if uid not in normalized:
+                normalized.append(uid)
+        if not normalized or len(normalized) > _MAX_TARGETED_CANCEL_REQUESTS:
+            raise RuntimeError("distributed cancel vote has an invalid UID count")
+        with self._lock:
+            epoch = max(
+                self._accepted_cancel_vote_epoch + 1,
+                self._last_cancel_epoch,
+                1,
+            )
+        return {
+            "kind": _CANCEL_VOTE_KIND,
+            "schema_version": _CANCEL_VOTE_SCHEMA_VERSION,
+            "epoch": epoch,
+            "uids": normalized,
+        }
+
+    def accept_cancel_vote(self, vote: Any) -> tuple[int, list[int]]:
+        """Validate one shared cancel epoch before any rank mutates its batch."""
+
+        if (
+            not isinstance(vote, dict)
+            or vote.get("kind") != _CANCEL_VOTE_KIND
+            or vote.get("schema_version") != _CANCEL_VOTE_SCHEMA_VERSION
+        ):
+            raise RuntimeError("distributed cancel vote envelope is invalid")
+        epoch = vote.get("epoch")
+        uids = vote.get("uids")
+        if not isinstance(epoch, int) or isinstance(epoch, bool) or epoch <= 0:
+            raise RuntimeError("distributed cancel vote epoch is invalid")
+        if not isinstance(uids, list):
+            raise RuntimeError("distributed cancel vote UID list is invalid")
+        normalized: list[int] = []
+        for uid in uids:
+            if not isinstance(uid, int) or isinstance(uid, bool) or uid < 0:
+                raise RuntimeError("distributed cancel vote contains an invalid UID")
+            if uid in normalized:
+                raise RuntimeError("distributed cancel vote contains duplicate UIDs")
+            normalized.append(uid)
+        if not normalized or len(normalized) > _MAX_TARGETED_CANCEL_REQUESTS:
+            raise RuntimeError("distributed cancel vote has an invalid UID count")
+        with self._lock:
+            if epoch <= self._accepted_cancel_vote_epoch:
+                raise RuntimeError(
+                    "distributed cancel vote epoch did not advance: "
+                    f"previous={self._accepted_cancel_vote_epoch}, received={epoch}"
+                )
+            self._accepted_cancel_vote_epoch = epoch
+        return epoch, normalized
+
+    def drain_cancel_boundary(self, epoch: int, uids: Any) -> None:
+        """Drain rank-local Metal work for a validated shared cancellation."""
+
+        with self._lock:
+            generator = self._batch_generator
+        drain = getattr(generator, "_omlx_drain_cancel_boundary", None)
+        if not callable(drain):
+            raise RuntimeError("distributed cancel vote has no live batch generator")
+        drain(epoch, uids)
+
+    def arm_cancel_boundary(self, epoch: int, uids: Any) -> None:
+        """Allow exactly the agreed UID removal after the rank rendezvous."""
+
+        with self._lock:
+            generator = self._batch_generator
+        arm = getattr(generator, "_omlx_arm_cancel_boundary", None)
+        if not callable(arm):
+            raise RuntimeError("distributed cancel vote has no live batch generator")
+        arm(epoch, uids)
+
     def observe_token(self, request_id: int) -> None:
         now = float(self._clock())
         with self._lock:
@@ -1033,10 +1114,23 @@ def install_server_telemetry(
             return uids
 
         def remove(self, uids: Any) -> Any:
-            telemetry.cancel_uids(uids)
-            for uid in uids:
+            uid_values = list(uids)
+            if world_size > 1:
+                prepared = self._omlx_prepared_cancel_vote
+                if prepared is None or prepared[1] != tuple(uid_values):
+                    raise RuntimeError(
+                        "distributed UID removal was not armed by the shared "
+                        "cancel epoch"
+                    )
+                self._omlx_prepared_cancel_vote = None
+            # Mutate the MLX-LM batch first. Only then publish cancellation and
+            # wake the HTTP collector; an exception during cache filtering must
+            # not advertise a request as safely removed when its graph remains.
+            result = super().remove(uid_values)
+            for uid in uid_values:
                 self._omlx_tokens.pop(uid, None)
-            return super().remove(uids)
+            telemetry.cancel_uids(uid_values)
+            return result
 
         def _omlx_snapshot_boundary(self, response: Any) -> None:
             """Save the batched prompt cache when prefill crosses a boundary.
@@ -1214,6 +1308,25 @@ def install_server_telemetry(
             return super().__next__()
 
     class TelemetryResponseGenerator(original):
+        @staticmethod
+        def _finish_shared_cancel_vote(shared: Any) -> Any:
+            if not (
+                isinstance(shared, dict)
+                and shared.get("kind") == _CANCEL_VOTE_KIND
+            ):
+                return shared
+            epoch, uids = telemetry.accept_cancel_vote(shared)
+            telemetry.drain_cancel_boundary(epoch, uids)
+            if control_plane is not None:
+                # TCP sendall is not a rendezvous: rank zero can otherwise
+                # filter its caches while the worker is still draining an
+                # indexer gather from the just-finished prompt chunk.
+                control_plane.barrier()
+            # ``remove`` is fail-closed in TP mode and accepts only this exact
+            # epoch/list after every peer completed the rendezvous.
+            telemetry.arm_cancel_boundary(epoch, uids)
+            return uids
+
         def _share_object(self, obj: Any) -> Any:
             if not bool(getattr(self, "_is_distributed", False)):
                 return super()._share_object(obj)
@@ -1224,6 +1337,8 @@ def install_server_telemetry(
             # UID on only one rank.
             if int(getattr(self, "_rank", 0)) == 0 and isinstance(obj, list):
                 obj = telemetry.merge_requested_cancel_uids(obj)
+                if obj:
+                    obj = telemetry.make_cancel_vote(obj)
             if control_plane is not None:
                 return control_plane.broadcast_object(obj)
             return super()._share_object(obj)

--- a/omlx/cluster/telemetry.py
+++ b/omlx/cluster/telemetry.py
@@ -1068,6 +1068,13 @@ def install_server_telemetry(
             self.__dict__["_omlx_local_should_stop"] = bool(value)
 
     class TelemetryResponseGenerator(original):
+        def _share_object(self, obj: Any) -> Any:
+            if not bool(getattr(self, "_is_distributed", False)):
+                return super()._share_object(obj)
+            if control_plane is not None:
+                return control_plane.broadcast_object(obj)
+            return super()._share_object(obj)
+
         def _share_request(self, request: Any) -> Any:
             shared = super()._share_request(request)
             if shared is None:

--- a/omlx/cluster/telemetry.py
+++ b/omlx/cluster/telemetry.py
@@ -128,6 +128,8 @@ class RuntimeTelemetry:
         heartbeat_interval: float = _DEFAULT_HEARTBEAT_INTERVAL,
         cancel_path: Path | None = None,
         cancel_deployment_id: str = "",
+        cancel_plan_hash: str = "",
+        cancel_epoch_floor: int = 0,
     ) -> None:
         if publish_interval < 0:
             raise ValueError("publish_interval must be non-negative")
@@ -182,8 +184,20 @@ class RuntimeTelemetry:
         self._batch_generator: Any | None = None
         self._cancel_path = cancel_path
         self._cancel_deployment_id = cancel_deployment_id
-        self._last_cancel_epoch = 0
+        self._cancel_plan_hash = cancel_plan_hash
+        self._cancel_epoch_floor = max(0, int(cancel_epoch_floor))
+        self._last_cancel_epoch = max(0, self._cancel_epoch_floor - 1)
+        self._accepted_cancel_vote_epoch = 0
         self._last_cancel_poll_at = float("-inf")
+        # A cancel marker is an edge, not durable desired state. Treat a file
+        # left by an earlier worker lifetime as the startup watermark instead
+        # of replaying it against the first request this process receives.
+        existing_cancel = self._read_cancel_request()
+        if existing_cancel is not None:
+            self._last_cancel_epoch = max(
+                self._last_cancel_epoch,
+                int(existing_cancel["epoch"]),
+            )
 
     def heartbeat(self) -> None:
         """Refresh the marker with nothing new to say.
@@ -515,6 +529,7 @@ class RuntimeTelemetry:
             return
         now = float(self._clock())
         changed = False
+        queues_to_close: list[Any] = []
         with self._lock:
             for uid in uid_values:
                 request_id = self._uid_to_request.pop(uid, None)
@@ -522,16 +537,24 @@ class RuntimeTelemetry:
                     continue
                 self._cancel_requested_requests.discard(request_id)
                 self._request_to_uid.pop(request_id, None)
-                changed = (
-                    self._finish_locked(
-                        request_id,
-                        now=now,
-                        status="cancelled",
-                    )
-                    or changed
+                queue = self._request_queues.get(request_id)
+                finished = self._finish_locked(
+                    request_id,
+                    now=now,
+                    status="cancelled",
                 )
+                if finished and queue is not None:
+                    queues_to_close.append(queue)
+                changed = finished or changed
             if changed:
                 self._publish_locked(now, force=True)
+        # Wake the HTTP collector only after releasing the telemetry lock.
+        # Worker dummy queues receive the same terminal sentinel harmlessly.
+        for queue in queues_to_close:
+            try:
+                queue.put(None)
+            except Exception as exc:
+                logger.debug("Could not terminate cancelled response queue: %s", exc)
 
     def register_batch_generator(self, generator: Any) -> None:
         """Remember the live BatchGenerator so force-cancel can reach it."""
@@ -565,37 +588,42 @@ class RuntimeTelemetry:
         return merged
 
     def force_cancel_all(self, *, reason: str = "coordinator cancel") -> int:
-        """Remove every active uid through MLX-LM's own cancel path.
+        """Request cancellation through MLX-LM's shared server-loop path.
 
-        ``BatchGenerator.remove`` is the same call MLX-LM handlers make on
-        client disconnect: it is processed by the batch loop at a step
-        boundary and shared with peer ranks, so both sides of the pipeline
-        abandon the request together and no collective is severed
-        mid-request. Returns the number of uids handed to the batch loop.
+        The heartbeat must not call ``BatchGenerator.remove`` directly: that
+        mutates rank zero on the heartbeat thread while peers keep decoding.
+        Stop the real generation contexts and let the generation thread merge,
+        broadcast, drain, rendezvous, and remove the same UIDs on every rank.
         """
 
         with self._lock:
-            generator = self._batch_generator
-            uids = [
-                uid
-                for request_id, uid in self._request_to_uid.items()
+            self._cancel_requested_requests.update(self._requests)
+            contexts = [
+                context
+                for request_id, context in self._request_contexts.items()
                 if request_id in self._requests
             ]
-        if generator is None or not uids:
+        if not contexts:
             return 0
-        try:
-            generator.remove(list(uids))
-        except Exception as exc:
-            # A cancel that failed must be loud but must not kill the rank;
-            # the coordinator falls back to process teardown.
-            logger.warning("Rank-side force-cancel failed: %s", exc)
+        requested = 0
+        for context in contexts:
+            stop = getattr(context, "stop", None)
+            if not callable(stop):
+                continue
+            try:
+                stop()
+            except Exception as exc:
+                logger.warning("Rank-side context cancel failed: %s", exc)
+                continue
+            requested += 1
+        if not requested:
             return 0
         logger.warning(
-            "Force-cancelled %d active rank-side request(s): %s",
-            len(uids),
+            "Requested synchronized cancellation for %d active request(s): %s",
+            requested,
             reason,
         )
-        return len(uids)
+        return requested
 
     def force_cancel_request(
         self,
@@ -655,8 +683,15 @@ class RuntimeTelemetry:
             and payload.get("deployment_id") != self._cancel_deployment_id
         ):
             return None
+        if (
+            self._cancel_plan_hash
+            and payload.get("plan_hash") != self._cancel_plan_hash
+        ):
+            return None
         epoch = payload.get("epoch")
         if not isinstance(epoch, int) or isinstance(epoch, bool):
+            return None
+        if epoch < self._cancel_epoch_floor:
             return None
         return payload
 
@@ -668,6 +703,7 @@ class RuntimeTelemetry:
         payload = {
             "schema_version": 1,
             "deployment_id": self._cancel_deployment_id,
+            "plan_hash": self._cancel_plan_hash,
             "epoch": epoch,
             "cancelled": cancelled,
             "at": time.time(),
@@ -1103,6 +1139,7 @@ def install_server_telemetry(
         if isinstance(marker_payload, dict)
         else ""
     )
+    worker_cancel_epoch_floor = int(time.time() * 1000)
     telemetry = RuntimeTelemetry(
         marker,
         execution=execution,
@@ -1114,6 +1151,8 @@ def install_server_telemetry(
             else None
         ),
         cancel_deployment_id=marker_deployment_id,
+        cancel_plan_hash=marker_plan_hash,
+        cancel_epoch_floor=worker_cancel_epoch_floor,
     )
 
     snapshot_ctx = threading.local()
@@ -1272,7 +1311,25 @@ def install_server_telemetry(
             # Full token sequence per in-flight uid, so a boundary snapshot can
             # be keyed while the batched prefill is still running.
             self._omlx_tokens: dict[Any, list[int]] = {}
+            self._omlx_prepared_cancel_vote: tuple[int, tuple[int, ...]] | None = None
             telemetry.register_batch_generator(self)
+
+        def _omlx_drain_cancel_boundary(self, epoch: int, uids: Any) -> None:
+            """Finish scheduled Metal work before the cancel rendezvous."""
+
+            if self._omlx_prepared_cancel_vote is not None:
+                raise RuntimeError("a distributed cancel vote is already armed")
+            stream = getattr(self, "stream", None)
+            if stream is None:
+                mx.synchronize()
+            else:
+                mx.synchronize(stream)
+
+        def _omlx_arm_cancel_boundary(self, epoch: int, uids: Any) -> None:
+            normalized = tuple(int(uid) for uid in uids)
+            if self._omlx_prepared_cancel_vote is not None:
+                raise RuntimeError("a distributed cancel vote is already armed")
+            self._omlx_prepared_cancel_vote = (int(epoch), normalized)
 
         def insert_segments(self, *args: Any, **kwargs: Any) -> Any:
             uids = super().insert_segments(*args, **kwargs)
@@ -1375,6 +1432,10 @@ def install_server_telemetry(
             return prompt_responses, generation_responses
 
     class TelemetryPromptCache(original_prompt_cache):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+            prompt_cache_instances.append(self)
+
         def _omlx_cache_inventory(self) -> tuple[int, int]:
             """Combined volatile LRU and durable rank-local snapshot tiers."""
 
@@ -1420,6 +1481,7 @@ def install_server_telemetry(
                     loaded = ssd_store.load(model, tokens, boundary)
                     if loaded is not None:
                         cache, rest = loaded, list(tokens[boundary:])
+            cache, rest = agree_prompt_cache_plan(cache, tokens, rest)
             entries, nbytes = self._omlx_cache_inventory()
             telemetry.observe_cache_lookup(
                 prompt_tokens=len(tokens),
@@ -1531,8 +1593,10 @@ def install_server_telemetry(
                 if obj:
                     obj = telemetry.make_cancel_vote(obj)
             if control_plane is not None:
-                return control_plane.broadcast_object(obj)
-            return super()._share_object(obj)
+                shared = control_plane.broadcast_object(obj)
+            else:
+                shared = super()._share_object(obj)
+            return self._finish_shared_cancel_vote(shared)
 
         def _share_request(self, request: Any) -> Any:
             shared = super()._share_request(request)

--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -249,6 +249,7 @@ class DistributedBatchedEngine(BatchedEngine):
                 self.deployment.deployment_id,
                 reason,
             )
+
     def _new_client(self, endpoint: str) -> httpx.AsyncClient:
         return httpx.AsyncClient(
             base_url=endpoint,
@@ -314,7 +315,9 @@ class DistributedBatchedEngine(BatchedEngine):
                 )
             payload = response.json()
             if not isinstance(payload, dict) or payload.get("status") != "ok":
-                raise DistributedInferenceError("rank 0 returned invalid cache-clear JSON")
+                raise DistributedInferenceError(
+                    "rank 0 returned invalid cache-clear JSON"
+                )
             return payload
 
         def clear_remote(rank: int, ssh_target: str) -> dict[str, Any]:

--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -219,7 +219,30 @@ class DistributedBatchedEngine(BatchedEngine):
         self._request_states: dict[str, _DistributedRequestState] = {}
         self._next_request_seq = 0
         self._last_cancel_epoch = 0
+        self._runtime_failed_reason: str | None = None
 
+    @property
+    def runtime_failed_reason(self) -> str | None:
+        """Terminal worker failure observed by the coordinator, if any."""
+
+        if self._runtime_failed_reason is None and self._loaded:
+            status = self._supervisor.status()
+            reason = status.failure_reason
+            if reason is None and status.returncode is not None:
+                reason = f"distributed job exited with code {status.returncode}"
+            if reason:
+                self._mark_runtime_failed(reason)
+        return self._runtime_failed_reason
+
+    def _mark_runtime_failed(self, reason: str) -> None:
+        reason = str(reason).strip()[:2000] or "distributed worker stopped"
+        if self._runtime_failed_reason is None:
+            self._runtime_failed_reason = reason
+            logger.error(
+                "Distributed runtime is no longer serviceable (%s): %s",
+                self.deployment.deployment_id,
+                reason,
+            )
     def _new_client(self, endpoint: str) -> httpx.AsyncClient:
         return httpx.AsyncClient(
             base_url=endpoint,
@@ -258,6 +281,7 @@ class DistributedBatchedEngine(BatchedEngine):
         if self._loaded:
             return
         self._validate_model_settings()
+        self._runtime_failed_reason = None
 
         # Tokenizer/config metadata stays in the oMLX process. No model weights
         # are loaded here.
@@ -354,6 +378,9 @@ class DistributedBatchedEngine(BatchedEngine):
             if tail and tail not in detail:
                 detail = f"{detail} · Worker log: {tail}" if detail else tail
             suffix = f": {detail}" if detail else ""
+            self._mark_runtime_failed(
+                detail or f"distributed job exited with code {status.returncode}"
+            )
             raise DistributedInferenceError(
                 f"distributed job exited with code {status.returncode}{suffix}"
             )

--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -108,6 +108,32 @@ class DistributedInferenceError(RuntimeError):
     """A bounded error surfaced when the private rank-zero backend fails."""
 
 
+class DistributedRequestAborted(DistributedInferenceError):
+    """Raised into a proxied request the coordinator has aborted."""
+
+
+class _DistributedRequestState:
+    """Coordinator-side tracking for one proxied request.
+
+    The local engine path has per-request abort and an orphan-collector
+    reaper through AsyncEngineCore; the distributed path had neither (G3/G4).
+    This record is the handle ``abort_request`` acts on and the evidence the
+    orphan reaper sweeps: ``finished_at`` stamps the moment the *backend*
+    finished, so a consumer that abandoned the generator instead of closing
+    it can be reaped after a grace period — pop-only, mirroring
+    ``AsyncEngineCore._reap_orphaned_collectors``.
+    """
+
+    __slots__ = ("request_id", "started_at", "finished_at", "response", "aborted")
+
+    def __init__(self, request_id: str, started_at: float) -> None:
+        self.request_id = request_id
+        self.started_at = started_at
+        self.finished_at: float | None = None
+        self.response: Any | None = None
+        self.aborted = False
+
+
 class DistributedBatchedEngine(BatchedEngine):
     """Keep oMLX's API/tokenizer layer while proxying model work to MLX ranks."""
 
@@ -599,13 +625,197 @@ class DistributedBatchedEngine(BatchedEngine):
             return f"<think>{reasoning_text}</think>{content_text}"
         return content_text
 
-    async def _enter_request(self) -> None:
+    async def _enter_request(self) -> str:
         async with self._active_lock:
             self._active_requests += 1
+            self._next_request_seq += 1
+            request_id = (
+                f"{self.deployment.deployment_id}-{self._next_request_seq}"
+            )
+            self._request_states[request_id] = _DistributedRequestState(
+                request_id,
+                time.monotonic(),
+            )
+            return request_id
 
-    async def _leave_request(self) -> None:
+    async def _leave_request(self, request_id: str | None = None) -> None:
         async with self._active_lock:
             self._active_requests = max(0, self._active_requests - 1)
+            if request_id is not None:
+                self._request_states.pop(request_id, None)
+
+    def _request_state(self, request_id: str) -> _DistributedRequestState | None:
+        return self._request_states.get(request_id)
+
+    def _raise_if_aborted(self, request_id: str) -> None:
+        state = self._request_states.get(request_id)
+        if state is not None and state.aborted:
+            raise DistributedRequestAborted(
+                f"distributed request {request_id} aborted by the coordinator"
+            )
+
+    def _mark_backend_finished(self, request_id: str) -> None:
+        """Stamp backend completion so the orphan reaper can sweep strays."""
+
+        state = self._request_states.get(request_id)
+        if state is not None and state.finished_at is None:
+            state.finished_at = time.monotonic()
+
+    def reap_orphaned_generators(
+        self,
+        *,
+        now: float | None = None,
+        grace: float | None = None,
+    ) -> int:
+        """Drop requests whose backend finished but whose consumer vanished.
+
+        Parallel to ``AsyncEngineCore._reap_orphaned_collectors``: when the
+        SSE generator chain is abandoned rather than closed, the ``finally``
+        that calls ``_leave_request`` only runs at GC time, so
+        ``_active_requests`` leaks and quiescence-gated unload blocks (G4) —
+        or worse, unblocks spuriously. Pop-only: any request whose backend
+        finished more than ``grace`` ago but is still tracked is reaped. A
+        live consumer drains in the same event-loop turn the backend
+        finishes, so the grace period cannot race it.
+        """
+
+        if not self._request_states:
+            return 0
+        current = time.monotonic() if now is None else now
+        limit = self._orphan_reap_grace if grace is None else grace
+        stale = [
+            request_id
+            for request_id, state in self._request_states.items()
+            if state.finished_at is not None
+            and current - state.finished_at >= limit
+        ]
+        for request_id in stale:
+            self._request_states.pop(request_id, None)
+            self._active_requests = max(0, self._active_requests - 1)
+        if stale:
+            logger.warning(
+                "Reaped %d orphaned distributed request(s) after consumer "
+                "abandonment: %s",
+                len(stale),
+                stale,
+            )
+        return len(stale)
+
+    def rank_side_active_requests(self) -> int | None:
+        """Active requests as rank zero's telemetry reports them, if known.
+
+        The coordinator's own counter only proves the httpx side closed;
+        the rank-0 marker's ``metrics.active_requests`` is the rank-side
+        quiescence evidence an abort or unload should wait for (G5).
+        """
+
+        marker = read_marker(
+            Path(self._supervisor.state_dir).expanduser()
+            / f"{self.deployment.deployment_id}-rank-0.json"
+        )
+        if not isinstance(marker, dict):
+            return None
+        metrics = marker.get("metrics")
+        if not isinstance(metrics, dict):
+            return None
+        active = metrics.get("active_requests")
+        if isinstance(active, int) and not isinstance(active, bool) and active >= 0:
+            return active
+        return None
+
+    async def abort_request(
+        self,
+        request_id: str,
+        *,
+        reason: str | None = None,
+        error_code: str | None = None,
+    ) -> bool:
+        """Abort one proxied request and close only its backend connection.
+
+        The abort flag ends the local generator at the next yield boundary;
+        closing the request's own connection makes the rank-0 handler reach
+        its ``finally`` and cancel the generation context through MLX-LM's
+        batch-loop removal — a step boundary every rank reaches, never a
+        mid-collective sever. Other in-flight requests keep their
+        connections (the old whole-client close in abort_all_requests is
+        retained there only as the nuclear option).
+        """
+
+        state = self._request_states.get(request_id)
+        if state is None:
+            return False
+        state.aborted = True
+        response = state.response
+        if response is not None:
+            with suppress(Exception):
+                await response.aclose()
+        logger.info(
+            "Aborted distributed request %s (%s)",
+            request_id,
+            reason or error_code or "no reason given",
+        )
+        return True
+
+    def _write_rank_cancel_request(self, *, reason: str | None) -> Path | None:
+        """Ask rank zero to force-cancel every active request at a step boundary.
+
+        The rank's telemetry heartbeat consumes this file and cancels through
+        ``BatchGenerator.remove`` — MLX-LM's own cancel path, which the batch
+        loop applies at a step boundary and shares with peer ranks. This is
+        the backstop for a handler wedged in a collective that never reaches
+        its disconnect ``finally`` (G3).
+        """
+
+        root = Path(self._supervisor.state_dir).expanduser()
+        path = root / f"{self.deployment.deployment_id}-cancel.json"
+        payload = {
+            "schema_version": 1,
+            "deployment_id": self.deployment.deployment_id,
+            "plan_hash": self.deployment.plan_hash,
+            "epoch": int(time.time() * 1000),
+            "scope": "all",
+            "reason": reason or "coordinator abort_all_requests",
+        }
+        try:
+            root.mkdir(parents=True, exist_ok=True)
+            temporary = path.with_name(path.name + ".tmp")
+            descriptor = os.open(
+                temporary, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600
+            )
+            with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+                json.dump(payload, stream, sort_keys=True)
+            os.replace(temporary, path)
+        except OSError as exc:
+            logger.warning("Could not write the rank cancel request: %s", exc)
+            return None
+        return path
+
+    async def _wait_for_backend_drain(self, *, timeout: float) -> bool:
+        """Wait for local generators AND rank-side telemetry to reach zero.
+
+        Client close alone never proved the ranks stopped generating (G5).
+        Drain is confirmed only when the coordinator counter is zero and the
+        rank-0 marker reports no active requests.
+        """
+
+        deadline = time.monotonic() + max(0.0, timeout)
+        while True:
+            self.reap_orphaned_generators()
+            local_active = self._active_requests
+            rank_active = self.rank_side_active_requests()
+            if local_active == 0 and rank_active == 0:
+                return True
+            if time.monotonic() >= deadline:
+                logger.warning(
+                    "Distributed backend drain unconfirmed after %.1fs "
+                    "(local active=%d, rank-zero active=%s)",
+                    timeout,
+                    local_active,
+                    "unknown" if rank_active is None else rank_active,
+                )
+                return False
+            await asyncio.sleep(0.1)
+
 
     async def chat(
         self,
@@ -654,7 +864,7 @@ class DistributedBatchedEngine(BatchedEngine):
             stream=False,
             kwargs=kwargs,
         )
-        await self._enter_request()
+        request_id = await self._enter_request()
         started_at = time.monotonic()
         try:
             response = await client.post("/v1/chat/completions", json=payload)
@@ -667,8 +877,10 @@ class DistributedBatchedEngine(BatchedEngine):
                     if response.status_code < 400:
                         break
             self._raise_for_backend(response)
+            self._raise_if_aborted(request_id)
             body = response.json()
         except httpx.ReadTimeout as exc:
+            self._cancel_backend_after_timeout(request_id)
             raise self._read_timeout_error(stream=False) from exc
         except httpx.HTTPError as exc:
             raise await self._transport_failure_error(
@@ -680,7 +892,8 @@ class DistributedBatchedEngine(BatchedEngine):
                 "rank-zero backend returned invalid chat JSON"
             ) from exc
         finally:
-            await self._leave_request()
+            self._mark_backend_finished(request_id)
+            await self._leave_request(request_id)
 
         try:
             choice = body["choices"][0]
@@ -769,7 +982,7 @@ class DistributedBatchedEngine(BatchedEngine):
         reasoning_open = False
         backend_tool_calls: dict[int, dict[str, Any]] = {}
 
-        await self._enter_request()
+        request_id = await self._enter_request()
         try:
             # A client that always sends an unsupported reasoning_effort must
             # never turn this into an unbounded retry loop: `attempts` is
@@ -924,6 +1137,7 @@ class DistributedBatchedEngine(BatchedEngine):
                 "rank-zero backend emitted invalid chat token counts"
             ) from exc
         except httpx.ReadTimeout as exc:
+            self._cancel_backend_after_timeout(request_id)
             raise self._read_timeout_error(stream=True) from exc
         except httpx.HTTPError as exc:
             raise await self._transport_failure_error(
@@ -931,7 +1145,8 @@ class DistributedBatchedEngine(BatchedEngine):
                 stream=True,
             ) from exc
         finally:
-            await self._leave_request()
+            self._mark_backend_finished(request_id)
+            await self._leave_request(request_id)
 
         pending_final_text = ""
         if reasoning_open:
@@ -992,7 +1207,7 @@ class DistributedBatchedEngine(BatchedEngine):
             stream=False,
             kwargs=kwargs,
         )
-        await self._enter_request()
+        request_id = await self._enter_request()
         started_at = time.monotonic()
         try:
             response = await client.post("/v1/completions", json=payload)
@@ -1005,8 +1220,10 @@ class DistributedBatchedEngine(BatchedEngine):
                     if response.status_code < 400:
                         break
             self._raise_for_backend(response)
+            self._raise_if_aborted(request_id)
             body = response.json()
         except httpx.ReadTimeout as exc:
+            self._cancel_backend_after_timeout(request_id)
             raise self._read_timeout_error(stream=False) from exc
         except httpx.HTTPError as exc:
             raise await self._transport_failure_error(
@@ -1018,7 +1235,8 @@ class DistributedBatchedEngine(BatchedEngine):
                 "rank-zero backend returned invalid completion JSON"
             ) from exc
         finally:
-            await self._leave_request()
+            self._mark_backend_finished(request_id)
+            await self._leave_request(request_id)
 
         try:
             choice = body["choices"][0]
@@ -1078,7 +1296,7 @@ class DistributedBatchedEngine(BatchedEngine):
         first_token_at: float | None = None
         request_started_at = time.monotonic()
 
-        await self._enter_request()
+        request_id = await self._enter_request()
         try:
             # See stream_chat for the retry-bound rationale.
             attempts = [payload]
@@ -1181,6 +1399,7 @@ class DistributedBatchedEngine(BatchedEngine):
                 "rank-zero backend emitted invalid token counts"
             ) from exc
         except httpx.ReadTimeout as exc:
+            self._cancel_backend_after_timeout(request_id)
             raise self._read_timeout_error(stream=True) from exc
         except httpx.HTTPError as exc:
             raise await self._transport_failure_error(
@@ -1188,7 +1407,8 @@ class DistributedBatchedEngine(BatchedEngine):
                 stream=True,
             ) from exc
         finally:
-            await self._leave_request()
+            self._mark_backend_finished(request_id)
+            await self._leave_request(request_id)
 
         finished_at = time.monotonic()
         await self._record_strategy_benchmark(
@@ -1355,7 +1575,27 @@ class DistributedBatchedEngine(BatchedEngine):
         return None
 
     def has_active_requests(self) -> bool:
+        # Sweep finished-but-abandoned requests first so a leaked generator
+        # cannot hold quiescence-gated unload open forever (G4).
+        self.reap_orphaned_generators()
         return self._active_requests > 0
+
+    def _cancel_backend_after_timeout(self, request_id: str) -> None:
+        """Follow a read timeout with a rank-side cancel (G5).
+
+        httpx closing its side never proved the rank stopped generating; a
+        stalled rank keeps the request alive (KV growth, prompt-cache churn)
+        with nobody reading. A 300 s inactivity bound means the rank is
+        stalled, not merely slow — keepalive frames rule that out — so the
+        coordinator-level cancel file is the proportionate follow-up.
+        """
+
+        state = self._request_states.get(request_id)
+        if state is not None:
+            state.aborted = True
+        self._write_rank_cancel_request(
+            reason=f"read timeout on {request_id}; possible rank stall"
+        )
 
     def get_stats(self) -> dict[str, Any]:
         return {
@@ -1376,13 +1616,30 @@ class DistributedBatchedEngine(BatchedEngine):
         reason: str | None = None,
         error_code: str | None = None,
     ) -> int:
-        # Closing the private client disconnects all rank-zero handlers. The
-        # MLX-LM handler cancels their generation contexts in ``finally``.
+        """Abort everything in flight and confirm the backend drained.
+
+        Three layers, in order: (1) flag every tracked request so its local
+        generator stops at the next yield boundary; (2) drop the rank-side
+        cancel file so rank 0 force-cancels through ``BatchGenerator.remove``
+        at a batch step boundary even if a handler is wedged in a collective
+        and never reaches its disconnect ``finally``; (3) close the shared
+        client, disconnecting every rank-zero handler. Then wait — bounded —
+        for both the coordinator counter and rank-side telemetry to report
+        zero active requests instead of trusting the client close (G5).
+        """
+
+        self.reap_orphaned_generators()
         active = self._active_requests
+        for state in self._request_states.values():
+            state.aborted = True
+        self._write_rank_cancel_request(reason=reason or error_code)
         client, self._client = self._client, None
         if client is not None:
             await client.aclose()
             endpoint = self._supervisor.endpoint
             if endpoint is not None and self._loaded:
                 self._client = self._new_client(endpoint)
+        rank_active = self.rank_side_active_requests()
+        if active or (rank_active or 0) > 0:
+            await self._wait_for_backend_drain(timeout=self._abort_drain_timeout)
         return active

--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -19,7 +19,11 @@ from typing import Any
 import httpx
 
 from ..cluster.deployment import ClusterDeployment
-from ..cluster.launch import DistributedJobSupervisor, DistributedLaunchError
+from ..cluster.launch import (
+    DistributedJobSupervisor,
+    DistributedLaunchError,
+    _run_cluster_ssh,
+)
 from ..cluster.liveness import check_peers, describe_failure, read_marker
 from ..reasoning_effort import _fallback_candidate, _normalized_input
 from .base import GenerationOutput

--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -31,6 +31,7 @@ _request_clock = time.monotonic
 # per peer, paid once per window) and how long a half-dead cluster can keep
 # answering 200s before requests start failing cleanly (#2708).
 _PEER_HEALTH_TTL = 10.0
+_MAX_TARGETED_CANCEL_REQUESTS = 256
 _MAX_TRANSPORT_REQUEST_ID_BYTES = 128
 
 
@@ -150,6 +151,8 @@ class _DistributedRequestState:
 class DistributedBatchedEngine(BatchedEngine):
     """Keep oMLX's API/tokenizer layer while proxying model work to MLX ranks."""
 
+    supports_request_scoped_abort = True
+
     # The coordinator does not own a local Scheduler: each rank process
     # creates and enforces its own prefill guard from the signed deployment.
     # This marker prevents ProcessMemoryEnforcer from reporting that expected
@@ -215,6 +218,7 @@ class DistributedBatchedEngine(BatchedEngine):
         self._orphan_reap_grace = float(orphan_reap_grace)
         self._request_states: dict[str, _DistributedRequestState] = {}
         self._next_request_seq = 0
+        self._last_cancel_epoch = 0
 
     def _new_client(self, endpoint: str) -> httpx.AsyncClient:
         return httpx.AsyncClient(
@@ -771,6 +775,10 @@ class DistributedBatchedEngine(BatchedEngine):
         if state is None:
             return False
         state.aborted = True
+        self._write_rank_cancel_request(
+            reason=reason or error_code,
+            request_id=request_id,
+        )
         response = state.response
         if response is not None:
             with suppress(Exception):
@@ -782,8 +790,13 @@ class DistributedBatchedEngine(BatchedEngine):
         )
         return True
 
-    def _write_rank_cancel_request(self, *, reason: str | None) -> Path | None:
-        """Ask rank zero to force-cancel every active request at a step boundary.
+    def _write_rank_cancel_request(
+        self,
+        *,
+        reason: str | None,
+        request_id: str | None = None,
+    ) -> Path | None:
+        """Ask rank zero to cancel request(s) at a shared step boundary.
 
         The rank's telemetry heartbeat consumes this file and cancels through
         ``BatchGenerator.remove`` — MLX-LM's own cancel path, which the batch
@@ -794,14 +807,69 @@ class DistributedBatchedEngine(BatchedEngine):
 
         root = Path(self._supervisor.state_dir).expanduser()
         path = root / f"{self.deployment.deployment_id}-cancel.json"
+        if request_id is not None and not _valid_transport_request_id(request_id):
+            logger.warning("Refusing malformed targeted cancel id")
+            return None
+
+        pending_request_ids: set[str] = set()
+        scope = "all" if request_id is None else "requests"
+        if request_id is not None:
+            pending_request_ids.add(request_id)
+        try:
+            existing = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            existing = None
+        ack_path = path.with_name(path.stem + "-ack.json")
+        try:
+            ack = json.loads(ack_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            ack = None
+        ack_epoch = (
+            int(ack.get("epoch", -1))
+            if isinstance(ack, dict)
+            and ack.get("deployment_id") == self.deployment.deployment_id
+            and ack.get("plan_hash") == self.deployment.plan_hash
+            and isinstance(ack.get("epoch"), int)
+            and not isinstance(ack.get("epoch"), bool)
+            else -1
+        )
+        if (
+            isinstance(existing, dict)
+            and existing.get("deployment_id") == self.deployment.deployment_id
+            and existing.get("plan_hash") == self.deployment.plan_hash
+            and isinstance(existing.get("epoch"), int)
+            and not isinstance(existing.get("epoch"), bool)
+            and int(existing["epoch"]) > ack_epoch
+        ):
+            if existing.get("scope") == "all":
+                scope = "all"
+            elif scope != "all":
+                candidates = existing.get("request_ids")
+                if existing.get("scope") == "request":
+                    candidates = [existing.get("request_id")]
+                if isinstance(candidates, list):
+                    pending_request_ids.update(
+                        candidate
+                        for candidate in candidates
+                        if _valid_transport_request_id(candidate)
+                    )
+
+        self._last_cancel_epoch = max(
+            int(time.time() * 1000),
+            self._last_cancel_epoch + 1,
+        )
         payload = {
             "schema_version": 1,
             "deployment_id": self.deployment.deployment_id,
             "plan_hash": self.deployment.plan_hash,
-            "epoch": int(time.time() * 1000),
-            "scope": "all",
+            "epoch": self._last_cancel_epoch,
+            "scope": scope,
             "reason": reason or "coordinator abort_all_requests",
         }
+        if scope == "requests":
+            newest = [request_id] if request_id in pending_request_ids else []
+            older = sorted(pending_request_ids.difference(newest))
+            payload["request_ids"] = (newest + older)[:_MAX_TARGETED_CANCEL_REQUESTS]
         try:
             root.mkdir(parents=True, exist_ok=True)
             temporary = path.with_name(path.name + ".tmp")
@@ -1649,7 +1717,8 @@ class DistributedBatchedEngine(BatchedEngine):
         if state is not None:
             state.aborted = True
         self._write_rank_cancel_request(
-            reason=f"read timeout on {request_id}; possible rank stall"
+            reason=f"read timeout on {request_id}; possible rank stall",
+            request_id=request_id,
         )
 
     def get_stats(self) -> dict[str, Any]:

--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -8,6 +8,7 @@ import json
 import logging
 import math
 import os
+import shlex
 import time
 from collections.abc import AsyncIterator
 from contextlib import suppress
@@ -276,6 +277,87 @@ class DistributedBatchedEngine(BatchedEngine):
         """Return the bounded launcher/rank state used by the admin UI."""
 
         return self._supervisor.status().to_dict()
+
+    async def clear_prompt_caches(
+        self,
+        *,
+        ssd: bool = False,
+        hot: bool = False,
+    ) -> dict[str, Any]:
+        """Quiescence-gated cache clear executed on every inference rank."""
+
+        if not ssd and not hot:
+            return {"status": "ok", "ranks": [], "ssd_deleted": 0, "hot_cleared": 0}
+        if not self._loaded or self._client is None or self._supervisor.port is None:
+            raise DistributedInferenceError("distributed engine is not loaded")
+        async with self._active_lock:
+            if self._active_requests:
+                raise DistributedInferenceError(
+                    "distributed cache clear refused while requests are active"
+                )
+        mode = "all" if ssd and hot else "ssd" if ssd else "hot"
+        path = f"/omlx/internal/cache/{mode}/clear"
+        headers = {"X-oMLX-Plan-Hash": self.deployment.plan_hash}
+
+        async def clear_rank_zero() -> dict[str, Any]:
+            response = await self._client.post(path, headers=headers)
+            if response.status_code >= 400:
+                raise DistributedInferenceError(
+                    "rank 0 cache clear failed: "
+                    f"HTTP {response.status_code} {response.text[:300]}"
+                )
+            payload = response.json()
+            if not isinstance(payload, dict) or payload.get("status") != "ok":
+                raise DistributedInferenceError("rank 0 returned invalid cache-clear JSON")
+            return payload
+
+        def clear_remote(rank: int, ssh_target: str) -> dict[str, Any]:
+            url = f"http://127.0.0.1:{self._supervisor.port}{path}"
+            command = shlex.join(
+                [
+                    "/usr/bin/curl",
+                    "-fsS",
+                    "--max-time",
+                    "40",
+                    "-X",
+                    "POST",
+                    "-H",
+                    f"X-oMLX-Plan-Hash: {self.deployment.plan_hash}",
+                    url,
+                ]
+            )
+            completed = _run_cluster_ssh(
+                ssh_target,
+                command,
+                timeout=45.0,
+            )
+            if completed.returncode != 0:
+                detail = completed.stderr.strip() or completed.stdout.strip()
+                raise DistributedInferenceError(
+                    f"rank {rank} cache clear failed over SSH: {detail[:300]}"
+                )
+            try:
+                payload = json.loads(completed.stdout)
+            except json.JSONDecodeError as exc:
+                raise DistributedInferenceError(
+                    f"rank {rank} returned invalid cache-clear JSON"
+                ) from exc
+            if not isinstance(payload, dict) or payload.get("status") != "ok":
+                raise DistributedInferenceError(
+                    f"rank {rank} returned an invalid cache-clear result"
+                )
+            return payload
+
+        tasks = [clear_rank_zero()]
+        for rank, host in enumerate(self.deployment.hosts[1:], start=1):
+            tasks.append(asyncio.to_thread(clear_remote, rank, host.ssh))
+        reports = await asyncio.gather(*tasks)
+        return {
+            "status": "ok",
+            "ranks": reports,
+            "ssd_deleted": sum(int(item.get("ssd_deleted", 0)) for item in reports),
+            "hot_cleared": sum(int(item.get("hot_cleared", 0)) for item in reports),
+        }
 
     async def start(self) -> None:
         if self._loaded:

--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -299,6 +299,7 @@ class DistributedBatchedEngine(BatchedEngine):
         mode = "all" if ssd and hot else "ssd" if ssd else "hot"
         path = f"/omlx/internal/cache/{mode}/clear"
         headers = {"X-oMLX-Plan-Hash": self.deployment.plan_hash}
+        maintenance_epoch = time.time_ns()
 
         async def clear_rank_zero() -> dict[str, Any]:
             response = await self._client.post(path, headers=headers)
@@ -313,18 +314,59 @@ class DistributedBatchedEngine(BatchedEngine):
             return payload
 
         def clear_remote(rank: int, ssh_target: str) -> dict[str, Any]:
-            url = f"http://127.0.0.1:{self._supervisor.port}{path}"
+            state_root = str(self._supervisor.state_dir).rstrip("/") or "."
+            request_path = (
+                f"{state_root}/{self.deployment.deployment_id}-cache-clear.json"
+            )
+            ack_path = (
+                f"{state_root}/{self.deployment.deployment_id}"
+                f"-cache-clear-rank-{rank}.json"
+            )
+            request_payload = json.dumps(
+                {
+                    "epoch": maintenance_epoch,
+                    "deployment_id": self.deployment.deployment_id,
+                    "plan_hash": self.deployment.plan_hash,
+                    "ssd": bool(ssd),
+                    "hot": bool(hot),
+                },
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+            script = r"""
+import json, os, sys, time
+from pathlib import Path
+request_path = Path(sys.argv[1]).expanduser()
+ack_path = Path(sys.argv[2]).expanduser()
+payload = json.loads(sys.argv[3])
+request_path.parent.mkdir(parents=True, exist_ok=True)
+temporary = request_path.with_name(request_path.name + '.tmp')
+descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+with os.fdopen(descriptor, 'w', encoding='utf-8') as stream:
+    json.dump(payload, stream, separators=(',', ':'), sort_keys=True)
+os.replace(temporary, request_path)
+deadline = time.monotonic() + 40.0
+while time.monotonic() < deadline:
+    try:
+        if ack_path.is_file() and ack_path.stat().st_size <= 65536:
+            ack = json.loads(ack_path.read_text(encoding='utf-8'))
+            if int(ack.get('epoch', 0)) == int(payload['epoch']):
+                print(json.dumps(ack, separators=(',', ':'), sort_keys=True))
+                raise SystemExit(0)
+    except (OSError, ValueError, TypeError, json.JSONDecodeError):
+        pass
+    time.sleep(0.1)
+print('rank cache-clear acknowledgement timed out', file=sys.stderr)
+raise SystemExit(2)
+""".strip()
             command = shlex.join(
                 [
-                    "/usr/bin/curl",
-                    "-fsS",
-                    "--max-time",
-                    "40",
-                    "-X",
-                    "POST",
-                    "-H",
-                    f"X-oMLX-Plan-Hash: {self.deployment.plan_hash}",
-                    url,
+                    "python3",
+                    "-c",
+                    script,
+                    request_path,
+                    ack_path,
+                    request_payload,
                 ]
             )
             completed = _run_cluster_ssh(

--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -871,6 +871,10 @@ class DistributedBatchedEngine(BatchedEngine):
             and existing.get("plan_hash") == self.deployment.plan_hash
             and isinstance(existing.get("epoch"), int)
             and not isinstance(existing.get("epoch"), bool)
+            # Only merge a marker written by this engine lifetime. A stale
+            # pre-restart `scope=all` file is a startup watermark, not pending
+            # work, and must never widen a new targeted disconnect.
+            and int(existing["epoch"]) == self._last_cancel_epoch
             and int(existing["epoch"]) > ack_epoch
         ):
             if existing.get("scope") == "all":

--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -357,6 +357,11 @@ class DistributedBatchedEngine(BatchedEngine):
             raise DistributedInferenceError(
                 f"distributed job exited with code {status.returncode}{suffix}"
             )
+        if status.failure_reason:
+            self._mark_runtime_failed(status.failure_reason)
+            raise DistributedInferenceError(
+                f"distributed cluster failure: {status.failure_reason}"
+            )
         return client
 
     def _read_timeout_error(self, *, stream: bool) -> DistributedInferenceError:

--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -18,18 +18,35 @@ import httpx
 
 from ..cluster.deployment import ClusterDeployment
 from ..cluster.launch import DistributedJobSupervisor, DistributedLaunchError
-from ..cluster.liveness import check_peers, describe_failure
+from ..cluster.liveness import check_peers, describe_failure, read_marker
 from ..reasoning_effort import _fallback_candidate, _normalized_input
 from .base import GenerationOutput
 from .batched import BatchedEngine
 
 logger = logging.getLogger(__name__)
+_request_clock = time.monotonic
 
 # How long one per-rank marker health read stays authoritative. Every request
 # preflights the cluster, so this bounds both the added latency (one SSH read
 # per peer, paid once per window) and how long a half-dead cluster can keep
 # answering 200s before requests start failing cleanly (#2708).
 _PEER_HEALTH_TTL = 10.0
+_MAX_TRANSPORT_REQUEST_ID_BYTES = 128
+
+
+def _valid_transport_request_id(value: Any) -> bool:
+    if not isinstance(value, str) or not value:
+        return False
+    try:
+        encoded = value.encode("ascii")
+    except UnicodeEncodeError:
+        return False
+    if len(encoded) > _MAX_TRANSPORT_REQUEST_ID_BYTES:
+        return False
+    allowed = frozenset(
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.:"
+    )
+    return all(character in allowed for character in value)
 
 
 def _reasoning_effort_retry_payloads(
@@ -81,13 +98,9 @@ def _reasoning_effort_retry_payloads(
     if candidate is not None and candidate != normalized:
         variants.append(_variant(candidate))
     logger.info(
-        "rank-zero rejected reasoning_effort=%r; retrying with %s, then "
-        "without it",
+        "rank-zero rejected reasoning_effort=%r; retrying with %s, then without it",
         value,
-        [
-            var["chat_template_kwargs"]["reasoning_effort"]
-            for var in variants
-        ],
+        [var["chat_template_kwargs"]["reasoning_effort"] for var in variants],
     )
 
     dropped_kwargs = {
@@ -108,7 +121,7 @@ class DistributedInferenceError(RuntimeError):
     """A bounded error surfaced when the private rank-zero backend fails."""
 
 
-class DistributedRequestAborted(DistributedInferenceError):
+class DistributedRequestAborted(DistributedInferenceError):  # noqa: N818
     """Raised into a proxied request the coordinator has aborted."""
 
 
@@ -154,6 +167,8 @@ class DistributedBatchedEngine(BatchedEngine):
         cwd: Path | None = None,
         load_timeout: float = 1800.0,
         request_read_timeout: float | None = None,
+        abort_drain_timeout: float = 15.0,
+        orphan_reap_grace: float = 5.0,
     ) -> None:
         if request_read_timeout is None:
             raw = os.environ.get("OMLX_DISTRIBUTED_REQUEST_READ_TIMEOUT", "300.0")
@@ -169,6 +184,8 @@ class DistributedBatchedEngine(BatchedEngine):
                 "distributed request read timeout must be a finite positive "
                 f"number, got {request_read_timeout!r}"
             )
+        if abort_drain_timeout < 0 or orphan_reap_grace < 0:
+            raise ValueError("distributed abort timeouts must be non-negative")
         super().__init__(
             model_name=deployment.model,
             trust_remote_code=deployment.trust_remote_code,
@@ -194,6 +211,10 @@ class DistributedBatchedEngine(BatchedEngine):
         self._active_lock = asyncio.Lock()
         self._peer_health: tuple[float, bool, str] | None = None
         self._peer_health_lock = asyncio.Lock()
+        self._abort_drain_timeout = float(abort_drain_timeout)
+        self._orphan_reap_grace = float(orphan_reap_grace)
+        self._request_states: dict[str, _DistributedRequestState] = {}
+        self._next_request_seq = 0
 
     def _new_client(self, endpoint: str) -> httpx.AsyncClient:
         return httpx.AsyncClient(
@@ -625,18 +646,24 @@ class DistributedBatchedEngine(BatchedEngine):
             return f"<think>{reasoning_text}</think>{content_text}"
         return content_text
 
-    async def _enter_request(self) -> str:
+    async def _enter_request(self, request_id: str | None = None) -> str:
         async with self._active_lock:
             self._active_requests += 1
             self._next_request_seq += 1
-            request_id = (
-                f"{self.deployment.deployment_id}-{self._next_request_seq}"
-            )
+            if (
+                not _valid_transport_request_id(request_id)
+                or request_id in self._request_states
+            ):
+                request_id = f"{self.deployment.deployment_id}-{self._next_request_seq}"
             self._request_states[request_id] = _DistributedRequestState(
                 request_id,
-                time.monotonic(),
+                _request_clock(),
             )
             return request_id
+
+    @staticmethod
+    def _backend_request_headers(request_id: str) -> dict[str, str]:
+        return {"X-oMLX-Request-ID": request_id}
 
     async def _leave_request(self, request_id: str | None = None) -> None:
         async with self._active_lock:
@@ -659,7 +686,7 @@ class DistributedBatchedEngine(BatchedEngine):
 
         state = self._request_states.get(request_id)
         if state is not None and state.finished_at is None:
-            state.finished_at = time.monotonic()
+            state.finished_at = _request_clock()
 
     def reap_orphaned_generators(
         self,
@@ -681,13 +708,12 @@ class DistributedBatchedEngine(BatchedEngine):
 
         if not self._request_states:
             return 0
-        current = time.monotonic() if now is None else now
+        current = _request_clock() if now is None else now
         limit = self._orphan_reap_grace if grace is None else grace
         stale = [
             request_id
             for request_id, state in self._request_states.items()
-            if state.finished_at is not None
-            and current - state.finished_at >= limit
+            if state.finished_at is not None and current - state.finished_at >= limit
         ]
         for request_id in stale:
             self._request_states.pop(request_id, None)
@@ -816,7 +842,6 @@ class DistributedBatchedEngine(BatchedEngine):
                 return False
             await asyncio.sleep(0.1)
 
-
     async def chat(
         self,
         messages: list[dict[str, Any]],
@@ -850,6 +875,7 @@ class DistributedBatchedEngine(BatchedEngine):
         if not self._loaded:
             await self.start()
         client = self._ensure_available()
+        requested_id = kwargs.pop("_request_id", None)
         payload = self._chat_payload(
             messages=messages,
             tools=tools,
@@ -864,15 +890,20 @@ class DistributedBatchedEngine(BatchedEngine):
             stream=False,
             kwargs=kwargs,
         )
-        request_id = await self._enter_request()
+        request_id = await self._enter_request(requested_id)
+        headers = self._backend_request_headers(request_id)
         started_at = time.monotonic()
         try:
-            response = await client.post("/v1/chat/completions", json=payload)
+            response = await client.post(
+                "/v1/chat/completions", json=payload, headers=headers
+            )
             if response.status_code >= 400:
                 detail = self._backend_error_detail(response)
                 for retry_payload in _reasoning_effort_retry_payloads(payload, detail):
                     response = await client.post(
-                        "/v1/chat/completions", json=retry_payload
+                        "/v1/chat/completions",
+                        json=retry_payload,
+                        headers=headers,
                     )
                     if response.status_code < 400:
                         break
@@ -883,6 +914,7 @@ class DistributedBatchedEngine(BatchedEngine):
             self._cancel_backend_after_timeout(request_id)
             raise self._read_timeout_error(stream=False) from exc
         except httpx.HTTPError as exc:
+            self._raise_if_aborted(request_id)
             raise await self._transport_failure_error(
                 exc,
                 stream=False,
@@ -958,6 +990,7 @@ class DistributedBatchedEngine(BatchedEngine):
         if not self._loaded:
             await self.start()
         client = self._ensure_available()
+        requested_id = kwargs.pop("_request_id", None)
         payload = self._chat_payload(
             messages=messages,
             tools=tools,
@@ -982,7 +1015,8 @@ class DistributedBatchedEngine(BatchedEngine):
         reasoning_open = False
         backend_tool_calls: dict[int, dict[str, Any]] = {}
 
-        request_id = await self._enter_request()
+        request_id = await self._enter_request(requested_id)
+        headers = self._backend_request_headers(request_id)
         try:
             # A client that always sends an unsupported reasoning_effort must
             # never turn this into an unbounded retry loop: `attempts` is
@@ -993,8 +1027,14 @@ class DistributedBatchedEngine(BatchedEngine):
             while True:
                 attempt_payload = attempts[attempt_index]
                 async with client.stream(
-                    "POST", "/v1/chat/completions", json=attempt_payload
+                    "POST",
+                    "/v1/chat/completions",
+                    json=attempt_payload,
+                    headers=headers,
                 ) as response:
+                    state = self._request_state(request_id)
+                    if state is not None:
+                        state.response = response
                     if response.status_code >= 400:
                         await response.aread()
                         if attempt_index == 0:
@@ -1009,6 +1049,7 @@ class DistributedBatchedEngine(BatchedEngine):
                             continue
                         self._raise_for_backend(response)
                     async for line in response.aiter_lines():
+                        self._raise_if_aborted(request_id)
                         if not line.startswith("data:"):
                             continue
                         data = line.removeprefix("data:").strip()
@@ -1087,9 +1128,9 @@ class DistributedBatchedEngine(BatchedEngine):
                                 if isinstance(function.get("name"), str):
                                     target["function"]["name"] += function["name"]
                                 if isinstance(function.get("arguments"), str):
-                                    target["function"]["arguments"] += (
-                                        function["arguments"]
-                                    )
+                                    target["function"]["arguments"] += function[
+                                        "arguments"
+                                    ]
 
                         new_text = ""
                         reasoning = delta.get("reasoning") or delta.get(
@@ -1140,6 +1181,7 @@ class DistributedBatchedEngine(BatchedEngine):
             self._cancel_backend_after_timeout(request_id)
             raise self._read_timeout_error(stream=True) from exc
         except httpx.HTTPError as exc:
+            self._raise_if_aborted(request_id)
             raise await self._transport_failure_error(
                 exc,
                 stream=True,
@@ -1194,6 +1236,7 @@ class DistributedBatchedEngine(BatchedEngine):
         if not self._loaded:
             await self.start()
         client = self._ensure_available()
+        requested_id = kwargs.pop("_request_id", None)
         payload = self._completion_payload(
             prompt=prompt,
             max_tokens=max_tokens,
@@ -1207,15 +1250,20 @@ class DistributedBatchedEngine(BatchedEngine):
             stream=False,
             kwargs=kwargs,
         )
-        request_id = await self._enter_request()
+        request_id = await self._enter_request(requested_id)
+        headers = self._backend_request_headers(request_id)
         started_at = time.monotonic()
         try:
-            response = await client.post("/v1/completions", json=payload)
+            response = await client.post(
+                "/v1/completions", json=payload, headers=headers
+            )
             if response.status_code >= 400:
                 detail = self._backend_error_detail(response)
                 for retry_payload in _reasoning_effort_retry_payloads(payload, detail):
                     response = await client.post(
-                        "/v1/completions", json=retry_payload
+                        "/v1/completions",
+                        json=retry_payload,
+                        headers=headers,
                     )
                     if response.status_code < 400:
                         break
@@ -1226,6 +1274,7 @@ class DistributedBatchedEngine(BatchedEngine):
             self._cancel_backend_after_timeout(request_id)
             raise self._read_timeout_error(stream=False) from exc
         except httpx.HTTPError as exc:
+            self._raise_if_aborted(request_id)
             raise await self._transport_failure_error(
                 exc,
                 stream=False,
@@ -1274,6 +1323,7 @@ class DistributedBatchedEngine(BatchedEngine):
         if not self._loaded:
             await self.start()
         client = self._ensure_available()
+        requested_id = kwargs.pop("_request_id", None)
         payload = self._completion_payload(
             prompt=prompt,
             max_tokens=max_tokens,
@@ -1296,7 +1346,8 @@ class DistributedBatchedEngine(BatchedEngine):
         first_token_at: float | None = None
         request_started_at = time.monotonic()
 
-        request_id = await self._enter_request()
+        request_id = await self._enter_request(requested_id)
+        headers = self._backend_request_headers(request_id)
         try:
             # See stream_chat for the retry-bound rationale.
             attempts = [payload]
@@ -1304,8 +1355,14 @@ class DistributedBatchedEngine(BatchedEngine):
             while True:
                 attempt_payload = attempts[attempt_index]
                 async with client.stream(
-                    "POST", "/v1/completions", json=attempt_payload
+                    "POST",
+                    "/v1/completions",
+                    json=attempt_payload,
+                    headers=headers,
                 ) as response:
+                    state = self._request_state(request_id)
+                    if state is not None:
+                        state.response = response
                     if response.status_code >= 400:
                         await response.aread()
                         if attempt_index == 0:
@@ -1320,6 +1377,7 @@ class DistributedBatchedEngine(BatchedEngine):
                             continue
                         self._raise_for_backend(response)
                     async for line in response.aiter_lines():
+                        self._raise_if_aborted(request_id)
                         if not line.startswith("data:"):
                             continue
                         data = line.removeprefix("data:").strip()
@@ -1402,6 +1460,7 @@ class DistributedBatchedEngine(BatchedEngine):
             self._cancel_backend_after_timeout(request_id)
             raise self._read_timeout_error(stream=True) from exc
         except httpx.HTTPError as exc:
+            self._raise_if_aborted(request_id)
             raise await self._transport_failure_error(
                 exc,
                 stream=True,
@@ -1531,9 +1590,7 @@ class DistributedBatchedEngine(BatchedEngine):
         if cached is None or time.monotonic() - cached[0] >= _PEER_HEALTH_TTL:
             async with self._peer_health_lock:
                 cached = self._peer_health
-                if cached is None or (
-                    time.monotonic() - cached[0] >= _PEER_HEALTH_TTL
-                ):
+                if cached is None or (time.monotonic() - cached[0] >= _PEER_HEALTH_TTL):
                     hosts_by_rank = {
                         rank: (host.node_id, host.ssh)
                         for rank, host in enumerate(self.deployment.hosts)
@@ -1560,9 +1617,7 @@ class DistributedBatchedEngine(BatchedEngine):
                         )
                     self._peer_health = cached
         if not cached[1]:
-            raise DistributedInferenceError(
-                f"cluster is not serving: {cached[2]}"
-            )
+            raise DistributedInferenceError(f"cluster is not serving: {cached[2]}")
 
     async def preflight_chat(self, *args: Any, **kwargs: Any) -> None:
         self._validate_request_features(kwargs)

--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -9,6 +9,7 @@ import logging
 import math
 import os
 import shlex
+import subprocess
 import time
 from collections.abc import AsyncIterator
 from contextlib import suppress
@@ -330,6 +331,7 @@ class DistributedBatchedEngine(BatchedEngine):
                 ssh_target,
                 command,
                 timeout=45.0,
+                runner=subprocess.run,
             )
             if completed.returncode != 0:
                 detail = completed.stderr.strip() or completed.stdout.strip()

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -1223,9 +1223,22 @@ class EnginePool:
         if not callable(has_active_requests):
             return False
         try:
-            return has_active_requests() is True
+            if has_active_requests() is True:
+                return True
         except Exception:
             return True
+        # Do not use instance getattr here: test doubles and dynamic proxies
+        # can manufacture a truthy method for any name. Only engines whose
+        # class explicitly implements rank-side telemetry participate.
+        rank_side = getattr(type(engine), "rank_side_active_requests", None)
+        if callable(rank_side):
+            try:
+                remaining = rank_side(engine)
+            except Exception:
+                remaining = None
+            if remaining:
+                return True
+        return False
 
     def _entry_is_busy(self, entry: EngineEntry) -> bool:
         return entry.in_use > 0 or self._entry_has_active_requests(entry)

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -46,7 +46,7 @@ import logging
 import os
 import time
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass, field
 from enum import Enum
@@ -1171,6 +1171,93 @@ class DebugRequestLoggingMiddleware:
         await self.app(scope, cached_receive, send)
 
 
+_DISCONNECT_SIGNAL_SCOPE_KEY = "omlx.client_disconnect_signal"
+_disconnect_callback_tasks: set[asyncio.Task] = set()
+
+
+class _ClientDisconnectSignal:
+    """Fan one ASGI disconnect message out to request-owned cleanup hooks.
+
+    Starlette's ``StreamingResponse`` and ``Request.is_disconnected()`` both
+    consume the same one-shot ``http.disconnect`` receive message.  Whichever
+    one wins used to hide it from the other.  In particular, a real Uvicorn
+    socket could close while a long distributed prefill kept running because
+    the response generator never reached its nested ``aclose()`` chain.
+
+    The outer ASGI middleware records the message before either consumer sees
+    it, then schedules request-scoped callbacks outside Starlette's response
+    cancellation scope.  A callback is keyed by the inference request id, so
+    cancelling one client can never fall back to aborting every active request.
+    """
+
+    def __init__(self) -> None:
+        self._disconnected = False
+        self._next_token = 0
+        self._callbacks: dict[int, Callable[[], Awaitable[None]]] = {}
+
+    def register(self, callback: Callable[[], Awaitable[None]]) -> int:
+        self._next_token += 1
+        token = self._next_token
+        if self._disconnected:
+            self._spawn(callback)
+        else:
+            self._callbacks[token] = callback
+        return token
+
+    def unregister(self, token: int) -> None:
+        self._callbacks.pop(token, None)
+
+    def disconnect(self) -> None:
+        if self._disconnected:
+            return
+        self._disconnected = True
+        callbacks = tuple(self._callbacks.values())
+        self._callbacks.clear()
+        for callback in callbacks:
+            self._spawn(callback)
+
+    @staticmethod
+    def _spawn(callback: Callable[[], Awaitable[None]]) -> None:
+        async def run_callback() -> None:
+            try:
+                await callback()
+            except Exception:
+                logger.exception("Request-scoped disconnect callback failed")
+
+        task = asyncio.create_task(run_callback())
+        # asyncio only holds weak task references.  Retain the detached abort
+        # until it completes; Starlette may already be cancelling the response
+        # task that observed the disconnect.
+        _disconnect_callback_tasks.add(task)
+        task.add_done_callback(_disconnect_callback_tasks.discard)
+
+
+class ClientDisconnectTrackingMiddleware:
+    """Record ``http.disconnect`` before competing ASGI consumers receive it."""
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        signal = _ClientDisconnectSignal()
+        scope[_DISCONNECT_SIGNAL_SCOPE_KEY] = signal
+
+        async def tracked_receive():
+            message = await receive()
+            if message.get("type") == "http.disconnect":
+                signal.disconnect()
+            return message
+
+        await self.app(scope, tracked_receive, send)
+
+
+# Keep this outside response middleware so every consumer of ASGI ``receive``
+# passes through the same one-shot disconnect fan-out.
+app.add_middleware(ClientDisconnectTrackingMiddleware)
 app.add_middleware(DebugRequestLoggingMiddleware)
 
 
@@ -3511,6 +3598,7 @@ async def create_completion(
         for prompt in prompts:
             await engine.preflight_completion(prompt, request_id=upstream_request_id)
         await _raise_if_llm_lease_abort_requested(lease)
+        inference_request_id = _request_abort_id(engine)
 
         if request.stream:
             response_id = f"cmpl-{uuid.uuid4().hex[:8]}"
@@ -3519,18 +3607,24 @@ async def create_completion(
                 keepalive = _completion_keepalive_chunk(response_id)
             return StreamingResponse(
                 _release_after_stream(
-                    _with_sse_keepalive(
-                        stream_completion(
-                            engine,
-                            prompts[0],
-                            request,
-                            model_load_duration=model_load_duration,
-                            prompt_token_ids=prompt_token_ids_by_prompt[0],
-                            resolved_model=resolved_model,
-                            response_id=response_id,
+                    _with_request_disconnect_abort(
+                        _with_sse_keepalive(
+                            stream_completion(
+                                engine,
+                                prompts[0],
+                                request,
+                                model_load_duration=model_load_duration,
+                                prompt_token_ids=prompt_token_ids_by_prompt[0],
+                                resolved_model=resolved_model,
+                                response_id=response_id,
+                                inference_request_id=inference_request_id,
+                            ),
+                            http_request=http_request,
+                            keepalive_chunk=keepalive,
                         ),
-                        http_request=http_request,
-                        keepalive_chunk=keepalive,
+                        http_request,
+                        engine,
+                        inference_request_id,
                     ),
                     lease,
                 ),
@@ -4046,6 +4140,9 @@ async def create_chat_completion(
         )
 
         await _raise_if_llm_lease_abort_requested(lease)
+        inference_request_id = _request_abort_id(engine)
+        if inference_request_id is not None:
+            chat_kwargs["_request_id"] = inference_request_id
 
         if request.stream:
             # Pre-mint the completion id so the keepalive frame (emitted before the
@@ -4059,18 +4156,23 @@ async def create_chat_completion(
                 sse_headers["Warning"] = response_format_warning
             return StreamingResponse(
                 _release_after_stream(
-                    _with_sse_keepalive(
-                        stream_chat_completion(
-                            engine,
-                            messages,
-                            request,
-                            model_load_duration=model_load_duration,
-                            resolved_model=resolved_model,
-                            response_id=response_id,
-                            **chat_kwargs,
+                    _with_request_disconnect_abort(
+                        _with_sse_keepalive(
+                            stream_chat_completion(
+                                engine,
+                                messages,
+                                request,
+                                model_load_duration=model_load_duration,
+                                resolved_model=resolved_model,
+                                response_id=response_id,
+                                **chat_kwargs,
+                            ),
+                            http_request=http_request,
+                            keepalive_chunk=keepalive,
                         ),
-                        http_request=http_request,
-                        keepalive_chunk=keepalive,
+                        http_request,
+                        engine,
+                        inference_request_id,
                     ),
                     lease,
                 ),
@@ -4625,6 +4727,7 @@ async def stream_completion(
     prompt_token_ids: list[int] | None = None,
     resolved_model: str | None = None,
     response_id: str | None = None,
+    inference_request_id: str | None = None,
 ) -> AsyncIterator[str]:
     """Stream completion response."""
     response_id = response_id or f"cmpl-{uuid.uuid4().hex[:8]}"
@@ -6320,20 +6423,28 @@ async def create_anthropic_message(
             **chat_kwargs,
         )
         await _raise_if_llm_lease_abort_requested(lease)
+        inference_request_id = _request_abort_id(engine)
+        if inference_request_id is not None:
+            chat_kwargs["_request_id"] = inference_request_id
 
         if request.stream:
             return StreamingResponse(
                 _release_after_stream(
-                    _with_sse_keepalive(
-                        stream_anthropic_messages(
-                            engine,
-                            messages,
-                            request,
-                            resolved_model=resolved_model,
-                            **chat_kwargs,
+                    _with_request_disconnect_abort(
+                        _with_sse_keepalive(
+                            stream_anthropic_messages(
+                                engine,
+                                messages,
+                                request,
+                                resolved_model=resolved_model,
+                                **chat_kwargs,
+                            ),
+                            http_request=http_request,
+                            keepalive_chunk=_resolve_keepalive("anthropic"),
                         ),
-                        http_request=http_request,
-                        keepalive_chunk=_resolve_keepalive("anthropic"),
+                        http_request,
+                        engine,
+                        inference_request_id,
                     ),
                     lease,
                 ),
@@ -6832,6 +6943,9 @@ async def create_response(
             **chat_kwargs,
         )
         await _raise_if_llm_lease_abort_requested(lease)
+        inference_request_id = _request_abort_id(engine)
+        if inference_request_id is not None:
+            chat_kwargs["_request_id"] = inference_request_id
 
         if request.stream:
             sse_headers = {"X-Accel-Buffering": "no", "Cache-Control": "no-cache"}
@@ -6839,21 +6953,26 @@ async def create_response(
                 sse_headers["Warning"] = response_format_warning
             return StreamingResponse(
                 _release_after_stream(
-                    _with_sse_keepalive(
-                        stream_responses_api(
-                            engine,
-                            messages,
-                            request,
-                            input_messages=current_input_messages,
-                            store_response=_should_store_response(request.store),
-                            model_load_duration=model_load_duration,
-                            resolved_model=resolved_model,
-                            response_format=response_format,
-                            native_reasoning=native_reasoning,
-                            **chat_kwargs,
+                    _with_request_disconnect_abort(
+                        _with_sse_keepalive(
+                            stream_responses_api(
+                                engine,
+                                messages,
+                                request,
+                                input_messages=current_input_messages,
+                                store_response=_should_store_response(request.store),
+                                model_load_duration=model_load_duration,
+                                resolved_model=resolved_model,
+                                response_format=response_format,
+                                native_reasoning=native_reasoning,
+                                **chat_kwargs,
+                            ),
+                            http_request=http_request,
+                            keepalive_chunk=_resolve_keepalive("openai_responses"),
                         ),
-                        http_request=http_request,
-                        keepalive_chunk=_resolve_keepalive("openai_responses"),
+                        http_request,
+                        engine,
+                        inference_request_id,
                     ),
                     lease,
                 ),

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -3720,6 +3720,8 @@ async def create_completion(
             thinking_budget = _resolve_thinking_budget(request, request.model)
             if thinking_budget is not None:
                 gen_kwargs["thinking_budget"] = thinking_budget
+            if inference_request_id is not None:
+                gen_kwargs["_request_id"] = inference_request_id
             # Widen the repetition-penalty look-back window when the client
             # asks for it (mlx-lm default window is 20 tokens).
             repetition_context_size = getattr(
@@ -4819,6 +4821,8 @@ async def stream_completion(
     thinking_budget = _resolve_thinking_budget(request, request.model)
     if thinking_budget is not None:
         gen_kwargs["thinking_budget"] = thinking_budget
+    if inference_request_id is not None:
+        gen_kwargs["_request_id"] = inference_request_id
     # Widen the repetition-penalty look-back window when the client
     # asks for it (mlx-lm default window is 20 tokens).
     repetition_context_size = getattr(

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2423,6 +2423,56 @@ async def _safe_anext(ait):
         return _KEEPALIVE_SENTINEL
 
 
+async def _aclose_async_iterator(iterator: object) -> None:
+    """Close an async generator when the response transport ends."""
+
+    close = getattr(iterator, "aclose", None)
+    if callable(close):
+        await close()
+
+
+def _request_abort_id(engine: BaseEngine) -> str | None:
+    """Mint an opaque id only for engines with targeted abort semantics."""
+
+    if not getattr(engine, "supports_request_scoped_abort", False):
+        return None
+    abort = getattr(engine, "abort_request", None)
+    if not callable(abort):
+        return None
+    return f"transport-{uuid.uuid4().hex}"
+
+
+async def _with_request_disconnect_abort(
+    generator: AsyncIterator[str],
+    http_request: FastAPIRequest,
+    engine: BaseEngine,
+    request_id: str | None,
+) -> AsyncIterator[str]:
+    """Bind one public response transport to one inference request."""
+
+    signal = http_request.scope.get(_DISCONNECT_SIGNAL_SCOPE_KEY)
+    token: int | None = None
+    if request_id is not None and isinstance(signal, _ClientDisconnectSignal):
+        abort = getattr(engine, "abort_request")
+
+        async def abort_disconnected_request() -> None:
+            await abort(
+                request_id,
+                reason="public client transport disconnected",
+                error_code="client_disconnected",
+            )
+
+        token = signal.register(abort_disconnected_request)
+
+    try:
+        async for chunk in generator:
+            yield chunk
+    finally:
+        if token is not None:
+            signal.unregister(token)
+        await _aclose_async_iterator(generator)
+
+
 async def _with_sse_keepalive(
     generator: AsyncIterator[str],
     http_request: Optional["FastAPIRequest"] = None,

--- a/tests/test_admin_distributed_cache_clear.py
+++ b/tests/test_admin_distributed_cache_clear.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Admin cache maintenance must reach every rank of a loaded cluster."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+import omlx.admin.routes as admin_routes
+
+
+def _pool(clear):
+    core = SimpleNamespace(scheduler=None, clear_prompt_caches=clear)
+    entry = SimpleNamespace(
+        engine=SimpleNamespace(_engine=SimpleNamespace(engine=core))
+    )
+    pool = SimpleNamespace()
+    pool.get_status = MagicMock(return_value={
+        "models": [{"id": "cluster-model", "loaded": True}]
+    })
+    pool._entries = {"cluster-model": entry}
+    return pool
+
+
+@pytest.mark.asyncio
+async def test_ssd_clear_aggregates_distributed_rank_results():
+    clear = AsyncMock(
+        return_value={
+            "status": "ok",
+            "ssd_deleted": 9,
+            "hot_cleared": 0,
+            "ranks": [{"rank": 0}, {"rank": 1}],
+        }
+    )
+    with (
+        patch.object(admin_routes, "_get_engine_pool", return_value=_pool(clear)),
+        patch.object(admin_routes, "_get_global_settings", return_value=None),
+    ):
+        result = await admin_routes.clear_ssd_cache(is_admin=True)
+
+    clear.assert_awaited_once_with(ssd=True)
+    assert result == {
+        "status": "ok",
+        "total_deleted": 9,
+        "distributed_ranks": 2,
+    }
+
+
+@pytest.mark.asyncio
+async def test_ssd_clear_surfaces_partial_cluster_failure():
+    clear = AsyncMock(side_effect=RuntimeError("rank 1 unreachable"))
+    with (
+        patch.object(admin_routes, "_get_engine_pool", return_value=_pool(clear)),
+        patch.object(admin_routes, "_get_global_settings", return_value=None),
+    ):
+        with pytest.raises(HTTPException) as raised:
+            await admin_routes.clear_ssd_cache(is_admin=True)
+
+    assert raised.value.status_code == 503
+    assert "rank 1 unreachable" in raised.value.detail

--- a/tests/test_admin_distributed_cache_clear.py
+++ b/tests/test_admin_distributed_cache_clear.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Admin cache maintenance must reach every rank of a loaded cluster."""
 
+import subprocess
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/test_admin_distributed_cache_clear.py
+++ b/tests/test_admin_distributed_cache_clear.py
@@ -12,9 +12,7 @@ import omlx.admin.routes as admin_routes
 
 def _pool(clear):
     core = SimpleNamespace(scheduler=None, clear_prompt_caches=clear)
-    entry = SimpleNamespace(
-        engine=SimpleNamespace(_engine=SimpleNamespace(engine=core))
-    )
+    entry = SimpleNamespace(engine=core)
     pool = SimpleNamespace()
     pool.get_status = MagicMock(return_value={
         "models": [{"id": "cluster-model", "loaded": True}]

--- a/tests/test_admin_distributed_cache_clear.py
+++ b/tests/test_admin_distributed_cache_clear.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Admin cache maintenance must reach every rank of a loaded cluster."""
 
-import subprocess
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -15,9 +14,9 @@ def _pool(clear):
     core = SimpleNamespace(scheduler=None, clear_prompt_caches=clear)
     entry = SimpleNamespace(engine=core)
     pool = SimpleNamespace()
-    pool.get_status = MagicMock(return_value={
-        "models": [{"id": "cluster-model", "loaded": True}]
-    })
+    pool.get_status = MagicMock(
+        return_value={"models": [{"id": "cluster-model", "loaded": True}]}
+    )
     pool._entries = {"cluster-model": entry}
     return pool
 
@@ -52,9 +51,9 @@ async def test_ssd_clear_surfaces_partial_cluster_failure():
     with (
         patch.object(admin_routes, "_get_engine_pool", return_value=_pool(clear)),
         patch.object(admin_routes, "_get_global_settings", return_value=None),
+        pytest.raises(HTTPException) as raised,
     ):
-        with pytest.raises(HTTPException) as raised:
-            await admin_routes.clear_ssd_cache(is_admin=True)
+        await admin_routes.clear_ssd_cache(is_admin=True)
 
     assert raised.value.status_code == 503
     assert "rank 1 unreachable" in raised.value.detail

--- a/tests/test_admin_distributed_cache_clear.py
+++ b/tests/test_admin_distributed_cache_clear.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Admin cache maintenance must reach every rank of a loaded cluster."""
 
+import subprocess
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -57,3 +58,71 @@ async def test_ssd_clear_surfaces_partial_cluster_failure():
 
     assert raised.value.status_code == 503
     assert "rank 1 unreachable" in raised.value.detail
+
+
+@pytest.mark.asyncio
+async def test_ssd_clear_removes_unloaded_local_cluster_roots(tmp_path):
+    cache_dir = tmp_path / "cache"
+    cluster_root = cache_dir / "cluster-prompt-snapshots"
+    legacy_root = tmp_path / "cluster/runtime/prompt-cache-ssd"
+    for root in (cluster_root, legacy_root):
+        root.mkdir(parents=True)
+        (root / "entry.safetensors").write_text("cached", encoding="utf-8")
+    pool = SimpleNamespace(
+        get_status=lambda: {"models": []},
+        _entries={},
+    )
+    settings = SimpleNamespace(
+        base_path=tmp_path,
+        cache=SimpleNamespace(get_ssd_cache_dir=lambda _base: cache_dir),
+    )
+
+    with (
+        patch.object(admin_routes, "_get_engine_pool", return_value=pool),
+        patch.object(admin_routes, "_get_global_settings", return_value=settings),
+        patch.object(
+            admin_routes,
+            "_clear_cold_remote_cluster_cache_roots",
+            return_value=(0, 0),
+        ),
+    ):
+        result = await admin_routes.clear_ssd_cache(is_admin=True)
+
+    assert result["total_deleted"] == 2
+    assert not cluster_root.exists()
+    assert not legacy_root.exists()
+
+
+def test_cold_ssd_clear_resolves_cache_paths_on_each_peer(tmp_path, monkeypatch):
+    from omlx.cluster.deployment import ClusterHost
+
+    roots = (
+        tmp_path / "cache/cluster-prompt-snapshots",
+        tmp_path / "cluster/runtime/prompt-cache-ssd",
+    )
+    hosts = (
+        ClusterHost("local", "127.0.0.1", ("10.0.0.1",)),
+        ClusterHost("peer", "peer.local", ("10.0.0.2",)),
+    )
+    registry = SimpleNamespace(list=lambda: (SimpleNamespace(hosts=hosts),))
+    calls = []
+
+    def run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return subprocess.CompletedProcess(argv, 0, "7\n", "")
+
+    monkeypatch.setattr(
+        "omlx.cluster.registry.get_cluster_registry",
+        lambda: registry,
+    )
+    deleted, ranks = admin_routes._clear_cold_remote_cluster_cache_roots(
+        roots,
+        runner=run,
+    )
+
+    assert (deleted, ranks) == (7, 2)
+    assert len(calls) == 1
+    command = calls[0][0][-1]
+    assert calls[0][0][-2] == "peer.local"
+    assert "GlobalSettings.load" in command
+    assert str(tmp_path) not in command

--- a/tests/test_admin_hot_cache_clear.py
+++ b/tests/test_admin_hot_cache_clear.py
@@ -121,7 +121,12 @@ class TestHotCacheClear:
         ):
             result = _run_clear()
 
-        assert set(result.keys()) == {"status", "total_cleared", "bytes_reclaimed"}
+        assert set(result.keys()) == {
+            "status",
+            "total_cleared",
+            "bytes_reclaimed",
+            "distributed_ranks",
+        }
         assert result["status"] == "ok"
 
 

--- a/tests/test_admin_hot_cache_clear.py
+++ b/tests/test_admin_hot_cache_clear.py
@@ -13,9 +13,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-import omlx.server  # noqa: F401 — triggers set_admin_getters
 import omlx.admin.routes as admin_routes
-
+import omlx.server  # noqa: F401 — triggers set_admin_getters
 
 MODEL_ID = "test-model"
 
@@ -193,9 +192,8 @@ class TestClearReclaimBranches:
         )
         with _reclaim_env() as env, patch.object(
             admin_routes, "_get_engine_pool", return_value=pool
-        ):
-            with pytest.raises(RuntimeError, match="boom"):
-                _run_clear()
+        ), pytest.raises(RuntimeError, match="boom"):
+            _run_clear()
         assert not env.get_mlx_executor.called, "must not fall back on a non-shutdown error"
 
     def test_mixed_loaded_and_orphan_no_double_count(self):

--- a/tests/test_cluster_control_plane.py
+++ b/tests/test_cluster_control_plane.py
@@ -63,6 +63,57 @@ def test_rank_control_plane_broadcasts_objects_in_sequence():
     assert received == expected
 
 
+def test_rank_control_plane_supports_barrier_and_nonzero_owned_bytes():
+    port = _free_port()
+    token = "c" * 64
+    worker_owned = b"worker-one-cache-plan"
+    coordinator_owned = b"rank-zero-follow-up"
+    received = {}
+    failures = []
+
+    def participant(rank):
+        try:
+            with RankControlPlane(
+                rank=rank,
+                world_size=3,
+                host="127.0.0.1",
+                port=port,
+                token=token,
+                connect_timeout=5,
+                io_timeout=5,
+            ) as control:
+                obj = control.broadcast_object(
+                    {"kind": "request"} if rank == 0 else None
+                )
+                control.barrier()
+                from_worker = control.broadcast_owned_bytes(
+                    worker_owned if rank == 1 else None,
+                    source_rank=1,
+                    expected_size=len(worker_owned),
+                )
+                from_coordinator = control.broadcast_owned_bytes(
+                    coordinator_owned if rank == 0 else None,
+                    source_rank=0,
+                    expected_size=len(coordinator_owned),
+                )
+                received[rank] = (obj, from_worker, from_coordinator)
+        except Exception as exc:  # pragma: no cover - relayed below
+            failures.append(exc)
+
+    threads = [threading.Thread(target=participant, args=(rank,)) for rank in range(3)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=8)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert failures == []
+    assert received == {
+        rank: ({"kind": "request"}, worker_owned, coordinator_owned)
+        for rank in range(3)
+    }
+
+
 def test_rank_control_plane_rejects_invalid_identity():
     try:
         RankControlPlane(
@@ -100,12 +151,13 @@ def test_invalid_handshake_is_dropped_without_blocking_a_valid_rank():
 
     thread = threading.Thread(target=coordinator)
     thread.start()
-    rogue = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     for _attempt in range(100):
+        rogue = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             rogue.connect(("127.0.0.1", port))
             break
         except ConnectionRefusedError:
+            rogue.close()
             threading.Event().wait(0.01)
     else:  # pragma: no cover - diagnostics for a wedged test host
         pytest.fail("coordinator listener did not start")

--- a/tests/test_cluster_inference_worker.py
+++ b/tests/test_cluster_inference_worker.py
@@ -1324,6 +1324,18 @@ def test_cancel_request_file_matches_the_telemetry_contract(tmp_path):
     assert payload["reason"] == "peer watchdog test"
 
 
+def test_cancel_request_epoch_advances_past_an_existing_clock_jump(tmp_path):
+    path = tmp_path / "dep-9-cancel.json"
+    path.write_text(json.dumps({"epoch": 9_999_999_999_999}), encoding="utf-8")
+
+    _write_cancel_request(
+        str(tmp_path), "dep-9", "new event", plan_hash="f" * 64
+    )
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["epoch"] == 10_000_000_000_000
+
+
 def _fake_mlx_core(calls: list[str], *, with_metal: bool = True) -> SimpleNamespace:
     metal = (
         SimpleNamespace(clear_cache=lambda: calls.append("metal.clear_cache"))

--- a/tests/test_cluster_launch.py
+++ b/tests/test_cluster_launch.py
@@ -2073,7 +2073,7 @@ def test_supervisor_stop_raises_and_keeps_state_when_group_survives(
     ]
     # State is kept so a later stop() retries instead of dropping the job.
     assert supervisor.process is launcher
-    assert supervisor.status().phase == "ready"
+    assert supervisor.status().phase == "failed"
     assert launch._launch_manifest_path(tmp_path, "cluster-test").exists()
 
 

--- a/tests/test_cluster_launch.py
+++ b/tests/test_cluster_launch.py
@@ -1496,8 +1496,8 @@ def test_prompt_cache_ssd_reaches_the_rank_and_scopes_its_directory(tmp_path):
     rank0 = _prompt_cache_ssd_dir(args, rank=0)
     rank1 = _prompt_cache_ssd_dir(args, rank=1)
     assert rank0 is not None and rank1 is not None
-    assert rank0.endswith(f"{args.deployment_id}-rank-0")
-    assert rank1.endswith(f"{args.deployment_id}-rank-1")
+    assert rank0.endswith(f"{args.deployment_id}/{args.plan_hash}/rank-0")
+    assert rank1.endswith(f"{args.deployment_id}/{args.plan_hash}/rank-1")
     assert rank0 != rank1
 
 

--- a/tests/test_cluster_prompt_snapshot_cache.py
+++ b/tests/test_cluster_prompt_snapshot_cache.py
@@ -325,6 +325,34 @@ def test_a_new_store_reclaims_what_a_dead_process_left(tmp_path):
     assert store.put(MODEL, list(range(STEP)), _kv())  # still fully usable
 
 
+def test_persistent_store_restores_its_chain_after_rank_restart(tmp_path):
+    tokens = list(range(8))
+    first = SSDPromptSnapshotStore(tmp_path, step=4, persistent=True)
+    kv = KVCache()
+    for boundary in (4, 8):
+        _feed(kv, 4)
+        assert first.put(MODEL, tokens[:boundary], [kv])
+
+    manifest = tmp_path / "index.json"
+    assert manifest.is_file()
+    second = SSDPromptSnapshotStore(tmp_path, step=4, persistent=True)
+    assert second.present_boundaries(MODEL, tokens) == (8, 4)
+    restored = second.load(MODEL, tokens, 8)
+    assert restored is not None
+    assert mx.array_equal(restored[0].state[0], kv.state[0])
+
+
+def test_invalid_persistent_manifest_fails_closed(tmp_path):
+    (tmp_path / "deadbeef.safetensors").write_bytes(b"stale")
+    (tmp_path / "index.json").write_text('{"version":1,"step":4,"entries":[{}]}')
+
+    store = SSDPromptSnapshotStore(tmp_path, step=4, persistent=True)
+
+    assert len(store) == 0
+    assert not (tmp_path / "deadbeef.safetensors").exists()
+    assert (tmp_path / "index.json").is_file()
+
+
 def test_an_unaligned_prompt_is_rejected(tmp_path):
     store = SSDPromptSnapshotStore(tmp_path, step=STEP)
     assert store.put(MODEL, list(range(STEP + 1)), _kv()) is False

--- a/tests/test_cluster_prompt_snapshot_cache.py
+++ b/tests/test_cluster_prompt_snapshot_cache.py
@@ -493,3 +493,15 @@ def test_a_failed_write_leaves_the_index_unchanged(tmp_path, monkeypatch):
     assert store.present_boundaries(MODEL, list(range(STEP))) == ()
     # No half-written temp file is left behind.
     assert list(tmp_path.glob("*")) == []
+
+
+def test_clear_removes_live_files_without_a_write_behind_flush(tmp_path):
+    store = SSDPromptSnapshotStore(tmp_path, step=STEP, persistent=True)
+    assert store.put(MODEL, list(range(STEP)), _kv()) is True
+    assert len(store) == 1
+
+    assert store.clear(timeout=0.01) == 1
+
+    assert len(store) == 0
+    assert store.nbytes == 0
+    assert list(tmp_path.glob("*.safetensors")) == []

--- a/tests/test_cluster_prompt_snapshot_integration.py
+++ b/tests/test_cluster_prompt_snapshot_integration.py
@@ -73,7 +73,7 @@ def test_prefill_boundaries_are_snapshotted_to_ssd(tmp_path, monkeypatch):
 
 def test_a_later_miss_restores_the_longest_ssd_prefix(tmp_path, monkeypatch):
     mlx_server, ctx = _install(tmp_path, monkeypatch)
-    with ctx:
+    with ctx as telemetry:
         cache = mlx_server.LRUPromptCache()
         first = list(range(8))
         cache.prefetch_nearest_cache(MODEL, first)
@@ -91,9 +91,15 @@ def test_a_later_miss_restores_the_longest_ssd_prefix(tmp_path, monkeypatch):
         longer = list(range(12))
         fresh = mlx_server.LRUPromptCache()
         restored, rest = fresh.prefetch_nearest_cache(MODEL, longer)
+        snapshot = telemetry.snapshot()
 
     assert restored is not None
     assert rest == [8, 9, 10, 11]
+    assert snapshot["cache"]["lookups"] == 2
+    assert snapshot["cache"]["hits"] == 1
+    assert snapshot["cache"]["tokens_reused"] == 8
+    assert snapshot["cache"]["entries"] == 2
+    assert snapshot["cache"]["bytes"] > 0
 
 
 def test_the_fetch_path_alone_carries_the_ssd_tier(tmp_path, monkeypatch):
@@ -222,6 +228,31 @@ def test_teardown_removes_the_snapshot_directory(tmp_path, monkeypatch):
         )
         assert sorted(tmp_path.glob("*.safetensors"))
     assert not tmp_path.exists()
+
+
+def test_persistent_tier_survives_telemetry_teardown(tmp_path, monkeypatch):
+    import mlx_lm.server as mlx_server
+
+    monkeypatch.setattr(mlx_server, "stream_generate", _fake_stream_generate)
+    with install_server_telemetry(
+        _Marker(),
+        ssd_cache_dir=str(tmp_path),
+        ssd_cache_persistent=True,
+        prefill_step_size=STEP,
+    ):
+        tokens = list(range(8))
+        mlx_server.LRUPromptCache().fetch_nearest_cache(MODEL, tokens)
+        list(
+            mlx_server.stream_generate(
+                model=None,
+                prompt=tokens,
+                prompt_cache=_kv(),
+                prompt_progress_callback=None,
+            )
+        )
+
+    assert (tmp_path / "index.json").is_file()
+    assert sorted(tmp_path.glob("*.safetensors"))
 
 
 class _FakeBaseBatchGenerator:

--- a/tests/test_cluster_telemetry.py
+++ b/tests/test_cluster_telemetry.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for rank-local, end-to-end distributed inference telemetry."""
 
+import json
 import threading
 import time
+from io import BytesIO
 from types import SimpleNamespace
 
 from omlx.cluster.performance import execution_profile

--- a/tests/test_cluster_telemetry.py
+++ b/tests/test_cluster_telemetry.py
@@ -554,3 +554,130 @@ def test_serving_starts_the_heartbeat_without_the_caller_asking(monkeypatch):
     settled = marker.count()
     time.sleep(0.1)
     assert marker.count() == settled, "the heartbeat outlived the serving block"
+
+
+class _BatchGenerator:
+    def __init__(self) -> None:
+        self.removed = []
+
+    def remove(self, uids):
+        self.removed.append(list(uids))
+
+
+def _cancel_telemetry(tmp_path, clock=None):
+    marker = _Marker()
+    telemetry = RuntimeTelemetry(
+        marker,
+        clock=clock or _Clock(),
+        publish_interval=0,
+        cancel_path=tmp_path / "dep-1-cancel.json",
+        cancel_deployment_id="dep-1",
+    )
+    return telemetry
+
+
+def test_force_cancel_all_removes_active_uids_through_the_batch_loop(tmp_path):
+    telemetry = _cancel_telemetry(tmp_path)
+    generator = _BatchGenerator()
+    telemetry.register_batch_generator(generator)
+    request_id = telemetry.begin_request()
+    telemetry.mark_pending_uid(request_id)
+    telemetry.bind_pending_uid((73,))
+
+    cancelled = telemetry.force_cancel_all(reason="test")
+
+    assert cancelled == 1
+    assert generator.removed == [[73]]
+    # remove() routes back through cancel_uids in production; here the
+    # fake does not, so the request is still tracked until it does.
+    telemetry.cancel_uids([73])
+    assert telemetry._requests == {}
+    assert telemetry._requests_cancelled == 1
+
+
+def test_force_cancel_all_without_generator_or_uids_is_a_noop(tmp_path):
+    telemetry = _cancel_telemetry(tmp_path)
+
+    assert telemetry.force_cancel_all(reason="test") == 0
+
+    generator = _BatchGenerator()
+    telemetry.register_batch_generator(generator)
+    assert telemetry.force_cancel_all(reason="test") == 0
+    assert generator.removed == []
+
+
+def test_force_cancel_all_survives_a_failing_batch_loop(tmp_path):
+    telemetry = _cancel_telemetry(tmp_path)
+
+    class BrokenGenerator:
+        def remove(self, uids):
+            raise RuntimeError("wedged")
+
+    telemetry.register_batch_generator(BrokenGenerator())
+    request_id = telemetry.begin_request()
+    telemetry.mark_pending_uid(request_id)
+    telemetry.bind_pending_uid((5,))
+
+    assert telemetry.force_cancel_all(reason="test") == 0
+    # The request stays tracked; the coordinator's process teardown is the
+    # fallback for this failure mode.
+    assert request_id in telemetry._requests
+
+
+def test_cancel_file_is_consumed_once_and_acked(tmp_path):
+    import json
+
+    telemetry = _cancel_telemetry(tmp_path)
+    generator = _BatchGenerator()
+    telemetry.register_batch_generator(generator)
+    request_id = telemetry.begin_request()
+    telemetry.mark_pending_uid(request_id)
+    telemetry.bind_pending_uid((9,))
+
+    cancel_path = tmp_path / "dep-1-cancel.json"
+    cancel_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "deployment_id": "dep-1",
+                "epoch": 42,
+                "scope": "all",
+                "reason": "memory pressure",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert telemetry.poll_cancel_requests(min_interval=0.0) == 1
+    assert generator.removed == [[9]]
+    ack = json.loads(
+        (tmp_path / "dep-1-cancel-ack.json").read_text(encoding="utf-8")
+    )
+    assert ack["epoch"] == 42
+    assert ack["cancelled"] == 1
+
+    # Same epoch is not consumed twice.
+    assert telemetry.poll_cancel_requests(min_interval=0.0) == 0
+    assert generator.removed == [[9]]
+
+
+def test_cancel_file_from_a_foreign_deployment_is_ignored(tmp_path):
+    import json
+
+    telemetry = _cancel_telemetry(tmp_path)
+    generator = _BatchGenerator()
+    telemetry.register_batch_generator(generator)
+    (tmp_path / "dep-1-cancel.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "deployment_id": "somebody-else",
+                "epoch": 7,
+                "scope": "all",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert telemetry.poll_cancel_requests(min_interval=0.0) == 0
+    assert generator.removed == []

--- a/tests/test_cluster_telemetry.py
+++ b/tests/test_cluster_telemetry.py
@@ -12,6 +12,7 @@ from omlx.cluster.planner import PipelineAssignment
 from omlx.cluster.telemetry import (
     RuntimeTelemetry,
     _TelemetryQueue,
+    _python_token_id,
     install_server_telemetry,
 )
 
@@ -39,6 +40,24 @@ class _Queue:
     def put(self, item, *args, **kwargs):
         self.items.append((item, args, kwargs))
         return "queued"
+
+
+def test_generated_token_is_normalized_for_logprob_indexing():
+    class Scalar:
+        def item(self):
+            return 129_279
+
+    assert _python_token_id(Scalar()) == 129_279
+    assert _python_token_id([[42]]) == 42
+
+
+def test_generated_token_normalization_rejects_non_scalar_and_high_bit():
+    import pytest
+
+    with pytest.raises(ValueError, match="scalar"):
+        _python_token_id([1, 2])
+    with pytest.raises(ValueError, match="signed int32"):
+        _python_token_id(2**31)
 
 
 def test_telemetry_calculates_ttft_prefill_and_decode_rates():

--- a/tests/test_cluster_telemetry.py
+++ b/tests/test_cluster_telemetry.py
@@ -4,15 +4,14 @@
 import json
 import threading
 import time
-from io import BytesIO
 from types import SimpleNamespace
 
 from omlx.cluster.performance import execution_profile
 from omlx.cluster.planner import PipelineAssignment
 from omlx.cluster.telemetry import (
     RuntimeTelemetry,
-    _TelemetryQueue,
     _python_token_id,
+    _TelemetryQueue,
     install_server_telemetry,
 )
 
@@ -372,9 +371,7 @@ def test_server_patch_binds_batch_uid_and_restores_mlx_lm_classes(monkeypatch):
         assert progress["active"] is True
         assert batch.remove([73]) == "removed"
         assert generator._tokenize(None, None, None)[0] == [1, 2, 3, 4]
-        assert generator.prompt_cache.fetch_nearest_cache(
-            "model", [1, 2, 3, 4]
-        ) == (
+        assert generator.prompt_cache.fetch_nearest_cache("model", [1, 2, 3, 4]) == (
             "cache",
             [3, 4],
         )
@@ -467,9 +464,7 @@ def test_an_idle_rank_still_refreshes_its_marker():
     """No requests, no tokens, nothing to report — and the marker still ages."""
 
     marker = _CountingMarker()
-    telemetry = RuntimeTelemetry(
-        marker, publish_interval=0, heartbeat_interval=0.01
-    )
+    telemetry = RuntimeTelemetry(marker, publish_interval=0, heartbeat_interval=0.01)
 
     telemetry.start_heartbeat()
     try:
@@ -485,9 +480,7 @@ def test_an_idle_rank_still_refreshes_its_marker():
 
 def test_stopping_the_heartbeat_ends_the_thread():
     marker = _CountingMarker()
-    telemetry = RuntimeTelemetry(
-        marker, publish_interval=0, heartbeat_interval=0.01
-    )
+    telemetry = RuntimeTelemetry(marker, publish_interval=0, heartbeat_interval=0.01)
     before = set(threading.enumerate())
 
     telemetry.start_heartbeat()
@@ -501,7 +494,8 @@ def test_stopping_the_heartbeat_ends_the_thread():
     leaked = {
         thread
         for thread in threading.enumerate()
-        if thread not in before and thread.is_alive()
+        if thread not in before
+        and thread.is_alive()
         and thread.name == "omlx-cluster-telemetry-heartbeat"
     }
     assert not leaked
@@ -646,7 +640,6 @@ def test_force_cancel_all_survives_a_failing_batch_loop(tmp_path):
 
 
 def test_cancel_file_is_consumed_once_and_acked(tmp_path):
-    import json
 
     telemetry = _cancel_telemetry(tmp_path)
     generator = _BatchGenerator()
@@ -671,9 +664,7 @@ def test_cancel_file_is_consumed_once_and_acked(tmp_path):
 
     assert telemetry.poll_cancel_requests(min_interval=0.0) == 1
     assert generator.removed == [[9]]
-    ack = json.loads(
-        (tmp_path / "dep-1-cancel-ack.json").read_text(encoding="utf-8")
-    )
+    ack = json.loads((tmp_path / "dep-1-cancel-ack.json").read_text(encoding="utf-8"))
     assert ack["epoch"] == 42
     assert ack["cancelled"] == 1
 
@@ -683,7 +674,6 @@ def test_cancel_file_is_consumed_once_and_acked(tmp_path):
 
 
 def test_cancel_file_from_a_foreign_deployment_is_ignored(tmp_path):
-    import json
 
     telemetry = _cancel_telemetry(tmp_path)
     generator = _BatchGenerator()

--- a/tests/test_cluster_telemetry.py
+++ b/tests/test_cluster_telemetry.py
@@ -2,9 +2,12 @@
 """Tests for rank-local, end-to-end distributed inference telemetry."""
 
 import json
+import struct
 import threading
 import time
 from types import SimpleNamespace
+
+import pytest
 
 from omlx.cluster.performance import execution_profile
 from omlx.cluster.planner import PipelineAssignment
@@ -211,6 +214,26 @@ def test_queue_observer_preserves_mlx_lm_queue_contract():
     assert snapshot["prompt_tokens_total"] == 4
     assert snapshot["cached_tokens_total"] == 1
     assert snapshot["completion_tokens_total"] == 1
+
+
+def test_shared_uid_removal_terminates_the_waiting_response_queue():
+    telemetry = RuntimeTelemetry(_Marker(), publish_interval=0)
+    target = _Queue()
+    queue = _TelemetryQueue(target, telemetry)
+    context = SimpleNamespace(
+        prompt=[1, 2, 3],
+        prompt_cache_count=0,
+        stop=lambda: None,
+    )
+    queue.put(context)
+    telemetry.bind_pending_uid((91,))
+
+    telemetry.cancel_uids([91])
+
+    assert [item[0] for item in target.items] == [context, None]
+    snapshot = telemetry.snapshot()
+    assert snapshot["active_requests"] == 0
+    assert snapshot["requests_cancelled"] == 1
 
 
 def test_telemetry_marker_failure_never_interrupts_inference():
@@ -579,7 +602,15 @@ class _BatchGenerator:
         self.removed.append(list(uids))
 
 
-def _cancel_telemetry(tmp_path, clock=None):
+class _GenerationContext:
+    def __init__(self) -> None:
+        self.stopped = False
+
+    def stop(self) -> None:
+        self.stopped = True
+
+
+def _cancel_telemetry(tmp_path, clock=None, *, plan_hash="", epoch_floor=0):
     marker = _Marker()
     telemetry = RuntimeTelemetry(
         marker,
@@ -587,25 +618,30 @@ def _cancel_telemetry(tmp_path, clock=None):
         publish_interval=0,
         cancel_path=tmp_path / "dep-1-cancel.json",
         cancel_deployment_id="dep-1",
+        cancel_plan_hash=plan_hash,
+        cancel_epoch_floor=epoch_floor,
     )
     return telemetry
 
 
-def test_force_cancel_all_removes_active_uids_through_the_batch_loop(tmp_path):
+def test_force_cancel_all_marks_context_for_the_shared_batch_loop(tmp_path):
     telemetry = _cancel_telemetry(tmp_path)
     generator = _BatchGenerator()
     telemetry.register_batch_generator(generator)
     request_id = telemetry.begin_request()
     telemetry.mark_pending_uid(request_id)
+    context = _GenerationContext()
+    telemetry.register_context(request_id, context)
     telemetry.bind_pending_uid((73,))
 
     cancelled = telemetry.force_cancel_all(reason="test")
 
     assert cancelled == 1
-    assert generator.removed == [[73]]
-    # remove() routes back through cancel_uids in production; here the
-    # fake does not, so the request is still tracked until it does.
+    assert context.stopped is True
+    assert generator.removed == [], "telemetry must never mutate one rank directly"
+    generator.remove([73])
     telemetry.cancel_uids([73])
+    assert generator.removed == [[73]]
     assert telemetry._requests == {}
     assert telemetry._requests_cancelled == 1
 
@@ -621,16 +657,16 @@ def test_force_cancel_all_without_generator_or_uids_is_a_noop(tmp_path):
     assert generator.removed == []
 
 
-def test_force_cancel_all_survives_a_failing_batch_loop(tmp_path):
+def test_force_cancel_all_survives_a_failing_generation_context(tmp_path):
     telemetry = _cancel_telemetry(tmp_path)
 
-    class BrokenGenerator:
-        def remove(self, uids):
+    class BrokenContext:
+        def stop(self):
             raise RuntimeError("wedged")
 
-    telemetry.register_batch_generator(BrokenGenerator())
     request_id = telemetry.begin_request()
     telemetry.mark_pending_uid(request_id)
+    telemetry.register_context(request_id, BrokenContext())
     telemetry.bind_pending_uid((5,))
 
     assert telemetry.force_cancel_all(reason="test") == 0
@@ -646,6 +682,8 @@ def test_cancel_file_is_consumed_once_and_acked(tmp_path):
     telemetry.register_batch_generator(generator)
     request_id = telemetry.begin_request()
     telemetry.mark_pending_uid(request_id)
+    context = _GenerationContext()
+    telemetry.register_context(request_id, context)
     telemetry.bind_pending_uid((9,))
 
     cancel_path = tmp_path / "dep-1-cancel.json"
@@ -663,14 +701,15 @@ def test_cancel_file_is_consumed_once_and_acked(tmp_path):
     )
 
     assert telemetry.poll_cancel_requests(min_interval=0.0) == 1
-    assert generator.removed == [[9]]
+    assert context.stopped is True
+    assert generator.removed == []
     ack = json.loads((tmp_path / "dep-1-cancel-ack.json").read_text(encoding="utf-8"))
     assert ack["epoch"] == 42
     assert ack["cancelled"] == 1
 
     # Same epoch is not consumed twice.
     assert telemetry.poll_cancel_requests(min_interval=0.0) == 0
-    assert generator.removed == [[9]]
+    assert generator.removed == []
 
 
 def test_cancel_file_from_a_foreign_deployment_is_ignored(tmp_path):
@@ -692,3 +731,224 @@ def test_cancel_file_from_a_foreign_deployment_is_ignored(tmp_path):
 
     assert telemetry.poll_cancel_requests(min_interval=0.0) == 0
     assert generator.removed == []
+
+
+def test_cancel_file_is_scoped_to_plan_and_worker_lifetime(tmp_path):
+    telemetry = _cancel_telemetry(
+        tmp_path,
+        plan_hash="current-plan",
+        epoch_floor=1000,
+    )
+    request_id = telemetry.begin_request()
+    telemetry.mark_pending_uid(request_id)
+    context = _GenerationContext()
+    telemetry.register_context(request_id, context)
+    telemetry.bind_pending_uid((11,))
+    cancel_path = tmp_path / "dep-1-cancel.json"
+
+    for plan_hash, epoch in (("old-plan", 2000), ("current-plan", 999)):
+        cancel_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "deployment_id": "dep-1",
+                    "plan_hash": plan_hash,
+                    "epoch": epoch,
+                    "scope": "all",
+                }
+            ),
+            encoding="utf-8",
+        )
+        assert telemetry.poll_cancel_requests(min_interval=0.0) == 0
+
+    cancel_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "deployment_id": "dep-1",
+                "plan_hash": "current-plan",
+                "epoch": 1001,
+                "scope": "all",
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert telemetry.poll_cancel_requests(min_interval=0.0) == 1
+    assert context.stopped is True
+    ack = json.loads((tmp_path / "dep-1-cancel-ack.json").read_text(encoding="utf-8"))
+    assert ack["plan_hash"] == "current-plan"
+
+
+def test_existing_matching_cancel_is_a_startup_watermark(tmp_path):
+    cancel_path = tmp_path / "dep-1-cancel.json"
+    cancel_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "deployment_id": "dep-1",
+                "plan_hash": "same-plan",
+                "epoch": 4242,
+                "scope": "all",
+            }
+        ),
+        encoding="utf-8",
+    )
+    telemetry = _cancel_telemetry(tmp_path, plan_hash="same-plan")
+    request_id = telemetry.begin_request()
+    telemetry.mark_pending_uid(request_id)
+    context = _GenerationContext()
+    telemetry.register_context(request_id, context)
+    telemetry.bind_pending_uid((12,))
+
+    assert telemetry.poll_cancel_requests(min_interval=0.0) == 0
+    payload = json.loads(cancel_path.read_text(encoding="utf-8"))
+    payload["epoch"] = 4243
+    cancel_path.write_text(json.dumps(payload), encoding="utf-8")
+    assert telemetry.poll_cancel_requests(min_interval=0.0) == 1
+    assert context.stopped is True
+
+
+def test_distributed_cancel_vote_drains_and_rendezvous_before_removal(monkeypatch):
+    import mlx.core as mx
+    import mlx_lm.server as mlx_server
+
+    events = []
+
+    class Group:
+        rank = staticmethod(lambda: 0)
+        size = staticmethod(lambda: 2)
+
+    class ControlPlane:
+        def broadcast_object(self, obj):
+            events.append(("broadcast", obj))
+            return obj
+
+        def barrier(self):
+            events.append(("barrier", None))
+
+    class FakeResponseGenerator:
+        def __init__(self):
+            self._is_distributed = True
+            self._rank = 0
+
+        def _share_object(self, _obj):
+            raise AssertionError("patched sharing must own cancellation")
+
+    class FakeBatchGenerator:
+        def remove(self, uids):
+            events.append(("remove", list(uids)))
+            return "removed"
+
+    monkeypatch.setattr(mx.distributed, "init", lambda: Group())
+    monkeypatch.setattr(mx, "synchronize", lambda *args: events.append(("drain", None)))
+    monkeypatch.setattr(mlx_server, "ResponseGenerator", FakeResponseGenerator)
+    monkeypatch.setattr(mlx_server, "BatchGenerator", FakeBatchGenerator)
+
+    with install_server_telemetry(
+        _Marker(),
+        heartbeat_interval=0,
+        control_plane=ControlPlane(),
+    ):
+        generator = mlx_server.ResponseGenerator()
+        batch = mlx_server.BatchGenerator()
+        with pytest.raises(RuntimeError, match="not armed"):
+            batch.remove([73])
+        assert generator._share_object([73]) == [73]
+        assert batch.remove([73]) == "removed"
+
+    assert [event[0] for event in events] == [
+        "broadcast",
+        "drain",
+        "barrier",
+        "remove",
+    ]
+
+
+def test_pipeline_cache_plan_requires_rank_agreement(monkeypatch):
+    import mlx.core as mx
+    import mlx_lm.server as mlx_server
+
+    class Group:
+        rank = staticmethod(lambda: 0)
+        size = staticmethod(lambda: 2)
+
+    class FakePromptCache:
+        def fetch_nearest_cache(self, _model, tokens):
+            return "rank-zero-cache", tokens[2:]
+
+        def __len__(self):
+            return 1
+
+        nbytes = 64
+
+    class ControlPlane:
+        peer_plan = (2, 2, 0)
+
+        def broadcast_owned_bytes(self, payload, *, source_rank, expected_size):
+            assert expected_size == 24
+            return payload if source_rank == 0 else struct.pack("!QQQ", *self.peer_plan)
+
+    monkeypatch.setattr(mx.distributed, "init", lambda: Group())
+    monkeypatch.setattr(mlx_server, "LRUPromptCache", FakePromptCache)
+    control = ControlPlane()
+
+    with install_server_telemetry(
+        _Marker(), heartbeat_interval=0, control_plane=control
+    ):
+        cache = mlx_server.LRUPromptCache()
+        tokens = [1, 2, 3, 4]
+        assert cache.fetch_nearest_cache("model", tokens) == (
+            "rank-zero-cache",
+            [3, 4],
+        )
+        control.peer_plan = (0, 4, 0)
+        assert cache.fetch_nearest_cache("model", tokens) == (None, tokens)
+
+
+def test_rank_hot_clear_reaches_live_prompt_cache_instances(monkeypatch):
+    from io import BytesIO
+
+    import mlx_lm.server as mlx_server
+
+    class Marker(_Marker):
+        payload = {"deployment_id": "dep", "plan_hash": "p" * 64}
+        path = None
+
+    class FakePromptCache:
+        def __init__(self):
+            self.entries = 3
+
+        def __len__(self):
+            return self.entries
+
+        @property
+        def nbytes(self):
+            return self.entries * 64
+
+        def trim_to(self, *, n_sequences, n_bytes):
+            assert (n_sequences, n_bytes) == (0, 0)
+            self.entries = 0
+
+    class Handler:
+        path = "/omlx/internal/cache/hot/clear"
+        headers = {"X-oMLX-Plan-Hash": "p" * 64}
+
+        def __init__(self):
+            self.wfile = BytesIO()
+            self.status = None
+
+        def _set_completion_headers(self, status):
+            self.status = status
+
+        def end_headers(self):
+            return None
+
+    monkeypatch.setattr(mlx_server, "LRUPromptCache", FakePromptCache)
+    with install_server_telemetry(Marker(), heartbeat_interval=0):
+        cache = mlx_server.LRUPromptCache()
+        handler = Handler()
+        mlx_server.APIHandler.do_POST(handler)
+
+    assert cache.entries == 0
+    assert handler.status == 200
+    assert json.loads(handler.wfile.getvalue())["hot_cleared"] == 3

--- a/tests/test_distributed_engine.py
+++ b/tests/test_distributed_engine.py
@@ -2,7 +2,6 @@
 
 import json
 import tempfile
-import time
 from dataclasses import replace
 from types import SimpleNamespace
 
@@ -877,9 +876,7 @@ def test_reasoning_effort_retry_payloads_ignores_when_not_requested():
 
     payload = {"chat_template_kwargs": {}}
     assert (
-        _reasoning_effort_retry_payloads(
-            payload, "Unexpected reasoning effort high."
-        )
+        _reasoning_effort_retry_payloads(payload, "Unexpected reasoning effort high.")
         == []
     )
 
@@ -905,7 +902,10 @@ async def test_distributed_chat_retries_unsupported_reasoning_effort():
             200,
             json={
                 "choices": [
-                    {"message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}
+                    {
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
                 ],
                 "usage": {"prompt_tokens": 1, "completion_tokens": 1},
             },

--- a/tests/test_distributed_engine.py
+++ b/tests/test_distributed_engine.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import tempfile
+import time
 from dataclasses import replace
 from types import SimpleNamespace
 
@@ -145,6 +147,9 @@ def _stalled_engine():
         raise httpx.ReadTimeout("collective stalled", request=request)
 
     engine = _ready_engine(handler)
+    # Read timeouts now drop a rank-side cancel file; keep it out of the
+    # real runtime state dir.
+    engine._supervisor.state_dir = tempfile.mkdtemp(prefix="omlx-test-runtime-")
     status_calls = []
 
     def status():

--- a/tests/test_distributed_engine.py
+++ b/tests/test_distributed_engine.py
@@ -1091,6 +1091,26 @@ def _healthy_supervisor_status():
     return SimpleNamespace(returncode=None, failure_reason=None)
 
 
+def test_runtime_failure_reconciles_supervisor_terminal_state(monkeypatch):
+    """Pool status/release must see a rank death even after a 200 response."""
+
+    engine = _ready_engine(lambda request: httpx.Response(200))
+    monkeypatch.setattr(
+        engine._supervisor,
+        "status",
+        lambda: SimpleNamespace(
+            returncode=0,
+            failure_reason=(
+                "rank 0 exited with code 75 after JACCL all_reduce made no progress"
+            ),
+            phase="failed",
+        ),
+    )
+
+    assert engine.runtime_failed_reason is not None
+    assert "rank 0 exited with code 75" in engine.runtime_failed_reason
+
+
 @pytest.mark.asyncio
 async def test_preflight_rejects_an_unhealthy_rank_before_streaming(monkeypatch):
     # The 200 commits before a streaming body runs, so preflight is the last

--- a/tests/test_distributed_engine.py
+++ b/tests/test_distributed_engine.py
@@ -89,8 +89,8 @@ async def test_distributed_ssd_clear_reaches_every_rank(monkeypatch):
     assert requests[0].url.path == "/omlx/internal/cache/ssd/clear"
     assert requests[0].headers["X-oMLX-Plan-Hash"] == "d" * 64
     assert remote_calls[0][0] == "peer.local"
-    assert "/omlx/internal/cache/ssd/clear" in remote_calls[0][1]
-    assert "X-oMLX-Plan-Hash" in remote_calls[0][1]
+    assert "engine-test-cache-clear.json" in remote_calls[0][1]
+    assert '"ssd":true' in remote_calls[0][1]
 
 
 @pytest.mark.asyncio

--- a/tests/test_distributed_engine.py
+++ b/tests/test_distributed_engine.py
@@ -54,6 +54,56 @@ def _ready_engine(handler) -> DistributedBatchedEngine:
     return engine
 
 
+@pytest.mark.asyncio
+async def test_distributed_ssd_clear_reaches_every_rank(monkeypatch):
+    requests = []
+
+    def handler(request):
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={"status": "ok", "rank": 0, "ssd_deleted": 3, "hot_cleared": 0},
+        )
+
+    remote_calls = []
+
+    def remote(ssh_target, command, timeout, runner):
+        remote_calls.append((ssh_target, command, timeout))
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(
+                {"status": "ok", "rank": 1, "ssd_deleted": 5, "hot_cleared": 0}
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(distributed, "_run_cluster_ssh", remote)
+    engine = _ready_engine(handler)
+    try:
+        result = await engine.clear_prompt_caches(ssd=True)
+    finally:
+        await engine._client.aclose()
+
+    assert result["ssd_deleted"] == 8
+    assert len(result["ranks"]) == 2
+    assert requests[0].url.path == "/omlx/internal/cache/ssd/clear"
+    assert requests[0].headers["X-oMLX-Plan-Hash"] == "d" * 64
+    assert remote_calls[0][0] == "peer.local"
+    assert "/omlx/internal/cache/ssd/clear" in remote_calls[0][1]
+    assert "X-oMLX-Plan-Hash" in remote_calls[0][1]
+
+
+@pytest.mark.asyncio
+async def test_distributed_cache_clear_refuses_active_requests():
+    engine = _ready_engine(lambda _request: httpx.Response(200, json={}))
+    engine._active_requests = 1
+    try:
+        with pytest.raises(DistributedInferenceError, match="requests are active"):
+            await engine.clear_prompt_caches(ssd=True)
+    finally:
+        await engine._client.aclose()
+
+
 def test_backend_chat_messages_serialize_native_tool_history_once():
     messages = [
         {

--- a/tests/test_distributed_engine.py
+++ b/tests/test_distributed_engine.py
@@ -50,6 +50,7 @@ def _ready_engine(handler) -> DistributedBatchedEngine:
         base_url="http://127.0.0.1:1",
         transport=httpx.MockTransport(handler),
     )
+    engine._supervisor.port = 8001
     return engine
 
 

--- a/tests/test_distributed_engine.py
+++ b/tests/test_distributed_engine.py
@@ -55,6 +55,48 @@ def _ready_engine(handler) -> DistributedBatchedEngine:
 
 
 @pytest.mark.asyncio
+async def test_acknowledged_cancel_all_does_not_widen_later_targeted_cancel(tmp_path):
+    engine = _ready_engine(lambda request: httpx.Response(200, json={}))
+    engine._supervisor.state_dir = str(tmp_path)
+    cancel_path = tmp_path / "engine-test-cancel.json"
+    ack_path = tmp_path / "engine-test-cancel-ack.json"
+    old_epoch = 9_999_999_999_999
+    cancel_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "deployment_id": "engine-test",
+                "plan_hash": "d" * 64,
+                "epoch": old_epoch,
+                "scope": "all",
+            }
+        ),
+        encoding="utf-8",
+    )
+    ack_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "deployment_id": "engine-test",
+                "plan_hash": "d" * 64,
+                "epoch": old_epoch,
+                "cancelled": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    request_id = await engine._enter_request("transport-new-client")
+    try:
+        assert await engine.abort_request(request_id, reason="socket closed") is True
+        payload = json.loads(cancel_path.read_text(encoding="utf-8"))
+        assert payload["scope"] == "requests"
+        assert payload["request_ids"] == [request_id]
+    finally:
+        await engine._leave_request(request_id)
+        await engine._client.aclose()
+
+
+@pytest.mark.asyncio
 async def test_distributed_ssd_clear_reaches_every_rank(monkeypatch):
     requests = []
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -67,6 +67,40 @@ class TestBoundarySnapshotLifecycle:
         assert stale_dir.exists()
 
 
+@pytest.mark.asyncio
+async def test_text_completion_stream_forwards_transport_request_id():
+    from omlx.api.openai_models import CompletionRequest
+    from omlx.server import stream_completion
+
+    class Engine:
+        tokenizer = None
+
+        def __init__(self):
+            self.kwargs = None
+
+        async def stream_generate(self, **kwargs):
+            self.kwargs = kwargs
+            if False:
+                yield None
+
+    engine = Engine()
+    request = CompletionRequest(model="model", prompt="hello", stream=True)
+
+    chunks = [
+        chunk
+        async for chunk in stream_completion(
+            engine,
+            "hello",
+            request,
+            prompt_token_ids=[],
+            inference_request_id="transport-completion-1",
+        )
+    ]
+
+    assert chunks == ["data: [DONE]\n\n"]
+    assert engine.kwargs["_request_id"] == "transport-completion-1"
+
+
 class TestDiffusionStructuredOutputGuard:
     class _DiffusionEngine:
         is_diffusion_model = True

--- a/tests/test_sse_keepalive.py
+++ b/tests/test_sse_keepalive.py
@@ -3,10 +3,15 @@
 
 import asyncio
 import json
+import socket
 
 import pytest
 
-from omlx.server import _with_sse_keepalive
+from omlx.server import (
+    ClientDisconnectTrackingMiddleware,
+    _with_request_disconnect_abort,
+    _with_sse_keepalive,
+)
 
 
 async def _collect(gen):
@@ -128,6 +133,81 @@ class TestSSEKeepaliveExceptionHandling:
         assert items[0] == ": keep-alive\n\n"
         assert request.checks == 2
         assert closed.is_set()
+
+
+@pytest.mark.asyncio
+async def test_real_uvicorn_socket_disconnect_aborts_only_its_request():
+    """Exercise the real Uvicorn/Starlette receive race, not a mocked Request."""
+
+    import uvicorn
+    from fastapi import FastAPI, Request
+    from fastapi.responses import StreamingResponse
+
+    aborted: list[str] = []
+    abort_seen = asyncio.Event()
+
+    class Engine:
+        supports_request_scoped_abort = True
+
+        async def abort_request(self, request_id, **_kwargs):
+            aborted.append(request_id)
+            abort_seen.set()
+            return True
+
+    engine = Engine()
+    socket_app = FastAPI()
+    socket_app.add_middleware(ClientDisconnectTrackingMiddleware)
+
+    @socket_app.get("/stream")
+    async def stream(http_request: Request):
+        async def prefill():
+            while True:
+                await asyncio.sleep(60)
+                yield "data: token\n\n"
+
+        body = _with_request_disconnect_abort(
+            _with_sse_keepalive(
+                prefill(),
+                http_request=http_request,
+                interval=60,
+                disconnect_poll=60,
+            ),
+            http_request,
+            engine,
+            "transport-socket-owner",
+        )
+        return StreamingResponse(body, media_type="text/event-stream")
+
+    listener = socket.socket()
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen()
+    listener.setblocking(False)
+    port = listener.getsockname()[1]
+    config = uvicorn.Config(socket_app, lifespan="off", log_level="warning")
+    server = uvicorn.Server(config)
+    server_task = asyncio.create_task(server.serve(sockets=[listener]))
+    try:
+        while not server.started:
+            await asyncio.sleep(0.01)
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        writer.write(
+            b"GET /stream HTTP/1.1\r\n"
+            b"Host: localhost\r\n"
+            b"Connection: close\r\n\r\n"
+        )
+        await writer.drain()
+        await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=2.0)
+        await asyncio.wait_for(reader.read(1024), timeout=2.0)  # initial keepalive
+        writer.close()
+        await writer.wait_closed()
+
+        await asyncio.wait_for(abort_seen.wait(), timeout=2.0)
+    finally:
+        server.should_exit = True
+        await asyncio.wait_for(server_task, timeout=5.0)
+
+    assert aborted == ["transport-socket-owner"]
 
 
 class TestKeepaliveChunkFormats:

--- a/tests/test_sse_keepalive.py
+++ b/tests/test_sse_keepalive.py
@@ -192,9 +192,7 @@ async def test_real_uvicorn_socket_disconnect_aborts_only_its_request():
             await asyncio.sleep(0.01)
         reader, writer = await asyncio.open_connection("127.0.0.1", port)
         writer.write(
-            b"GET /stream HTTP/1.1\r\n"
-            b"Host: localhost\r\n"
-            b"Connection: close\r\n\r\n"
+            b"GET /stream HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
         )
         await writer.drain()
         await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=2.0)
@@ -348,7 +346,9 @@ class TestChatKeepaliveCarriesRole:
     def test_id_sharing_frame_carries_assistant_role(self):
         from omlx.server import _chat_keepalive_chunk
 
-        assert self._first_chunk_role(_chat_keepalive_chunk("chatcmpl-x")) == "assistant"
+        assert (
+            self._first_chunk_role(_chat_keepalive_chunk("chatcmpl-x")) == "assistant"
+        )
 
 
 class TestResolveKeepalive:
@@ -376,7 +376,9 @@ class TestResolveKeepalive:
         try:
             self._set_mode("chunk")
             assert _resolve_keepalive("openai_chat") == _KEEPALIVE_CHAT_CHUNK
-            assert _resolve_keepalive("openai_completion") == _KEEPALIVE_COMPLETION_CHUNK
+            assert (
+                _resolve_keepalive("openai_completion") == _KEEPALIVE_COMPLETION_CHUNK
+            )
             assert _resolve_keepalive("anthropic") == _KEEPALIVE_ANTHROPIC_PING
             # Responses API has no official ping; chunk mode disables keepalive
             assert _resolve_keepalive("openai_responses") is None
@@ -391,7 +393,12 @@ class TestResolveKeepalive:
         original = _server_state.global_settings.server.sse_keepalive_mode
         try:
             self._set_mode("comment")
-            for protocol in ("openai_chat", "openai_completion", "anthropic", "openai_responses"):
+            for protocol in (
+                "openai_chat",
+                "openai_completion",
+                "anthropic",
+                "openai_responses",
+            ):
                 assert _resolve_keepalive(protocol) == _KEEPALIVE_COMMENT
         finally:
             _server_state.global_settings.server.sse_keepalive_mode = original
@@ -404,7 +411,12 @@ class TestResolveKeepalive:
         original = _server_state.global_settings.server.sse_keepalive_mode
         try:
             self._set_mode("off")
-            for protocol in ("openai_chat", "openai_completion", "anthropic", "openai_responses"):
+            for protocol in (
+                "openai_chat",
+                "openai_completion",
+                "anthropic",
+                "openai_responses",
+            ):
                 assert _resolve_keepalive(protocol) is None
         finally:
             _server_state.global_settings.server.sse_keepalive_mode = original


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked draft (4/4). Depends on #3155, #3256, and #3257.** This is opened now so the full backend series is visible upstream. Until the dependencies merge, GitHub shows their inherited commits because the dependency branches live on the fork. This branch will be restacked after each merge so the final review is the 20-commit incremental serving/cancellation/telemetry/cache delta.

Incremental fork review and green CI: [jonathan308/omlx#6](https://github.com/jonathan308/omlx/pull/6).

## Scope

- base TP and pipeline serving lifecycle
- public request IDs propagated to rank zero
- request-scoped disconnect aborts
- targeted rank cancellation with bounded atomic request sets and acknowledgements
- bounded prefill cancellation at synchronized chunk boundaries
- cancellation fencing before distributed batch mutation
- runtime-failure reconciliation and stale-engine suppression
- per-request and aggregate prefill/decode/cache telemetry
- pipeline prompt-cache agreement and response-token normalization
- persistent rank-local prompt snapshots across restarts
- cluster-wide hot/SSD cache clearing on loaded and unloaded peers
- quiescence gates for unload and cache maintenance

## Deliberately excluded

- Phase split and Cluster v2 UI
- DS4, ANE, MTP, native kernels, and other model/single-Mac optimizations
- updater, release, repository, and branding changes

## Validation

- incremental branch CI: Python 3.11, 3.12, and 3.13 green
- full local suite: 10,632 passed, 102 skipped
- focused serving/cancellation/telemetry/cache suites: green
- Ruff and `git diff --check`: passed
