### PR TITLE
feat(moe): SSD Expert Streaming and Soft-REAP for MoE models

### DIFF
--- a/Formula/omlx.rb
+++ b/Formula/omlx.rb
@@ -1,5 +1,5 @@
 class Omlx < Formula
-  CUSTOM_KERNELS = %w[bonsai glm_moe_dsa minimax_m3 qwen35_prefill].freeze
+  CUSTOM_KERNELS = %w[bonsai fast_resource_loading glm_moe_dsa minimax_m3 qwen35_prefill].freeze
 
   desc "LLM inference server optimized for Apple Silicon"
   homepage "https://github.com/jundot/omlx"

--- a/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
@@ -1014,6 +1014,22 @@ private struct ExpertStreamingSection: View {
                 }
 
                 Row(
+                    label: String(localized: "settings.expert_streaming.fast_resource_loading.label",
+                                  defaultValue: "Fast Resource Loading",
+                                  comment: "Row label for Metal Fast Resource Loading in SSD expert streaming"),
+                    sublabel: String(localized: "settings.expert_streaming.fast_resource_loading.sub",
+                                     defaultValue: "Use Apple Metal I/O for one-shot cold expert batches. Improves prefill without changing hot-cache promotions.",
+                                     comment: "Sublabel describing scratch-only Fast Resource Loading for SSD experts")
+                ) {
+                    Toggle(
+                        "",
+                        isOn: vm.bindProfile($vm.expertStreamingFastResourceLoading)
+                    )
+                    .labelsHidden()
+                    .toggleStyle(.switch)
+                }
+
+                Row(
                     label: String(localized: "settings.expert_streaming.threshold.label",
                                   defaultValue: "Substitution Threshold",
                                   comment: "Row label for SSD expert substitution threshold"),

--- a/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
@@ -17,7 +17,9 @@
 // Save / Cancel / Load Defaults buttons live as a top-right toolbar that
 // only does navigation back to Models.
 
+import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct ModelSettingsScreen: View {
     let modelID: String
@@ -826,6 +828,18 @@ private struct AdvancedTab: View {
             }
         }
 
+        if !vm.isDiffusionModel, vm.model?.expertStreamingSupported == true {
+            SectionHeader(
+                String(localized: "settings.expert_streaming.section",
+                       defaultValue: "SSD Expert Streaming",
+                       comment: "Section header above SSD expert streaming model settings"),
+                subtitle: String(localized: "settings.expert_streaming.subtitle",
+                                 defaultValue: "Keep selected MoE experts resident and stream cold experts from SSD on demand.",
+                                 comment: "Subtitle for SSD expert streaming model settings")
+            )
+            ExpertStreamingSection(vm: vm, client: client)
+        }
+
         SectionHeader(
             String(localized: "settings.advanced.chat_template.section",
                    defaultValue: "Chat Template Kwargs",
@@ -856,6 +870,181 @@ private struct AdvancedTab: View {
                                  comment: "Subtitle for the Experimental settings section")
             )
             ExperimentalSection(vm: vm, client: client)
+        }
+    }
+}
+
+// MARK: - SSD Expert Streaming
+
+private struct ExpertStreamingSection: View {
+    @Bindable var vm: ModelSettingsScreenVM
+    let client: OMLXClient
+
+    @Environment(\.omlxTheme) private var theme
+
+    private var modeHint: String {
+        if vm.expertStreamingMode == "cache_only" {
+            return String(localized: "settings.expert_streaming.mode.cache_only.hint",
+                          defaultValue: "Start with no pinned experts; the analytical hot cache learns which experts to retain.",
+                          comment: "Hint for SSD expert streaming analytical cache-only mode")
+        }
+        return String(localized: "settings.expert_streaming.mode.soft_reap.hint",
+                      defaultValue: "Pin manifest-selected experts in memory and cache other frequently routed experts.",
+                      comment: "Hint for Soft-REAP manifest pinning mode")
+    }
+
+    var body: some View {
+        ListGroup {
+            Row(
+                label: String(localized: "settings.expert_streaming.enabled.label",
+                              defaultValue: "SSD Expert Streaming",
+                              comment: "Row label for the SSD expert streaming toggle"),
+                sublabel: String(localized: "settings.expert_streaming.enabled.sub",
+                                 defaultValue: "Reduce MoE memory use by keeping cold expert weights on SSD.",
+                                 comment: "Sublabel for the SSD expert streaming toggle"),
+                isLast: !vm.expertStreamingEnabled
+            ) {
+                Toggle("", isOn: vm.bindProfile($vm.expertStreamingEnabled))
+                    .labelsHidden()
+                    .toggleStyle(.switch)
+            }
+
+            if vm.expertStreamingEnabled {
+                Row(
+                    label: String(localized: "settings.expert_streaming.mode.label",
+                                  defaultValue: "Mode",
+                                  comment: "Row label for SSD expert streaming mode"),
+                    sublabel: modeHint
+                ) {
+                    Popup(
+                        selection: vm.bindProfile($vm.expertStreamingMode),
+                        width: 190,
+                        options: ModelSettingsScreenVM.expertStreamingModeOptions
+                    )
+                }
+
+                if vm.expertStreamingMode == "soft_reap" {
+                    Row(
+                        label: String(localized: "settings.expert_streaming.manifest.label",
+                                      defaultValue: "Soft-REAP Manifest",
+                                      comment: "Row label for the Soft-REAP expert manifest picker"),
+                        sublabel: vm.expertManifestSummary ?? String(
+                            localized: "settings.expert_streaming.manifest.sub",
+                            defaultValue: "A JSON file selecting the experts pinned in memory for each layer.",
+                            comment: "Sublabel for the Soft-REAP expert manifest picker"
+                        )
+                    ) {
+                        HStack(spacing: 8) {
+                            if !vm.expertManifestFileName.isEmpty {
+                                Text(vm.expertManifestFileName)
+                                    .font(.omlxMono(11, weight: .medium))
+                                    .foregroundStyle(theme.textSecondary)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                                    .frame(maxWidth: 150)
+                            }
+                            if vm.expertManifestUploadInProgress {
+                                ProgressView()
+                                    .controlSize(.small)
+                            } else {
+                                Button(String(localized: "settings.expert_streaming.manifest.choose",
+                                              defaultValue: "Choose JSON…",
+                                              comment: "Button that opens the Soft-REAP expert manifest picker")) {
+                                    chooseManifest()
+                                }
+                                .buttonStyle(.omlx(.normal, size: .small))
+                            }
+                        }
+                    }
+                }
+
+                Row(
+                    label: String(localized: "settings.expert_streaming.cache.label",
+                                  defaultValue: "Hot Expert Cache",
+                                  comment: "Row label for SSD expert streaming cache size"),
+                    sublabel: String(localized: "settings.expert_streaming.cache.sub",
+                                     defaultValue: "Preallocated cache slots per layer for frequently used non-pinned experts.",
+                                     comment: "Sublabel for SSD expert streaming cache size")
+                ) {
+                    TextInput(
+                        text: vm.bindProfile($vm.expertStreamingCacheExperts),
+                        isNumeric: true,
+                        range: 0...512,
+                        step: 1,
+                        suffix: String(localized: "settings.expert_streaming.cache.suffix",
+                                       defaultValue: "experts",
+                                       comment: "Unit suffix for SSD expert streaming cache size"),
+                        width: 150
+                    )
+                }
+
+                Row(
+                    label: String(localized: "settings.expert_streaming.policy.label",
+                                  defaultValue: "Execution Policy",
+                                  comment: "Row label for SSD expert streaming execution policy"),
+                    sublabel: String(localized: "settings.expert_streaming.policy.sub",
+                                     defaultValue: "Speculative mode overlaps loading with execution; Checked prioritizes predictable correctness.",
+                                     comment: "Sublabel for SSD expert streaming execution policy")
+                ) {
+                    Popup(
+                        selection: vm.bindProfile($vm.expertStreamingExecutionPolicy),
+                        width: 145,
+                        options: ModelSettingsScreenVM.expertStreamingExecutionPolicyOptions
+                    )
+                }
+
+                Row(
+                    label: String(localized: "settings.expert_streaming.threshold.label",
+                                  defaultValue: "Substitution Threshold",
+                                  comment: "Row label for SSD expert substitution threshold"),
+                    sublabel: String(localized: "settings.expert_streaming.threshold.sub",
+                                     defaultValue: "Use a resident expert when its router weight is within this percentage of an unloaded choice. 0% disables substitution.",
+                                     comment: "Sublabel for SSD expert substitution threshold"),
+                    isLast: (vm.model?.expertStreamingResidentBytes ?? 0) <= 0
+                ) {
+                    TextInput(
+                        text: vm.bindProfile($vm.expertStreamingSubstitutionThresholdPercent),
+                        isNumeric: true,
+                        range: 0...100,
+                        step: 0.1,
+                        suffix: "%",
+                        width: 120
+                    )
+                }
+
+                if let bytes = vm.model?.expertStreamingResidentBytes, bytes > 0 {
+                    Row(
+                        label: String(localized: "settings.expert_streaming.resident.label",
+                                      defaultValue: "Projected Resident Memory",
+                                      comment: "Row label for projected SSD expert streaming memory use"),
+                        sublabel: String(localized: "settings.expert_streaming.resident.sub",
+                                         defaultValue: "Pinned experts, PLE, and configured hot-cache slots.",
+                                         comment: "Sublabel for projected SSD expert streaming memory use"),
+                        isLast: true
+                    ) {
+                        Text(formatBytes(bytes))
+                            .font(.omlxMono(12, weight: .semibold))
+                            .foregroundStyle(theme.text)
+                    }
+                }
+            }
+        }
+    }
+
+    private func chooseManifest() {
+        let panel = NSOpenPanel()
+        panel.title = String(localized: "settings.expert_streaming.manifest.panel_title",
+                             defaultValue: "Choose Soft-REAP Expert Manifest",
+                             comment: "Title of the Soft-REAP expert manifest file picker")
+        panel.allowedContentTypes = [.json]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else { return }
+            Task { @MainActor in
+                await vm.uploadExpertManifest(url: url, client: client)
+            }
         }
     }
 }

--- a/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
@@ -994,6 +994,26 @@ private struct ExpertStreamingSection: View {
                 }
 
                 Row(
+                    label: String(localized: "settings.expert_streaming.scratch.label",
+                                  defaultValue: "Cold Execution Bank",
+                                  comment: "Row label for SSD expert streaming scratch size"),
+                    sublabel: String(localized: "settings.expert_streaming.scratch.sub",
+                                     defaultValue: "Extra preallocated slots that batch cold experts without evicting the hot cache.",
+                                     comment: "Sublabel for SSD expert streaming scratch size")
+                ) {
+                    TextInput(
+                        text: vm.bindProfile($vm.expertStreamingScratchExperts),
+                        isNumeric: true,
+                        range: 0...512,
+                        step: 1,
+                        suffix: String(localized: "settings.expert_streaming.cache.suffix",
+                                       defaultValue: "experts",
+                                       comment: "Unit suffix for SSD expert streaming scratch size"),
+                        width: 150
+                    )
+                }
+
+                Row(
                     label: String(localized: "settings.expert_streaming.threshold.label",
                                   defaultValue: "Substitution Threshold",
                                   comment: "Row label for SSD expert substitution threshold"),
@@ -1018,7 +1038,7 @@ private struct ExpertStreamingSection: View {
                                       defaultValue: "Projected Resident Memory",
                                       comment: "Row label for projected SSD expert streaming memory use"),
                         sublabel: String(localized: "settings.expert_streaming.resident.sub",
-                                         defaultValue: "Pinned experts, PLE, and configured hot-cache slots.",
+                                         defaultValue: "Pinned experts, PLE, hot-cache slots, and the cold execution bank.",
                                          comment: "Sublabel for projected SSD expert streaming memory use"),
                         isLast: true
                     ) {

--- a/apps/omlx-mac/Sources/AppView/Utils/ProfileWorkingState.swift
+++ b/apps/omlx-mac/Sources/AppView/Utils/ProfileWorkingState.swift
@@ -145,6 +145,7 @@ enum ProfileSettingsKey {
     static let expertStreamingManifest = "expert_streaming_manifest"
     static let expertStreamingCacheExperts = "expert_streaming_cache_experts"
     static let expertStreamingScratchExperts = "expert_streaming_scratch_experts"
+    static let expertStreamingFastResourceLoading = "expert_streaming_fast_resource_loading"
     static let expertStreamingSubstitutionThresholdPercent = "expert_streaming_substitution_threshold_percent"
     static let expertStreamingExecutionPolicy = "expert_streaming_execution_policy"
     static let turboquantKvEnabled = "turboquant_kv_enabled"

--- a/apps/omlx-mac/Sources/AppView/Utils/ProfileWorkingState.swift
+++ b/apps/omlx-mac/Sources/AppView/Utils/ProfileWorkingState.swift
@@ -144,6 +144,7 @@ enum ProfileSettingsKey {
     static let expertStreamingMode = "expert_streaming_mode"
     static let expertStreamingManifest = "expert_streaming_manifest"
     static let expertStreamingCacheExperts = "expert_streaming_cache_experts"
+    static let expertStreamingScratchExperts = "expert_streaming_scratch_experts"
     static let expertStreamingSubstitutionThresholdPercent = "expert_streaming_substitution_threshold_percent"
     static let expertStreamingExecutionPolicy = "expert_streaming_execution_policy"
     static let turboquantKvEnabled = "turboquant_kv_enabled"

--- a/apps/omlx-mac/Sources/AppView/Utils/ProfileWorkingState.swift
+++ b/apps/omlx-mac/Sources/AppView/Utils/ProfileWorkingState.swift
@@ -140,6 +140,12 @@ enum ProfileSettingsKey {
     // Model-specific
     static let modelTypeOverride = "model_type_override"
     static let trustRemoteCode = "trust_remote_code"
+    static let expertStreamingEnabled = "expert_streaming_enabled"
+    static let expertStreamingMode = "expert_streaming_mode"
+    static let expertStreamingManifest = "expert_streaming_manifest"
+    static let expertStreamingCacheExperts = "expert_streaming_cache_experts"
+    static let expertStreamingSubstitutionThresholdPercent = "expert_streaming_substitution_threshold_percent"
+    static let expertStreamingExecutionPolicy = "expert_streaming_execution_policy"
     static let turboquantKvEnabled = "turboquant_kv_enabled"
     static let turboquantKvBits = "turboquant_kv_bits"
     static let qwen35AnePrefillEnabled = "qwen35_ane_prefill_enabled"

--- a/apps/omlx-mac/Sources/AppView/ViewModels/ModelSettingsScreenVM.swift
+++ b/apps/omlx-mac/Sources/AppView/ViewModels/ModelSettingsScreenVM.swift
@@ -269,6 +269,7 @@ final class ModelSettingsScreenVM {
     var expertStreamingManifest: String = ""
     var expertStreamingCacheExperts: String = "32"
     var expertStreamingScratchExperts: String = "32"
+    var expertStreamingFastResourceLoading: Bool = false
     var expertStreamingSubstitutionThresholdPercent: String = "0"
     var expertStreamingExecutionPolicy: String = "checked"
     var expertManifestUploadInProgress: Bool = false
@@ -558,6 +559,7 @@ final class ModelSettingsScreenVM {
                 self.expertStreamingManifest = s?.expertStreamingManifest ?? ""
                 self.expertStreamingCacheExperts = s?.expertStreamingCacheExperts.map(String.init) ?? "32"
                 self.expertStreamingScratchExperts = s?.expertStreamingScratchExperts.map(String.init) ?? "32"
+                self.expertStreamingFastResourceLoading = s?.expertStreamingFastResourceLoading ?? false
                 self.expertStreamingSubstitutionThresholdPercent = s?.expertStreamingSubstitutionThresholdPercent
                     .map { Self.formatPct($0) } ?? "0"
                 self.expertStreamingExecutionPolicy = s?.expertStreamingExecutionPolicy ?? "checked"
@@ -1249,6 +1251,10 @@ final class ModelSettingsScreenVM {
                 }
                 putInt(ProfileSettingsKey.expertStreamingCacheExperts, expertStreamingCacheExperts)
                 putInt(ProfileSettingsKey.expertStreamingScratchExperts, expertStreamingScratchExperts)
+                putBool(
+                    ProfileSettingsKey.expertStreamingFastResourceLoading,
+                    expertStreamingFastResourceLoading
+                )
                 putDouble(
                     ProfileSettingsKey.expertStreamingSubstitutionThresholdPercent,
                     expertStreamingSubstitutionThresholdPercent

--- a/apps/omlx-mac/Sources/AppView/ViewModels/ModelSettingsScreenVM.swift
+++ b/apps/omlx-mac/Sources/AppView/ViewModels/ModelSettingsScreenVM.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SwiftUI
 
 @MainActor
@@ -109,6 +110,28 @@ final class ModelSettingsScreenVM {
             ("8", String(localized: "settings.turboquant.bits.8",
                          defaultValue: "8-bit",
                          comment: "TurboQuant KV bit-width option")),
+        ]
+    }
+
+    static var expertStreamingModeOptions: [(String, String)] {
+        [
+            ("soft_reap", String(localized: "settings.expert_streaming.mode.soft_reap",
+                                 defaultValue: "Soft-REAP pinning",
+                                 comment: "SSD expert streaming mode that pins experts selected by a manifest")),
+            ("cache_only", String(localized: "settings.expert_streaming.mode.cache_only",
+                                  defaultValue: "Analytical cache only",
+                                  comment: "SSD expert streaming mode with no automatically pinned experts")),
+        ]
+    }
+
+    static var expertStreamingExecutionPolicyOptions: [(String, String)] {
+        [
+            ("checked", String(localized: "settings.expert_streaming.policy.checked",
+                               defaultValue: "Checked",
+                               comment: "SSD expert streaming execution policy that verifies residency before dispatch")),
+            ("speculative", String(localized: "settings.expert_streaming.policy.speculative",
+                                   defaultValue: "Speculative",
+                                   comment: "SSD expert streaming execution policy that overlaps expert loading and dispatch")),
         ]
     }
 
@@ -241,6 +264,14 @@ final class ModelSettingsScreenVM {
     var qwen4PleSsdOffload: Bool = false
     var qwen4PleSsdOffloadSupported: Bool = false
     var qwen4PleSsdOffloadForced: Bool = false
+    var expertStreamingEnabled: Bool = false
+    var expertStreamingMode: String = "soft_reap"
+    var expertStreamingManifest: String = ""
+    var expertStreamingCacheExperts: String = "32"
+    var expertStreamingSubstitutionThresholdPercent: String = "0"
+    var expertStreamingExecutionPolicy: String = "checked"
+    var expertManifestUploadInProgress: Bool = false
+    var expertManifestSummary: String?
     var thinkingBudgetEnabled: Bool = false
     var thinkingBudgetTokens: String = "8192"
     var limitToolResults: Bool = false
@@ -376,6 +407,11 @@ final class ModelSettingsScreenVM {
         (model?.configModelType ?? "")
             .lowercased()
             .replacingOccurrences(of: "-", with: "_") == "qwen4_exp"
+    }
+
+    var expertManifestFileName: String {
+        guard !expertStreamingManifest.isEmpty else { return "" }
+        return (expertStreamingManifest as NSString).lastPathComponent
     }
 
     private func isDiffusionUnsupportedField(_ field: Field) -> Bool {
@@ -516,6 +552,14 @@ final class ModelSettingsScreenVM {
                     m.qwen4PleSsdOffloadSupported ?? false
                 self.qwen4PleSsdOffload = self.qwen4PleSsdOffloadForced
                     || (s?.qwen4PleSsdOffload ?? false)
+                self.expertStreamingEnabled = s?.expertStreamingEnabled ?? false
+                self.expertStreamingMode = s?.expertStreamingMode ?? "soft_reap"
+                self.expertStreamingManifest = s?.expertStreamingManifest ?? ""
+                self.expertStreamingCacheExperts = s?.expertStreamingCacheExperts.map(String.init) ?? "32"
+                self.expertStreamingSubstitutionThresholdPercent = s?.expertStreamingSubstitutionThresholdPercent
+                    .map { Self.formatPct($0) } ?? "0"
+                self.expertStreamingExecutionPolicy = s?.expertStreamingExecutionPolicy ?? "checked"
+                self.expertManifestSummary = nil
                 self.thinkingBudgetEnabled = s?.thinkingBudgetEnabled ?? false
                 self.thinkingBudgetTokens = s?.thinkingBudgetTokens.map(String.init) ?? "8192"
                 self.limitToolResults = (s?.maxToolResultTokens ?? 0) > 0
@@ -878,6 +922,49 @@ final class ModelSettingsScreenVM {
         }
     }
 
+    func uploadExpertManifest(url: URL, client: OMLXClient) async {
+        guard !expertManifestUploadInProgress else { return }
+        expertManifestUploadInProgress = true
+        defer { expertManifestUploadInProgress = false }
+
+        let accessed = url.startAccessingSecurityScopedResource()
+        defer {
+            if accessed { url.stopAccessingSecurityScopedResource() }
+        }
+
+        do {
+            let fileSize = try url.resourceValues(forKeys: [.fileSizeKey]).fileSize
+            guard (fileSize ?? 0) <= 2 * 1024 * 1024 else {
+                lastError = String(localized: "settings.expert_streaming.manifest.too_large",
+                                   defaultValue: "The expert manifest must be 2 MiB or smaller.",
+                                   comment: "Validation error when an expert manifest exceeds the upload limit")
+                return
+            }
+            let data = try Data(contentsOf: url, options: .mappedIfSafe)
+            guard data.count <= 2 * 1024 * 1024 else {
+                lastError = String(localized: "settings.expert_streaming.manifest.too_large",
+                                   defaultValue: "The expert manifest must be 2 MiB or smaller.",
+                                   comment: "Validation error when an expert manifest exceeds the upload limit")
+                return
+            }
+            let response = try await client.uploadExpertManifest(
+                id: modelID,
+                fileName: url.lastPathComponent,
+                data: data
+            )
+            expertStreamingManifest = response.manifestPath
+            expertManifestSummary = String(
+                localized: "settings.expert_streaming.manifest.summary",
+                defaultValue: "\(response.layers) layers · \(response.pinnedCountMin)–\(response.pinnedCountMax) pinned experts per layer",
+                comment: "Summary shown after a Soft-REAP expert manifest is validated and uploaded"
+            )
+            profileDirty = true
+            lastError = nil
+        } catch {
+            lastError = error.omlxDescription
+        }
+    }
+
     /// Stage the best tuner result in the working profile. The user can then
     /// update the active profile or save it as a new one without detaching the
     /// model from its current profile via a direct settings write.
@@ -1152,6 +1239,22 @@ final class ModelSettingsScreenVM {
 
         // Model-specific — experimental
         if !isDiffusion {
+            putBool(ProfileSettingsKey.expertStreamingEnabled, expertStreamingEnabled)
+            if expertStreamingEnabled {
+                putString(ProfileSettingsKey.expertStreamingMode, expertStreamingMode)
+                if expertStreamingMode == "soft_reap" {
+                    putString(ProfileSettingsKey.expertStreamingManifest, expertStreamingManifest)
+                }
+                putInt(ProfileSettingsKey.expertStreamingCacheExperts, expertStreamingCacheExperts)
+                putDouble(
+                    ProfileSettingsKey.expertStreamingSubstitutionThresholdPercent,
+                    expertStreamingSubstitutionThresholdPercent
+                )
+                putString(
+                    ProfileSettingsKey.expertStreamingExecutionPolicy,
+                    expertStreamingExecutionPolicy
+                )
+            }
             putBool(ProfileSettingsKey.turboquantKvEnabled, turboquantKvEnabled)
             if turboquantKvEnabled, let bits = Double(turboquantKvBits) {
                 out[ProfileSettingsKey.turboquantKvBits] = AnyCodable(bits)
@@ -1352,7 +1455,7 @@ final class ModelSettingsScreenVM {
     func saveWorkingAs(scope: ProfileScope, name: String, client: OMLXClient) async {
         let cleanName = name.trimmingCharacters(in: .whitespaces)
         guard !cleanName.isEmpty, scope != .preset else { return }
-        guard validateQwenAneWorkingSettings() else { return }
+        guard validateQwenAneWorkingSettings(), validateExpertStreamingWorkingSettings() else { return }
         let settings = currentSettingsDict()
         do {
             switch scope {
@@ -1399,7 +1502,7 @@ final class ModelSettingsScreenVM {
     /// ProfileDetailCard preview's "Update with working" button.
     func updateProfileWithWorking(scope: ProfileScope, name: String, client: OMLXClient) async {
         guard scope != .preset else { return }
-        guard validateQwenAneWorkingSettings() else { return }
+        guard validateQwenAneWorkingSettings(), validateExpertStreamingWorkingSettings() else { return }
         let settings = currentSettingsDict()
         do {
             switch scope {
@@ -1474,6 +1577,45 @@ final class ModelSettingsScreenVM {
         case .success: return true
         case .failure(let error): lastError = error.message; return false
         }
+    }
+
+    private func validateExpertStreamingWorkingSettings() -> Bool {
+        guard expertStreamingEnabled else { return true }
+        guard Self.expertStreamingModeOptions.contains(where: { $0.0 == expertStreamingMode }) else {
+            lastError = String(localized: "settings.expert_streaming.validation.mode",
+                               defaultValue: "Choose a valid SSD Expert Streaming mode.",
+                               comment: "Validation error for an unknown SSD expert streaming mode")
+            return false
+        }
+        if expertStreamingMode == "soft_reap",
+           expertStreamingManifest.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            lastError = String(localized: "settings.expert_streaming.validation.manifest",
+                               defaultValue: "Choose a Soft-REAP expert manifest before saving.",
+                               comment: "Validation error when Soft-REAP mode has no expert manifest")
+            return false
+        }
+        guard let cacheExperts = Int(expertStreamingCacheExperts), (0...512).contains(cacheExperts) else {
+            lastError = String(localized: "settings.expert_streaming.validation.cache",
+                               defaultValue: "Hot cache size must be a whole number from 0 to 512 experts per layer.",
+                               comment: "Validation error for SSD expert streaming hot cache size")
+            return false
+        }
+        guard let threshold = Double(expertStreamingSubstitutionThresholdPercent),
+              (0...100).contains(threshold) else {
+            lastError = String(localized: "settings.expert_streaming.validation.threshold",
+                               defaultValue: "Substitution threshold must be between 0% and 100%.",
+                               comment: "Validation error for SSD expert streaming substitution threshold")
+            return false
+        }
+        guard Self.expertStreamingExecutionPolicyOptions.contains(where: {
+            $0.0 == expertStreamingExecutionPolicy
+        }) else {
+            lastError = String(localized: "settings.expert_streaming.validation.policy",
+                               defaultValue: "Choose a valid SSD Expert Streaming execution policy.",
+                               comment: "Validation error for an unknown SSD expert streaming execution policy")
+            return false
+        }
+        return true
     }
 
     /// Discard working changes by reloading the server's view.

--- a/apps/omlx-mac/Sources/AppView/ViewModels/ModelSettingsScreenVM.swift
+++ b/apps/omlx-mac/Sources/AppView/ViewModels/ModelSettingsScreenVM.swift
@@ -268,6 +268,7 @@ final class ModelSettingsScreenVM {
     var expertStreamingMode: String = "soft_reap"
     var expertStreamingManifest: String = ""
     var expertStreamingCacheExperts: String = "32"
+    var expertStreamingScratchExperts: String = "32"
     var expertStreamingSubstitutionThresholdPercent: String = "0"
     var expertStreamingExecutionPolicy: String = "checked"
     var expertManifestUploadInProgress: Bool = false
@@ -556,6 +557,7 @@ final class ModelSettingsScreenVM {
                 self.expertStreamingMode = s?.expertStreamingMode ?? "soft_reap"
                 self.expertStreamingManifest = s?.expertStreamingManifest ?? ""
                 self.expertStreamingCacheExperts = s?.expertStreamingCacheExperts.map(String.init) ?? "32"
+                self.expertStreamingScratchExperts = s?.expertStreamingScratchExperts.map(String.init) ?? "32"
                 self.expertStreamingSubstitutionThresholdPercent = s?.expertStreamingSubstitutionThresholdPercent
                     .map { Self.formatPct($0) } ?? "0"
                 self.expertStreamingExecutionPolicy = s?.expertStreamingExecutionPolicy ?? "checked"
@@ -1246,6 +1248,7 @@ final class ModelSettingsScreenVM {
                     putString(ProfileSettingsKey.expertStreamingManifest, expertStreamingManifest)
                 }
                 putInt(ProfileSettingsKey.expertStreamingCacheExperts, expertStreamingCacheExperts)
+                putInt(ProfileSettingsKey.expertStreamingScratchExperts, expertStreamingScratchExperts)
                 putDouble(
                     ProfileSettingsKey.expertStreamingSubstitutionThresholdPercent,
                     expertStreamingSubstitutionThresholdPercent
@@ -1598,6 +1601,15 @@ final class ModelSettingsScreenVM {
             lastError = String(localized: "settings.expert_streaming.validation.cache",
                                defaultValue: "Hot cache size must be a whole number from 0 to 512 experts per layer.",
                                comment: "Validation error for SSD expert streaming hot cache size")
+            return false
+        }
+        guard let scratchExperts = Int(expertStreamingScratchExperts),
+              (0...512).contains(scratchExperts) else {
+            lastError = String(
+                localized: "settings.expert_streaming.validation.scratch",
+                defaultValue: "Cold execution size must be a whole number from 0 to 512 experts per layer.",
+                comment: "Validation error for SSD expert streaming scratch size"
+            )
             return false
         }
         guard let threshold = Double(expertStreamingSubstitutionThresholdPercent),

--- a/apps/omlx-mac/Sources/Net/DTO/ModelsDTO.swift
+++ b/apps/omlx-mac/Sources/Net/DTO/ModelsDTO.swift
@@ -98,6 +98,7 @@ struct ModelSettingsDTO: Codable, Equatable, Sendable {
     let expertStreamingMode: String?
     let expertStreamingManifest: String?
     let expertStreamingCacheExperts: Int?
+    let expertStreamingScratchExperts: Int?
     let expertStreamingSubstitutionThresholdPercent: Double?
     let expertStreamingExecutionPolicy: String?
     let thinkingBudgetEnabled: Bool?
@@ -192,6 +193,7 @@ struct ModelSettingsPatch: Encodable, Equatable, Sendable {
     var expertStreamingMode: String? = nil
     var expertStreamingManifest: String? = nil
     var expertStreamingCacheExperts: Int? = nil
+    var expertStreamingScratchExperts: Int? = nil
     var expertStreamingSubstitutionThresholdPercent: Double? = nil
     var expertStreamingExecutionPolicy: String? = nil
     var thinkingBudgetEnabled: Bool? = nil

--- a/apps/omlx-mac/Sources/Net/DTO/ModelsDTO.swift
+++ b/apps/omlx-mac/Sources/Net/DTO/ModelsDTO.swift
@@ -99,6 +99,7 @@ struct ModelSettingsDTO: Codable, Equatable, Sendable {
     let expertStreamingManifest: String?
     let expertStreamingCacheExperts: Int?
     let expertStreamingScratchExperts: Int?
+    let expertStreamingFastResourceLoading: Bool?
     let expertStreamingSubstitutionThresholdPercent: Double?
     let expertStreamingExecutionPolicy: String?
     let thinkingBudgetEnabled: Bool?
@@ -194,6 +195,7 @@ struct ModelSettingsPatch: Encodable, Equatable, Sendable {
     var expertStreamingManifest: String? = nil
     var expertStreamingCacheExperts: Int? = nil
     var expertStreamingScratchExperts: Int? = nil
+    var expertStreamingFastResourceLoading: Bool? = nil
     var expertStreamingSubstitutionThresholdPercent: Double? = nil
     var expertStreamingExecutionPolicy: String? = nil
     var thinkingBudgetEnabled: Bool? = nil

--- a/apps/omlx-mac/Sources/Net/DTO/ModelsDTO.swift
+++ b/apps/omlx-mac/Sources/Net/DTO/ModelsDTO.swift
@@ -57,6 +57,10 @@ struct ModelDTO: Codable, Equatable, Sendable, Identifiable {
     let qwen4PleSsdOffloadForced: Bool?
     let qwen4PleResidentBytes: Int64?
     let qwen4PleMmapBytes: Int64?
+    /// MoE expert streaming capability and the currently projected resident
+    /// footprint for pinned experts, PLE, and configured hot-cache slots.
+    let expertStreamingSupported: Bool?
+    let expertStreamingResidentBytes: Int64?
     /// True for builtin virtual entries (e.g. the MarkItDown document
     /// converter) that have no real load/unload lifecycle.
     let virtual: Bool?
@@ -89,6 +93,13 @@ struct ModelSettingsDTO: Codable, Equatable, Sendable {
     let maxToolResultTokens: Int?
     let enableThinking: Bool?
     let qwen4PleSsdOffload: Bool?
+    // SSD Expert Streaming / Soft-REAP
+    let expertStreamingEnabled: Bool?
+    let expertStreamingMode: String?
+    let expertStreamingManifest: String?
+    let expertStreamingCacheExperts: Int?
+    let expertStreamingSubstitutionThresholdPercent: Double?
+    let expertStreamingExecutionPolicy: String?
     let thinkingBudgetEnabled: Bool?
     let thinkingBudgetTokens: Int?
     let reasoningParser: String?
@@ -176,6 +187,13 @@ struct ModelSettingsPatch: Encodable, Equatable, Sendable {
     var ttlSeconds: Int? = nil
     var enableThinking: Bool? = nil
     var qwen4PleSsdOffload: Bool? = nil
+    // SSD Expert Streaming / Soft-REAP
+    var expertStreamingEnabled: Bool? = nil
+    var expertStreamingMode: String? = nil
+    var expertStreamingManifest: String? = nil
+    var expertStreamingCacheExperts: Int? = nil
+    var expertStreamingSubstitutionThresholdPercent: Double? = nil
+    var expertStreamingExecutionPolicy: String? = nil
     var thinkingBudgetEnabled: Bool? = nil
     var thinkingBudgetTokens: Int? = nil
     var maxToolResultTokens: Int? = nil
@@ -238,6 +256,16 @@ struct ModelSettingsPatch: Encodable, Equatable, Sendable {
     var vlmMtpEnabled: Bool? = nil
     var vlmMtpDraftModel: String? = nil
     var vlmMtpDraftBlockSize: Int? = nil
+}
+
+/// Result returned after the server validates and stores a Soft-REAP JSON
+/// manifest for a model.
+struct ExpertManifestUploadResponse: Codable, Equatable, Sendable {
+    let success: Bool
+    let manifestPath: String
+    let layers: Int
+    let pinnedCountMin: Int
+    let pinnedCountMax: Int
 }
 
 /// Generic acknowledgment shape returned by non-streaming admin endpoints

--- a/apps/omlx-mac/Sources/Net/Endpoints.swift
+++ b/apps/omlx-mac/Sources/Net/Endpoints.swift
@@ -25,6 +25,7 @@ enum AdminAPI {
     static func loadModel(_ id: String) -> String   { "\(models)/\(id)/load" }
     static func unloadModel(_ id: String) -> String { "\(models)/\(id)/unload" }
     static func modelSettings(_ id: String) -> String { "\(models)/\(id)/settings" }
+    static func expertManifest(_ id: String) -> String { "\(models)/\(id)/expert-manifest" }
     static let reloadModels    = "\(prefix)/reload"
 
     static func modelProfiles(_ id: String) -> String { "\(models)/\(id)/profiles" }

--- a/apps/omlx-mac/Sources/Net/OMLXClient.swift
+++ b/apps/omlx-mac/Sources/Net/OMLXClient.swift
@@ -148,6 +148,32 @@ final class OMLXClient: ObservableObject {
         try await put(AdminAPI.modelSettings(id), body: patch)
     }
 
+    func uploadExpertManifest(
+        id: String,
+        fileName: String,
+        data: Data
+    ) async throws -> ExpertManifestUploadResponse {
+        let boundary = "omlx-\(UUID().uuidString)"
+        let safeFileName = fileName
+            .replacingOccurrences(of: "\r", with: "")
+            .replacingOccurrences(of: "\n", with: "")
+            .replacingOccurrences(of: "\"", with: "_")
+        var body = Data()
+        body.append(Data("--\(boundary)\r\n".utf8))
+        body.append(Data(
+            "Content-Disposition: form-data; name=\"file\"; filename=\"\(safeFileName)\"\r\n".utf8
+        ))
+        body.append(Data("Content-Type: application/json\r\n\r\n".utf8))
+        body.append(data)
+        body.append(Data("\r\n--\(boundary)--\r\n".utf8))
+        return try await request(
+            "POST",
+            path: AdminAPI.expertManifest(id),
+            body: body,
+            contentType: "multipart/form-data; boundary=\(boundary)"
+        )
+    }
+
     func listModelProfiles(id: String) async throws -> ProfileListResponse {
         try await get(AdminAPI.modelProfiles(id))
     }
@@ -543,6 +569,7 @@ final class OMLXClient: ObservableObject {
         path: String,
         query: [URLQueryItem] = [],
         body: Data?,
+        contentType: String? = nil,
         isRetry: Bool = false
     ) async throws -> T {
         var components = URLComponents()
@@ -557,7 +584,7 @@ final class OMLXClient: ObservableObject {
         req.httpMethod = method
         req.setValue("application/json", forHTTPHeaderField: "Accept")
         if body != nil {
-            req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            req.setValue(contentType ?? "application/json", forHTTPHeaderField: "Content-Type")
             req.httpBody = body
         }
 
@@ -569,7 +596,14 @@ final class OMLXClient: ObservableObject {
                 throw OMLXClientError.unauthenticated
             }
             try await login(apiKey: key)
-            return try await request(method, path: path, query: query, body: body, isRetry: true)
+            return try await request(
+                method,
+                path: path,
+                query: query,
+                body: body,
+                contentType: contentType,
+                isRetry: true
+            )
         }
 
         guard 200..<300 ~= http.statusCode else {

--- a/apps/omlx-mac/Tests/oMLXTests/MenubarControllerModelsTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/MenubarControllerModelsTests.swift
@@ -226,6 +226,8 @@ final class MenubarControllerModelsTests: XCTestCase {
             qwen4PleSsdOffloadForced: nil,
             qwen4PleResidentBytes: nil,
             qwen4PleMmapBytes: nil,
+            expertStreamingSupported: nil,
+            expertStreamingResidentBytes: nil,
             virtual: virtual,
             settings: nil
         )

--- a/apps/omlx-mac/Tests/oMLXTests/ModelSettingsScreenVMTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/ModelSettingsScreenVMTests.swift
@@ -260,6 +260,95 @@ final class ModelSettingsScreenVMTests: XCTestCase {
         XCTAssertEqual(object?["qwen4_ple_ssd_offload"] as? Bool, true)
     }
 
+    func testExpertStreamingDefaultsAndOptions() {
+        let vm = ModelSettingsScreenVM()
+
+        XCTAssertFalse(vm.expertStreamingEnabled)
+        XCTAssertEqual(vm.expertStreamingMode, "soft_reap")
+        XCTAssertEqual(vm.expertStreamingCacheExperts, "32")
+        XCTAssertEqual(vm.expertStreamingSubstitutionThresholdPercent, "0")
+        XCTAssertEqual(vm.expertStreamingExecutionPolicy, "checked")
+        XCTAssertEqual(
+            ModelSettingsScreenVM.expertStreamingModeOptions.map(\.0),
+            ["soft_reap", "cache_only"]
+        )
+        XCTAssertEqual(
+            ModelSettingsScreenVM.expertStreamingExecutionPolicyOptions.map(\.0),
+            ["checked", "speculative"]
+        )
+    }
+
+    func testExpertStreamingWireKeysDecodeAndEncode() throws {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let dto = try decoder.decode(
+            ModelSettingsDTO.self,
+            from: Data(#"""
+            {
+              "expert_streaming_enabled": true,
+              "expert_streaming_mode": "soft_reap",
+              "expert_streaming_manifest": "/tmp/manifest.json",
+              "expert_streaming_cache_experts": 48,
+              "expert_streaming_substitution_threshold_percent": 2.5,
+              "expert_streaming_execution_policy": "speculative"
+            }
+            """#.utf8)
+        )
+        XCTAssertEqual(dto.expertStreamingEnabled, true)
+        XCTAssertEqual(dto.expertStreamingMode, "soft_reap")
+        XCTAssertEqual(dto.expertStreamingManifest, "/tmp/manifest.json")
+        XCTAssertEqual(dto.expertStreamingCacheExperts, 48)
+        XCTAssertEqual(dto.expertStreamingSubstitutionThresholdPercent, 2.5)
+        XCTAssertEqual(dto.expertStreamingExecutionPolicy, "speculative")
+
+        var patch = ModelSettingsPatch()
+        patch.expertStreamingEnabled = true
+        patch.expertStreamingMode = "cache_only"
+        patch.expertStreamingCacheExperts = 64
+        patch.expertStreamingSubstitutionThresholdPercent = 1.25
+        patch.expertStreamingExecutionPolicy = "checked"
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        let object = try JSONSerialization.jsonObject(with: encoder.encode(patch)) as? [String: Any]
+        XCTAssertEqual(object?["expert_streaming_enabled"] as? Bool, true)
+        XCTAssertEqual(object?["expert_streaming_mode"] as? String, "cache_only")
+        XCTAssertEqual(object?["expert_streaming_cache_experts"] as? Int, 64)
+        XCTAssertEqual(object?["expert_streaming_substitution_threshold_percent"] as? Double, 1.25)
+        XCTAssertEqual(object?["expert_streaming_execution_policy"] as? String, "checked")
+    }
+
+    func testSoftReapSettingsAreIncludedInWorkingProfile() {
+        let vm = ModelSettingsScreenVM()
+        vm.expertStreamingEnabled = true
+        vm.expertStreamingMode = "soft_reap"
+        vm.expertStreamingManifest = "/manifests/qwen.json"
+        vm.expertStreamingCacheExperts = "40"
+        vm.expertStreamingSubstitutionThresholdPercent = "3.5"
+        vm.expertStreamingExecutionPolicy = "speculative"
+
+        let settings = vm.currentSettingsDict()
+
+        XCTAssertEqual(settings["expert_streaming_enabled"]?.value as? Bool, true)
+        XCTAssertEqual(settings["expert_streaming_mode"]?.value as? String, "soft_reap")
+        XCTAssertEqual(settings["expert_streaming_manifest"]?.value as? String, "/manifests/qwen.json")
+        XCTAssertEqual(settings["expert_streaming_cache_experts"]?.value as? Int, 40)
+        XCTAssertEqual(settings["expert_streaming_substitution_threshold_percent"]?.value as? Double, 3.5)
+        XCTAssertEqual(settings["expert_streaming_execution_policy"]?.value as? String, "speculative")
+    }
+
+    func testCacheOnlyProfileDoesNotPersistManifest() {
+        let vm = ModelSettingsScreenVM()
+        vm.expertStreamingEnabled = true
+        vm.expertStreamingMode = "cache_only"
+        vm.expertStreamingManifest = "/manifests/old.json"
+
+        let settings = vm.currentSettingsDict()
+
+        XCTAssertEqual(settings["expert_streaming_enabled"]?.value as? Bool, true)
+        XCTAssertEqual(settings["expert_streaming_mode"]?.value as? String, "cache_only")
+        XCTAssertNil(settings["expert_streaming_manifest"])
+    }
+
     func testQwenAneSettingsDecodeFromServerAndEncodeForPatch() throws {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
@@ -367,6 +456,8 @@ final class ModelSettingsScreenVMTests: XCTestCase {
             qwen4PleSsdOffloadForced: nil,
             qwen4PleResidentBytes: nil,
             qwen4PleMmapBytes: nil,
+            expertStreamingSupported: nil,
+            expertStreamingResidentBytes: nil,
             virtual: nil,
             settings: nil
         )

--- a/apps/omlx-mac/Tests/oMLXTests/ModelSettingsScreenVMTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/ModelSettingsScreenVMTests.swift
@@ -267,6 +267,7 @@ final class ModelSettingsScreenVMTests: XCTestCase {
         XCTAssertEqual(vm.expertStreamingMode, "soft_reap")
         XCTAssertEqual(vm.expertStreamingCacheExperts, "32")
         XCTAssertEqual(vm.expertStreamingScratchExperts, "32")
+        XCTAssertFalse(vm.expertStreamingFastResourceLoading)
         XCTAssertEqual(vm.expertStreamingSubstitutionThresholdPercent, "0")
         XCTAssertEqual(vm.expertStreamingExecutionPolicy, "checked")
         XCTAssertEqual(
@@ -291,6 +292,7 @@ final class ModelSettingsScreenVMTests: XCTestCase {
               "expert_streaming_manifest": "/tmp/manifest.json",
               "expert_streaming_cache_experts": 48,
               "expert_streaming_scratch_experts": 24,
+              "expert_streaming_fast_resource_loading": true,
               "expert_streaming_substitution_threshold_percent": 2.5,
               "expert_streaming_execution_policy": "speculative"
             }
@@ -301,6 +303,7 @@ final class ModelSettingsScreenVMTests: XCTestCase {
         XCTAssertEqual(dto.expertStreamingManifest, "/tmp/manifest.json")
         XCTAssertEqual(dto.expertStreamingCacheExperts, 48)
         XCTAssertEqual(dto.expertStreamingScratchExperts, 24)
+        XCTAssertEqual(dto.expertStreamingFastResourceLoading, true)
         XCTAssertEqual(dto.expertStreamingSubstitutionThresholdPercent, 2.5)
         XCTAssertEqual(dto.expertStreamingExecutionPolicy, "speculative")
 
@@ -309,6 +312,7 @@ final class ModelSettingsScreenVMTests: XCTestCase {
         patch.expertStreamingMode = "cache_only"
         patch.expertStreamingCacheExperts = 64
         patch.expertStreamingScratchExperts = 16
+        patch.expertStreamingFastResourceLoading = true
         patch.expertStreamingSubstitutionThresholdPercent = 1.25
         patch.expertStreamingExecutionPolicy = "checked"
         let encoder = JSONEncoder()
@@ -318,6 +322,7 @@ final class ModelSettingsScreenVMTests: XCTestCase {
         XCTAssertEqual(object?["expert_streaming_mode"] as? String, "cache_only")
         XCTAssertEqual(object?["expert_streaming_cache_experts"] as? Int, 64)
         XCTAssertEqual(object?["expert_streaming_scratch_experts"] as? Int, 16)
+        XCTAssertEqual(object?["expert_streaming_fast_resource_loading"] as? Bool, true)
         XCTAssertEqual(object?["expert_streaming_substitution_threshold_percent"] as? Double, 1.25)
         XCTAssertEqual(object?["expert_streaming_execution_policy"] as? String, "checked")
     }
@@ -329,6 +334,7 @@ final class ModelSettingsScreenVMTests: XCTestCase {
         vm.expertStreamingManifest = "/manifests/qwen.json"
         vm.expertStreamingCacheExperts = "40"
         vm.expertStreamingScratchExperts = "20"
+        vm.expertStreamingFastResourceLoading = true
         vm.expertStreamingSubstitutionThresholdPercent = "3.5"
         vm.expertStreamingExecutionPolicy = "speculative"
 
@@ -339,6 +345,7 @@ final class ModelSettingsScreenVMTests: XCTestCase {
         XCTAssertEqual(settings["expert_streaming_manifest"]?.value as? String, "/manifests/qwen.json")
         XCTAssertEqual(settings["expert_streaming_cache_experts"]?.value as? Int, 40)
         XCTAssertEqual(settings["expert_streaming_scratch_experts"]?.value as? Int, 20)
+        XCTAssertEqual(settings["expert_streaming_fast_resource_loading"]?.value as? Bool, true)
         XCTAssertEqual(settings["expert_streaming_substitution_threshold_percent"]?.value as? Double, 3.5)
         XCTAssertEqual(settings["expert_streaming_execution_policy"]?.value as? String, "speculative")
     }

--- a/apps/omlx-mac/Tests/oMLXTests/ModelSettingsScreenVMTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/ModelSettingsScreenVMTests.swift
@@ -266,6 +266,7 @@ final class ModelSettingsScreenVMTests: XCTestCase {
         XCTAssertFalse(vm.expertStreamingEnabled)
         XCTAssertEqual(vm.expertStreamingMode, "soft_reap")
         XCTAssertEqual(vm.expertStreamingCacheExperts, "32")
+        XCTAssertEqual(vm.expertStreamingScratchExperts, "32")
         XCTAssertEqual(vm.expertStreamingSubstitutionThresholdPercent, "0")
         XCTAssertEqual(vm.expertStreamingExecutionPolicy, "checked")
         XCTAssertEqual(
@@ -289,6 +290,7 @@ final class ModelSettingsScreenVMTests: XCTestCase {
               "expert_streaming_mode": "soft_reap",
               "expert_streaming_manifest": "/tmp/manifest.json",
               "expert_streaming_cache_experts": 48,
+              "expert_streaming_scratch_experts": 24,
               "expert_streaming_substitution_threshold_percent": 2.5,
               "expert_streaming_execution_policy": "speculative"
             }
@@ -298,6 +300,7 @@ final class ModelSettingsScreenVMTests: XCTestCase {
         XCTAssertEqual(dto.expertStreamingMode, "soft_reap")
         XCTAssertEqual(dto.expertStreamingManifest, "/tmp/manifest.json")
         XCTAssertEqual(dto.expertStreamingCacheExperts, 48)
+        XCTAssertEqual(dto.expertStreamingScratchExperts, 24)
         XCTAssertEqual(dto.expertStreamingSubstitutionThresholdPercent, 2.5)
         XCTAssertEqual(dto.expertStreamingExecutionPolicy, "speculative")
 
@@ -305,6 +308,7 @@ final class ModelSettingsScreenVMTests: XCTestCase {
         patch.expertStreamingEnabled = true
         patch.expertStreamingMode = "cache_only"
         patch.expertStreamingCacheExperts = 64
+        patch.expertStreamingScratchExperts = 16
         patch.expertStreamingSubstitutionThresholdPercent = 1.25
         patch.expertStreamingExecutionPolicy = "checked"
         let encoder = JSONEncoder()
@@ -313,6 +317,7 @@ final class ModelSettingsScreenVMTests: XCTestCase {
         XCTAssertEqual(object?["expert_streaming_enabled"] as? Bool, true)
         XCTAssertEqual(object?["expert_streaming_mode"] as? String, "cache_only")
         XCTAssertEqual(object?["expert_streaming_cache_experts"] as? Int, 64)
+        XCTAssertEqual(object?["expert_streaming_scratch_experts"] as? Int, 16)
         XCTAssertEqual(object?["expert_streaming_substitution_threshold_percent"] as? Double, 1.25)
         XCTAssertEqual(object?["expert_streaming_execution_policy"] as? String, "checked")
     }
@@ -323,6 +328,7 @@ final class ModelSettingsScreenVMTests: XCTestCase {
         vm.expertStreamingMode = "soft_reap"
         vm.expertStreamingManifest = "/manifests/qwen.json"
         vm.expertStreamingCacheExperts = "40"
+        vm.expertStreamingScratchExperts = "20"
         vm.expertStreamingSubstitutionThresholdPercent = "3.5"
         vm.expertStreamingExecutionPolicy = "speculative"
 
@@ -332,6 +338,7 @@ final class ModelSettingsScreenVMTests: XCTestCase {
         XCTAssertEqual(settings["expert_streaming_mode"]?.value as? String, "soft_reap")
         XCTAssertEqual(settings["expert_streaming_manifest"]?.value as? String, "/manifests/qwen.json")
         XCTAssertEqual(settings["expert_streaming_cache_experts"]?.value as? Int, 40)
+        XCTAssertEqual(settings["expert_streaming_scratch_experts"]?.value as? Int, 20)
         XCTAssertEqual(settings["expert_streaming_substitution_threshold_percent"]?.value as? Double, 3.5)
         XCTAssertEqual(settings["expert_streaming_execution_policy"]?.value as? String, "speculative")
     }

--- a/apps/omlx-mac/Tests/oMLXTests/ModelsScreenSortingTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/ModelsScreenSortingTests.swift
@@ -68,6 +68,8 @@ final class ModelsScreenSortingTests: XCTestCase {
             qwen4PleSsdOffloadForced: nil,
             qwen4PleResidentBytes: nil,
             qwen4PleMmapBytes: nil,
+            expertStreamingSupported: nil,
+            expertStreamingResidentBytes: nil,
             virtual: nil,
             settings: nil
         )

--- a/benchmarks/expert_streaming_optimization_microbench.py
+++ b/benchmarks/expert_streaming_optimization_microbench.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import statistics
 import tempfile
 import time
 from collections.abc import Callable
@@ -68,6 +69,9 @@ def _pool(
     experts: int,
     top_k: int,
     cache_slots: int,
+    fuse_gate_up: bool = True,
+    scratch_slots: int = 0,
+    sort_prefill: bool = True,
 ) -> StreamingSwitchGLU:
     return StreamingSwitchGLU(
         layer=0,
@@ -82,6 +86,9 @@ def _pool(
         },
         activation=SwiGLU(),
         reader=reader,
+        fuse_gate_up=fuse_gate_up,
+        scratch_slots=scratch_slots,
+        sort_prefill=sort_prefill,
     )
 
 
@@ -111,6 +118,227 @@ def _eager_promote(pool: StreamingSwitchGLU, values: tuple[int, ...]) -> None:
         for part in pool.projection_metadata[projection]["parts"]
     ]
     mx.eval(*arrays, pool._slot_map, pool._resident_mask)
+
+
+def _gate_up_fusion_benchmark(
+    index: SafetensorExpertIndex,
+    *,
+    experts: int,
+    hidden: int,
+    top_k: int,
+    tokens: int,
+    repeats: int,
+) -> dict[str, Any]:
+    readers = [ExpertReader(index), ExpertReader(index)]
+    separate = _pool(
+        index,
+        readers[0],
+        experts=experts,
+        top_k=top_k,
+        cache_slots=128,
+        fuse_gate_up=False,
+    )
+    fused = _pool(
+        index,
+        readers[1],
+        experts=experts,
+        top_k=top_k,
+        cache_slots=128,
+        fuse_gate_up=True,
+    )
+    try:
+        _preload(separate, 128)
+        _preload(fused, 128)
+        x = mx.random.normal((1, tokens, hidden)).astype(mx.float16)
+        route = np.arange(tokens * top_k, dtype=np.int32) % 128
+        indices = mx.array(route.reshape(1, tokens, top_k))
+        scores = mx.full(
+            (1, tokens, top_k), 1.0 / top_k, dtype=mx.float16
+        )
+
+        def run(pool: StreamingSwitchGLU) -> mx.array:
+            output = None
+            for _ in range(repeats):
+                output = pool(x, indices, scores=scores, weighted_sum=True)
+                mx.eval(output)
+            return output
+
+        mx.eval(run(separate), run(fused))
+        separate.stats.qmm_calls = 0
+        fused.stats.qmm_calls = 0
+        separate_output, separate_s, _, _ = _timed(lambda: run(separate))
+        fused_output, fused_s, _, _ = _timed(lambda: run(fused))
+        return {
+            "exact": bool(mx.all(separate_output == fused_output).item()),
+            "tokens": tokens,
+            "repeats": repeats,
+            "separate_tokens_per_second": tokens * repeats / separate_s,
+            "fused_tokens_per_second": tokens * repeats / fused_s,
+            "speedup": separate_s / fused_s,
+            "separate_qmm_calls": separate.stats.qmm_calls,
+            "fused_qmm_calls": fused.stats.qmm_calls,
+        }
+    finally:
+        for reader in readers:
+            reader.close()
+
+
+def _scratch_preservation_benchmark(
+    index: SafetensorExpertIndex,
+    *,
+    experts: int,
+    hidden: int,
+    top_k: int,
+) -> dict[str, Any]:
+    readers = [ExpertReader(index), ExpertReader(index)]
+    polluting = _pool(
+        index,
+        readers[0],
+        experts=experts,
+        top_k=top_k,
+        cache_slots=128,
+    )
+    scratch = _pool(
+        index,
+        readers[1],
+        experts=experts,
+        top_k=top_k,
+        cache_slots=128,
+        scratch_slots=32,
+    )
+    try:
+        _preload(polluting, 128)
+        _preload(scratch, 128)
+        prefill_tokens = experts // top_k
+        x = mx.random.normal((1, prefill_tokens, hidden)).astype(mx.float16)
+        indices = mx.array(
+            np.arange(experts, dtype=np.int32).reshape(
+                1, prefill_tokens, top_k
+            )
+        )
+        scores = mx.full(
+            (1, prefill_tokens, top_k), 1.0 / top_k, dtype=mx.float16
+        )
+        decode_x = x[:, :1]
+        decode_indices = mx.array(
+            np.arange(96, 96 + top_k, dtype=np.int32).reshape(1, 1, top_k)
+        )
+        decode_scores = scores[:, :1]
+
+        def run(pool: StreamingSwitchGLU) -> tuple[mx.array, mx.array]:
+            prefill = pool(x, indices, scores=scores, weighted_sum=True)
+            mx.eval(prefill)
+            decode = pool(
+                decode_x,
+                decode_indices,
+                scores=decode_scores,
+                weighted_sum=True,
+            )
+            mx.eval(decode)
+            return prefill, decode
+
+        polluting_outputs, polluting_s, _, _ = _timed(lambda: run(polluting))
+        scratch_outputs, scratch_s, scratch_active, scratch_peak = _timed(
+            lambda: run(scratch)
+        )
+        exact = all(
+            bool(mx.all(left == right).item())
+            for left, right in zip(
+                polluting_outputs, scratch_outputs, strict=True
+            )
+        )
+        return {
+            "exact": exact,
+            "polluting_ms": polluting_s * 1000,
+            "scratch_ms": scratch_s * 1000,
+            "speedup": polluting_s / scratch_s,
+            "polluting_loads": polluting.stats.cold_loads,
+            "scratch_loads": scratch.stats.cold_loads,
+            "polluting_evictions": polluting.stats.evictions,
+            "scratch_evictions": scratch.stats.evictions,
+            "scratch_peak_delta_mib": (scratch_peak - scratch_active) / 1024**2,
+        }
+    finally:
+        for reader in readers:
+            reader.close()
+
+
+def _resident_slot_sort_benchmark(
+    index: SafetensorExpertIndex,
+    *,
+    experts: int,
+    hidden: int,
+    top_k: int,
+    tokens: int,
+    samples: int = 5,
+) -> dict[str, Any]:
+    readers = [ExpertReader(index), ExpertReader(index)]
+    unsorted = _pool(
+        index,
+        readers[0],
+        experts=experts,
+        top_k=top_k,
+        cache_slots=128,
+        sort_prefill=False,
+    )
+    sorted_pool = _pool(
+        index,
+        readers[1],
+        experts=experts,
+        top_k=top_k,
+        cache_slots=128,
+        sort_prefill=True,
+    )
+    try:
+        _preload(unsorted, 128)
+        _preload(sorted_pool, 128)
+        x = mx.random.normal((1, tokens, hidden)).astype(mx.float16)
+        indices_np = np.fromfunction(
+            lambda _batch, token, route: (token * 37 + route * 17) % 128,
+            (1, tokens, top_k),
+            dtype=int,
+        ).astype(np.int32)
+        indices = mx.array(indices_np)
+        scores = mx.full(
+            (1, tokens, top_k), 1.0 / top_k, dtype=mx.float16
+        )
+
+        def run(pool: StreamingSwitchGLU) -> mx.array:
+            return pool(x, indices, scores=scores, weighted_sum=True)
+
+        mx.eval(run(unsorted), run(sorted_pool))
+        unsorted_samples: list[float] = []
+        sorted_samples: list[float] = []
+        unsorted_output = sorted_output = None
+        for _ in range(samples):
+            unsorted_output, elapsed, _, _ = _timed(lambda: run(unsorted))
+            unsorted_samples.append(elapsed)
+            sorted_output, elapsed, _, _ = _timed(lambda: run(sorted_pool))
+            sorted_samples.append(elapsed)
+
+        delta = mx.abs(
+            sorted_output.astype(mx.float32) - unsorted_output.astype(mx.float32)
+        )
+        baseline = mx.abs(unsorted_output.astype(mx.float32))
+        mx.eval(delta, baseline)
+        unsorted_median = statistics.median(unsorted_samples)
+        sorted_median = statistics.median(sorted_samples)
+        return {
+            "tokens": tokens,
+            "samples": samples,
+            "all_finite": bool(mx.all(mx.isfinite(sorted_output)).item()),
+            "max_abs_delta_from_unsorted": float(delta.max().item()),
+            "mean_abs_delta_from_unsorted": float(delta.mean().item()),
+            "mean_abs_output": float(baseline.mean().item()),
+            "unsorted_tokens_per_second": tokens / unsorted_median,
+            "sorted_tokens_per_second": tokens / sorted_median,
+            "speedup": unsorted_median / sorted_median,
+            "sorted_groups": sorted_pool.stats.sorted_prefill_groups,
+            "sorted_qmm_calls": sorted_pool.stats.sorted_qmm_calls,
+        }
+    finally:
+        for reader in readers:
+            reader.close()
 
 
 def _promotion_benchmark(
@@ -704,6 +932,27 @@ def main() -> None:
                 "top_k": args.top_k,
             },
             "lazy_promotion": _promotion_benchmark(
+                index,
+                experts=args.experts,
+                hidden=args.hidden,
+                top_k=args.top_k,
+            ),
+            "resident_gate_up_fusion": _gate_up_fusion_benchmark(
+                index,
+                experts=args.experts,
+                hidden=args.hidden,
+                top_k=args.top_k,
+                tokens=args.prefill_tokens,
+                repeats=max(2, args.prefill_repeats),
+            ),
+            "resident_physical_slot_sort": _resident_slot_sort_benchmark(
+                index,
+                experts=args.experts,
+                hidden=args.hidden,
+                top_k=args.top_k,
+                tokens=args.prefill_tokens,
+            ),
+            "scratch_cache_preservation": _scratch_preservation_benchmark(
                 index,
                 experts=args.experts,
                 hidden=args.hidden,

--- a/benchmarks/expert_streaming_optimization_microbench.py
+++ b/benchmarks/expert_streaming_optimization_microbench.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+"""Bounded microbenchmarks for proposed SSD expert-streaming optimizations.
+
+This intentionally uses a synthetic one-shard checkpoint.  It exercises the
+real safetensor reader, cache, quantized expert banks, and speculative executor
+without loading a production model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+import time
+from collections.abc import Callable
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import mlx.core as mx
+import numpy as np
+from mlx_lm.models.switch_layers import SwiGLU
+
+from omlx.expert_streaming.execution import SpeculativeExecution
+from omlx.expert_streaming.pool import StreamingSwitchGLU
+from omlx.expert_streaming.safetensors import ExpertReader, SafetensorExpertIndex
+
+PROJECTIONS = (
+    ("gate_proj", "intermediate", "hidden"),
+    ("up_proj", "intermediate", "hidden"),
+    ("down_proj", "hidden", "intermediate"),
+)
+
+
+def _checkpoint(
+    path: Path,
+    *,
+    experts: int,
+    hidden: int,
+    intermediate: int,
+) -> None:
+    tensors: dict[str, mx.array] = {}
+    dimensions = {"hidden": hidden, "intermediate": intermediate}
+    for projection, output_name, input_name in PROJECTIONS:
+        dense = (
+            mx.random.normal((experts, dimensions[output_name], dimensions[input_name]))
+            / dimensions[input_name] ** 0.5
+        )
+        dense = dense.astype(mx.float16)
+        weight, scales, biases = mx.quantize(
+            dense, group_size=32, bits=4, mode="affine"
+        )
+        prefix = f"language_model.model.layers.0.mlp.switch_mlp.{projection}"
+        tensors[f"{prefix}.weight"] = weight
+        tensors[f"{prefix}.scales"] = scales
+        tensors[f"{prefix}.biases"] = biases
+    shard = "model.safetensors"
+    mx.save_safetensors(str(path / shard), tensors, metadata={"format": "mlx"})
+    (path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {key: shard for key in tensors}})
+    )
+
+
+def _pool(
+    index: SafetensorExpertIndex,
+    reader: ExpertReader,
+    *,
+    experts: int,
+    top_k: int,
+    cache_slots: int,
+) -> StreamingSwitchGLU:
+    return StreamingSwitchGLU(
+        layer=0,
+        num_experts=experts,
+        top_k=top_k,
+        pinned_experts=(),
+        cache_slots=cache_slots,
+        locations=index.layer(0),
+        projection_metadata={
+            name: {"group_size": 32, "bits": 4, "mode": "affine"}
+            for name in ("gate_proj", "up_proj", "down_proj")
+        },
+        activation=SwiGLU(),
+        reader=reader,
+    )
+
+
+def _timed(call: Callable[[], Any]) -> tuple[Any, float, int, int]:
+    mx.reset_peak_memory()
+    active = int(mx.get_active_memory())
+    started = time.perf_counter()
+    result = call()
+    arrays = result if isinstance(result, (list, tuple)) else [result]
+    mx.eval(*arrays)
+    mx.synchronize()
+    elapsed = time.perf_counter() - started
+    peak = int(mx.get_peak_memory())
+    return result, elapsed, active, peak
+
+
+def _preload(pool: StreamingSwitchGLU, count: int) -> None:
+    pool.preload_hotlist([(expert, count - expert) for expert in range(count)])
+
+
+def _eager_promote(pool: StreamingSwitchGLU, values: tuple[int, ...]) -> None:
+    """Reproduce the former eager bank commit for the comparison baseline."""
+    pool.promote(values)
+    arrays = [
+        pool._array(projection, part)
+        for projection, _, _ in PROJECTIONS
+        for part in pool.projection_metadata[projection]["parts"]
+    ]
+    mx.eval(*arrays, pool._slot_map, pool._resident_mask)
+
+
+def _promotion_benchmark(
+    index: SafetensorExpertIndex,
+    *,
+    experts: int,
+    hidden: int,
+    top_k: int,
+) -> dict[str, Any]:
+    del hidden
+    readers = [ExpertReader(index), ExpertReader(index)]
+    eager = _pool(index, readers[0], experts=experts, top_k=top_k, cache_slots=128)
+    lazy = _pool(index, readers[1], experts=experts, top_k=top_k, cache_slots=128)
+    try:
+        _preload(eager, 128)
+        _preload(lazy, 128)
+        x = mx.random.normal((1, 1, eager.gate_proj.input_dims)).astype(mx.float16)
+        scores = mx.full((1, 1, top_k), 1.0 / top_k, dtype=mx.float16)
+
+        def one(
+            pool: StreamingSwitchGLU,
+            promote: Callable[[StreamingSwitchGLU, tuple[int, ...]], None],
+            group: tuple[int, ...],
+        ) -> mx.array:
+            promote(pool, group)
+            indices = mx.array([[group]], dtype=mx.int32)
+            return pool(x, indices, scores=scores, weighted_sum=True)
+
+        # Compile the lazy-scatter and retry shapes before measurement.
+        warm_group = tuple(range(138, 138 + top_k))
+        mx.eval(one(eager, _eager_promote, warm_group))
+        mx.eval(one(lazy, lambda pool, values: pool.promote(values), warm_group))
+
+        groups = [
+            tuple(range(128, 128 + top_k)),
+            tuple(range(118, 118 + top_k)),
+        ] * 10
+
+        def run(
+            pool: StreamingSwitchGLU,
+            promote: Callable[[StreamingSwitchGLU, tuple[int, ...]], None],
+        ) -> list[mx.array]:
+            outputs = []
+            for group in groups:
+                output = one(pool, promote, group)
+                mx.eval(output)
+                outputs.append(output)
+            return outputs
+
+        eager_outputs, eager_s, eager_active, eager_peak = _timed(
+            lambda: run(eager, _eager_promote)
+        )
+        lazy_outputs, lazy_s, lazy_active, lazy_peak = _timed(
+            lambda: run(lazy, lambda pool, values: pool.promote(values))
+        )
+        exact = all(
+            bool(mx.all(left == right).item())
+            for left, right in zip(eager_outputs, lazy_outputs, strict=True)
+        )
+        return {
+            "exact": exact,
+            "iterations": len(groups),
+            "eager_ms_per_miss": eager_s * 1000 / len(groups),
+            "lazy_ms_per_miss": lazy_s * 1000 / len(groups),
+            "speedup": eager_s / lazy_s,
+            "eager_peak_delta_mib": (eager_peak - eager_active) / 1024**2,
+            "lazy_peak_delta_mib": (lazy_peak - lazy_active) / 1024**2,
+        }
+    finally:
+        for reader in readers:
+            reader.close()
+
+
+def _capped_forward(
+    pool: StreamingSwitchGLU,
+    x: mx.array,
+    indices: mx.array,
+    scores: mx.array,
+    *,
+    group_size: int,
+) -> mx.array:
+    values = pool._flatten_indices(indices)
+    configured = pool.cache_slots
+    try:
+        pool.cache_slots = group_size
+        output = pool._forward_expert_major(x, indices, values)
+    finally:
+        pool.cache_slots = configured
+    return (output * scores[..., None].astype(output.dtype)).sum(-2)
+
+
+def _prefill_benchmark(
+    index: SafetensorExpertIndex,
+    *,
+    experts: int,
+    hidden: int,
+    top_k: int,
+    tokens: int,
+    layers: int,
+    repeats: int,
+) -> dict[str, Any]:
+    readers = [ExpertReader(index) for _ in range(4)]
+    pools = {
+        "cache_group": _pool(
+            index, readers[0], experts=experts, top_k=top_k, cache_slots=128
+        ),
+        "capped_64": _pool(
+            index, readers[1], experts=experts, top_k=top_k, cache_slots=128
+        ),
+        "capped_96": _pool(
+            index, readers[2], experts=experts, top_k=top_k, cache_slots=128
+        ),
+        "capped_32": _pool(
+            index, readers[3], experts=experts, top_k=top_k, cache_slots=128
+        ),
+    }
+    try:
+        for pool in pools.values():
+            _preload(pool, 128)
+        indices_np = np.fromfunction(
+            lambda _batch, token, route: (token * top_k + route * 17) % 128,
+            (1, tokens, top_k),
+            dtype=int,
+        ).astype(np.int32)
+        indices = mx.array(indices_np)
+        scores = mx.full((1, tokens, top_k), 1.0 / top_k, dtype=mx.float16)
+        initial = mx.random.normal((1, tokens, hidden)).astype(mx.float16)
+
+        def stack(pool: StreamingSwitchGLU, *, cap: int | None) -> mx.array:
+            value = initial
+            for _ in range(layers):
+                value = (
+                    pool(value, indices, scores=scores, weighted_sum=True)
+                    if cap is None
+                    else _capped_forward(pool, value, indices, scores, group_size=cap)
+                )
+            return value
+
+        mx.eval(stack(pools["cache_group"], cap=None))
+        mx.eval(stack(pools["capped_96"], cap=96))
+        mx.eval(stack(pools["capped_64"], cap=64))
+        mx.eval(stack(pools["capped_32"], cap=32))
+
+        def repeated(pool: StreamingSwitchGLU, cap: int | None) -> list[mx.array]:
+            outputs = []
+            for _ in range(repeats):
+                output = stack(pool, cap=cap)
+                mx.eval(output)
+                outputs.append(output)
+            return outputs
+
+        measurements = {
+            "cache_group": _timed(lambda: repeated(pools["cache_group"], None)),
+            "capped_96": _timed(lambda: repeated(pools["capped_96"], 96)),
+            "capped_64": _timed(lambda: repeated(pools["capped_64"], 64)),
+            "capped_32": _timed(lambda: repeated(pools["capped_32"], 32)),
+        }
+        wide_outputs = measurements["cache_group"][0]
+        exact = {
+            name: all(
+                bool(mx.all(left == right).item())
+                for left, right in zip(wide_outputs, measurement[0], strict=True)
+            )
+            for name, measurement in measurements.items()
+            if name != "cache_group"
+        }
+        work_tokens = tokens * repeats
+        return {
+            "exact": exact,
+            "tokens": tokens,
+            "layers": layers,
+            "repeats": repeats,
+            "variants": {
+                name: {
+                    "tokens_per_second": work_tokens / measurement[1],
+                    "relative_throughput": (
+                        measurements["cache_group"][1] / measurement[1]
+                    ),
+                    "peak_delta_mib": (measurement[3] - measurement[2]) / 1024**2,
+                }
+                for name, measurement in measurements.items()
+            },
+        }
+    finally:
+        for reader in readers:
+            reader.close()
+
+
+class _Cache:
+    def __init__(self):
+        self.offset = 0
+
+
+class _DecodeModel:
+    def __init__(self, pools: list[StreamingSwitchGLU], top_k: int):
+        self.pools = pools
+        self.top_k = top_k
+
+    def __call__(self, input_ids: mx.array, cache: _Cache | None = None):
+        token = int(input_ids.item())
+        start = (token % 4) * self.top_k
+        indices = mx.array(
+            [[[start + route for route in range(self.top_k)]]], dtype=mx.int32
+        )
+        scores = mx.full((1, 1, self.top_k), 1.0 / self.top_k, dtype=mx.float16)
+        value = mx.full(
+            (1, 1, self.pools[0].gate_proj.input_dims),
+            (token + 1) / 32,
+            dtype=mx.float16,
+        )
+        if cache is not None:
+            cache.offset += 1
+        for pool in self.pools:
+            value = pool(value, indices, scores=scores, weighted_sum=True)
+        return SimpleNamespace(logits=value)
+
+
+class _UngatedSpeculativeExecution(SpeculativeExecution):
+    """Former behavior retained only as a microbenchmark baseline."""
+
+    def _cache_ready_for_speculation(self) -> bool:
+        return True
+
+
+def _reset_pool(pool: StreamingSwitchGLU) -> None:
+    pool._expert_to_slot.clear()
+    pool._dynamic_lru.clear()
+    pool._resident_mask_np[:] = False
+    pool._slot_map_np[:] = 0
+    pool._resident_mask = mx.array(pool._resident_mask_np)
+    pool._slot_map = mx.array(pool._slot_map_np)
+    pool._free_slots = list(range(pool.pinned_count, pool.pool_size))
+    pool._route_hotness[:] = 0
+    pool._route_counts[:] = 0
+    pool._last_used[:] = 0
+    pool._route_tokens = 0
+    pool._next_hotness_decay = pool._hotness_decay_interval
+    pool._access_clock = 0
+    pool._last_indices = None
+    pool._last_slots = None
+    pool.stats = type(pool.stats)()
+
+
+def _decode_variant(
+    model: _DecodeModel,
+    execution: SpeculativeExecution,
+    *,
+    tokens: int,
+) -> tuple[list[mx.array], float, int, int, dict[str, int]]:
+    cache = _Cache()
+    # Compile the model and speculative wrapper, then return to a cold cache.
+    mx.eval(model(mx.array([[3]], dtype=mx.int32), cache=cache).logits)
+    for pool in model.pools:
+        _reset_pool(pool)
+    execution._has_checked_pass = False
+    execution._cache_fill_ready = False
+    execution.stats = type(execution.stats)()
+    cache.offset = 0
+
+    def run() -> list[mx.array]:
+        outputs = []
+        for token in range(tokens):
+            result = model(mx.array([[token]], dtype=mx.int32), cache=cache)
+            mx.eval(result.logits)
+            outputs.append(result.logits)
+        return outputs
+
+    outputs, elapsed, active, peak = _timed(run)
+    assert cache.offset == tokens
+    return outputs, elapsed, active, peak, execution.stats.as_dict()
+
+
+def _fill_gated_speculation_benchmark(
+    index: SafetensorExpertIndex,
+    *,
+    experts: int,
+    top_k: int,
+    tokens: int,
+) -> dict[str, Any]:
+    readers = [ExpertReader(index), ExpertReader(index)]
+    pool_sets = [
+        [
+            _pool(index, reader, experts=experts, top_k=top_k, cache_slots=40)
+            for _ in range(4)
+        ]
+        for reader in readers
+    ]
+    runtimes = [SimpleNamespace(pools=pools) for pools in pool_sets]
+    models = [_DecodeModel(pools, top_k) for pools in pool_sets]
+    executions = [
+        _UngatedSpeculativeExecution(runtimes[0], policy="speculative"),
+        SpeculativeExecution(runtimes[1], policy="speculative"),
+    ]
+    for execution, model in zip(executions, models, strict=True):
+        execution.attach(model)
+    try:
+        ungated = _decode_variant(models[0], executions[0], tokens=tokens)
+        gated = _decode_variant(models[1], executions[1], tokens=tokens)
+        ungated_outputs, ungated_s, ungated_active, ungated_peak, ungated_stats = (
+            ungated
+        )
+        gated_outputs, gated_s, gated_active, gated_peak, gated_stats = gated
+        exact = all(
+            bool(mx.all(left == right).item())
+            for left, right in zip(ungated_outputs, gated_outputs, strict=True)
+        )
+        return {
+            "exact": exact,
+            "tokens": tokens,
+            "ungated_tokens_per_second": tokens / ungated_s,
+            "fill_gated_tokens_per_second": tokens / gated_s,
+            "speedup": ungated_s / gated_s,
+            "ungated_peak_delta_mib": (ungated_peak - ungated_active) / 1024**2,
+            "fill_gated_peak_delta_mib": (gated_peak - gated_active) / 1024**2,
+            "ungated_execution": ungated_stats,
+            "fill_gated_execution": gated_stats,
+        }
+    finally:
+        for execution in executions:
+            execution.close()
+        for reader in readers:
+            reader.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--experts", type=int, default=160)
+    parser.add_argument("--hidden", type=int, default=1024)
+    parser.add_argument("--intermediate", type=int, default=256)
+    parser.add_argument("--top-k", type=int, default=10)
+    parser.add_argument("--prefill-tokens", type=int, default=256)
+    parser.add_argument("--prefill-layers", type=int, default=12)
+    parser.add_argument("--prefill-repeats", type=int, default=2)
+    parser.add_argument("--decode-tokens", type=int, default=12)
+    args = parser.parse_args()
+    if args.experts < 160:
+        parser.error("--experts must be at least 160")
+    if args.top_k > 10:
+        parser.error("--top-k must be at most 10 for the default route fixtures")
+
+    mx.random.seed(0)
+
+    with tempfile.TemporaryDirectory(prefix="omlx-expert-microbench-") as temporary:
+        path = Path(temporary)
+        _checkpoint(
+            path,
+            experts=args.experts,
+            hidden=args.hidden,
+            intermediate=args.intermediate,
+        )
+        index = SafetensorExpertIndex(path)
+        started = time.perf_counter()
+        report = {
+            "geometry": {
+                "experts": args.experts,
+                "hidden": args.hidden,
+                "intermediate": args.intermediate,
+                "top_k": args.top_k,
+            },
+            "lazy_promotion": _promotion_benchmark(
+                index,
+                experts=args.experts,
+                hidden=args.hidden,
+                top_k=args.top_k,
+            ),
+            "prefill_group_cap": _prefill_benchmark(
+                index,
+                experts=args.experts,
+                hidden=args.hidden,
+                top_k=args.top_k,
+                tokens=args.prefill_tokens,
+                layers=args.prefill_layers,
+                repeats=args.prefill_repeats,
+            ),
+            "fill_gated_speculation": _fill_gated_speculation_benchmark(
+                index,
+                experts=args.experts,
+                top_k=args.top_k,
+                tokens=args.decode_tokens,
+            ),
+        }
+        report["wall_seconds"] = time.perf_counter() - started
+        report["peak_mib"] = mx.get_peak_memory() / 1024**2
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/expert_streaming_optimization_microbench.py
+++ b/benchmarks/expert_streaming_optimization_microbench.py
@@ -305,13 +305,20 @@ class _Cache:
 
 
 class _DecodeModel:
-    def __init__(self, pools: list[StreamingSwitchGLU], top_k: int):
+    def __init__(
+        self,
+        pools: list[StreamingSwitchGLU],
+        top_k: int,
+        *,
+        route_groups: int = 4,
+    ):
         self.pools = pools
         self.top_k = top_k
+        self.route_groups = route_groups
 
     def __call__(self, input_ids: mx.array, cache: _Cache | None = None):
         token = int(input_ids.item())
-        start = (token % 4) * self.top_k
+        start = (token % self.route_groups) * self.top_k
         indices = mx.array(
             [[[start + route for route in range(self.top_k)]]], dtype=mx.int32
         )
@@ -332,6 +339,42 @@ class _UngatedSpeculativeExecution(SpeculativeExecution):
     """Former behavior retained only as a microbenchmark baseline."""
 
     def _cache_ready_for_speculation(self) -> bool:
+        return True
+
+
+class _WorkingSetSpeculativeExecution(SpeculativeExecution):
+    """Prototype readiness based on observed resident-route coverage."""
+
+    def __init__(
+        self,
+        runtime: Any,
+        *,
+        policy: str,
+        min_observed_tokens: int = 4,
+        minimum_coverage: float = 0.95,
+    ):
+        super().__init__(runtime, policy=policy)
+        self.min_observed_tokens = min_observed_tokens
+        self.minimum_coverage = minimum_coverage
+
+    def _cache_ready_for_speculation(self) -> bool:
+        if self._cache_fill_ready:
+            return True
+        for pool in self.runtime.pools:
+            if pool._route_tokens < self.min_observed_tokens:
+                return False
+            total = int(np.sum(pool._route_hotness, dtype=np.uint64))
+            if total <= 0:
+                return False
+            resident = int(
+                np.sum(
+                    pool._route_hotness[pool._resident_mask_np],
+                    dtype=np.uint64,
+                )
+            )
+            if resident / total < self.minimum_coverage:
+                return False
+        self._cache_fill_ready = True
         return True
 
 
@@ -435,6 +478,194 @@ def _fill_gated_speculation_benchmark(
             reader.close()
 
 
+def _capacity_scaling_benchmark(
+    index: SafetensorExpertIndex,
+    *,
+    experts: int,
+    top_k: int,
+    tokens: int,
+    prefill_tokens: int,
+) -> dict[str, Any]:
+    """Isolate hot-bank width and capacity-independent speculation readiness."""
+    readers = [ExpertReader(index) for _ in range(4)]
+    hot_pool_sets = [
+        [
+            _pool(
+                index,
+                readers[variant],
+                experts=experts,
+                top_k=top_k,
+                cache_slots=capacity,
+            )
+            for _ in range(4)
+        ]
+        for variant, capacity in enumerate((32, 128))
+    ]
+    gate_pool_sets = [
+        [
+            _pool(
+                index,
+                readers[variant + 2],
+                experts=experts,
+                top_k=top_k,
+                cache_slots=128,
+            )
+            for _ in range(4)
+        ]
+        for variant in range(2)
+    ]
+    hot_models = [_DecodeModel(pools, top_k, route_groups=3) for pools in hot_pool_sets]
+    gate_models = [_DecodeModel(pools, top_k) for pools in gate_pool_sets]
+    gate_runtimes = [SimpleNamespace(pools=pools) for pools in gate_pool_sets]
+    gate_executions = [
+        SpeculativeExecution(gate_runtimes[0], policy="speculative"),
+        _WorkingSetSpeculativeExecution(
+            gate_runtimes[1],
+            policy="speculative",
+            min_observed_tokens=4,
+        ),
+    ]
+    for execution, model in zip(gate_executions, gate_models, strict=True):
+        execution.attach(model)
+
+    try:
+        hot_count = top_k * 3
+        for pools in hot_pool_sets:
+            for pool in pools:
+                _preload(pool, hot_count)
+
+        def hot_run(model: _DecodeModel, run_tokens: int = tokens) -> list[mx.array]:
+            cache = _Cache()
+            outputs = []
+            for token in range(run_tokens):
+                result = model(mx.array([[token]], dtype=mx.int32), cache=cache)
+                mx.eval(result.logits)
+                outputs.append(result.logits)
+            assert cache.offset == run_tokens
+            return outputs
+
+        # Compile both fixed bank shapes before measuring identical hot routes.
+        mx.eval(hot_models[0](mx.array([[0]], dtype=mx.int32)).logits)
+        mx.eval(hot_models[1](mx.array([[0]], dtype=mx.int32)).logits)
+        hot_32 = _timed(lambda: hot_run(hot_models[0]))
+        hot_128 = _timed(lambda: hot_run(hot_models[1]))
+        hot_exact = all(
+            bool(mx.all(left == right).item())
+            for left, right in zip(hot_32[0], hot_128[0], strict=True)
+        )
+
+        prefill_indices_np = np.fromfunction(
+            lambda _batch, token, route: (token * top_k + route * 17) % 100,
+            (1, prefill_tokens, top_k),
+            dtype=int,
+        ).astype(np.int32)
+        prefill_indices = mx.array(prefill_indices_np)
+        prefill_scores = mx.full(
+            (1, prefill_tokens, top_k),
+            1.0 / top_k,
+            dtype=mx.float16,
+        )
+        prefill_input = mx.random.normal(
+            (1, prefill_tokens, hot_pool_sets[0][0].gate_proj.input_dims)
+        ).astype(mx.float16)
+
+        def prefill_stack(pool: StreamingSwitchGLU) -> mx.array:
+            value = prefill_input
+            for _ in range(4):
+                value = pool(
+                    value,
+                    prefill_indices,
+                    scores=prefill_scores,
+                    weighted_sum=True,
+                )
+            return value
+
+        mx.eval(prefill_stack(hot_pool_sets[0][0]))
+        mx.eval(prefill_stack(hot_pool_sets[1][0]))
+        prefill_32 = _timed(lambda: prefill_stack(hot_pool_sets[0][0]))
+        prefill_128 = _timed(lambda: prefill_stack(hot_pool_sets[1][0]))
+        prefill_exact = bool(mx.all(prefill_32[0] == prefill_128[0]).item())
+
+        full_gate = _decode_variant(gate_models[0], gate_executions[0], tokens=tokens)
+        working_set_gate = _decode_variant(
+            gate_models[1], gate_executions[1], tokens=tokens
+        )
+        gate_exact = all(
+            bool(mx.all(left == right).item())
+            for left, right in zip(full_gate[0], working_set_gate[0], strict=True)
+        )
+
+        expanding_sparse = _DecodeModel(gate_pool_sets[0], top_k, route_groups=12)
+        expanding_full = _DecodeModel(hot_pool_sets[1], top_k, route_groups=12)
+        expansion_tokens = 12
+        sparse_bytes_before = readers[2].file_cache_bytes_read
+        sparse_loads_before = sum(pool.stats.loads for pool in gate_pool_sets[0])
+        sparse_expansion = _timed(lambda: hot_run(expanding_sparse, expansion_tokens))
+        sparse_bytes = readers[2].file_cache_bytes_read - sparse_bytes_before
+        sparse_loads = (
+            sum(pool.stats.loads for pool in gate_pool_sets[0]) - sparse_loads_before
+        )
+        full_bytes_before = readers[1].file_cache_bytes_read
+        full_loads_before = sum(pool.stats.loads for pool in hot_pool_sets[1])
+        full_expansion = _timed(lambda: hot_run(expanding_full, expansion_tokens))
+        full_bytes = readers[1].file_cache_bytes_read - full_bytes_before
+        full_loads = (
+            sum(pool.stats.loads for pool in hot_pool_sets[1]) - full_loads_before
+        )
+        expansion_exact = all(
+            bool(mx.all(left == right).item())
+            for left, right in zip(sparse_expansion[0], full_expansion[0], strict=True)
+        )
+
+        return {
+            "exact": {
+                "hot_capacity_32_vs_128": hot_exact,
+                "prefill_capacity_32_vs_128": prefill_exact,
+                "full_vs_working_set_gate": gate_exact,
+                "sparse_vs_optimistic_fill": expansion_exact,
+            },
+            "tokens": tokens,
+            "hot_decode": {
+                "capacity_32_tokens_per_second": tokens / hot_32[1],
+                "capacity_128_tokens_per_second": tokens / hot_128[1],
+                "capacity_128_relative_throughput": hot_32[1] / hot_128[1],
+                "capacity_32_peak_delta_mib": (hot_32[3] - hot_32[2]) / 1024**2,
+                "capacity_128_peak_delta_mib": (hot_128[3] - hot_128[2]) / 1024**2,
+            },
+            "prefill": {
+                "tokens": prefill_tokens,
+                "capacity_32_tokens_per_second": prefill_tokens / prefill_32[1],
+                "capacity_128_tokens_per_second": prefill_tokens / prefill_128[1],
+                "capacity_128_relative_throughput": prefill_32[1] / prefill_128[1],
+                "capacity_32_peak_delta_mib": (prefill_32[3] - prefill_32[2]) / 1024**2,
+                "capacity_128_peak_delta_mib": (prefill_128[3] - prefill_128[2])
+                / 1024**2,
+            },
+            "speculation_readiness_at_128": {
+                "full_gate_tokens_per_second": tokens / full_gate[1],
+                "working_set_gate_tokens_per_second": tokens / working_set_gate[1],
+                "working_set_speedup": full_gate[1] / working_set_gate[1],
+                "full_gate_execution": full_gate[4],
+                "working_set_execution": working_set_gate[4],
+            },
+            "optimistic_fill_at_128": {
+                "tokens": expansion_tokens,
+                "sparse_tokens_per_second": expansion_tokens / sparse_expansion[1],
+                "full_tokens_per_second": expansion_tokens / full_expansion[1],
+                "speedup": sparse_expansion[1] / full_expansion[1],
+                "sparse_cold_loads": sparse_loads,
+                "full_cold_loads": full_loads,
+                "sparse_ssd_bytes": sparse_bytes,
+                "full_ssd_bytes": full_bytes,
+            },
+        }
+    finally:
+        for execution in gate_executions:
+            execution.close()
+        for reader in readers:
+            reader.close()
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--experts", type=int, default=160)
@@ -445,6 +676,8 @@ def main() -> None:
     parser.add_argument("--prefill-layers", type=int, default=12)
     parser.add_argument("--prefill-repeats", type=int, default=2)
     parser.add_argument("--decode-tokens", type=int, default=12)
+    parser.add_argument("--capacity-decode-tokens", type=int, default=128)
+    parser.add_argument("--capacity-prefill-tokens", type=int, default=128)
     args = parser.parse_args()
     if args.experts < 160:
         parser.error("--experts must be at least 160")
@@ -490,6 +723,13 @@ def main() -> None:
                 experts=args.experts,
                 top_k=args.top_k,
                 tokens=args.decode_tokens,
+            ),
+            "capacity_scaling": _capacity_scaling_benchmark(
+                index,
+                experts=args.experts,
+                top_k=args.top_k,
+                tokens=args.capacity_decode_tokens,
+                prefill_tokens=args.capacity_prefill_tokens,
             ),
         }
         report["wall_seconds"] = time.perf_counter() - started

--- a/benchmarks/fast_resource_loading_full.py
+++ b/benchmarks/fast_resource_loading_full.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Guarded full-model A/B benchmark for expert Fast Resource Loading."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import time
+from pathlib import Path
+
+import mlx.core as mx
+import psutil
+
+
+def gib(value: int | float) -> float:
+    return round(float(value) / 1024**3, 3)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--fast-resource-loading", action="store_true")
+    parser.add_argument("--frl-scope", choices=("off", "scratch", "all"), default=None)
+    parser.add_argument("--cache-experts", type=int, default=48)
+    parser.add_argument("--scratch-experts", type=int, default=48)
+    parser.add_argument("--max-tokens", type=int, default=64)
+    parser.add_argument("--prompt-repeat", type=int, default=48)
+    parser.add_argument("--memory-limit-gib", type=int, default=72)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    model_path = args.model.expanduser().resolve()
+    if not model_path.is_dir():
+        raise SystemExit(f"Model directory does not exist: {model_path}")
+    mx.set_memory_limit(args.memory_limit_gib * 1024**3)
+    with contextlib.suppress(AttributeError, RuntimeError):
+        mx.set_wired_limit(args.memory_limit_gib * 1024**3)
+    mx.reset_peak_memory()
+
+    from mlx_vlm import generate
+    from mlx_vlm.utils import load as vlm_load
+
+    from omlx.engine.vlm import _force_qwen4_exp_sanitize_on_load
+    from omlx.expert_streaming import install_expert_streaming
+    from omlx.model_settings import ModelSettings
+    from omlx.utils.model_loading import (
+        materialize_lazy_state,
+        maybe_apply_pre_load_patches,
+    )
+
+    settings = ModelSettings(
+        expert_streaming_enabled=True,
+        expert_streaming_mode="cache_only",
+        expert_streaming_cache_experts=args.cache_experts,
+        expert_streaming_scratch_experts=args.scratch_experts,
+        expert_streaming_execution_policy="checked",
+        qwen4_ple_ssd_offload=True,
+        mtp_enabled=True,
+    )
+    frl_scope = args.frl_scope or ("all" if args.fast_resource_loading else "off")
+    report: dict = {
+        "variant": "baseline" if frl_scope == "off" else f"frl_{frl_scope}",
+        "pid": os.getpid(),
+        "model": str(model_path),
+        "cache_experts": args.cache_experts,
+        "scratch_experts": args.scratch_experts,
+        "memory_limit_gib": args.memory_limit_gib,
+    }
+
+    maybe_apply_pre_load_patches(model_path, model_settings=settings, for_vlm=True)
+    load_started = time.perf_counter()
+    with _force_qwen4_exp_sanitize_on_load(model_path):
+        model, processor = vlm_load(str(model_path), lazy=True)
+    runtime = install_expert_streaming(
+        model,
+        model_path,
+        None,
+        cache_experts=args.cache_experts,
+        scratch_experts=args.scratch_experts,
+        execution_policy="checked",
+        streaming_mode="cache_only",
+        hotlist_profile_dir=None,
+        fast_resource_loading=frl_scope,
+    )
+    materialize_lazy_state(model)
+    report["load_seconds"] = round(time.perf_counter() - load_started, 3)
+    report["loaded_memory"] = {
+        "mlx_active_gib": gib(mx.get_active_memory()),
+        "mlx_peak_gib": gib(mx.get_peak_memory()),
+        "process_rss_gib": gib(psutil.Process().memory_info().rss),
+    }
+    print(json.dumps({"stage": "loaded", **report}), flush=True)
+
+    user_prompt = (
+        "Explain the performance trade-offs in a memory-limited mixture-of-experts "
+        "inference server, including storage latency, routing locality, cache eviction, "
+        "prefill parallelism, and token-generation latency. "
+    ) * args.prompt_repeat
+    tokenizer = getattr(processor, "tokenizer", processor)
+    prompt = tokenizer.apply_chat_template(
+        [{"role": "user", "content": user_prompt}],
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+    result = generate(
+        model,
+        processor,
+        prompt,
+        max_tokens=args.max_tokens,
+        temp=0.0,
+        verbose=False,
+    )
+    report["generation"] = {
+        "prompt_tokens": int(result.prompt_tokens),
+        "generation_tokens": int(result.generation_tokens),
+        "prompt_tps": round(float(result.prompt_tps), 4),
+        "generation_tps": round(float(result.generation_tps), 4),
+        "output": result.text,
+    }
+    report["final_memory"] = {
+        "mlx_active_gib": gib(mx.get_active_memory()),
+        "mlx_peak_gib": gib(mx.get_peak_memory()),
+        "process_rss_gib": gib(psutil.Process().memory_info().rss),
+    }
+    streaming = runtime.stats()
+    report["streaming"] = {
+        key: streaming[key]
+        for key in (
+            "fast_resource_loading",
+            "fast_resource_loading_scope",
+            "ssd_bytes_read",
+            "ssd_read_operations",
+            "ssd_io_seconds",
+            "ssd_decode_seconds",
+            "frl_loads",
+            "frl_bytes_read",
+            "frl_read_operations",
+            "frl_io_wait_seconds",
+            "frl_copy_seconds",
+            "scratch_prefetch_wait_seconds",
+            "scratch_mlx_materialize_seconds",
+            "bank_bind_seconds",
+            "bank_materialize_seconds",
+            "cache_hits",
+            "cache_misses",
+            "scratch_loads",
+            "qmm_calls",
+        )
+    }
+    print(json.dumps({"stage": "complete", **report}), flush=True)
+    runtime.close()
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/fast_resource_loading_micro.py
+++ b/benchmarks/fast_resource_loading_micro.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Compare the current CPU staging path with Metal FRL plus bank blit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+from pathlib import Path
+
+import mlx.core as mx
+
+from omlx.expert_streaming.safetensors import ExpertReader, SafetensorExpertIndex
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--experts", type=int, default=48)
+    parser.add_argument("--repeats", type=int, default=5)
+    args = parser.parse_args()
+    index = SafetensorExpertIndex(args.model.expanduser().resolve())
+    locations = index.layer(index.expert_layer_ids()[0])
+    count = locations[next(iter(locations))].shape[0]
+    experts = [round(i * (count - 1) / (args.experts - 1)) for i in range(args.experts)]
+    cpu = ExpertReader(index)
+    frl = ExpertReader(index, fast_resource_loading=True)
+    targets = {
+        key: mx.zeros(
+            (args.experts, *location.shape[1:]),
+            dtype={
+                "U32": mx.uint32,
+                "U8": mx.uint8,
+                "I8": mx.int8,
+                "F32": mx.float32,
+                "F16": mx.float16,
+                "BF16": mx.bfloat16,
+            }[location.dtype],
+        )
+        for key, location in locations.items()
+    }
+    mx.eval(*targets.values())
+    cpu_times: list[float] = []
+    frl_times: list[float] = []
+    exact = True
+    try:
+        for _ in range(args.repeats):
+            started = time.perf_counter()
+            components = cpu.read_many(locations, experts, use_file_cache=True)
+            for key, rows in components.items():
+                targets[key][:] = rows
+            mx.eval(*targets.values())
+            cpu_times.append(time.perf_counter() - started)
+
+            expected = {key: mx.array(value) for key, value in targets.items()}
+            mx.eval(*expected.values())
+            started = time.perf_counter()
+            load = frl.begin_fast_many(locations, experts)
+            frl.finish_fast_many(
+                load,
+                list(range(args.experts)),
+                {key: (target, 0) for key, target in targets.items()},
+            )
+            mx.synchronize()
+            frl_times.append(time.perf_counter() - started)
+            exact &= all(
+                bool(mx.array_equal(targets[key], expected[key]).item())
+                for key in targets
+            )
+    finally:
+        cpu.close()
+        frl.close()
+    cpu_median = statistics.median(cpu_times)
+    frl_median = statistics.median(frl_times)
+    print(
+        json.dumps(
+            {
+                "experts": args.experts,
+                "bytes_per_wave": frl.fast_bytes_read // args.repeats,
+                "cpu_median_ms": round(cpu_median * 1000, 3),
+                "frl_median_ms": round(frl_median * 1000, 3),
+                "speedup": round(cpu_median / frl_median, 3),
+                "byte_exact": exact,
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/soft_reap_streaming.py
+++ b/benchmarks/soft_reap_streaming.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Reproducible Soft-REAP memory, exactness, and end-to-end benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import mlx.core as mx
+import psutil
+
+from omlx.expert_streaming import (
+    estimate_expert_streaming_residency,
+    install_expert_streaming,
+)
+from omlx.expert_streaming.manifest import load_soft_reap_manifest
+from omlx.expert_streaming.safetensors import ExpertReader, SafetensorExpertIndex
+
+
+def _geometry(model_path: Path) -> tuple[int, int, int]:
+    config = json.loads((model_path / "config.json").read_text())
+    text = config.get("text_config") or config
+    return (
+        int(text["num_hidden_layers"]),
+        int(text.get("num_experts", text.get("n_routed_experts"))),
+        int(text.get("num_experts_per_tok", text.get("num_experts_per_token"))),
+    )
+
+
+def _gib(value: int) -> float:
+    return round(value / 1024**3, 3)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path)
+    parser.add_argument(
+        "--streaming-mode",
+        choices=("soft_reap", "cache_only"),
+        default="soft_reap",
+    )
+    parser.add_argument("--cache-experts", type=int, default=32)
+    parser.add_argument("--substitution-threshold-percent", type=float, default=0.0)
+    parser.add_argument(
+        "--execution-policy",
+        choices=("checked", "speculative"),
+        default="checked",
+    )
+    parser.add_argument("--full-load", action="store_true")
+    parser.add_argument("--max-tokens", type=int, default=32)
+    parser.add_argument("--prompt", default="Hi")
+    parser.add_argument("--runs", type=int, default=1)
+    parser.add_argument(
+        "--direct-replay",
+        action="store_true",
+        help="Replay an identical language-model forward to isolate a hot no-miss pass.",
+    )
+    args = parser.parse_args()
+    if args.streaming_mode == "soft_reap" and args.manifest is None:
+        parser.error("--manifest is required in soft_reap mode")
+    layers, experts, top_k = _geometry(args.model)
+    manifest = (
+        load_soft_reap_manifest(args.manifest, num_layers=layers, num_experts=experts)
+        if args.manifest is not None
+        else None
+    )
+    estimate = estimate_expert_streaming_residency(
+        args.model,
+        args.manifest,
+        cache_experts=args.cache_experts,
+        num_layers=layers,
+        num_experts=experts,
+        top_k=top_k,
+        streaming_mode=args.streaming_mode,
+    )
+    report = {
+        "model": str(args.model.resolve()),
+        "layers": layers,
+        "experts": experts,
+        "top_k": top_k,
+        "streaming_mode": args.streaming_mode,
+        "pinned_range": manifest.pinned_count_range if manifest else (0, 0),
+        "checkpoint_gib": _gib(estimate.checkpoint_bytes),
+        "fixed_ple_trunk_gib": _gib(estimate.fixed_bytes),
+        "pinned_gib": _gib(estimate.pinned_bytes),
+        "cache_gib": _gib(estimate.cache_bytes),
+        "projected_resident_gib": _gib(estimate.resident_bytes),
+        "cache_slots_per_layer": estimate.cache_slots_per_layer,
+        "execution_policy": args.execution_policy,
+    }
+
+    # Always verify direct SSD row reads against MLX's checkpoint mapping.
+    index = SafetensorExpertIndex(args.model)
+    reader = ExpertReader(index)
+    location = index.layer(0)[("gate_proj", "weight")]
+    sample_ids = (
+        list(manifest.experts_for_layer(0)[:2]) + [experts - 1]
+        if manifest
+        else [0, experts - 1]
+    )
+    started = time.perf_counter()
+    rows = reader.read_rows(location, sample_ids)
+    mx.eval(rows)
+    elapsed = time.perf_counter() - started
+    reference = mx.load(str(location.path))[location.name][sample_ids]
+    mx.eval(reference)
+    report["row_read_exact"] = bool(mx.all(rows == reference).item())
+    report["sample_read_ms"] = round(elapsed * 1000, 3)
+    report["sample_read_mib"] = round(reader.bytes_read / 1024**2, 3)
+    reader.close()
+
+    if args.full_load:
+        from mlx_vlm import generate
+        from mlx_vlm.utils import load as vlm_load
+
+        from omlx.model_settings import ModelSettings
+        from omlx.utils.model_loading import (
+            materialize_lazy_state,
+            maybe_apply_pre_load_patches,
+        )
+
+        settings = ModelSettings(
+            expert_streaming_enabled=True,
+            expert_streaming_mode=args.streaming_mode,
+            expert_streaming_manifest=(
+                str(args.manifest.resolve()) if args.manifest else None
+            ),
+            expert_streaming_cache_experts=args.cache_experts,
+            expert_streaming_substitution_threshold_percent=(
+                args.substitution_threshold_percent
+            ),
+            expert_streaming_execution_policy=args.execution_policy,
+            qwen4_ple_ssd_offload=False,
+            mtp_enabled=True,
+        )
+        maybe_apply_pre_load_patches(args.model, model_settings=settings, for_vlm=True)
+        started = time.perf_counter()
+        model, processor = vlm_load(str(args.model), lazy=True)
+        runtime = install_expert_streaming(
+            model,
+            args.model,
+            args.manifest,
+            cache_experts=args.cache_experts,
+            substitution_threshold_percent=args.substitution_threshold_percent,
+            execution_policy=args.execution_policy,
+            streaming_mode=args.streaming_mode,
+        )
+        materialize_lazy_state(model)
+        report["load_seconds"] = round(time.perf_counter() - started, 3)
+        report["mlx_active_gib"] = _gib(mx.get_active_memory())
+        report["mlx_peak_gib"] = _gib(mx.get_peak_memory())
+        report["process_rss_gib"] = _gib(psutil.Process().memory_info().rss)
+        print(
+            json.dumps(
+                {
+                    "stage": "loaded",
+                    "load_seconds": report["load_seconds"],
+                    "mlx_active_gib": report["mlx_active_gib"],
+                    "mlx_peak_gib": report["mlx_peak_gib"],
+                    "process_rss_gib": report["process_rss_gib"],
+                }
+            ),
+            flush=True,
+        )
+
+        report["runs"] = []
+        if args.direct_replay:
+            tokenizer = getattr(processor, "tokenizer", processor)
+            input_ids = mx.array([tokenizer.encode(args.prompt)])
+            language_model = getattr(model, "language_model", model)
+            outputs = []
+            for run in range(2):
+                started = time.perf_counter()
+                result = language_model(input_ids, cache=None)
+                logits = getattr(result, "logits", result)
+                mx.eval(logits)
+                outputs.append(logits)
+                report["runs"].append(
+                    {
+                        "run": run + 1,
+                        "forward_seconds": round(time.perf_counter() - started, 3),
+                    }
+                )
+            report["direct_replay_exact"] = bool(
+                mx.all(outputs[0] == outputs[1]).item()
+            )
+            report["direct_replay_max_abs"] = float(
+                mx.max(mx.abs(outputs[0] - outputs[1])).item()
+            )
+        else:
+            for run in range(args.runs):
+                started = time.perf_counter()
+                result = generate(
+                    model,
+                    processor,
+                    args.prompt,
+                    max_tokens=args.max_tokens,
+                    temp=0.0,
+                    verbose=False,
+                )
+                generation_seconds = time.perf_counter() - started
+                report["runs"].append(
+                    {
+                        "run": run + 1,
+                        "generation_seconds": round(generation_seconds, 3),
+                        "generation_tokens": int(result.generation_tokens),
+                        "generation_tokens_per_second": round(
+                            result.generation_tokens / generation_seconds, 3
+                        ),
+                        "output": result.text,
+                    }
+                )
+                print(
+                    json.dumps({"stage": "run", **report["runs"][-1]}),
+                    flush=True,
+                )
+        report["streaming"] = runtime.stats()
+        runtime.close()
+
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/soft_reap_streaming.py
+++ b/benchmarks/soft_reap_streaming.py
@@ -62,8 +62,12 @@ def main() -> None:
     if args.streaming_mode == "soft_reap" and args.manifest is None:
         parser.error("--manifest is required in soft_reap mode")
     layers, experts, top_k = _geometry(args.model)
+    index = SafetensorExpertIndex(args.model)
+    layer_ids = index.expert_layer_ids() or list(range(layers))
     manifest = (
-        load_soft_reap_manifest(args.manifest, num_layers=layers, num_experts=experts)
+        load_soft_reap_manifest(
+            args.manifest, layer_ids=layer_ids, num_experts=experts
+        )
         if args.manifest is not None
         else None
     )
@@ -93,11 +97,15 @@ def main() -> None:
     }
 
     # Always verify direct SSD row reads against MLX's checkpoint mapping.
-    index = SafetensorExpertIndex(args.model)
     reader = ExpertReader(index)
-    location = index.layer(0)[("gate_proj", "weight")]
+    sample_layer = layer_ids[0]
+    ffn_marker = f"layers.{sample_layer}.ffn."
+    container = "ffn" if any(ffn_marker in key for key in index.weight_map) else "mlp"
+    location = index.layer(sample_layer, container_name=container)[
+        ("gate_proj", "weight")
+    ]
     sample_ids = (
-        list(manifest.experts_for_layer(0)[:2]) + [experts - 1]
+        list(manifest.experts_for_layer(sample_layer)[:2]) + [experts - 1]
         if manifest
         else [0, experts - 1]
     )

--- a/docs/soft_reap.md
+++ b/docs/soft_reap.md
@@ -86,9 +86,15 @@ back to the checked path. Rejected passes are never returned, so routing remains
 exact at a `0%` substitution threshold.
 
 Prompt and multi-token prefill always use checked mode. This warms the hot cache
-and prevents a new request from cascading through many speculative misses. MTP
-hidden-state forwards use the same whole-pass cache transaction as ordinary
-decode.
+and prevents a new request from cascading through many speculative misses.
+Single-token decoding also remains checked until every layer's evictable cache
+has reached its configured capacity. Readiness is latched after the cache fills,
+so steady-state decoding does not scan every layer on each token. A speculative
+miss binds the promoted bank rows lazily; the retry's QMM materializes those writes
+with their first consumer instead of forcing a redundant full-bank evaluation.
+MTP hidden-state forwards use the same whole-pass cache transaction as ordinary
+decode. Runtime execution stats expose how many otherwise-speculative passes were
+held back by the cache-fill gate.
 
 ## Performance status
 
@@ -112,7 +118,9 @@ measured separately, and low hit rates increase SSD traffic substantially.
 Warm-SSD, two-token generation produced identical text in both modes. Checked
 mode completed in 14.709 s. Speculative mode completed in 166.965 s because both
 speculative calls still missed after two promotions and fell back; it is therefore
-not the default. In an isolated identical-forward replay with all 48 layers hot,
+not the default. That measurement predates the cache-fill gate; the current path
+keeps such a partially filled cache in checked mode and avoids those rejected
+whole-model passes. In an isolated identical-forward replay with all 48 layers hot,
 speculative output was bit-identical (`max_abs=0`) and took 0.579 s versus 0.556 s
 for checked mode. This baseline shows no current throughput benefit from the
 larger speculative graph, even at a 100% resident hit rate.
@@ -136,7 +144,16 @@ slots, and submits all dynamic weight/scale/bias reads through one persistent
 parallel `pread` queue. It also applies Darwin read-ahead hints to cacheable cold
 reads and uses a learned popularity hotlist to warm ordinary evictable slots on
 future loads. Runtime stats split SSD I/O, payload decode, bank binding, and bank
-materialization time. These are compatible with MLX's fixed-shape banks.
+materialization time and count QMM projection invocations. These are compatible
+with MLX's fixed-shape banks.
+
+Local throughput benchmarks store per-trial streaming counter deltas alongside
+active and peak Metal memory. The benchmark log identifies the configured cache
+and execution-bank width, hotlist preload count, hit rate, misses, evictions,
+expert loads, SSD traffic, I/O and decode time, bank update time, expert-major
+calls, QMM calls, resident fill, and hotlist warm-start coverage. Analytical-cache
+runs with incomplete warm-start coverage are marked and should only be compared
+with a run having the same coverage.
 
 Further promising work, in priority order:
 

--- a/docs/soft_reap.md
+++ b/docs/soft_reap.md
@@ -22,6 +22,13 @@ recency as a tie-break. Experts used repeatedly by the current workload therefor
 survive one-off routes without becoming permanent. The minimum cache remains the
 model's top-k so one decode route can always execute exactly.
 
+When the scheduler has an SSD cache directory, both modes also maintain a compact
+learned hotlist there. On clean shutdown, oMLX stores per-layer router selection
+counts. A later load pre-fills the fixed hot tier with the most-used experts. These
+entries remain fully evictable and do not change the configured expert count,
+resident memory, or Soft-REAP manifest. Profiles are checkpoint-fingerprinted,
+written atomically, and ignored if stale or malformed.
+
 ## Manifest
 
 Official REAP maps are accepted directly:
@@ -126,15 +133,16 @@ and host-side SSD decisions cannot be captured inside the compiled graph.
 The cache now adopts DwarfStar's decayed route-hotness eviction and recency
 tie-break, protects experts in the current route from eviction, reuses fixed bank
 slots, and submits all dynamic weight/scale/bias reads through one persistent
-parallel `pread` queue. These are compatible with MLX's fixed-shape banks.
+parallel `pread` queue. It also applies Darwin read-ahead hints to cacheable cold
+reads and uses a learned popularity hotlist to warm ordinary evictable slots on
+future loads. Runtime stats split SSD I/O, payload decode, bank binding, and bank
+materialization time. These are compatible with MLX's fixed-shape banks.
 
 Further promising work, in priority order:
 
 1. An expert-major sidecar that stores all nine quantized components contiguously,
    reducing random reads and safetensor-header fragmentation.
-2. An optional learned hotlist profile that preloads experts as *evictable* cache
-   entries, unlike Soft-REAP pins.
-3. Per-layer read/bind/wait timings and adaptive cache sizing from real miss cost.
-4. Cross-layer predictive prefetch. Exact next-layer routing is data-dependent, so
+2. Adaptive per-layer cache sizing driven by measured miss and bank-update cost.
+3. Cross-layer predictive prefetch. Exact next-layer routing is data-dependent, so
    this requires either a predictor or deeper graph/runtime changes and carries a
    higher regression risk.

--- a/docs/soft_reap.md
+++ b/docs/soft_reap.md
@@ -1,0 +1,124 @@
+# Soft-REAP expert streaming
+
+Soft-REAP keeps manifest-selected MoE experts and the rest of the model resident,
+then loads non-pinned experts from the original safetensor shards into a fixed
+expert bank. The bank is allocated once at model load, so its shape does not change
+as experts are promoted or evicted. Dynamic slots use decayed route-frequency
+scoring rather than plain LRU.
+
+The setting **Hot experts per layer** is an expert count, not a byte budget. oMLX
+reserves at least the model's top-k working set. The model settings page shows the
+projected resident size before load.
+
+## Residency modes
+
+**Soft-REAP pinning** keeps every expert in the uploaded manifest permanently
+resident. Non-pinned experts share the additional hot cache.
+
+**Analytical cache only** requires no manifest and pins no routed experts. Every
+expert slot is evictable. The cache scores actual router selections, including
+misses, halves the scores every 16 routed tokens, and evicts the lowest score with
+recency as a tie-break. Experts used repeatedly by the current workload therefore
+survive one-off routes without becoming permanent. The minimum cache remains the
+model's top-k so one decode route can always execute exactly.
+
+## Manifest
+
+Official REAP maps are accepted directly:
+
+```json
+{
+  "0": [1, 4, 9],
+  "1": [0, 3, 8]
+}
+```
+
+The wrapped keys `layers`, `pinned_experts`, and `kept_experts` are also accepted.
+Every routed layer must be present, and IDs must be unique and valid for the model.
+
+## Resident substitution
+
+The optional substitution threshold is the maximum relative router-weight loss
+allowed when replacing a cold expert with a resident pinned or hot expert. For
+example, at 5%, a resident expert with at least 95% of the cold expert's router
+weight may displace it. Original router weights are retained and renormalized after
+selection.
+
+- `0%` preserves exact routing.
+- Small non-zero values are approximate and require task-specific evaluation.
+- `100%` restricts routing to the resident set.
+
+## Execution modes
+
+**Checked** is the default. It reads router IDs at each layer and loads any
+misses before that layer runs. Although this introduces per-layer synchronization,
+it avoids wasted whole-model passes when any SSD miss is possible.
+
+**Speculative** is an opt-in resident-hit mode. It maps logical expert IDs to the
+fixed resident bank entirely inside the MLX graph, avoiding a CPU/GPU
+synchronization at every layer. The completed forward pass is checked once. If a
+cold expert was selected, oMLX restores the pre-pass KV/SSM cache state, promotes
+the first missing layer from SSD, and retries once. If that retry misses, it falls
+back to the checked path. Rejected passes are never returned, so routing remains
+exact at a `0%` substitution threshold.
+
+Prompt and multi-token prefill always use checked mode. This warms the hot cache
+and prevents a new request from cascading through many speculative misses. MTP
+hidden-state forwards use the same whole-pass cache transaction as ordinary
+decode.
+
+## Performance status
+
+On the 98.995 GiB Qwen3.8-Flash-Next oQ4e MTP baseline with the 288-expert REAP
+manifest:
+
+| Hot experts/layer | MLX active after load | Load time |
+| ---: | ---: | ---: |
+| 10 | 72.565 GiB | 19.8-20.3 s |
+| 32 | 75.281 GiB | 20.1 s |
+
+For the same checkpoint, cache-only mode with 32 experts per layer removes the
+35.596 GiB pinned tier; its header-based projected residency is approximately
+41.65 GiB including the estimator's safety overhead. The measured MLX active
+memory was 39.684 GiB and load time was 6.794 s. A warm-SSD two-token smoke test
+completed in 1.918 s with the same `", what"` output as the pinned baseline. It
+loaded 933 experts (2.402 GiB) dynamically and had a 35.2% route hit rate. This is
+still a capacity-oriented mode: cold-storage and longer-run results must be
+measured separately, and low hit rates increase SSD traffic substantially.
+
+Warm-SSD, two-token generation produced identical text in both modes. Checked
+mode completed in 14.709 s. Speculative mode completed in 166.965 s because both
+speculative calls still missed after two promotions and fell back; it is therefore
+not the default. In an isolated identical-forward replay with all 48 layers hot,
+speculative output was bit-identical (`max_abs=0`) and took 0.579 s versus 0.556 s
+for checked mode. This baseline shows no current throughput benefit from the
+larger speculative graph, even at a 100% resident hit rate.
+
+The streamed expert computation is bit-exact at a `0%` threshold. Before the
+graph-native speculative path, exact on-demand loading required reading router IDs
+back to the host at every MoE layer: a one-token cold run measured 127.9-132.8
+seconds, while a repeated warm-cache run measured 78.4 seconds. The controlled
+execution-mode results above supersede those earlier timings. The 5% substitution
+experiment remains disabled by default pending end-to-end quality evaluation.
+
+MLX `export_function` can persist graph IR, but imported functions still need
+`mx.compile` in the new process. It does not persist a ready-to-run Metal executable,
+and host-side SSD decisions cannot be captured inside the compiled graph.
+
+## DwarfStar-derived optimizations
+
+The cache now adopts DwarfStar's decayed route-hotness eviction and recency
+tie-break, protects experts in the current route from eviction, reuses fixed bank
+slots, and submits all dynamic weight/scale/bias reads through one persistent
+parallel `pread` queue. These are compatible with MLX's fixed-shape banks.
+
+Further promising work, in priority order:
+
+1. An expert-major sidecar that stores all nine quantized components contiguously,
+   reducing random reads and safetensor-header fragmentation.
+2. An optional learned hotlist profile that preloads experts as *evictable* cache
+   entries, unlike Soft-REAP pins.
+3. Per-layer read/bind/wait timings and adaptive cache sizing from real miss cost.
+4. Cross-layer predictive prefetch. Exact next-layer routing is data-dependent, so
+   this requires either a predictor or deeper graph/runtime changes and carries a
+   higher regression risk.

--- a/docs/soft_reap.md
+++ b/docs/soft_reap.md
@@ -24,10 +24,14 @@ model's top-k so one decode route can always execute exactly.
 
 When the scheduler has an SSD cache directory, both modes also maintain a compact
 learned hotlist there. On clean shutdown, oMLX stores per-layer router selection
-counts. A later load pre-fills the fixed hot tier with the most-used experts. These
-entries remain fully evictable and do not change the configured expert count,
-resident memory, or Soft-REAP manifest. Profiles are checkpoint-fingerprinted,
-written atomically, and ignored if stale or malformed.
+counts. A later load prioritizes the most-used experts, then optimistically fills
+every remaining configured slot with unobserved experts. Both learned and
+optimistic entries remain fully evictable; optimistic entries start at zero
+hotness and are therefore the first eviction candidates when real routing data
+arrives. The configured RAM is fully populated without changing the expert count,
+pinning fallback experts, or altering the Soft-REAP manifest. Profiles are
+checkpoint-fingerprinted and written atomically. A missing, stale, or malformed
+profile falls back to a fully populated optimistic cache.
 
 ## Manifest
 
@@ -153,7 +157,9 @@ and execution-bank width, hotlist preload count, hit rate, misses, evictions,
 expert loads, SSD traffic, I/O and decode time, bank update time, expert-major
 calls, QMM calls, resident fill, and hotlist warm-start coverage. Analytical-cache
 runs with incomplete warm-start coverage are marked and should only be compared
-with a run having the same coverage.
+with a run having the same learned coverage. Optimistic preload count and total
+startup-fill coverage are reported separately; total startup fill should equal the
+user-configured capacity even when no learned profile exists.
 
 Further promising work, in priority order:
 

--- a/docs/soft_reap.md
+++ b/docs/soft_reap.md
@@ -35,6 +35,22 @@ Official REAP maps are accepted directly:
 
 The wrapped keys `layers`, `pinned_experts`, and `kept_experts` are also accepted.
 Every routed layer must be present, and IDs must be unique and valid for the model.
+Models with dense and sparse layers use their original model-layer IDs; dense layers
+must not appear in the manifest.
+
+## Supported MoE layouts
+
+SSD Expert Streaming discovers routed layers under both `mlp` and `ffn` and skips
+dense layers. It supports stacked and per-expert safetensor layouts, separate and
+fused gate/up projections, affine, MXFP4, and NVFP4 metadata, optional quantization
+biases, and routed layers that request an internal weighted sum. This covers the
+SwitchGLU implementations used by Qwen 3.5/3.8/4-Exp, DeepSeek V3.2/V4, GLM
+MoE/GLM5, MiMo-v2, Hy-v3, Laguna, Bailing Hybrid, and compatible MiniMax variants.
+
+Resident substitution remains Qwen-only because each family applies its router
+correction, normalization, and shared-expert path differently. Exact `0%` routing,
+Soft-REAP pinning, and analytical cache-only mode are shared across the supported
+families.
 
 ## Resident substitution
 

--- a/docs/soft_reap.md
+++ b/docs/soft_reap.md
@@ -6,9 +6,12 @@ expert bank. The bank is allocated once at model load, so its shape does not cha
 as experts are promoted or evicted. Dynamic slots use decayed route-frequency
 scoring rather than plain LRU.
 
-The setting **Hot experts per layer** is an expert count, not a byte budget. oMLX
-reserves at least the model's top-k working set. The model settings page shows the
-projected resident size before load.
+The settings **Hot experts per layer** and **Cold execution bank** are expert
+counts, not byte budgets. oMLX reserves at least the model's top-k hot working
+set. The cold execution bank is a separate fixed allocation used only by wide
+miss-heavy batches; it never reduces or evicts the configured hot cache. The
+model settings page includes both banks in the projected resident size before
+load.
 
 ## Residency modes
 
@@ -100,6 +103,23 @@ MTP hidden-state forwards use the same whole-pass cache transaction as ordinary
 decode. Runtime execution stats expose how many otherwise-speculative passes were
 held back by the cache-fill gate.
 
+When prefill selects more cold experts than the hot tier can hold, oMLX executes
+them in groups through the preallocated cold execution bank. The first cold group
+is requested while resident experts execute, and each following group is requested
+while the current group runs. Only one bounded group is in flight. Prefetch workers
+perform CPU-only `pread` and NumPy decoding; MLX array construction remains on the
+inference thread so thread-local Metal streams are never transferred between
+threads. Small nearby
+safetensor reads are coalesced with a 64 KiB maximum gap; pinned preload remains
+strictly component-at-a-time to cap transient memory. This keeps one-shot prefill
+experts from replacing analytically hot experts and avoids unbounded read-ahead.
+
+Resident prefill routes are sorted by their physical bank slot once a group reaches
+64 routed rows, restoring MLX's standard sorted gather-QMM path even when manifest
+order and cache placement differ from logical expert IDs. Gate and up projections
+share one preallocated quantized bank and one gather-QMM; decode therefore uses two
+expert QMM launches per layer instead of three, without increasing bank memory.
+
 ## Performance status
 
 On the 98.995 GiB Qwen3.8-Flash-Next oQ4e MTP baseline with the 288-expert REAP
@@ -140,6 +160,16 @@ MLX `export_function` can persist graph IR, but imported functions still need
 `mx.compile` in the new process. It does not persist a ready-to-run Metal executable,
 and host-side SSD decisions cannot be captured inside the compiled graph.
 
+Bounded synthetic measurements at 512×128 and 1024×256 expert geometry validated
+the current optimizations without loading the production checkpoint. The cold
+execution bank preserved exact output, reduced hot-cache evictions from 42 to 0,
+and made the miss-heavy prefill-to-decode fixture 2.12-2.19× faster. At 1024×256,
+physical-slot sorting improved 256-token prefill throughput by 26.6%; its output
+was bit-identical to MLX's standard sorted path. Gate/up fusion reduced decode-shape
+QMM calls from three to two and improved the isolated single-token fixture by 8.6%;
+it was neutral within noise for prefill. Peak MLX memory for that isolated run was
+391 MiB.
+
 ## DwarfStar-derived optimizations
 
 The cache now adopts DwarfStar's decayed route-hotness eviction and recency
@@ -149,13 +179,16 @@ parallel `pread` queue. It also applies Darwin read-ahead hints to cacheable col
 reads and uses a learned popularity hotlist to warm ordinary evictable slots on
 future loads. Runtime stats split SSD I/O, payload decode, bank binding, and bank
 materialization time and count QMM projection invocations. These are compatible
-with MLX's fixed-shape banks.
+with MLX's fixed-shape banks. The separate cold execution bank, bounded overlapped
+group loading, 64 KiB read coalescing, gate/up bank fusion, and physical-slot
+sorting are oMLX-specific extensions around that cache foundation.
 
 Local throughput benchmarks store per-trial streaming counter deltas alongside
 active and peak Metal memory. The benchmark log identifies the configured cache
 and execution-bank width, hotlist preload count, hit rate, misses, evictions,
 expert loads, SSD traffic, I/O and decode time, bank update time, expert-major
-calls, QMM calls, resident fill, and hotlist warm-start coverage. Analytical-cache
+calls, scratch prefetch wait, sorted groups and routes, QMM calls, resident fill,
+and hotlist warm-start coverage. Analytical-cache
 runs with incomplete warm-start coverage are marked and should only be compared
 with a run having the same learned coverage. Optimistic preload count and total
 startup-fill coverage are reported separately; total startup fill should equal the

--- a/omlx/admin/benchmark.py
+++ b/omlx/admin/benchmark.py
@@ -647,6 +647,124 @@ def _compute_single_metrics(
     }
 
 
+_EXPERT_STREAMING_DELTA_FIELDS = (
+    "route_lookups",
+    "pinned_hits",
+    "cache_hits",
+    "cache_misses",
+    "evictions",
+    "loads",
+    "pinned_loads",
+    "cold_loads",
+    "warm_start_loads",
+    "expert_major_calls",
+    "qmm_calls",
+    "speculative_routes",
+    "speculative_misses",
+    "hotness_decays",
+    "ssd_bytes_read",
+    "ssd_read_operations",
+    "ssd_preload_bytes_read",
+    "ssd_preload_read_operations",
+    "ssd_cold_bytes_read",
+    "ssd_cold_read_operations",
+    "ssd_io_seconds",
+    "ssd_decode_seconds",
+    "bank_bind_seconds",
+    "bank_materialize_seconds",
+)
+
+_EXPERT_STREAMING_CONFIG_FIELDS = (
+    "cache_budget_bytes",
+    "cache_slots_per_layer",
+    "layer_count",
+    "resident_experts",
+    "resident_capacity",
+    "execution_bank_slots",
+    "execution_banks_per_layer",
+    "substitution_threshold_percent",
+    "streaming_mode",
+    "cache_policy",
+    "execution_policy",
+    "hotlist_profile",
+    "hotlist_preloaded",
+    "hotlist_profile_error",
+)
+
+
+def _expert_streaming_snapshot(engine: Any) -> dict[str, Any] | None:
+    """Read the engine's cumulative streaming counters when available."""
+    getter = getattr(engine, "get_stats", None)
+    if not callable(getter):
+        return None
+    try:
+        stats = getter()
+    except Exception:
+        logger.debug(
+            "Could not snapshot benchmark expert streaming stats", exc_info=True
+        )
+        return None
+    if not isinstance(stats, dict):
+        return None
+    streaming = stats.get("expert_streaming")
+    return dict(streaming) if isinstance(streaming, dict) else None
+
+
+def _expert_streaming_delta(
+    before: dict[str, Any] | None,
+    after: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Return per-trial counters without copying the large per-layer snapshot."""
+    if after is None:
+        return None
+    before = before or {}
+    result = {
+        key: after.get(key) for key in _EXPERT_STREAMING_CONFIG_FIELDS if key in after
+    }
+    for key in _EXPERT_STREAMING_DELTA_FIELDS:
+        if key not in after:
+            continue
+        current = after.get(key, 0)
+        previous = before.get(key, 0)
+        try:
+            result[key] = max(0, current - previous)
+        except TypeError:
+            continue
+    attempts = sum(
+        int(result.get(key, 0) or 0)
+        for key in ("pinned_hits", "cache_hits", "cache_misses")
+    )
+    result["hit_rate"] = (
+        (int(result.get("pinned_hits", 0) or 0) + int(result.get("cache_hits", 0) or 0))
+        / attempts
+        if attempts
+        else 1.0
+    )
+    capacity = int(result.get("resident_capacity", 0) or 0)
+    result["resident_fill_rate"] = (
+        int(result.get("resident_experts", 0) or 0) / capacity
+        if capacity
+        else 1.0
+    )
+    hot_capacity = (
+        int(result.get("cache_slots_per_layer", 0) or 0)
+        * int(result.get("layer_count", 0) or 0)
+    )
+    result["hotlist_preload_fill_rate"] = (
+        min(1.0, int(result.get("hotlist_preloaded", 0) or 0) / hot_capacity)
+        if hot_capacity
+        else 1.0
+    )
+    return result
+
+
+def _active_metal_memory() -> int:
+    try:
+        return int(mx.get_active_memory())
+    except Exception:
+        return 0
+
+
 def _pin_speed_priority(engine_pool: Any) -> bool | None:
     """Force prefill speed priority for the benchmark's duration.
 
@@ -712,6 +830,9 @@ async def _run_single_test(
             f"Benchmark prompt length mismatch before pp{pp_len}: "
             f"built {len(prompt)} tokens"
         )
+
+    streaming_before = _expert_streaming_snapshot(engine)
+    active_memory_start = _active_metal_memory()
 
     # Reset peak memory tracking
     try:
@@ -785,6 +906,8 @@ async def _run_single_test(
         peak_memory = mx.get_peak_memory()
     except Exception:
         peak_memory = 0
+    active_memory_end = _active_metal_memory()
+    streaming_after = _expert_streaming_snapshot(engine)
 
     if last_output is None:
         raise RuntimeError(f"Benchmark pp{pp_len} produced no engine output")
@@ -878,6 +1001,14 @@ async def _run_single_test(
     )
     if ane_trace_config is not None:
         metrics["ane_trace"] = ane_trace
+    metrics["metal_memory"] = {
+        "active_start_bytes": active_memory_start,
+        "active_end_bytes": active_memory_end,
+        "peak_bytes": peak_memory,
+    }
+    streaming_delta = _expert_streaming_delta(streaming_before, streaming_after)
+    if streaming_delta is not None:
+        metrics["expert_streaming"] = streaming_delta
     return metrics
 
 
@@ -1067,6 +1198,8 @@ async def _run_batch_test(
         temperature=0.0,
         top_p=1.0,
     )
+    streaming_before = _expert_streaming_snapshot(engine)
+    active_memory_start = _active_metal_memory()
 
     async def _single_request(prompt: list[int]) -> dict:
         """Run a single request within the batch."""
@@ -1125,6 +1258,8 @@ async def _run_batch_test(
             peak_memory = mx.get_peak_memory()
         except Exception:
             peak_memory = 0
+    active_memory_end = _active_metal_memory()
+    streaming_after = _expert_streaming_snapshot(engine)
 
     # Aggregate metrics
     total_gen_tokens = sum(r["completion_tokens"] for r in results)
@@ -1142,7 +1277,7 @@ async def _run_batch_test(
     gen_wall_time = wall_end - max_first_token
     tg_tps = total_gen_tokens / max(gen_wall_time, 1e-9)
 
-    return {
+    metrics = {
         "pp_tps": round(pp_tps, 1),
         "tg_tps": round(tg_tps, 1),
         "avg_ttft_ms": round(avg_ttft_ms, 1),
@@ -1150,7 +1285,16 @@ async def _run_batch_test(
         "peak_memory_bytes": peak_memory,
         "total_gen_tokens": total_gen_tokens,
         "batch_size": batch_size,
+        "metal_memory": {
+            "active_start_bytes": active_memory_start,
+            "active_end_bytes": active_memory_end,
+            "peak_bytes": peak_memory,
+        },
     }
+    streaming_delta = _expert_streaming_delta(streaming_before, streaming_after)
+    if streaming_delta is not None:
+        metrics["expert_streaming"] = streaming_delta
+    return metrics
 
 
 async def _run_external_single_test(
@@ -1962,6 +2106,76 @@ async def run_benchmark(run: BenchmarkRun, engine_pool: Any) -> None:
                 float(metrics.get("e2e_latency_s", 0.0) or 0.0) * 1000.0,
                 int(metrics.get("cached_tokens", 0) or 0),
             )
+            streaming_metrics = metrics.get("expert_streaming")
+            if isinstance(streaming_metrics, dict):
+                logger.info(
+                    "[benchmark-expert-streaming] pp=%d slots=%s "
+                    "execution_bank=%s banks=%s hit_rate=%.4f hits=%d "
+                    "misses=%d evictions=%d loads=%d ssd_bytes=%d "
+                    "ssd_io_ms=%.3f decode_ms=%.3f bind_ms=%.3f "
+                    "materialize_ms=%.3f expert_major=%d qmm_calls=%d "
+                    "resident_fill=%.4f hotlist_preloaded=%s "
+                    "hotlist_fill=%.4f metal_start_gib=%.3f "
+                    "metal_end_gib=%.3f metal_peak_gib=%.3f",
+                    pp_len,
+                    streaming_metrics.get("cache_slots_per_layer"),
+                    streaming_metrics.get("execution_bank_slots"),
+                    streaming_metrics.get("execution_banks_per_layer"),
+                    float(streaming_metrics.get("hit_rate", 1.0) or 0.0),
+                    int(streaming_metrics.get("pinned_hits", 0) or 0)
+                    + int(streaming_metrics.get("cache_hits", 0) or 0),
+                    int(streaming_metrics.get("cache_misses", 0) or 0),
+                    int(streaming_metrics.get("evictions", 0) or 0),
+                    int(streaming_metrics.get("loads", 0) or 0),
+                    int(streaming_metrics.get("ssd_bytes_read", 0) or 0),
+                    float(streaming_metrics.get("ssd_io_seconds", 0.0) or 0.0)
+                    * 1000.0,
+                    float(
+                        streaming_metrics.get("ssd_decode_seconds", 0.0) or 0.0
+                    )
+                    * 1000.0,
+                    float(
+                        streaming_metrics.get("bank_bind_seconds", 0.0) or 0.0
+                    )
+                    * 1000.0,
+                    float(
+                        streaming_metrics.get("bank_materialize_seconds", 0.0)
+                        or 0.0
+                    )
+                    * 1000.0,
+                    int(streaming_metrics.get("expert_major_calls", 0) or 0),
+                    int(streaming_metrics.get("qmm_calls", 0) or 0),
+                    float(streaming_metrics.get("resident_fill_rate", 1.0) or 0.0),
+                    streaming_metrics.get("hotlist_preloaded"),
+                    float(
+                        streaming_metrics.get("hotlist_preload_fill_rate", 1.0)
+                        or 0.0
+                    ),
+                    float(metrics["metal_memory"]["active_start_bytes"]) / 1024**3,
+                    float(metrics["metal_memory"]["active_end_bytes"]) / 1024**3,
+                    float(metrics["metal_memory"]["peak_bytes"]) / 1024**3,
+                )
+                if (
+                    streaming_metrics.get("streaming_mode") == "cache_only"
+                    and float(
+                        streaming_metrics.get("hotlist_preload_fill_rate", 0.0)
+                        or 0.0
+                    )
+                    < 1.0
+                ):
+                    logger.warning(
+                        "[benchmark-expert-streaming] pp=%d analytical cache "
+                        "hotlist was only %.1f%% prefilled; compare only with a "
+                        "run having the same warm-start coverage",
+                        pp_len,
+                        float(
+                            streaming_metrics.get(
+                                "hotlist_preload_fill_rate", 0.0
+                            )
+                            or 0.0
+                        )
+                        * 100.0,
+                    )
 
             result = {
                 "test_type": "single",
@@ -2015,6 +2229,21 @@ async def run_benchmark(run: BenchmarkRun, engine_pool: Any) -> None:
                 batch_size=batch_size,
             )
             batch_metrics["system_metrics"] = _sample_window(run, window_start)
+            batch_streaming = batch_metrics.get("expert_streaming")
+            if isinstance(batch_streaming, dict):
+                logger.info(
+                    "[benchmark-expert-streaming-batch] batch=%d slots=%s "
+                    "hit_rate=%.4f misses=%d evictions=%d ssd_bytes=%d "
+                    "qmm_calls=%d metal_peak_gib=%.3f",
+                    batch_size,
+                    batch_streaming.get("cache_slots_per_layer"),
+                    float(batch_streaming.get("hit_rate", 1.0) or 0.0),
+                    int(batch_streaming.get("cache_misses", 0) or 0),
+                    int(batch_streaming.get("evictions", 0) or 0),
+                    int(batch_streaming.get("ssd_bytes_read", 0) or 0),
+                    int(batch_streaming.get("qmm_calls", 0) or 0),
+                    float(batch_metrics["metal_memory"]["peak_bytes"]) / 1024**3,
+                )
 
             result = {
                 "test_type": "batch",

--- a/omlx/admin/benchmark.py
+++ b/omlx/admin/benchmark.py
@@ -656,9 +656,14 @@ _EXPERT_STREAMING_DELTA_FIELDS = (
     "loads",
     "pinned_loads",
     "cold_loads",
+    "scratch_loads",
+    "scratch_prefetch_requests",
     "warm_start_loads",
     "expert_major_calls",
     "qmm_calls",
+    "sorted_prefill_groups",
+    "sorted_prefill_routes",
+    "sorted_qmm_calls",
     "speculative_routes",
     "speculative_misses",
     "hotness_decays",
@@ -672,16 +677,22 @@ _EXPERT_STREAMING_DELTA_FIELDS = (
     "ssd_decode_seconds",
     "bank_bind_seconds",
     "bank_materialize_seconds",
+    "scratch_prefetch_wait_seconds",
+    "scratch_mlx_materialize_seconds",
 )
 
 _EXPERT_STREAMING_CONFIG_FIELDS = (
     "cache_budget_bytes",
     "cache_slots_per_layer",
+    "scratch_budget_bytes",
+    "scratch_slots_per_layer",
     "layer_count",
     "resident_experts",
     "resident_capacity",
     "execution_bank_slots",
     "execution_banks_per_layer",
+    "fused_gate_up",
+    "sorted_prefill",
     "substitution_threshold_percent",
     "streaming_mode",
     "cache_policy",
@@ -2123,18 +2134,24 @@ async def run_benchmark(run: BenchmarkRun, engine_pool: Any) -> None:
             if isinstance(streaming_metrics, dict):
                 logger.info(
                     "[benchmark-expert-streaming] pp=%d slots=%s "
-                    "execution_bank=%s banks=%s hit_rate=%.4f hits=%d "
+                    "scratch=%s execution_bank=%s banks=%s fused_gate_up=%s "
+                    "hit_rate=%.4f hits=%d "
                     "misses=%d evictions=%d loads=%d ssd_bytes=%d "
                     "ssd_io_ms=%.3f decode_ms=%.3f bind_ms=%.3f "
-                    "materialize_ms=%.3f expert_major=%d qmm_calls=%d "
+                    "materialize_ms=%.3f scratch_wait_ms=%.3f "
+                    "scratch_mlx_ms=%.3f "
+                    "expert_major=%d qmm_calls=%d sorted_groups=%d "
+                    "sorted_routes=%d sorted_qmm=%d "
                     "resident_fill=%.4f hotlist_preloaded=%s "
                     "optimistic_preloaded=%s hotlist_fill=%.4f "
                     "startup_fill=%.4f metal_start_gib=%.3f "
                     "metal_end_gib=%.3f metal_peak_gib=%.3f",
                     pp_len,
                     streaming_metrics.get("cache_slots_per_layer"),
+                    streaming_metrics.get("scratch_slots_per_layer"),
                     streaming_metrics.get("execution_bank_slots"),
                     streaming_metrics.get("execution_banks_per_layer"),
+                    streaming_metrics.get("fused_gate_up"),
                     float(streaming_metrics.get("hit_rate", 1.0) or 0.0),
                     int(streaming_metrics.get("pinned_hits", 0) or 0)
                     + int(streaming_metrics.get("cache_hits", 0) or 0),
@@ -2157,8 +2174,23 @@ async def run_benchmark(run: BenchmarkRun, engine_pool: Any) -> None:
                         or 0.0
                     )
                     * 1000.0,
+                    float(
+                        streaming_metrics.get("scratch_prefetch_wait_seconds", 0.0)
+                        or 0.0
+                    )
+                    * 1000.0,
+                    float(
+                        streaming_metrics.get(
+                            "scratch_mlx_materialize_seconds", 0.0
+                        )
+                        or 0.0
+                    )
+                    * 1000.0,
                     int(streaming_metrics.get("expert_major_calls", 0) or 0),
                     int(streaming_metrics.get("qmm_calls", 0) or 0),
+                    int(streaming_metrics.get("sorted_prefill_groups", 0) or 0),
+                    int(streaming_metrics.get("sorted_prefill_routes", 0) or 0),
+                    int(streaming_metrics.get("sorted_qmm_calls", 0) or 0),
                     float(streaming_metrics.get("resident_fill_rate", 1.0) or 0.0),
                     streaming_metrics.get("hotlist_preloaded"),
                     streaming_metrics.get("optimistic_preloaded"),

--- a/omlx/admin/benchmark.py
+++ b/omlx/admin/benchmark.py
@@ -688,6 +688,7 @@ _EXPERT_STREAMING_CONFIG_FIELDS = (
     "execution_policy",
     "hotlist_profile",
     "hotlist_preloaded",
+    "optimistic_preloaded",
     "hotlist_profile_error",
 )
 
@@ -752,6 +753,18 @@ def _expert_streaming_delta(
     )
     result["hotlist_preload_fill_rate"] = (
         min(1.0, int(result.get("hotlist_preloaded", 0) or 0) / hot_capacity)
+        if hot_capacity
+        else 1.0
+    )
+    result["startup_preload_fill_rate"] = (
+        min(
+            1.0,
+            (
+                int(result.get("hotlist_preloaded", 0) or 0)
+                + int(result.get("optimistic_preloaded", 0) or 0)
+            )
+            / hot_capacity,
+        )
         if hot_capacity
         else 1.0
     )
@@ -2115,7 +2128,8 @@ async def run_benchmark(run: BenchmarkRun, engine_pool: Any) -> None:
                     "ssd_io_ms=%.3f decode_ms=%.3f bind_ms=%.3f "
                     "materialize_ms=%.3f expert_major=%d qmm_calls=%d "
                     "resident_fill=%.4f hotlist_preloaded=%s "
-                    "hotlist_fill=%.4f metal_start_gib=%.3f "
+                    "optimistic_preloaded=%s hotlist_fill=%.4f "
+                    "startup_fill=%.4f metal_start_gib=%.3f "
                     "metal_end_gib=%.3f metal_peak_gib=%.3f",
                     pp_len,
                     streaming_metrics.get("cache_slots_per_layer"),
@@ -2147,8 +2161,13 @@ async def run_benchmark(run: BenchmarkRun, engine_pool: Any) -> None:
                     int(streaming_metrics.get("qmm_calls", 0) or 0),
                     float(streaming_metrics.get("resident_fill_rate", 1.0) or 0.0),
                     streaming_metrics.get("hotlist_preloaded"),
+                    streaming_metrics.get("optimistic_preloaded"),
                     float(
                         streaming_metrics.get("hotlist_preload_fill_rate", 1.0)
+                        or 0.0
+                    ),
+                    float(
+                        streaming_metrics.get("startup_preload_fill_rate", 1.0)
                         or 0.0
                     ),
                     float(metrics["metal_memory"]["active_start_bytes"]) / 1024**3,

--- a/omlx/admin/i18n/en.json
+++ b/omlx/admin/i18n/en.json
@@ -1130,5 +1130,22 @@
   "js.success.download_started": "Download started: {repo_id}",
   "js.success.settings_saved": "Settings saved successfully",
   "settings.mcp.expose_tools": "Expose backend MCP tools to clients",
-  "settings.mcp.expose_tools_hint": "Merge backend MCP tools into chat completions. Disable if your client has its own MCP servers."
+  "settings.mcp.expose_tools_hint": "Merge backend MCP tools into chat completions. Disable if your client has its own MCP servers.",
+  "modal.model_settings.expert_streaming": "SSD Expert Streaming",
+  "modal.model_settings.expert_streaming_hint": "Stream routed experts from SSD using fixed pins, an analytical cache, or both.",
+  "modal.model_settings.expert_streaming_mode": "Residency mode",
+  "modal.model_settings.expert_streaming_mode_soft_reap": "Soft-REAP pinning",
+  "modal.model_settings.expert_streaming_mode_cache_only": "Analytical cache only",
+  "modal.model_settings.expert_streaming_mode_soft_reap_hint": "Manifest experts remain pinned; the extra cache learns non-pinned routes.",
+  "modal.model_settings.expert_streaming_mode_cache_only_hint": "No experts are pinned. A decayed route-frequency cache learns the active workload.",
+  "modal.model_settings.expert_manifest": "Expert pin manifest",
+  "modal.model_settings.expert_cache": "Hot experts per layer",
+  "modal.model_settings.expert_cache_hint": "Extra memory for frequently used non-pinned experts. A small working set is always reserved.",
+  "modal.model_settings.expert_substitution_threshold": "Resident substitution threshold (%)",
+  "modal.model_settings.expert_substitution_threshold_hint": "Allow a resident expert to replace a cold expert when its router weight is within this percentage. 0 keeps exact routing.",
+  "modal.model_settings.expert_execution_policy": "Execution mode",
+  "modal.model_settings.expert_execution_speculative": "Speculative (resident-hit optimized)",
+  "modal.model_settings.expert_execution_checked": "Checked (recommended)",
+  "modal.model_settings.expert_execution_policy_hint": "Checked mode is fastest when SSD misses are possible. Speculative mode is intended for measured near-perfect resident hit rates.",
+  "modal.model_settings.expert_projected_resident": "Projected resident model:"
 }

--- a/omlx/admin/i18n/en.json
+++ b/omlx/admin/i18n/en.json
@@ -1141,6 +1141,8 @@
   "modal.model_settings.expert_manifest": "Expert pin manifest",
   "modal.model_settings.expert_cache": "Hot experts per layer",
   "modal.model_settings.expert_cache_hint": "Extra memory for frequently used non-pinned experts. A small working set is always reserved.",
+  "modal.model_settings.expert_scratch": "Cold execution bank",
+  "modal.model_settings.expert_scratch_hint": "Extra preallocated slots that batch cold experts without evicting the hot cache.",
   "modal.model_settings.expert_substitution_threshold": "Resident substitution threshold (%)",
   "modal.model_settings.expert_substitution_threshold_hint": "Allow a resident expert to replace a cold expert when its router weight is within this percentage. 0 keeps exact routing.",
   "modal.model_settings.expert_execution_policy": "Execution mode",

--- a/omlx/admin/i18n/en.json
+++ b/omlx/admin/i18n/en.json
@@ -1143,6 +1143,8 @@
   "modal.model_settings.expert_cache_hint": "Extra memory for frequently used non-pinned experts. A small working set is always reserved.",
   "modal.model_settings.expert_scratch": "Cold execution bank",
   "modal.model_settings.expert_scratch_hint": "Extra preallocated slots that batch cold experts without evicting the hot cache.",
+  "modal.model_settings.expert_fast_resource_loading": "Fast Resource Loading",
+  "modal.model_settings.expert_fast_resource_loading_hint": "Use Apple Metal I/O for one-shot cold expert batches. Improves prefill without changing hot-cache promotions.",
   "modal.model_settings.expert_substitution_threshold": "Resident substitution threshold (%)",
   "modal.model_settings.expert_substitution_threshold_hint": "Allow a resident expert to replace a cold expert when its router weight is within this percentage. 0 keeps exact routing.",
   "modal.model_settings.expert_execution_policy": "Execution mode",

--- a/omlx/admin/i18n/es.json
+++ b/omlx/admin/i18n/es.json
@@ -1143,6 +1143,8 @@
   "modal.model_settings.expert_cache_hint": "Memoria adicional para expertos no fijados usados con frecuencia.",
   "modal.model_settings.expert_scratch": "Banco de ejecución en frío",
   "modal.model_settings.expert_scratch_hint": "Ranuras preasignadas adicionales para agrupar expertos fríos sin expulsar la caché activa.",
+  "modal.model_settings.expert_fast_resource_loading": "Carga rápida de recursos",
+  "modal.model_settings.expert_fast_resource_loading_hint": "Usa E/S de Apple Metal para lotes únicos de expertos fríos. Mejora el prellenado sin cambiar las promociones de la caché activa.",
   "modal.model_settings.expert_substitution_threshold": "Umbral de sustitución residente (%)",
   "modal.model_settings.expert_substitution_threshold_hint": "Permite sustituir un experto frío por uno residente cuando su peso de enrutamiento esté dentro de este porcentaje. 0 mantiene el enrutamiento exacto.",
   "modal.model_settings.expert_execution_policy": "Modo de ejecución",

--- a/omlx/admin/i18n/es.json
+++ b/omlx/admin/i18n/es.json
@@ -1130,5 +1130,22 @@
   "js.success.download_started": "Descarga iniciada: {repo_id}",
   "js.success.settings_saved": "Configuración guardada correctamente",
   "settings.mcp.expose_tools": "Exponer herramientas MCP del backend a los clientes",
-  "settings.mcp.expose_tools_hint": "Combina las herramientas MCP del backend en las respuestas. Desactívalo si tu cliente tiene sus propios servidores MCP."
+  "settings.mcp.expose_tools_hint": "Combina las herramientas MCP del backend en las respuestas. Desactívalo si tu cliente tiene sus propios servidores MCP.",
+  "modal.model_settings.expert_streaming": "Transmisión de expertos desde SSD",
+  "modal.model_settings.expert_streaming_hint": "Transmite expertos desde SSD usando fijación, caché analítica o ambas.",
+  "modal.model_settings.expert_streaming_mode": "Modo de residencia",
+  "modal.model_settings.expert_streaming_mode_soft_reap": "Fijación Soft-REAP",
+  "modal.model_settings.expert_streaming_mode_cache_only": "Solo caché analítica",
+  "modal.model_settings.expert_streaming_mode_soft_reap_hint": "Los expertos del manifiesto permanecen fijados; la caché adicional aprende las demás rutas.",
+  "modal.model_settings.expert_streaming_mode_cache_only_hint": "No se fija ningún experto. Una caché de frecuencia con decaimiento aprende la carga activa.",
+  "modal.model_settings.expert_manifest": "Manifiesto de expertos fijados",
+  "modal.model_settings.expert_cache": "Expertos activos por capa",
+  "modal.model_settings.expert_cache_hint": "Memoria adicional para expertos no fijados usados con frecuencia.",
+  "modal.model_settings.expert_substitution_threshold": "Umbral de sustitución residente (%)",
+  "modal.model_settings.expert_substitution_threshold_hint": "Permite sustituir un experto frío por uno residente cuando su peso de enrutamiento esté dentro de este porcentaje. 0 mantiene el enrutamiento exacto.",
+  "modal.model_settings.expert_execution_policy": "Modo de ejecución",
+  "modal.model_settings.expert_execution_speculative": "Especulativo (para aciertos residentes)",
+  "modal.model_settings.expert_execution_checked": "Comprobado (recomendado)",
+  "modal.model_settings.expert_execution_policy_hint": "El modo especulativo ejecuta las rutas residentes como un solo grafo y reintenta exactamente tras un fallo de SSD. El modo comprobado carga los fallos capa por capa.",
+  "modal.model_settings.expert_projected_resident": "Modelo residente estimado:"
 }

--- a/omlx/admin/i18n/es.json
+++ b/omlx/admin/i18n/es.json
@@ -1141,6 +1141,8 @@
   "modal.model_settings.expert_manifest": "Manifiesto de expertos fijados",
   "modal.model_settings.expert_cache": "Expertos activos por capa",
   "modal.model_settings.expert_cache_hint": "Memoria adicional para expertos no fijados usados con frecuencia.",
+  "modal.model_settings.expert_scratch": "Banco de ejecución en frío",
+  "modal.model_settings.expert_scratch_hint": "Ranuras preasignadas adicionales para agrupar expertos fríos sin expulsar la caché activa.",
   "modal.model_settings.expert_substitution_threshold": "Umbral de sustitución residente (%)",
   "modal.model_settings.expert_substitution_threshold_hint": "Permite sustituir un experto frío por uno residente cuando su peso de enrutamiento esté dentro de este porcentaje. 0 mantiene el enrutamiento exacto.",
   "modal.model_settings.expert_execution_policy": "Modo de ejecución",

--- a/omlx/admin/i18n/fr.json
+++ b/omlx/admin/i18n/fr.json
@@ -1130,5 +1130,22 @@
   "js.success.download_started": "Téléchargement démarré : {repo_id}",
   "js.success.settings_saved": "Paramètres enregistrés avec succès",
   "settings.mcp.expose_tools": "Exposer les outils MCP du backend aux clients",
-  "settings.mcp.expose_tools_hint": "Fusionne les outils MCP du backend dans les réponses. Désactivez si votre client possède ses propres serveurs MCP."
+  "settings.mcp.expose_tools_hint": "Fusionne les outils MCP du backend dans les réponses. Désactivez si votre client possède ses propres serveurs MCP.",
+  "modal.model_settings.expert_streaming": "Streaming d’experts depuis le SSD",
+  "modal.model_settings.expert_streaming_hint": "Diffuse les experts depuis le SSD avec épinglage, cache analytique ou les deux.",
+  "modal.model_settings.expert_streaming_mode": "Mode de résidence",
+  "modal.model_settings.expert_streaming_mode_soft_reap": "Épinglage Soft-REAP",
+  "modal.model_settings.expert_streaming_mode_cache_only": "Cache analytique uniquement",
+  "modal.model_settings.expert_streaming_mode_soft_reap_hint": "Les experts du manifeste restent épinglés ; le cache apprend les autres routes.",
+  "modal.model_settings.expert_streaming_mode_cache_only_hint": "Aucun expert n’est épinglé. Un cache de fréquence à décroissance apprend la charge active.",
+  "modal.model_settings.expert_manifest": "Manifeste des experts épinglés",
+  "modal.model_settings.expert_cache": "Experts actifs par couche",
+  "modal.model_settings.expert_cache_hint": "Mémoire supplémentaire pour les experts non épinglés fréquemment utilisés.",
+  "modal.model_settings.expert_substitution_threshold": "Seuil de substitution résidente (%)",
+  "modal.model_settings.expert_substitution_threshold_hint": "Autorise un expert résident à remplacer un expert froid si son poids de routage est dans ce pourcentage. 0 conserve le routage exact.",
+  "modal.model_settings.expert_execution_policy": "Mode d’exécution",
+  "modal.model_settings.expert_execution_speculative": "Spéculatif (pour les succès résidents)",
+  "modal.model_settings.expert_execution_checked": "Vérifié (recommandé)",
+  "modal.model_settings.expert_execution_policy_hint": "Le mode spéculatif exécute les routes résidentes dans un seul graphe et réessaie exactement après un défaut SSD. Le mode vérifié charge les défauts couche par couche.",
+  "modal.model_settings.expert_projected_resident": "Modèle résident estimé :"
 }

--- a/omlx/admin/i18n/fr.json
+++ b/omlx/admin/i18n/fr.json
@@ -1141,6 +1141,8 @@
   "modal.model_settings.expert_manifest": "Manifeste des experts épinglés",
   "modal.model_settings.expert_cache": "Experts actifs par couche",
   "modal.model_settings.expert_cache_hint": "Mémoire supplémentaire pour les experts non épinglés fréquemment utilisés.",
+  "modal.model_settings.expert_scratch": "Banque d’exécution froide",
+  "modal.model_settings.expert_scratch_hint": "Emplacements préalloués supplémentaires pour regrouper les experts froids sans évincer le cache actif.",
   "modal.model_settings.expert_substitution_threshold": "Seuil de substitution résidente (%)",
   "modal.model_settings.expert_substitution_threshold_hint": "Autorise un expert résident à remplacer un expert froid si son poids de routage est dans ce pourcentage. 0 conserve le routage exact.",
   "modal.model_settings.expert_execution_policy": "Mode d’exécution",

--- a/omlx/admin/i18n/fr.json
+++ b/omlx/admin/i18n/fr.json
@@ -1143,6 +1143,8 @@
   "modal.model_settings.expert_cache_hint": "Mémoire supplémentaire pour les experts non épinglés fréquemment utilisés.",
   "modal.model_settings.expert_scratch": "Banque d’exécution froide",
   "modal.model_settings.expert_scratch_hint": "Emplacements préalloués supplémentaires pour regrouper les experts froids sans évincer le cache actif.",
+  "modal.model_settings.expert_fast_resource_loading": "Chargement rapide des ressources",
+  "modal.model_settings.expert_fast_resource_loading_hint": "Utilise les E/S Apple Metal pour les lots ponctuels d’experts froids. Accélère le préremplissage sans modifier les promotions du cache actif.",
   "modal.model_settings.expert_substitution_threshold": "Seuil de substitution résidente (%)",
   "modal.model_settings.expert_substitution_threshold_hint": "Autorise un expert résident à remplacer un expert froid si son poids de routage est dans ce pourcentage. 0 conserve le routage exact.",
   "modal.model_settings.expert_execution_policy": "Mode d’exécution",

--- a/omlx/admin/i18n/ja.json
+++ b/omlx/admin/i18n/ja.json
@@ -1130,5 +1130,22 @@
   "js.success.download_started": "ダウンロード開始: {repo_id}",
   "js.success.settings_saved": "設定が保存されました",
   "settings.mcp.expose_tools": "バックエンドMCPツールをクライアントに公開",
-  "settings.mcp.expose_tools_hint": "バックエンドのMCPツールをチャット応答にマージします。クライアントが独自のMCPサーバーを持つ場合は無効にしてください。"
+  "settings.mcp.expose_tools_hint": "バックエンドのMCPツールをチャット応答にマージします。クライアントが独自のMCPサーバーを持つ場合は無効にしてください。",
+  "modal.model_settings.expert_streaming": "SSD エキスパートストリーミング",
+  "modal.model_settings.expert_streaming_hint": "固定、分析キャッシュ、またはその両方を使ってSSDからエキスパートを読み込みます。",
+  "modal.model_settings.expert_streaming_mode": "常駐モード",
+  "modal.model_settings.expert_streaming_mode_soft_reap": "Soft-REAP 固定",
+  "modal.model_settings.expert_streaming_mode_cache_only": "分析キャッシュのみ",
+  "modal.model_settings.expert_streaming_mode_soft_reap_hint": "マニフェストのエキスパートを固定し、追加キャッシュが他のルートを学習します。",
+  "modal.model_settings.expert_streaming_mode_cache_only_hint": "固定エキスパートはありません。減衰付きルート頻度キャッシュが実行中の負荷を学習します。",
+  "modal.model_settings.expert_manifest": "エキスパート固定マニフェスト",
+  "modal.model_settings.expert_cache": "レイヤーごとのホットエキスパート数",
+  "modal.model_settings.expert_cache_hint": "頻繁に使う非固定エキスパート用の追加メモリです。",
+  "modal.model_settings.expert_substitution_threshold": "常駐置換しきい値（%）",
+  "modal.model_settings.expert_substitution_threshold_hint": "ルーター重みの差がこの割合以内なら、コールドエキスパートを常駐エキスパートで置換します。0は正確なルーティングを維持します。",
+  "modal.model_settings.expert_execution_policy": "実行モード",
+  "modal.model_settings.expert_execution_speculative": "投機的（常駐ヒット向け）",
+  "modal.model_settings.expert_execution_checked": "確認済み（推奨）",
+  "modal.model_settings.expert_execution_policy_hint": "投機モードは常駐ルートを単一グラフで実行し、SSDミス後に正確に再試行します。確認モードはレイヤーごとにミスを読み込みます。",
+  "modal.model_settings.expert_projected_resident": "推定常駐モデル:"
 }

--- a/omlx/admin/i18n/ja.json
+++ b/omlx/admin/i18n/ja.json
@@ -1141,6 +1141,8 @@
   "modal.model_settings.expert_manifest": "エキスパート固定マニフェスト",
   "modal.model_settings.expert_cache": "レイヤーごとのホットエキスパート数",
   "modal.model_settings.expert_cache_hint": "頻繁に使う非固定エキスパート用の追加メモリです。",
+  "modal.model_settings.expert_scratch": "コールド実行バンク",
+  "modal.model_settings.expert_scratch_hint": "ホットキャッシュを追い出さずにコールドエキスパートをまとめて処理する追加の事前割り当てスロットです。",
   "modal.model_settings.expert_substitution_threshold": "常駐置換しきい値（%）",
   "modal.model_settings.expert_substitution_threshold_hint": "ルーター重みの差がこの割合以内なら、コールドエキスパートを常駐エキスパートで置換します。0は正確なルーティングを維持します。",
   "modal.model_settings.expert_execution_policy": "実行モード",

--- a/omlx/admin/i18n/ja.json
+++ b/omlx/admin/i18n/ja.json
@@ -1143,6 +1143,8 @@
   "modal.model_settings.expert_cache_hint": "頻繁に使う非固定エキスパート用の追加メモリです。",
   "modal.model_settings.expert_scratch": "コールド実行バンク",
   "modal.model_settings.expert_scratch_hint": "ホットキャッシュを追い出さずにコールドエキスパートをまとめて処理する追加の事前割り当てスロットです。",
+  "modal.model_settings.expert_fast_resource_loading": "高速リソース読み込み",
+  "modal.model_settings.expert_fast_resource_loading_hint": "一度だけ使うコールドエキスパートのバッチをApple Metal I/Oで読み込みます。ホットキャッシュの昇格を変えずにプリフィルを高速化します。",
   "modal.model_settings.expert_substitution_threshold": "常駐置換しきい値（%）",
   "modal.model_settings.expert_substitution_threshold_hint": "ルーター重みの差がこの割合以内なら、コールドエキスパートを常駐エキスパートで置換します。0は正確なルーティングを維持します。",
   "modal.model_settings.expert_execution_policy": "実行モード",

--- a/omlx/admin/i18n/ko.json
+++ b/omlx/admin/i18n/ko.json
@@ -1130,5 +1130,22 @@
   "js.success.download_started": "다운로드 시작: {repo_id}",
   "js.success.settings_saved": "설정이 저장되었습니다",
   "settings.mcp.expose_tools": "백엔드 MCP 도구를 클라이언트에 노출",
-  "settings.mcp.expose_tools_hint": "백엔드 MCP 도구를 채팅 응답에 병합합니다. 클라이언트에 자체 MCP 서버가 있는 경우 비활성화하세요."
+  "settings.mcp.expose_tools_hint": "백엔드 MCP 도구를 채팅 응답에 병합합니다. 클라이언트에 자체 MCP 서버가 있는 경우 비활성화하세요.",
+  "modal.model_settings.expert_streaming": "SSD 전문가 스트리밍",
+  "modal.model_settings.expert_streaming_hint": "고정, 분석 캐시 또는 둘 다를 사용해 SSD에서 전문가를 스트리밍합니다.",
+  "modal.model_settings.expert_streaming_mode": "상주 모드",
+  "modal.model_settings.expert_streaming_mode_soft_reap": "Soft-REAP 고정",
+  "modal.model_settings.expert_streaming_mode_cache_only": "분석 캐시 전용",
+  "modal.model_settings.expert_streaming_mode_soft_reap_hint": "매니페스트 전문가는 고정되고 추가 캐시는 나머지 경로를 학습합니다.",
+  "modal.model_settings.expert_streaming_mode_cache_only_hint": "고정 전문가는 없습니다. 감쇠 경로 빈도 캐시가 활성 작업을 학습합니다.",
+  "modal.model_settings.expert_manifest": "전문가 고정 매니페스트",
+  "modal.model_settings.expert_cache": "레이어당 핫 전문가 수",
+  "modal.model_settings.expert_cache_hint": "자주 사용하는 비고정 전문가를 위한 추가 메모리입니다.",
+  "modal.model_settings.expert_substitution_threshold": "상주 전문가 대체 임계값(%)",
+  "modal.model_settings.expert_substitution_threshold_hint": "라우터 가중치 차이가 이 비율 이내이면 콜드 전문가를 상주 전문가로 대체합니다. 0은 정확한 라우팅을 유지합니다.",
+  "modal.model_settings.expert_execution_policy": "실행 모드",
+  "modal.model_settings.expert_execution_speculative": "추측 실행(상주 적중용)",
+  "modal.model_settings.expert_execution_checked": "확인 실행(권장)",
+  "modal.model_settings.expert_execution_policy_hint": "추측 모드는 상주 경로를 하나의 그래프로 실행하고 SSD 미스 후 정확히 재시도합니다. 확인 모드는 레이어별로 미스를 로드합니다.",
+  "modal.model_settings.expert_projected_resident": "예상 상주 모델:"
 }

--- a/omlx/admin/i18n/ko.json
+++ b/omlx/admin/i18n/ko.json
@@ -1141,6 +1141,8 @@
   "modal.model_settings.expert_manifest": "전문가 고정 매니페스트",
   "modal.model_settings.expert_cache": "레이어당 핫 전문가 수",
   "modal.model_settings.expert_cache_hint": "자주 사용하는 비고정 전문가를 위한 추가 메모리입니다.",
+  "modal.model_settings.expert_scratch": "콜드 실행 뱅크",
+  "modal.model_settings.expert_scratch_hint": "핫 캐시를 축출하지 않고 콜드 전문가를 일괄 처리하는 추가 사전 할당 슬롯입니다.",
   "modal.model_settings.expert_substitution_threshold": "상주 전문가 대체 임계값(%)",
   "modal.model_settings.expert_substitution_threshold_hint": "라우터 가중치 차이가 이 비율 이내이면 콜드 전문가를 상주 전문가로 대체합니다. 0은 정확한 라우팅을 유지합니다.",
   "modal.model_settings.expert_execution_policy": "실행 모드",

--- a/omlx/admin/i18n/ko.json
+++ b/omlx/admin/i18n/ko.json
@@ -1143,6 +1143,8 @@
   "modal.model_settings.expert_cache_hint": "자주 사용하는 비고정 전문가를 위한 추가 메모리입니다.",
   "modal.model_settings.expert_scratch": "콜드 실행 뱅크",
   "modal.model_settings.expert_scratch_hint": "핫 캐시를 축출하지 않고 콜드 전문가를 일괄 처리하는 추가 사전 할당 슬롯입니다.",
+  "modal.model_settings.expert_fast_resource_loading": "빠른 리소스 로딩",
+  "modal.model_settings.expert_fast_resource_loading_hint": "일회성 콜드 전문가 배치에 Apple Metal I/O를 사용합니다. 핫 캐시 승격을 변경하지 않고 프리필을 가속합니다.",
   "modal.model_settings.expert_substitution_threshold": "상주 전문가 대체 임계값(%)",
   "modal.model_settings.expert_substitution_threshold_hint": "라우터 가중치 차이가 이 비율 이내이면 콜드 전문가를 상주 전문가로 대체합니다. 0은 정확한 라우팅을 유지합니다.",
   "modal.model_settings.expert_execution_policy": "실행 모드",

--- a/omlx/admin/i18n/pt-BR.json
+++ b/omlx/admin/i18n/pt-BR.json
@@ -1130,5 +1130,22 @@
   "js.success.download_started": "Download iniciado: {repo_id}",
   "js.success.settings_saved": "Configurações salvas com sucesso",
   "settings.mcp.expose_tools": "Expor ferramentas MCP do backend para clientes",
-  "settings.mcp.expose_tools_hint": "Mescla as ferramentas MCP do backend nas respostas. Desative se o seu cliente tiver seus próprios servidores MCP."
+  "settings.mcp.expose_tools_hint": "Mescla as ferramentas MCP do backend nas respostas. Desative se o seu cliente tiver seus próprios servidores MCP.",
+  "modal.model_settings.expert_streaming": "Streaming de especialistas via SSD",
+  "modal.model_settings.expert_streaming_hint": "Transmite especialistas do SSD usando fixação, cache analítico ou ambos.",
+  "modal.model_settings.expert_streaming_mode": "Modo de residência",
+  "modal.model_settings.expert_streaming_mode_soft_reap": "Fixação Soft-REAP",
+  "modal.model_settings.expert_streaming_mode_cache_only": "Somente cache analítico",
+  "modal.model_settings.expert_streaming_mode_soft_reap_hint": "Os especialistas do manifesto permanecem fixados; o cache extra aprende as outras rotas.",
+  "modal.model_settings.expert_streaming_mode_cache_only_hint": "Nenhum especialista é fixado. Um cache de frequência com decaimento aprende a carga ativa.",
+  "modal.model_settings.expert_manifest": "Manifesto de especialistas fixados",
+  "modal.model_settings.expert_cache": "Especialistas ativos por camada",
+  "modal.model_settings.expert_cache_hint": "Memória extra para especialistas não fixados usados com frequência.",
+  "modal.model_settings.expert_substitution_threshold": "Limite de substituição residente (%)",
+  "modal.model_settings.expert_substitution_threshold_hint": "Permite substituir um especialista frio por um residente quando o peso do roteador estiver dentro desta porcentagem. 0 mantém o roteamento exato.",
+  "modal.model_settings.expert_execution_policy": "Modo de execução",
+  "modal.model_settings.expert_execution_speculative": "Especulativo (para acertos residentes)",
+  "modal.model_settings.expert_execution_checked": "Verificado (recomendado)",
+  "modal.model_settings.expert_execution_policy_hint": "O modo especulativo executa rotas residentes em um único grafo e repete exatamente após uma falha no SSD. O modo verificado carrega falhas camada por camada.",
+  "modal.model_settings.expert_projected_resident": "Modelo residente estimado:"
 }

--- a/omlx/admin/i18n/pt-BR.json
+++ b/omlx/admin/i18n/pt-BR.json
@@ -1143,6 +1143,8 @@
   "modal.model_settings.expert_cache_hint": "Memória extra para especialistas não fixados usados com frequência.",
   "modal.model_settings.expert_scratch": "Banco de execução fria",
   "modal.model_settings.expert_scratch_hint": "Slots pré-alocados adicionais para agrupar especialistas frios sem expulsar o cache ativo.",
+  "modal.model_settings.expert_fast_resource_loading": "Carregamento rápido de recursos",
+  "modal.model_settings.expert_fast_resource_loading_hint": "Usa E/S do Apple Metal para lotes únicos de especialistas frios. Acelera o prefill sem alterar as promoções do cache ativo.",
   "modal.model_settings.expert_substitution_threshold": "Limite de substituição residente (%)",
   "modal.model_settings.expert_substitution_threshold_hint": "Permite substituir um especialista frio por um residente quando o peso do roteador estiver dentro desta porcentagem. 0 mantém o roteamento exato.",
   "modal.model_settings.expert_execution_policy": "Modo de execução",

--- a/omlx/admin/i18n/pt-BR.json
+++ b/omlx/admin/i18n/pt-BR.json
@@ -1141,6 +1141,8 @@
   "modal.model_settings.expert_manifest": "Manifesto de especialistas fixados",
   "modal.model_settings.expert_cache": "Especialistas ativos por camada",
   "modal.model_settings.expert_cache_hint": "Memória extra para especialistas não fixados usados com frequência.",
+  "modal.model_settings.expert_scratch": "Banco de execução fria",
+  "modal.model_settings.expert_scratch_hint": "Slots pré-alocados adicionais para agrupar especialistas frios sem expulsar o cache ativo.",
   "modal.model_settings.expert_substitution_threshold": "Limite de substituição residente (%)",
   "modal.model_settings.expert_substitution_threshold_hint": "Permite substituir um especialista frio por um residente quando o peso do roteador estiver dentro desta porcentagem. 0 mantém o roteamento exato.",
   "modal.model_settings.expert_execution_policy": "Modo de execução",

--- a/omlx/admin/i18n/ru.json
+++ b/omlx/admin/i18n/ru.json
@@ -1143,6 +1143,8 @@
   "modal.model_settings.expert_cache_hint": "Дополнительная память для часто используемых незакреплённых экспертов.",
   "modal.model_settings.expert_scratch": "Банк холодного выполнения",
   "modal.model_settings.expert_scratch_hint": "Дополнительные заранее выделенные слоты для пакетной обработки холодных экспертов без вытеснения горячего кэша.",
+  "modal.model_settings.expert_fast_resource_loading": "Быстрая загрузка ресурсов",
+  "modal.model_settings.expert_fast_resource_loading_hint": "Использует Apple Metal I/O для одноразовых пакетов холодных экспертов. Ускоряет префилл, не меняя продвижение в горячий кэш.",
   "modal.model_settings.expert_substitution_threshold": "Порог замены резидентным экспертом (%)",
   "modal.model_settings.expert_substitution_threshold_hint": "Разрешает замену холодного эксперта резидентным, если вес маршрутизации отличается не более чем на этот процент. 0 сохраняет точную маршрутизацию.",
   "modal.model_settings.expert_execution_policy": "Режим выполнения",

--- a/omlx/admin/i18n/ru.json
+++ b/omlx/admin/i18n/ru.json
@@ -1130,5 +1130,22 @@
   "js.success.download_started": "Загрузка начата: {repo_id}",
   "js.success.settings_saved": "Настройки успешно сохранены",
   "settings.mcp.expose_tools": "Показывать инструменты MCP бэкенда клиентам",
-  "settings.mcp.expose_tools_hint": "Объединяет инструменты MCP бэкенда с ответами. Отключите, если ваш клиент использует свои собственные MCP-серверы."
+  "settings.mcp.expose_tools_hint": "Объединяет инструменты MCP бэкенда с ответами. Отключите, если ваш клиент использует свои собственные MCP-серверы.",
+  "modal.model_settings.expert_streaming": "Потоковая загрузка экспертов с SSD",
+  "modal.model_settings.expert_streaming_hint": "Загружает экспертов с SSD, используя закрепление, аналитический кэш или оба режима.",
+  "modal.model_settings.expert_streaming_mode": "Режим резидентности",
+  "modal.model_settings.expert_streaming_mode_soft_reap": "Закрепление Soft-REAP",
+  "modal.model_settings.expert_streaming_mode_cache_only": "Только аналитический кэш",
+  "modal.model_settings.expert_streaming_mode_soft_reap_hint": "Эксперты из манифеста закреплены; дополнительный кэш изучает остальные маршруты.",
+  "modal.model_settings.expert_streaming_mode_cache_only_hint": "Закреплённых экспертов нет. Кэш частоты маршрутов с затуханием изучает активную нагрузку.",
+  "modal.model_settings.expert_manifest": "Манифест закреплённых экспертов",
+  "modal.model_settings.expert_cache": "Горячих экспертов на слой",
+  "modal.model_settings.expert_cache_hint": "Дополнительная память для часто используемых незакреплённых экспертов.",
+  "modal.model_settings.expert_substitution_threshold": "Порог замены резидентным экспертом (%)",
+  "modal.model_settings.expert_substitution_threshold_hint": "Разрешает замену холодного эксперта резидентным, если вес маршрутизации отличается не более чем на этот процент. 0 сохраняет точную маршрутизацию.",
+  "modal.model_settings.expert_execution_policy": "Режим выполнения",
+  "modal.model_settings.expert_execution_speculative": "Спекулятивный (для резидентных попаданий)",
+  "modal.model_settings.expert_execution_checked": "Проверяемый (рекомендуется)",
+  "modal.model_settings.expert_execution_policy_hint": "Спекулятивный режим выполняет резидентные маршруты одним графом и точно повторяет проход после промаха SSD. Проверяемый режим загружает промахи послойно.",
+  "modal.model_settings.expert_projected_resident": "Ожидаемый размер в памяти:"
 }

--- a/omlx/admin/i18n/ru.json
+++ b/omlx/admin/i18n/ru.json
@@ -1141,6 +1141,8 @@
   "modal.model_settings.expert_manifest": "Манифест закреплённых экспертов",
   "modal.model_settings.expert_cache": "Горячих экспертов на слой",
   "modal.model_settings.expert_cache_hint": "Дополнительная память для часто используемых незакреплённых экспертов.",
+  "modal.model_settings.expert_scratch": "Банк холодного выполнения",
+  "modal.model_settings.expert_scratch_hint": "Дополнительные заранее выделенные слоты для пакетной обработки холодных экспертов без вытеснения горячего кэша.",
   "modal.model_settings.expert_substitution_threshold": "Порог замены резидентным экспертом (%)",
   "modal.model_settings.expert_substitution_threshold_hint": "Разрешает замену холодного эксперта резидентным, если вес маршрутизации отличается не более чем на этот процент. 0 сохраняет точную маршрутизацию.",
   "modal.model_settings.expert_execution_policy": "Режим выполнения",

--- a/omlx/admin/i18n/zh-TW.json
+++ b/omlx/admin/i18n/zh-TW.json
@@ -1141,6 +1141,8 @@
   "modal.model_settings.expert_manifest": "專家固定清單",
   "modal.model_settings.expert_cache": "每層熱門專家數",
   "modal.model_settings.expert_cache_hint": "提供給常用非固定專家的額外記憶體。",
+  "modal.model_settings.expert_scratch": "冷專家執行區",
+  "modal.model_settings.expert_scratch_hint": "額外預先配置的插槽，可批次執行冷專家而不逐出熱門快取。",
   "modal.model_settings.expert_substitution_threshold": "常駐專家替換閾值（%）",
   "modal.model_settings.expert_substitution_threshold_hint": "當路由權重差在此百分比內時，允許常駐專家替換冷專家。0 會保留精確路由。",
   "modal.model_settings.expert_execution_policy": "執行模式",

--- a/omlx/admin/i18n/zh-TW.json
+++ b/omlx/admin/i18n/zh-TW.json
@@ -1143,6 +1143,8 @@
   "modal.model_settings.expert_cache_hint": "提供給常用非固定專家的額外記憶體。",
   "modal.model_settings.expert_scratch": "冷專家執行區",
   "modal.model_settings.expert_scratch_hint": "額外預先配置的插槽，可批次執行冷專家而不逐出熱門快取。",
+  "modal.model_settings.expert_fast_resource_loading": "快速資源載入",
+  "modal.model_settings.expert_fast_resource_loading_hint": "使用 Apple Metal I/O 載入一次性冷專家批次。在不改變熱門快取晉升的情況下加速預填充。",
   "modal.model_settings.expert_substitution_threshold": "常駐專家替換閾值（%）",
   "modal.model_settings.expert_substitution_threshold_hint": "當路由權重差在此百分比內時，允許常駐專家替換冷專家。0 會保留精確路由。",
   "modal.model_settings.expert_execution_policy": "執行模式",

--- a/omlx/admin/i18n/zh-TW.json
+++ b/omlx/admin/i18n/zh-TW.json
@@ -1130,5 +1130,22 @@
   "js.success.download_started": "已開始下載：{repo_id}",
   "js.success.settings_saved": "設定儲存成功",
   "settings.mcp.expose_tools": "向客戶端公開後端 MCP 工具",
-  "settings.mcp.expose_tools_hint": "將後端 MCP 工具合併到聊天回應中。如果您的用戶端有自己的 MCP 伺服器，請停用此選項。"
+  "settings.mcp.expose_tools_hint": "將後端 MCP 工具合併到聊天回應中。如果您的用戶端有自己的 MCP 伺服器，請停用此選項。",
+  "modal.model_settings.expert_streaming": "SSD 專家串流",
+  "modal.model_settings.expert_streaming_hint": "使用固定、分析快取或兩者從 SSD 串流專家。",
+  "modal.model_settings.expert_streaming_mode": "常駐模式",
+  "modal.model_settings.expert_streaming_mode_soft_reap": "Soft-REAP 固定",
+  "modal.model_settings.expert_streaming_mode_cache_only": "僅分析快取",
+  "modal.model_settings.expert_streaming_mode_soft_reap_hint": "清單專家保持固定；額外快取會學習其他路由。",
+  "modal.model_settings.expert_streaming_mode_cache_only_hint": "不固定任何專家。具衰減的路由頻率快取會學習目前工作負載。",
+  "modal.model_settings.expert_manifest": "專家固定清單",
+  "modal.model_settings.expert_cache": "每層熱門專家數",
+  "modal.model_settings.expert_cache_hint": "提供給常用非固定專家的額外記憶體。",
+  "modal.model_settings.expert_substitution_threshold": "常駐專家替換閾值（%）",
+  "modal.model_settings.expert_substitution_threshold_hint": "當路由權重差在此百分比內時，允許常駐專家替換冷專家。0 會保留精確路由。",
+  "modal.model_settings.expert_execution_policy": "執行模式",
+  "modal.model_settings.expert_execution_speculative": "推測執行（適用於常駐命中）",
+  "modal.model_settings.expert_execution_checked": "檢查執行（建議）",
+  "modal.model_settings.expert_execution_policy_hint": "推測模式以單一圖執行常駐路由，SSD 未命中後精確重試。檢查模式逐層載入未命中專家。",
+  "modal.model_settings.expert_projected_resident": "預估常駐模型："
 }

--- a/omlx/admin/i18n/zh.json
+++ b/omlx/admin/i18n/zh.json
@@ -1143,6 +1143,8 @@
   "modal.model_settings.expert_cache_hint": "为常用的非固定专家提供额外内存。",
   "modal.model_settings.expert_scratch": "冷专家执行区",
   "modal.model_settings.expert_scratch_hint": "额外预分配的槽位，可批量执行冷专家而不逐出热门缓存。",
+  "modal.model_settings.expert_fast_resource_loading": "快速资源加载",
+  "modal.model_settings.expert_fast_resource_loading_hint": "使用 Apple Metal I/O 加载一次性冷专家批次。在不改变热门缓存晋升的情况下加速预填充。",
   "modal.model_settings.expert_substitution_threshold": "常驻专家替换阈值（%）",
   "modal.model_settings.expert_substitution_threshold_hint": "当路由权重差在此百分比内时，允许常驻专家替换冷专家。0 保持精确路由。",
   "modal.model_settings.expert_execution_policy": "执行模式",

--- a/omlx/admin/i18n/zh.json
+++ b/omlx/admin/i18n/zh.json
@@ -1130,5 +1130,22 @@
   "js.success.download_started": "已开始下载：{repo_id}",
   "js.success.settings_saved": "设置已成功保存",
   "settings.mcp.expose_tools": "向客户端公开后端 MCP 工具",
-  "settings.mcp.expose_tools_hint": "将后端 MCP 工具合并到聊天响应中。如果您的客户端有自己的 MCP 服务器，请禁用此选项。"
+  "settings.mcp.expose_tools_hint": "将后端 MCP 工具合并到聊天响应中。如果您的客户端有自己的 MCP 服务器，请禁用此选项。",
+  "modal.model_settings.expert_streaming": "SSD 专家流式加载",
+  "modal.model_settings.expert_streaming_hint": "使用固定、分析缓存或两者从 SSD 流式加载专家。",
+  "modal.model_settings.expert_streaming_mode": "常驻模式",
+  "modal.model_settings.expert_streaming_mode_soft_reap": "Soft-REAP 固定",
+  "modal.model_settings.expert_streaming_mode_cache_only": "仅分析缓存",
+  "modal.model_settings.expert_streaming_mode_soft_reap_hint": "清单专家保持固定；额外缓存会学习其他路由。",
+  "modal.model_settings.expert_streaming_mode_cache_only_hint": "不固定任何专家。带衰减的路由频率缓存会学习当前工作负载。",
+  "modal.model_settings.expert_manifest": "专家固定清单",
+  "modal.model_settings.expert_cache": "每层热门专家数",
+  "modal.model_settings.expert_cache_hint": "为常用的非固定专家提供额外内存。",
+  "modal.model_settings.expert_substitution_threshold": "常驻专家替换阈值（%）",
+  "modal.model_settings.expert_substitution_threshold_hint": "当路由权重差在此百分比内时，允许常驻专家替换冷专家。0 保持精确路由。",
+  "modal.model_settings.expert_execution_policy": "执行模式",
+  "modal.model_settings.expert_execution_speculative": "推测执行（适用于常驻命中）",
+  "modal.model_settings.expert_execution_checked": "检查执行（推荐）",
+  "modal.model_settings.expert_execution_policy_hint": "推测模式将常驻路由作为单个计算图执行，并在 SSD 未命中后精确重试。检查模式逐层加载未命中专家。",
+  "modal.model_settings.expert_projected_resident": "预计常驻模型："
 }

--- a/omlx/admin/i18n/zh.json
+++ b/omlx/admin/i18n/zh.json
@@ -1141,6 +1141,8 @@
   "modal.model_settings.expert_manifest": "专家固定清单",
   "modal.model_settings.expert_cache": "每层热门专家数",
   "modal.model_settings.expert_cache_hint": "为常用的非固定专家提供额外内存。",
+  "modal.model_settings.expert_scratch": "冷专家执行区",
+  "modal.model_settings.expert_scratch_hint": "额外预分配的槽位，可批量执行冷专家而不逐出热门缓存。",
   "modal.model_settings.expert_substitution_threshold": "常驻专家替换阈值（%）",
   "modal.model_settings.expert_substitution_threshold_hint": "当路由权重差在此百分比内时，允许常驻专家替换冷专家。0 保持精确路由。",
   "modal.model_settings.expert_execution_policy": "执行模式",

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -144,6 +144,7 @@ class ModelSettingsRequest(BaseModel):
     expert_streaming_manifest: str | None = None
     expert_streaming_cache_experts: int | None = None
     expert_streaming_scratch_experts: int | None = None
+    expert_streaming_fast_resource_loading: bool | None = None
     expert_streaming_substitution_threshold_percent: float | None = None
     expert_streaming_execution_policy: str | None = None
     thinking_budget_enabled: bool | None = None
@@ -2505,6 +2506,10 @@ async def update_model_settings(
                 detail="Expert scratch size must be between 0 and 512 experts per layer.",
             )
         current_settings.expert_streaming_scratch_experts = int(scratch_experts)
+    if "expert_streaming_fast_resource_loading" in sent:
+        current_settings.expert_streaming_fast_resource_loading = bool(
+            request.expert_streaming_fast_resource_loading
+        )
     if "expert_streaming_substitution_threshold_percent" in sent:
         threshold = request.expert_streaming_substitution_threshold_percent
         if threshold is None or not 0 <= threshold <= 100:

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -2292,14 +2292,16 @@ async def upload_expert_manifest(
         from ..expert_streaming.manifest import validate_soft_reap_manifest_data
         from ..expert_streaming.safetensors import SafetensorExpertIndex
 
+        index = SafetensorExpertIndex(entry.model_path)
+        layer_ids = index.expert_layer_ids()
         manifest = validate_soft_reap_manifest_data(
             data,
-            num_layers=num_layers,
+            num_layers=num_layers if not layer_ids else None,
+            layer_ids=layer_ids or None,
             num_experts=num_experts,
         )
-        index = SafetensorExpertIndex(entry.model_path)
         for layer in manifest.layers:
-            index.layer(layer)
+            index.expert_storage_bytes(layer)
     except (OSError, UnicodeError, TypeError, ValueError, json.JSONDecodeError) as exc:
         raise HTTPException(
             status_code=400, detail=f"Invalid Soft-REAP manifest: {exc}"

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -143,6 +143,7 @@ class ModelSettingsRequest(BaseModel):
     expert_streaming_mode: str | None = None
     expert_streaming_manifest: str | None = None
     expert_streaming_cache_experts: int | None = None
+    expert_streaming_scratch_experts: int | None = None
     expert_streaming_substitution_threshold_percent: float | None = None
     expert_streaming_execution_policy: str | None = None
     thinking_budget_enabled: bool | None = None
@@ -2496,6 +2497,14 @@ async def update_model_settings(
                 detail="Expert cache size must be between 0 and 512 experts per layer.",
             )
         current_settings.expert_streaming_cache_experts = int(cache_experts)
+    if "expert_streaming_scratch_experts" in sent:
+        scratch_experts = request.expert_streaming_scratch_experts
+        if scratch_experts is None or not 0 <= scratch_experts <= 512:
+            raise HTTPException(
+                status_code=400,
+                detail="Expert scratch size must be between 0 and 512 experts per layer.",
+            )
+        current_settings.expert_streaming_scratch_experts = int(scratch_experts)
     if "expert_streaming_substitution_threshold_percent" in sent:
         threshold = request.expert_streaming_substitution_threshold_percent
         if threshold is None or not 0 <= threshold <= 100:

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -9,6 +9,7 @@ This module provides HTTP routes for the admin panel including:
 """
 
 import asyncio
+import hashlib
 import inspect
 import json
 import logging
@@ -25,7 +26,7 @@ from pathlib import Path
 from typing import Any, Literal, Optional
 
 import requests
-from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi import APIRouter, Depends, File, HTTPException, Request, Response, UploadFile
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -138,6 +139,12 @@ class ModelSettingsRequest(BaseModel):
     # template supports it). Mirrors ModelSettings.preserve_thinking.
     preserve_thinking: bool | None = None
     qwen4_ple_ssd_offload: bool | None = None
+    expert_streaming_enabled: bool | None = None
+    expert_streaming_mode: str | None = None
+    expert_streaming_manifest: str | None = None
+    expert_streaming_cache_experts: int | None = None
+    expert_streaming_substitution_threshold_percent: float | None = None
+    expert_streaming_execution_policy: str | None = None
     thinking_budget_enabled: bool | None = None
     thinking_budget_tokens: int | None = None
     # MTP draft tokens per cycle for legacy MTP (None = adaptive default).
@@ -1951,6 +1958,31 @@ async def list_models(is_admin: bool = Depends(require_admin)):
         qwen4_ple_ssd_offload_forced = False
         qwen4_resident_bytes = 0
         qwen4_mmap_bytes = 0
+        expert_streaming_supported = False
+        expert_streaming_resident_bytes = 0
+        try:
+            model_path = Path(model_info.get("model_path", ""))
+            config = json.loads((model_path / "config.json").read_text())
+            text_config = config.get("text_config") or config
+            num_experts = int(
+                text_config.get(
+                    "num_experts", text_config.get("n_routed_experts", 0)
+                )
+                or 0
+            )
+            if num_experts > 0:
+                from ..expert_streaming.safetensors import SafetensorExpertIndex
+
+                SafetensorExpertIndex(model_path).layer(0)
+                expert_streaming_supported = True
+            if settings and settings.expert_streaming_enabled:
+                from ..expert_streaming.residency import estimate_for_model_settings
+
+                streaming_estimate = estimate_for_model_settings(model_path, settings)
+                if streaming_estimate is not None:
+                    expert_streaming_resident_bytes = streaming_estimate.resident_bytes
+        except (OSError, TypeError, ValueError, KeyError, json.JSONDecodeError):
+            pass
         if (model_info.get("config_model_type") or "").replace(
             "-", "_"
         ).lower() == "qwen4_exp":
@@ -1966,6 +1998,14 @@ async def list_models(is_admin: bool = Depends(require_admin)):
                 qwen4_ple_ssd_offload_forced = estimate.force_ssd_offload(
                     residency_ceiling
                 )
+                if (
+                    expert_streaming_resident_bytes
+                    and (
+                        residency_ceiling <= 0
+                        or expert_streaming_resident_bytes <= residency_ceiling
+                    )
+                ):
+                    qwen4_ple_ssd_offload_forced = False
                 qwen4_resident_bytes = estimate.resident_bytes
                 qwen4_mmap_bytes = estimate.mmap_bytes
             except (OSError, TypeError, ValueError):
@@ -2028,6 +2068,8 @@ async def list_models(is_admin: bool = Depends(require_admin)):
             "qwen4_ple_ssd_offload_forced": qwen4_ple_ssd_offload_forced,
             "qwen4_ple_resident_bytes": qwen4_resident_bytes,
             "qwen4_ple_mmap_bytes": qwen4_mmap_bytes,
+            "expert_streaming_supported": expert_streaming_supported,
+            "expert_streaming_resident_bytes": expert_streaming_resident_bytes,
             "is_paroquant": is_paroquant,
             "paroquant_reason": paroquant_reason,
         }
@@ -2215,6 +2257,73 @@ async def reload_models(is_admin: bool = Depends(require_admin)):
     raise HTTPException(status_code=500, detail=message)
 
 
+@router.post("/api/models/{model_id}/expert-manifest")
+async def upload_expert_manifest(
+    model_id: str,
+    file: UploadFile = File(...),
+    is_admin: bool = Depends(require_admin),
+):
+    """Validate and retain a small Soft-REAP expert-pinning manifest."""
+
+    del is_admin
+    engine_pool = _get_engine_pool()
+    settings_manager = _get_settings_manager()
+    if engine_pool is None or settings_manager is None:
+        raise HTTPException(status_code=503, detail="Server not initialized")
+    entry = engine_pool.get_entry(model_id)
+    if entry is None:
+        raise HTTPException(status_code=404, detail=f"Model not found: {model_id}")
+    payload = await file.read(2 * 1024 * 1024 + 1)
+    if len(payload) > 2 * 1024 * 1024:
+        raise HTTPException(status_code=413, detail="Expert manifest exceeds 2 MiB")
+    try:
+        data = json.loads(payload.decode("utf-8"))
+        config = json.loads(
+            (Path(entry.model_path) / "config.json").read_text(encoding="utf-8")
+        )
+        text_config = config.get("text_config") or config
+        num_layers = int(text_config.get("num_hidden_layers", 0) or 0)
+        num_experts = int(
+            text_config.get(
+                "num_experts", text_config.get("n_routed_experts", 0)
+            )
+            or 0
+        )
+        from ..expert_streaming.manifest import validate_soft_reap_manifest_data
+        from ..expert_streaming.safetensors import SafetensorExpertIndex
+
+        manifest = validate_soft_reap_manifest_data(
+            data,
+            num_layers=num_layers,
+            num_experts=num_experts,
+        )
+        index = SafetensorExpertIndex(entry.model_path)
+        for layer in manifest.layers:
+            index.layer(layer)
+    except (OSError, UnicodeError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise HTTPException(
+            status_code=400, detail=f"Invalid Soft-REAP manifest: {exc}"
+        ) from exc
+
+    digest = hashlib.sha256(payload).hexdigest()[:16]
+    directory = settings_manager.base_path / "expert_manifests"
+    directory.mkdir(parents=True, exist_ok=True)
+    destination = directory / f"{digest}.json"
+    temporary = destination.with_suffix(f".{os.getpid()}.tmp")
+    try:
+        temporary.write_bytes(payload)
+        temporary.replace(destination)
+    finally:
+        temporary.unlink(missing_ok=True)
+    return {
+        "success": True,
+        "manifest_path": str(destination),
+        "layers": manifest.layer_count,
+        "pinned_count_min": manifest.pinned_count_range[0],
+        "pinned_count_max": manifest.pinned_count_range[1],
+    }
+
+
 @router.put("/api/models/{model_id}/settings")
 async def update_model_settings(
     model_id: str,
@@ -2359,6 +2468,67 @@ async def update_model_settings(
         current_settings.qwen4_ple_ssd_offload = bool(
             request.qwen4_ple_ssd_offload and is_qwen4_exp
         )
+    if "expert_streaming_enabled" in sent:
+        current_settings.expert_streaming_enabled = bool(
+            request.expert_streaming_enabled
+        )
+    if "expert_streaming_mode" in sent:
+        streaming_mode = str(request.expert_streaming_mode or "")
+        if streaming_mode not in {"soft_reap", "cache_only"}:
+            raise HTTPException(
+                status_code=400,
+                detail="Expert streaming mode must be soft_reap or cache_only.",
+            )
+        current_settings.expert_streaming_mode = streaming_mode
+    if "expert_streaming_manifest" in sent:
+        current_settings.expert_streaming_manifest = (
+            request.expert_streaming_manifest.strip()
+            if request.expert_streaming_manifest
+            else None
+        )
+    if "expert_streaming_cache_experts" in sent:
+        cache_experts = request.expert_streaming_cache_experts
+        if cache_experts is None or not 0 <= cache_experts <= 512:
+            raise HTTPException(
+                status_code=400,
+                detail="Expert cache size must be between 0 and 512 experts per layer.",
+            )
+        current_settings.expert_streaming_cache_experts = int(cache_experts)
+    if "expert_streaming_substitution_threshold_percent" in sent:
+        threshold = request.expert_streaming_substitution_threshold_percent
+        if threshold is None or not 0 <= threshold <= 100:
+            raise HTTPException(
+                status_code=400,
+                detail="Expert substitution threshold must be between 0% and 100%.",
+            )
+        current_settings.expert_streaming_substitution_threshold_percent = float(
+            threshold
+        )
+    if "expert_streaming_execution_policy" in sent:
+        execution_policy = str(request.expert_streaming_execution_policy or "")
+        if execution_policy not in {"checked", "speculative"}:
+            raise HTTPException(
+                status_code=400,
+                detail="Expert streaming execution policy must be checked or speculative.",
+            )
+        current_settings.expert_streaming_execution_policy = execution_policy
+    if current_settings.expert_streaming_enabled:
+        streaming_mode = current_settings.expert_streaming_mode
+        manifest_path = current_settings.expert_streaming_manifest
+        if streaming_mode == "soft_reap" and not manifest_path:
+            raise HTTPException(
+                status_code=400,
+                detail="Upload a Soft-REAP manifest before enabling expert streaming.",
+            )
+        try:
+            from ..expert_streaming.residency import estimate_for_model_settings
+
+            estimate_for_model_settings(entry.model_path, current_settings)
+        except (OSError, TypeError, ValueError) as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid Soft-REAP configuration: {exc}",
+            ) from exc
     if "thinking_budget_enabled" in sent:
         current_settings.thinking_budget_enabled = (
             request.thinking_budget_enabled or False

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -7391,6 +7391,8 @@
                         s.expert_streaming_cache_experts ?? 32,
                     expert_streaming_scratch_experts:
                         s.expert_streaming_scratch_experts ?? 32,
+                    expert_streaming_fast_resource_loading:
+                        s.expert_streaming_fast_resource_loading === true,
                     expert_streaming_substitution_threshold_percent:
                         s.expert_streaming_substitution_threshold_percent ?? 0,
                     expert_streaming_execution_policy:
@@ -8353,6 +8355,9 @@
                                     Number(this.modelSettings.expert_streaming_cache_experts) || 0,
                                 expert_streaming_scratch_experts:
                                     Number(this.modelSettings.expert_streaming_scratch_experts) || 0,
+                                expert_streaming_fast_resource_loading:
+                                    !!this.modelSettings.expert_streaming_enabled
+                                    && !!this.modelSettings.expert_streaming_fast_resource_loading,
                                 expert_streaming_substitution_threshold_percent:
                                     Number(this.modelSettings.expert_streaming_substitution_threshold_percent) || 0,
                                 expert_streaming_execution_policy:

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -7378,6 +7378,23 @@
                         model?.qwen4_ple_ssd_offload_supported === true,
                     qwen4_ple_ssd_offload_forced:
                         model?.qwen4_ple_ssd_offload_forced === true,
+                    expert_streaming_supported:
+                        model?.expert_streaming_supported === true,
+                    expert_streaming_enabled: s.expert_streaming_enabled === true,
+                    expert_streaming_mode: s.expert_streaming_mode || 'soft_reap',
+                    expert_streaming_manifest: s.expert_streaming_manifest || '',
+                    expert_streaming_manifest_name: s.expert_streaming_manifest
+                        ? s.expert_streaming_manifest.split('/').pop()
+                        : '',
+                    expert_streaming_manifest_file: null,
+                    expert_streaming_cache_experts:
+                        s.expert_streaming_cache_experts ?? 32,
+                    expert_streaming_substitution_threshold_percent:
+                        s.expert_streaming_substitution_threshold_percent ?? 0,
+                    expert_streaming_execution_policy:
+                        s.expert_streaming_execution_policy || 'checked',
+                    expert_streaming_resident_bytes:
+                        model?.expert_streaming_resident_bytes || 0,
                     enableThinkingBudget: !!(s.thinking_budget_tokens),
                     thinking_budget_tokens: s.thinking_budget_tokens || null,
                     guided_grammar_enabled: s.guided_grammar_enabled || false,
@@ -8247,6 +8264,28 @@
 
                 this.savingModelSettings = true;
                 try {
+                    let expertManifestPath = this.modelSettings.expert_streaming_manifest || '';
+                    const manifestFile = this.modelSettings.expert_streaming_manifest_file;
+                    const softReapMode =
+                        this.modelSettings.expert_streaming_mode === 'soft_reap';
+                    if (this.modelSettings.expert_streaming_enabled && softReapMode && manifestFile) {
+                        const form = new FormData();
+                        form.append('file', manifestFile);
+                        const uploadResponse = await fetch(
+                            `/admin/api/models/${encodeURIComponent(this.selectedModel.id)}/expert-manifest`,
+                            { method: 'POST', body: form },
+                        );
+                        const uploadData = await uploadResponse.json();
+                        if (!uploadResponse.ok) {
+                            throw new Error(uploadData.detail || 'Invalid Soft-REAP manifest');
+                        }
+                        expertManifestPath = uploadData.manifest_path;
+                        this.modelSettings.expert_streaming_manifest = expertManifestPath;
+                        this.modelSettings.expert_streaming_manifest_name = manifestFile.name;
+                    }
+                    if (this.modelSettings.expert_streaming_enabled && softReapMode && !expertManifestPath) {
+                        throw new Error('Upload a Soft-REAP manifest before enabling expert streaming.');
+                    }
                     const response = await fetch(`/admin/api/models/${encodeURIComponent(this.selectedModel.id)}/settings`, {
                         method: 'PUT',
                         headers: { 'Content-Type': 'application/json' },
@@ -8300,6 +8339,20 @@
                                 enable_thinking: this.modelSettings.enable_thinking,
                                 qwen4_ple_ssd_offload:
                                     !!this.modelSettings.qwen4_ple_ssd_offload,
+                                expert_streaming_enabled:
+                                    !!this.modelSettings.expert_streaming_enabled,
+                                expert_streaming_mode:
+                                    this.modelSettings.expert_streaming_mode || 'soft_reap',
+                                expert_streaming_manifest:
+                                    this.modelSettings.expert_streaming_enabled && softReapMode
+                                        ? (expertManifestPath || null)
+                                        : null,
+                                expert_streaming_cache_experts:
+                                    Number(this.modelSettings.expert_streaming_cache_experts) || 0,
+                                expert_streaming_substitution_threshold_percent:
+                                    Number(this.modelSettings.expert_streaming_substitution_threshold_percent) || 0,
+                                expert_streaming_execution_policy:
+                                    this.modelSettings.expert_streaming_execution_policy || 'checked',
                                 thinking_budget_enabled: this.modelSettings.enableThinkingBudget,
                                 thinking_budget_tokens: this.modelSettings.enableThinkingBudget
                                     ? (this.modelSettings.thinking_budget_tokens || null)
@@ -8500,7 +8553,7 @@
                     }
                 } catch (err) {
                     console.error('Failed to save model settings:', err);
-                    alert(window.t('js.error.save_model_settings_failed'));
+                    alert(err?.message || window.t('js.error.save_model_settings_failed'));
                 } finally {
                     this.savingModelSettings = false;
                 }

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -7389,6 +7389,8 @@
                     expert_streaming_manifest_file: null,
                     expert_streaming_cache_experts:
                         s.expert_streaming_cache_experts ?? 32,
+                    expert_streaming_scratch_experts:
+                        s.expert_streaming_scratch_experts ?? 32,
                     expert_streaming_substitution_threshold_percent:
                         s.expert_streaming_substitution_threshold_percent ?? 0,
                     expert_streaming_execution_policy:
@@ -8349,6 +8351,8 @@
                                         : null,
                                 expert_streaming_cache_experts:
                                     Number(this.modelSettings.expert_streaming_cache_experts) || 0,
+                                expert_streaming_scratch_experts:
+                                    Number(this.modelSettings.expert_streaming_scratch_experts) || 0,
                                 expert_streaming_substitution_threshold_percent:
                                     Number(this.modelSettings.expert_streaming_substitution_threshold_percent) || 0,
                                 expert_streaming_execution_policy:

--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -528,6 +528,13 @@
                                         <span class="block mt-1 text-xs text-neutral-400">{{ t('modal.model_settings.expert_execution_policy_hint') }}</span>
                                     </label>
                                     <label class="block">
+                                        <span class="text-xs font-medium text-neutral-600">{{ t('modal.model_settings.expert_scratch') }}</span>
+                                        <input type="number" x-model.number="modelSettings.expert_streaming_scratch_experts"
+                                               min="0" max="512" step="1"
+                                               class="mt-1 w-full px-3 py-2 border border-neutral-200 rounded-xl text-sm focus:ring-2 focus:ring-neutral-900 focus:border-transparent">
+                                        <span class="block mt-1 text-xs text-neutral-400">{{ t('modal.model_settings.expert_scratch_hint') }}</span>
+                                    </label>
+                                    <label class="block">
                                         <span class="text-xs font-medium text-neutral-600">{{ t('modal.model_settings.expert_substitution_threshold') }}</span>
                                         <input type="number" x-model.number="modelSettings.expert_streaming_substitution_threshold_percent"
                                                min="0" max="100" step="0.1"

--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -534,6 +534,19 @@
                                                class="mt-1 w-full px-3 py-2 border border-neutral-200 rounded-xl text-sm focus:ring-2 focus:ring-neutral-900 focus:border-transparent">
                                         <span class="block mt-1 text-xs text-neutral-400">{{ t('modal.model_settings.expert_scratch_hint') }}</span>
                                     </label>
+                                    <div class="flex items-start justify-between gap-3">
+                                        <div class="min-w-0">
+                                            <span class="text-xs font-medium text-neutral-600">{{ t('modal.model_settings.expert_fast_resource_loading') }}</span>
+                                            <p class="text-xs text-neutral-400 mt-0.5">{{ t('modal.model_settings.expert_fast_resource_loading_hint') }}</p>
+                                        </div>
+                                        <button type="button"
+                                                @click="modelSettings.expert_streaming_fast_resource_loading = !modelSettings.expert_streaming_fast_resource_loading"
+                                                :class="modelSettings.expert_streaming_fast_resource_loading ? 'bg-black' : 'bg-neutral-200'"
+                                                class="relative flex-shrink-0 w-11 h-6 mt-0.5 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
+                                            <span :class="modelSettings.expert_streaming_fast_resource_loading ? 'translate-x-5' : 'translate-x-0'"
+                                                  class="block w-5 h-5 bg-white rounded-full shadow-sm transform transition-transform duration-300 absolute top-0.5 left-0.5"></span>
+                                        </button>
+                                    </div>
                                     <label class="block">
                                         <span class="text-xs font-medium text-neutral-600">{{ t('modal.model_settings.expert_substitution_threshold') }}</span>
                                         <input type="number" x-model.number="modelSettings.expert_streaming_substitution_threshold_percent"

--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -475,6 +475,71 @@
                                    class="text-xs text-amber-600">{{ t('modal.model_settings.qwen4_ple_ssd_offload_forced') }}</p>
                             </div>
 
+                            <!-- SSD Expert Streaming -->
+                            <div class="p-4 bg-neutral-50 rounded-xl space-y-3"
+                                 x-show="modelSettings.expert_streaming_supported" x-cloak>
+                                <div class="flex items-start justify-between gap-3">
+                                    <div class="min-w-0">
+                                        <span class="text-sm font-medium text-neutral-700">{{ t('modal.model_settings.expert_streaming') }}</span>
+                                        <p class="text-xs text-neutral-500 mt-0.5">{{ t('modal.model_settings.expert_streaming_hint') }}</p>
+                                    </div>
+                                    <button type="button"
+                                            @click="modelSettings.expert_streaming_enabled = !modelSettings.expert_streaming_enabled"
+                                            :class="modelSettings.expert_streaming_enabled ? 'bg-black' : 'bg-neutral-200'"
+                                            class="relative flex-shrink-0 w-11 h-6 mt-0.5 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
+                                        <span :class="modelSettings.expert_streaming_enabled ? 'translate-x-5' : 'translate-x-0'"
+                                              class="block w-5 h-5 bg-white rounded-full shadow-sm transform transition-transform duration-300 absolute top-0.5 left-0.5"></span>
+                                    </button>
+                                </div>
+                                <div x-show="modelSettings.expert_streaming_enabled" x-transition class="space-y-3 pt-1">
+                                    <label class="block">
+                                        <span class="text-xs font-medium text-neutral-600">{{ t('modal.model_settings.expert_streaming_mode') }}</span>
+                                        <select x-model="modelSettings.expert_streaming_mode"
+                                                class="mt-1 w-full px-3 py-2 border border-neutral-200 rounded-xl text-sm focus:ring-2 focus:ring-neutral-900 focus:border-transparent">
+                                            <option value="soft_reap">{{ t('modal.model_settings.expert_streaming_mode_soft_reap') }}</option>
+                                            <option value="cache_only">{{ t('modal.model_settings.expert_streaming_mode_cache_only') }}</option>
+                                        </select>
+                                        <span class="block mt-1 text-xs text-neutral-400"
+                                              x-text="modelSettings.expert_streaming_mode === 'cache_only' ? '{{ t('modal.model_settings.expert_streaming_mode_cache_only_hint')|replace('\\', '\\\\')|replace("'", "\\'") }}' : '{{ t('modal.model_settings.expert_streaming_mode_soft_reap_hint')|replace('\\', '\\\\')|replace("'", "\\'") }}'"></span>
+                                    </label>
+                                    <label class="block" x-show="modelSettings.expert_streaming_mode === 'soft_reap'">
+                                        <span class="text-xs font-medium text-neutral-600">{{ t('modal.model_settings.expert_manifest') }}</span>
+                                        <input type="file" accept="application/json,.json"
+                                               @change="modelSettings.expert_streaming_manifest_file = $event.target.files[0] || null; if (modelSettings.expert_streaming_manifest_file) modelSettings.expert_streaming_manifest_name = modelSettings.expert_streaming_manifest_file.name"
+                                               class="mt-1 block w-full text-xs text-neutral-600 file:mr-3 file:rounded-lg file:border-0 file:bg-neutral-200 file:px-3 file:py-2 file:text-xs file:font-medium file:text-neutral-700 hover:file:bg-neutral-300">
+                                        <span x-show="modelSettings.expert_streaming_manifest_name"
+                                              x-text="modelSettings.expert_streaming_manifest_name"
+                                              class="block mt-1 text-xs text-neutral-400 truncate"></span>
+                                    </label>
+                                    <label class="block">
+                                        <span class="text-xs font-medium text-neutral-600">{{ t('modal.model_settings.expert_cache') }}</span>
+                                        <input type="number" x-model.number="modelSettings.expert_streaming_cache_experts"
+                                               min="0" max="512" step="1"
+                                               class="mt-1 w-full px-3 py-2 border border-neutral-200 rounded-xl text-sm focus:ring-2 focus:ring-neutral-900 focus:border-transparent">
+                                        <span class="block mt-1 text-xs text-neutral-400">{{ t('modal.model_settings.expert_cache_hint') }}</span>
+                                    </label>
+                                    <label class="block">
+                                        <span class="text-xs font-medium text-neutral-600">{{ t('modal.model_settings.expert_execution_policy') }}</span>
+                                        <select x-model="modelSettings.expert_streaming_execution_policy"
+                                                class="mt-1 w-full px-3 py-2 border border-neutral-200 rounded-xl text-sm focus:ring-2 focus:ring-neutral-900 focus:border-transparent">
+                                            <option value="checked">{{ t('modal.model_settings.expert_execution_checked') }}</option>
+                                            <option value="speculative">{{ t('modal.model_settings.expert_execution_speculative') }}</option>
+                                        </select>
+                                        <span class="block mt-1 text-xs text-neutral-400">{{ t('modal.model_settings.expert_execution_policy_hint') }}</span>
+                                    </label>
+                                    <label class="block">
+                                        <span class="text-xs font-medium text-neutral-600">{{ t('modal.model_settings.expert_substitution_threshold') }}</span>
+                                        <input type="number" x-model.number="modelSettings.expert_streaming_substitution_threshold_percent"
+                                               min="0" max="100" step="0.1"
+                                               class="mt-1 w-full px-3 py-2 border border-neutral-200 rounded-xl text-sm focus:ring-2 focus:ring-neutral-900 focus:border-transparent">
+                                        <span class="block mt-1 text-xs text-neutral-400">{{ t('modal.model_settings.expert_substitution_threshold_hint') }}</span>
+                                    </label>
+                                    <p x-show="modelSettings.expert_streaming_resident_bytes > 0"
+                                       class="text-xs text-neutral-500"
+                                       x-text="'{{ t('modal.model_settings.expert_projected_resident')|replace('\\', '\\\\')|replace("'", "\\'") }} ' + formatSizeBytes(modelSettings.expert_streaming_resident_bytes)"></p>
+                                </div>
+                            </div>
+
                             <!-- Thinking Budget -->
                             <div class="p-4 bg-neutral-50 rounded-xl space-y-3"
                                  x-show="!modelSettings.is_diffusion_model" x-cloak>

--- a/omlx/custom_kernels/__init__.py
+++ b/omlx/custom_kernels/__init__.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 
 import importlib
 
-NATIVE_KERNEL_PACKAGES = ("bonsai", "glm_moe_dsa", "minimax_m3", "qwen35_prefill")
+NATIVE_KERNEL_PACKAGES = (
+    "bonsai",
+    "fast_resource_loading",
+    "glm_moe_dsa",
+    "minimax_m3",
+    "qwen35_prefill",
+)
 
 
 def native_kernel_status() -> dict[str, dict[str, object]]:

--- a/omlx/custom_kernels/fast_resource_loading/__init__.py
+++ b/omlx/custom_kernels/fast_resource_loading/__init__.py
@@ -1,0 +1,32 @@
+"""Apple Metal Fast Resource Loading bridge for expert streaming."""
+
+from __future__ import annotations
+
+try:
+    from ._ext import FastResourceLoader, abi_probe
+
+    _IMPORT_ERROR: Exception | None = None
+except Exception as exc:  # pragma: no cover - depends on optional native build
+    FastResourceLoader = None  # type: ignore[assignment,misc]
+    abi_probe = None  # type: ignore[assignment]
+    _IMPORT_ERROR = exc
+
+
+def available() -> bool:
+    """Return whether the native bridge is built and ABI-compatible."""
+
+    if FastResourceLoader is None or abi_probe is None:
+        return False
+    try:
+        import mlx.core as mx
+
+        return abi_probe(mx.zeros((1,), dtype=mx.uint8)) == 1
+    except Exception:
+        return False
+
+
+def import_error() -> str | None:
+    return str(_IMPORT_ERROR) if _IMPORT_ERROR is not None else None
+
+
+__all__ = ["FastResourceLoader", "available", "import_error"]

--- a/omlx/custom_kernels/fast_resource_loading/csrc/CMakeLists.txt
+++ b/omlx/custom_kernels/fast_resource_loading/csrc/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.27)
+
+project(omlx_fast_resource_loading LANGUAGES CXX OBJCXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+find_package(Python 3.8 COMPONENTS Interpreter Development.Module REQUIRED)
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE nanobind_ROOT)
+find_package(nanobind CONFIG REQUIRED)
+
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -m mlx --cmake-dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE MLX_ROOT)
+find_package(MLX CONFIG REQUIRED)
+
+nanobind_add_module(
+  _ext
+  NB_STATIC
+  STABLE_ABI
+  LTO
+  NOMINSIZE
+  NB_DOMAIN
+  mlx
+  ${CMAKE_CURRENT_LIST_DIR}/bindings.mm)
+target_compile_options(_ext PRIVATE -fobjc-arc)
+target_link_libraries(_ext PRIVATE mlx "-framework Foundation" "-framework Metal")
+target_link_options(_ext PRIVATE -Wl,-rpath,@loader_path/../../../mlx/lib)

--- a/omlx/custom_kernels/fast_resource_loading/csrc/bindings.mm
+++ b/omlx/custom_kernels/fast_resource_loading/csrc/bindings.mm
@@ -1,0 +1,259 @@
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+#import <mach/mach_time.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/string.h>
+
+#include <mlx/array.h>
+#include <mlx/backend/metal/device.h>
+#include <mlx/device.h>
+
+namespace nb = nanobind;
+using namespace nb::literals;
+
+namespace {
+
+struct LoadTicket {
+  id<MTLBuffer> staging = nil;
+  id<MTLBuffer> status = nil;
+  id<MTLIOCommandBuffer> command_buffer = nil;
+  uint64_t bytes = 0;
+  uint64_t commands = 0;
+  bool finished = false;
+};
+
+class FastResourceLoader {
+ public:
+  FastResourceLoader() {
+    @autoreleasepool {
+      auto& mlx_device = mlx::core::metal::device(mlx::core::Device::gpu);
+      device_ = (__bridge id<MTLDevice>)(static_cast<void*>(mlx_device.mtl_device()));
+      if (device_ == nil) {
+        throw std::runtime_error("MLX did not provide a Metal device");
+      }
+      MTLIOCommandQueueDescriptor* descriptor =
+          [[MTLIOCommandQueueDescriptor alloc] init];
+      descriptor.type = MTLIOCommandQueueTypeConcurrent;
+      descriptor.priority = MTLIOPriorityHigh;
+      descriptor.maxCommandBufferCount = 2;
+      descriptor.maxCommandsInFlight = 0;
+      NSError* error = nil;
+      io_queue_ = [device_ newIOCommandQueueWithDescriptor:descriptor error:&error];
+      if (io_queue_ == nil) {
+        throw std::runtime_error(
+            "Could not create Metal IO queue: " + error_string(error));
+      }
+      blit_queue_ = [device_ newCommandQueue];
+      if (blit_queue_ == nil) {
+        throw std::runtime_error("Could not create Metal blit queue");
+      }
+    }
+  }
+
+  std::shared_ptr<LoadTicket> begin(const nb::list& requests) {
+    @autoreleasepool {
+      if (requests.size() == 0) {
+        throw std::invalid_argument("Fast resource load requires requests");
+      }
+      uint64_t total_bytes = 0;
+      for (nb::handle item : requests) {
+        nb::tuple request = nb::cast<nb::tuple>(item);
+        if (request.size() != 4) {
+          throw std::invalid_argument(
+              "Load requests must be (path, source_offset, size, destination_offset)");
+        }
+        const uint64_t size = nb::cast<uint64_t>(request[2]);
+        const uint64_t destination = nb::cast<uint64_t>(request[3]);
+        total_bytes = std::max(total_bytes, destination + size);
+      }
+
+      auto ticket = std::make_shared<LoadTicket>();
+      ticket->staging = [device_ newBufferWithLength:total_bytes
+                                             options:MTLResourceStorageModeShared];
+      ticket->status = [device_ newBufferWithLength:sizeof(uint32_t)
+                                            options:MTLResourceStorageModeShared];
+      if (ticket->staging == nil || ticket->status == nil) {
+        throw std::runtime_error("Metal could not allocate FRL staging buffers");
+      }
+      *static_cast<uint32_t*>(ticket->status.contents) = 0;
+      ticket->command_buffer = [io_queue_ commandBuffer];
+      if (ticket->command_buffer == nil) {
+        throw std::runtime_error("Metal IO queue did not create a command buffer");
+      }
+
+      for (nb::handle item : requests) {
+        nb::tuple request = nb::cast<nb::tuple>(item);
+        const std::string path = nb::cast<std::string>(request[0]);
+        const uint64_t source = nb::cast<uint64_t>(request[1]);
+        const uint64_t size = nb::cast<uint64_t>(request[2]);
+        const uint64_t destination = nb::cast<uint64_t>(request[3]);
+        id<MTLIOFileHandle> handle = file_handle(path);
+        [ticket->command_buffer loadBuffer:ticket->staging
+                                    offset:destination
+                                      size:size
+                              sourceHandle:handle
+                        sourceHandleOffset:source];
+        ticket->bytes += size;
+        ticket->commands += 1;
+      }
+      [ticket->command_buffer copyStatusToBuffer:ticket->status offset:0];
+      [ticket->command_buffer commit];
+      return ticket;
+    }
+  }
+
+  nb::dict finish(
+      const std::shared_ptr<LoadTicket>& ticket,
+      const nb::list& copies) {
+    @autoreleasepool {
+      if (!ticket || ticket->command_buffer == nil) {
+        throw std::invalid_argument("Invalid fast resource load ticket");
+      }
+      if (ticket->finished) {
+        throw std::invalid_argument("Fast resource load ticket is already finished");
+      }
+      const auto io_started = clock_now();
+      [ticket->command_buffer waitUntilCompleted];
+      const double io_seconds = clock_now() - io_started;
+      const uint32_t status = *static_cast<uint32_t*>(ticket->status.contents);
+      if (status != static_cast<uint32_t>(MTLIOStatusComplete)) {
+        throw std::runtime_error(
+            "Metal IO command buffer failed with status " + std::to_string(status));
+      }
+
+      const auto copy_started = clock_now();
+      id<MTLCommandBuffer> command_buffer = [blit_queue_ commandBuffer];
+      id<MTLBlitCommandEncoder> encoder = [command_buffer blitCommandEncoder];
+      uint64_t copied_bytes = 0;
+      for (nb::handle item : copies) {
+        nb::tuple copy = nb::cast<nb::tuple>(item);
+        if (copy.size() != 4) {
+          throw std::invalid_argument(
+              "Copies must be (array, destination_offset, source_offset, size)");
+        }
+        const mlx::core::array& array = nb::cast<const mlx::core::array&>(copy[0]);
+        if (array.status() == mlx::core::array::unscheduled) {
+          throw std::invalid_argument("FRL destination MLX array is not evaluated");
+        }
+        const uint64_t destination = nb::cast<uint64_t>(copy[1]);
+        const uint64_t source = nb::cast<uint64_t>(copy[2]);
+        const uint64_t size = nb::cast<uint64_t>(copy[3]);
+        if (source + size > ticket->staging.length) {
+          throw std::out_of_range("FRL source copy exceeds staging buffer");
+        }
+        if (array.offset() < 0 ||
+            static_cast<uint64_t>(array.offset()) + destination + size >
+                array.buffer_size()) {
+          throw std::out_of_range("FRL destination copy exceeds MLX buffer");
+        }
+        id<MTLBuffer> target = (__bridge id<MTLBuffer>)(array.buffer().ptr());
+        if (target == nil) {
+          throw std::runtime_error("MLX destination has no Metal buffer");
+        }
+        [encoder copyFromBuffer:ticket->staging
+                   sourceOffset:source
+                       toBuffer:target
+              destinationOffset:destination + array.offset()
+                           size:size];
+        copied_bytes += size;
+      }
+      [encoder endEncoding];
+      [command_buffer commit];
+      [command_buffer waitUntilCompleted];
+      const double copy_seconds = clock_now() - copy_started;
+      if (command_buffer.status == MTLCommandBufferStatusError) {
+        throw std::runtime_error(
+            "Metal FRL blit failed: " + error_string(command_buffer.error));
+      }
+      ticket->finished = true;
+      nb::dict result;
+      result["io_wait_seconds"] = io_seconds;
+      result["copy_seconds"] = copy_seconds;
+      result["bytes"] = ticket->bytes;
+      result["commands"] = ticket->commands;
+      result["copied_bytes"] = copied_bytes;
+      return result;
+    }
+  }
+
+ private:
+  static double clock_now() {
+    return static_cast<double>(mach_absolute_time()) * timebase_seconds();
+  }
+
+  static double timebase_seconds() {
+    static double value = [] {
+      mach_timebase_info_data_t info{};
+      mach_timebase_info(&info);
+      return static_cast<double>(info.numer) /
+          static_cast<double>(info.denom) / 1e9;
+    }();
+    return value;
+  }
+
+  static std::string error_string(NSError* error) {
+    return error == nil ? "unknown error" : std::string(error.localizedDescription.UTF8String);
+  }
+
+  id<MTLIOFileHandle> file_handle(const std::string& path) {
+    std::lock_guard<std::mutex> lock(handles_mutex_);
+    auto found = handles_.find(path);
+    if (found != handles_.end()) {
+      return found->second;
+    }
+    NSURL* url = [NSURL fileURLWithPath:[NSString stringWithUTF8String:path.c_str()]];
+    NSError* error = nil;
+    id<MTLIOFileHandle> handle = nil;
+    if ([device_ respondsToSelector:@selector(newIOFileHandleWithURL:error:)]) {
+      handle = [device_ newIOFileHandleWithURL:url error:&error];
+    } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+      handle = [device_ newIOHandleWithURL:url error:&error];
+#pragma clang diagnostic pop
+    }
+    if (handle == nil) {
+      throw std::runtime_error(
+          "Could not open Metal IO file handle for " + path + ": " +
+          error_string(error));
+    }
+    handles_.emplace(path, handle);
+    return handle;
+  }
+
+  id<MTLDevice> device_ = nil;
+  id<MTLIOCommandQueue> io_queue_ = nil;
+  id<MTLCommandQueue> blit_queue_ = nil;
+  std::mutex handles_mutex_;
+  std::unordered_map<std::string, id<MTLIOFileHandle>> handles_;
+};
+
+}  // namespace
+
+NB_MODULE(_ext, m) {
+  m.doc() = "Metal Fast Resource Loading for oMLX expert banks";
+  m.def(
+      "abi_probe",
+      [](const mlx::core::array& array) {
+        return static_cast<int64_t>(array.size());
+      },
+      "array"_a);
+  nb::class_<LoadTicket>(m, "LoadTicket")
+      .def_prop_ro("bytes", [](const LoadTicket& ticket) { return ticket.bytes; })
+      .def_prop_ro("commands", [](const LoadTicket& ticket) { return ticket.commands; });
+  nb::class_<FastResourceLoader>(m, "FastResourceLoader")
+      .def(nb::init<>())
+      .def("begin", &FastResourceLoader::begin, "requests"_a)
+      .def("finish", &FastResourceLoader::finish, "ticket"_a, "copies"_a);
+}

--- a/omlx/custom_kernels/fast_resource_loading/fast.py
+++ b/omlx/custom_kernels/fast_resource_loading/fast.py
@@ -1,0 +1,12 @@
+"""Availability facade used by the native-kernel status endpoint."""
+
+from __future__ import annotations
+
+from . import available, import_error
+
+
+def is_native_available() -> bool:
+    return available()
+
+
+__all__ = ["import_error", "is_native_available"]

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -349,6 +349,17 @@ class BatchedEngine(BaseEngine):
                     ),
                     streaming_mode=streaming_mode,
                     hotlist_profile_dir=hotlist_profile_dir,
+                    fast_resource_loading=(
+                        "scratch"
+                        if bool(
+                            getattr(
+                                self._model_settings,
+                                "expert_streaming_fast_resource_loading",
+                                False,
+                            )
+                        )
+                        else False
+                    ),
                 ),
             )
 

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -270,6 +270,12 @@ class BatchedEngine(BaseEngine):
                 self._model_name,
                 tokenizer_config=tokenizer_config,
                 trust_remote_code=self._trust_remote_code,
+                lazy=bool(
+                    self._model_settings is not None
+                    and getattr(
+                        self._model_settings, "expert_streaming_enabled", False
+                    )
+                ),
             )
 
         loop = asyncio.get_running_loop()
@@ -285,6 +291,50 @@ class BatchedEngine(BaseEngine):
 
         self._model = apply_post_load_transforms(self._model, self._model_settings)
 
+        if getattr(self._model_settings, "expert_streaming_enabled", False):
+            from ..expert_streaming import install_expert_streaming
+
+            manifest_path = getattr(
+                self._model_settings, "expert_streaming_manifest", None
+            )
+            streaming_mode = str(
+                getattr(self._model_settings, "expert_streaming_mode", "soft_reap")
+            )
+            if streaming_mode == "soft_reap" and not manifest_path:
+                raise ValueError(
+                    "Expert streaming is enabled without a Soft-REAP manifest"
+                )
+            await loop.run_in_executor(
+                get_mlx_executor(),
+                lambda: install_expert_streaming(
+                    self._model,
+                    self._model_name,
+                    manifest_path,
+                    cache_experts=int(
+                        getattr(
+                            self._model_settings,
+                            "expert_streaming_cache_experts",
+                            32,
+                        )
+                    ),
+                    substitution_threshold_percent=float(
+                        getattr(
+                            self._model_settings,
+                            "expert_streaming_substitution_threshold_percent",
+                            0.0,
+                        )
+                    ),
+                    execution_policy=str(
+                        getattr(
+                            self._model_settings,
+                            "expert_streaming_execution_policy",
+                            "checked",
+                        )
+                    ),
+                    streaming_mode=streaming_mode,
+                ),
+            )
+
         # Materialize lazy buffers on the loader thread so per-engine
         # inference threads can read them (#1304).
         await loop.run_in_executor(
@@ -298,6 +348,9 @@ class BatchedEngine(BaseEngine):
         if (
             getattr(self._model_settings, "moe_gate_up_fusion_enabled", True)
             is not False
+            and not getattr(
+                self._model_settings, "expert_streaming_enabled", False
+            )
         ):
             try:
                 from ..patches.qwen35_moe_gate_up import (
@@ -660,6 +713,7 @@ class BatchedEngine(BaseEngine):
 
     async def stop(self) -> None:
         """Stop the engine and cleanup resources."""
+        runtime = getattr(self._model, "_omlx_expert_streaming_runtime", None)
         if self._engine:
             await self._engine.stop()
             if hasattr(self._engine, "engine") and self._engine.engine is not None:
@@ -667,6 +721,11 @@ class BatchedEngine(BaseEngine):
                     self._engine.engine.close()
                 except Exception as e:
                     logger.warning(f"Error closing engine: {e}")
+        if runtime is not None:
+            try:
+                runtime.close()
+            except Exception:
+                logger.warning("Error closing expert streaming runtime", exc_info=True)
         _clear_teardown_references(
             self,
             none_attrs=(
@@ -1288,6 +1347,9 @@ class BatchedEngine(BaseEngine):
         }
         if self._engine:
             stats.update(self._engine.get_stats())
+        runtime = getattr(self._model, "_omlx_expert_streaming_runtime", None)
+        if runtime is not None:
+            stats["expert_streaming"] = runtime.stats()
         return stats
 
     def get_cache_stats(self) -> dict[str, Any] | None:

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -9,6 +9,7 @@ for better throughput when serving multiple concurrent requests.
 import copy
 import logging
 from collections.abc import AsyncIterator
+from pathlib import Path
 from typing import Any
 
 from ..api.tool_calling import convert_tools_for_template
@@ -304,6 +305,14 @@ class BatchedEngine(BaseEngine):
                 raise ValueError(
                     "Expert streaming is enabled without a Soft-REAP manifest"
                 )
+            hotlist_cache_root = getattr(
+                self._scheduler_config, "paged_ssd_cache_dir", None
+            )
+            hotlist_profile_dir = (
+                Path(hotlist_cache_root) / "expert-hotlists"
+                if hotlist_cache_root
+                else None
+            )
             await loop.run_in_executor(
                 get_mlx_executor(),
                 lambda: install_expert_streaming(
@@ -332,6 +341,7 @@ class BatchedEngine(BaseEngine):
                         )
                     ),
                     streaming_mode=streaming_mode,
+                    hotlist_profile_dir=hotlist_profile_dir,
                 ),
             )
 

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -326,6 +326,13 @@ class BatchedEngine(BaseEngine):
                             32,
                         )
                     ),
+                    scratch_experts=int(
+                        getattr(
+                            self._model_settings,
+                            "expert_streaming_scratch_experts",
+                            32,
+                        )
+                    ),
                     substitution_threshold_percent=float(
                         getattr(
                             self._model_settings,

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1753,6 +1753,17 @@ class VLMBatchedEngine(BaseEngine):
                     ),
                     streaming_mode=streaming_mode,
                     hotlist_profile_dir=hotlist_profile_dir,
+                    fast_resource_loading=(
+                        "scratch"
+                        if bool(
+                            getattr(
+                                self._model_settings,
+                                "expert_streaming_fast_resource_loading",
+                                False,
+                            )
+                        )
+                        else False
+                    ),
                 ),
             )
 

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1696,6 +1696,50 @@ class VLMBatchedEngine(BaseEngine):
             get_mlx_executor(), _load_vlm_sync
         )
 
+        if getattr(self._model_settings, "expert_streaming_enabled", False):
+            from ..expert_streaming import install_expert_streaming
+
+            manifest_path = getattr(
+                self._model_settings, "expert_streaming_manifest", None
+            )
+            streaming_mode = str(
+                getattr(self._model_settings, "expert_streaming_mode", "soft_reap")
+            )
+            if streaming_mode == "soft_reap" and not manifest_path:
+                raise ValueError(
+                    "Expert streaming is enabled without a Soft-REAP manifest"
+                )
+            await loop.run_in_executor(
+                get_mlx_executor(),
+                lambda: install_expert_streaming(
+                    self._vlm_model,
+                    self._model_name,
+                    manifest_path,
+                    cache_experts=int(
+                        getattr(
+                            self._model_settings,
+                            "expert_streaming_cache_experts",
+                            32,
+                        )
+                    ),
+                    substitution_threshold_percent=float(
+                        getattr(
+                            self._model_settings,
+                            "expert_streaming_substitution_threshold_percent",
+                            0.0,
+                        )
+                    ),
+                    execution_policy=str(
+                        getattr(
+                            self._model_settings,
+                            "expert_streaming_execution_policy",
+                            "checked",
+                        )
+                    ),
+                    streaming_mode=streaming_mode,
+                ),
+            )
+
         if self.model_type == "unlimited-ocr":
             from ..utils.tokenizer import (
                 create_streaming_detokenizer,
@@ -1752,6 +1796,9 @@ class VLMBatchedEngine(BaseEngine):
         if (
             getattr(self._model_settings, "moe_gate_up_fusion_enabled", True)
             is not False
+            and not getattr(
+                self._model_settings, "expert_streaming_enabled", False
+            )
         ):
             try:
                 from ..patches.qwen35_moe_gate_up import (
@@ -1823,6 +1870,11 @@ class VLMBatchedEngine(BaseEngine):
         # mlx-vlm models now handle per-sequence mx.array offsets natively
         # and batched decode is fixed, so no separate mlx-lm decode model needed.
         self._adapter = VLMModelAdapter(self._vlm_model)
+        streaming_runtime = getattr(
+            self._vlm_model, "_omlx_expert_streaming_runtime", None
+        )
+        if streaming_runtime is not None:
+            streaming_runtime.attach_model(self._adapter)
 
         # Create scheduler config
         scheduler_config = (
@@ -2246,12 +2298,20 @@ class VLMBatchedEngine(BaseEngine):
     async def stop(self) -> None:
         """Stop the engine and cleanup resources."""
         engine = self._engine
-
+        runtime = getattr(
+            self._vlm_model, "_omlx_expert_streaming_runtime", None
+        )
         for cancel_event in getattr(self, "_diffusion_cancel_events", ()):
             cancel_event.set()
 
         if engine:
             await engine.stop()
+
+        if runtime is not None:
+            try:
+                runtime.close()
+            except Exception:
+                logger.warning("Error closing expert streaming runtime", exc_info=True)
 
         if self._vision_cache is not None:
             try:
@@ -4567,6 +4627,9 @@ class VLMBatchedEngine(BaseEngine):
             stats["active_requests"] = self._diffusion_active_requests
         if self._engine:
             stats.update(self._engine.get_stats())
+        runtime = getattr(self._vlm_model, "_omlx_expert_streaming_runtime", None)
+        if runtime is not None:
+            stats["expert_streaming"] = runtime.stats()
         return stats
 
     def get_cache_stats(self) -> dict[str, Any] | None:

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1730,6 +1730,13 @@ class VLMBatchedEngine(BaseEngine):
                             32,
                         )
                     ),
+                    scratch_experts=int(
+                        getattr(
+                            self._model_settings,
+                            "expert_streaming_scratch_experts",
+                            32,
+                        )
+                    ),
                     substitution_threshold_percent=float(
                         getattr(
                             self._model_settings,

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1709,6 +1709,14 @@ class VLMBatchedEngine(BaseEngine):
                 raise ValueError(
                     "Expert streaming is enabled without a Soft-REAP manifest"
                 )
+            hotlist_cache_root = getattr(
+                self._scheduler_config, "paged_ssd_cache_dir", None
+            )
+            hotlist_profile_dir = (
+                Path(hotlist_cache_root) / "expert-hotlists"
+                if hotlist_cache_root
+                else None
+            )
             await loop.run_in_executor(
                 get_mlx_executor(),
                 lambda: install_expert_streaming(
@@ -1737,6 +1745,7 @@ class VLMBatchedEngine(BaseEngine):
                         )
                     ),
                     streaming_mode=streaming_mode,
+                    hotlist_profile_dir=hotlist_profile_dir,
                 ),
             )
 

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -636,6 +636,10 @@ class EnginePool:
                 data.get("expert_streaming_cache_experts", 32),
             )
             add(
+                "expert_streaming_scratch_experts",
+                data.get("expert_streaming_scratch_experts", 32),
+            )
+            add(
                 "expert_streaming_substitution_threshold_percent",
                 data.get("expert_streaming_substitution_threshold_percent", 0.0),
             )

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -349,11 +349,15 @@ class EnginePool:
         base = self._entry_resident_size(entry) if base_size is None else base_size
         if self._distributed_deployment_for_entry(entry) is not None:
             return base
-        qwen4_offload, _, qwen4_estimate = self._qwen4_ple_offload_status(
-            entry, runtime_settings
-        )
-        if qwen4_offload and qwen4_estimate is not None:
-            base = min(base, qwen4_estimate.mmap_bytes)
+        streaming_estimate = self._expert_streaming_estimate(entry, runtime_settings)
+        if streaming_estimate is not None:
+            base = streaming_estimate.resident_bytes
+        else:
+            qwen4_offload, _, qwen4_estimate = self._qwen4_ple_offload_status(
+                entry, runtime_settings
+            )
+            if qwen4_offload and qwen4_estimate is not None:
+                base = min(base, qwen4_estimate.mmap_bytes)
         extra = _qwen35_cpu_share_estimated_bytes(entry.model_path, runtime_settings)
         if extra is None:
             # An enabled CPU path with unreadable geometry must not silently
@@ -372,6 +376,23 @@ class EnginePool:
                 entry.model_id,
             )
         return base + extra
+
+    @staticmethod
+    def _expert_streaming_estimate(entry: EngineEntry, settings: object | None):
+        try:
+            from .expert_streaming.residency import estimate_for_model_settings
+
+            return estimate_for_model_settings(entry.model_path, settings)
+        except (OSError, TypeError, ValueError):
+            if settings is not None and getattr(
+                settings, "expert_streaming_enabled", False
+            ):
+                logger.warning(
+                    "Could not estimate Soft-REAP residency for %s",
+                    entry.model_id,
+                    exc_info=True,
+                )
+            return None
 
     def _qwen4_ple_offload_status(
         self,
@@ -403,6 +424,12 @@ class EnginePool:
         requested = bool(
             settings is not None and getattr(settings, "qwen4_ple_ssd_offload", False)
         )
+        # A valid Soft-REAP layout can make the complete PLE-resident model fit.
+        # Only preserve a forced PLE mmap decision if that reduced layout still
+        # exceeds the configured ceiling; an explicit user request remains valid.
+        streaming = self._expert_streaming_estimate(entry, settings)
+        if streaming is not None and (ceiling <= 0 or streaming.resident_bytes <= ceiling):
+            forced = False
         return requested or forced, forced, estimate if estimate.supported else None
 
     def _effective_qwen4_model_settings(
@@ -594,6 +621,28 @@ class EnginePool:
         if entry is not None:
             qwen4_offload, _, _ = self._qwen4_ple_offload_status(entry, settings)
             add("qwen4_ple_ssd_offload", qwen4_offload)
+        expert_streaming = bool(data.get("expert_streaming_enabled", False))
+        add("expert_streaming_enabled", expert_streaming)
+        if expert_streaming:
+            streaming_mode = data.get("expert_streaming_mode", "soft_reap")
+            add("expert_streaming_mode", streaming_mode)
+            if streaming_mode == "soft_reap":
+                add(
+                    "expert_streaming_manifest",
+                    data.get("expert_streaming_manifest"),
+                )
+            add(
+                "expert_streaming_cache_experts",
+                data.get("expert_streaming_cache_experts", 32),
+            )
+            add(
+                "expert_streaming_substitution_threshold_percent",
+                data.get("expert_streaming_substitution_threshold_percent", 0.0),
+            )
+            add(
+                "expert_streaming_execution_policy",
+                data.get("expert_streaming_execution_policy", "checked"),
+            )
 
         turboquant_active = bool(data.get("turboquant_kv_enabled", False))
         add("turboquant_kv_enabled", turboquant_active)

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -640,6 +640,10 @@ class EnginePool:
                 data.get("expert_streaming_scratch_experts", 32),
             )
             add(
+                "expert_streaming_fast_resource_loading",
+                bool(data.get("expert_streaming_fast_resource_loading", False)),
+            )
+            add(
                 "expert_streaming_substitution_threshold_percent",
                 data.get("expert_streaming_substitution_threshold_percent", 0.0),
             )

--- a/omlx/expert_streaming/__init__.py
+++ b/omlx/expert_streaming/__init__.py
@@ -1,0 +1,14 @@
+"""SSD-backed routed-expert streaming for MLX MoE models."""
+
+from .integrate import ExpertStreamingRuntime, install_expert_streaming
+from .manifest import SoftReapManifest, load_soft_reap_manifest
+from .residency import ExpertStreamingEstimate, estimate_expert_streaming_residency
+
+__all__ = [
+    "ExpertStreamingEstimate",
+    "ExpertStreamingRuntime",
+    "SoftReapManifest",
+    "estimate_expert_streaming_residency",
+    "install_expert_streaming",
+    "load_soft_reap_manifest",
+]

--- a/omlx/expert_streaming/adapters.py
+++ b/omlx/expert_streaming/adapters.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Model-family normalization for SwitchGLU expert streaming."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class MoELayerAdapter:
+    """A routed layer normalized across the supported model families."""
+
+    layer_id: int
+    layer: Any
+    container_name: str
+    moe: Any
+    switch_mlp: Any
+    num_experts: int
+    top_k: int
+
+    def replace_switch(self, replacement: Any) -> None:
+        self.moe.switch_mlp = replacement
+
+
+def _main_layers(model: Any) -> list[Any]:
+    candidates = (
+        getattr(
+            getattr(getattr(model, "language_model", None), "model", None),
+            "layers",
+            None,
+        ),
+        getattr(getattr(model, "model", None), "layers", None),
+        getattr(getattr(model, "model", None), "pipeline_layers", None),
+        getattr(model, "layers", None),
+        getattr(model, "pipeline_layers", None),
+    )
+    for layers in candidates:
+        if isinstance(layers, (list, tuple)) and layers:
+            return list(layers)
+    raise ValueError("Could not locate the model's routed MoE layers")
+
+
+def _first_int(objects: tuple[Any, ...], names: tuple[str, ...]) -> int:
+    for obj in objects:
+        if obj is None:
+            continue
+        for name in names:
+            value = getattr(obj, name, None)
+            if value is not None:
+                try:
+                    result = int(value)
+                except (TypeError, ValueError):
+                    continue
+                if result > 0:
+                    return result
+    return 0
+
+
+def discover_moe_layers(model: Any) -> list[MoELayerAdapter]:
+    """Find Qwen, DeepSeek, GLM, MiMo, Hy, Laguna and similar SwitchGLUs."""
+
+    result: list[MoELayerAdapter] = []
+    for layer_id, layer in enumerate(_main_layers(model)):
+        if layer is None:
+            continue
+        container_name = ""
+        moe = None
+        for candidate in ("mlp", "ffn"):
+            value = getattr(layer, candidate, None)
+            if getattr(value, "switch_mlp", None) is not None:
+                container_name = candidate
+                moe = value
+                break
+        if moe is None:
+            continue
+        switch = moe.switch_mlp
+        projection = getattr(switch, "up_proj", None) or getattr(
+            switch, "gate_up_proj", None
+        )
+        projection_experts = 0
+        if projection is not None:
+            projection_experts = _first_int(
+                (projection,), ("num_experts",)
+            )
+            if not projection_experts:
+                weight = getattr(projection, "weight", None)
+                if weight is not None and len(weight.shape) >= 3:
+                    projection_experts = int(weight.shape[0])
+        gate = getattr(moe, "gate", None) or getattr(moe, "router", None)
+        config = getattr(moe, "config", None) or getattr(moe, "args", None)
+        num_experts = _first_int(
+            (moe, gate, config),
+            ("num_experts", "n_routed_experts", "n_routed"),
+        ) or projection_experts
+        top_k = _first_int(
+            (moe, gate, config),
+            ("top_k", "num_experts_per_tok", "num_experts_per_token"),
+        )
+        if getattr(moe, "pack_shared_expert", False):
+            top_k += 1
+        if not num_experts or not top_k:
+            raise ValueError(
+                f"Layer {layer_id} does not expose compatible MoE geometry"
+            )
+        result.append(
+            MoELayerAdapter(
+                layer_id=layer_id,
+                layer=layer,
+                container_name=container_name,
+                moe=moe,
+                switch_mlp=switch,
+                num_experts=num_experts,
+                top_k=top_k,
+            )
+        )
+    if not result:
+        raise ValueError("The selected model has no compatible SwitchGLU MoE layers")
+    geometry = {(target.num_experts, target.top_k) for target in result}
+    if len(geometry) != 1:
+        raise ValueError(f"Mixed routed-expert geometry is unsupported: {geometry}")
+    return result
+
+
+def projection_schema(switch_mlp: Any) -> dict[str, dict[str, Any]]:
+    """Describe separate or fused affine/MXFP/NVFP expert projections."""
+
+    metadata: dict[str, dict[str, Any]] = {}
+    gate_up = getattr(switch_mlp, "gate_up_proj", None)
+    for projection in ("gate_proj", "up_proj", "down_proj"):
+        module = getattr(switch_mlp, projection, None)
+        fused_half = None
+        if module is None and projection in {"gate_proj", "up_proj"}:
+            module = gate_up
+            fused_half = "gate" if projection == "gate_proj" else "up"
+        if module is None or not all(
+            hasattr(module, name) for name in ("weight", "scales")
+        ):
+            raise ValueError(
+                "Expert streaming requires stacked quantized SwitchGLU weights"
+            )
+        parts = ["weight", "scales"]
+        if getattr(module, "biases", None) is not None:
+            parts.append("biases")
+        if getattr(module, "bias", None) is not None:
+            parts.append("bias")
+        metadata[projection] = {
+            "group_size": int(getattr(module, "group_size", 64)),
+            "bits": int(getattr(module, "bits", 4)),
+            "mode": str(getattr(module, "mode", "affine")),
+            "parts": tuple(parts),
+            "source_projection": "gate_up_proj" if fused_half else projection,
+            "fused_half": fused_half,
+            "arrays": {part: getattr(module, part) for part in parts},
+        }
+    return metadata

--- a/omlx/expert_streaming/execution.py
+++ b/omlx/expert_streaming/execution.py
@@ -1,0 +1,317 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Whole-forward execution policies for graph-native expert streaming."""
+
+from __future__ import annotations
+
+import dataclasses
+import threading
+import weakref
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+
+@dataclass
+class ExpertExecutionStats:
+    checked_passes: int = 0
+    speculative_passes: int = 0
+    speculative_hits: int = 0
+    speculative_retries: int = 0
+    speculative_fallbacks: int = 0
+
+    def as_dict(self) -> dict[str, int]:
+        return dataclasses.asdict(self)
+
+
+def _clone_state_value(value: Any) -> Any:
+    if isinstance(value, list):
+        return list(value)
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, set):
+        return set(value)
+    if isinstance(value, tuple):
+        return tuple(value)
+    return value
+
+
+class CacheSnapshot:
+    """Shallow transactional snapshot of MLX cache objects and metadata.
+
+    MLX caches append by replacing array references or by writing beyond their
+    previous logical offset. Restoring both the old references and offsets is
+    therefore sufficient for rejecting a whole forward pass. A retry writes
+    the same append region again before it can be observed.
+    """
+
+    def __init__(self, cache: Any):
+        self._states: list[tuple[Any, dict[str, Any]]] = []
+        self._containers: list[tuple[Any, Any]] = []
+        self._seen: set[int] = set()
+        self._capture(cache)
+
+    @staticmethod
+    def _is_leaf(value: Any) -> bool:
+        return value is None or isinstance(
+            value, (mx.array, str, bytes, int, float, bool, np.ndarray, type)
+        )
+
+    def _capture(self, value: Any) -> None:
+        if self._is_leaf(value):
+            return
+        if id(value) in self._seen:
+            return
+        self._seen.add(id(value))
+        if isinstance(value, dict):
+            self._containers.append((value, dict(value)))
+            for child in value.values():
+                self._capture(child)
+            return
+        if isinstance(value, list):
+            self._containers.append((value, list(value)))
+            for child in value:
+                self._capture(child)
+            return
+        if isinstance(value, set):
+            self._containers.append((value, set(value)))
+            for child in value:
+                self._capture(child)
+            return
+        if isinstance(value, tuple):
+            for child in value:
+                self._capture(child)
+            return
+        # A cache should never own a model, but avoid traversing one if a
+        # third-party cache keeps a back-reference.
+        if isinstance(value, nn.Module):
+            return
+        state = getattr(value, "__dict__", None)
+        if state is None:
+            return
+        copied = {key: _clone_state_value(item) for key, item in state.items()}
+        self._states.append((value, copied))
+        for child in state.values():
+            self._capture(child)
+
+    def restore(self) -> None:
+        for cache_object, state in reversed(self._states):
+            current = getattr(cache_object, "__dict__", None)
+            if current is None:
+                continue
+            current.clear()
+            current.update(
+                {key: _clone_state_value(value) for key, value in state.items()}
+            )
+        for container, state in reversed(self._containers):
+            if isinstance(container, dict):
+                container.clear()
+                container.update(state)
+            elif isinstance(container, list):
+                container[:] = state
+            elif isinstance(container, set):
+                container.clear()
+                container.update(state)
+
+
+def _result_arrays(value: Any, seen: set[int] | None = None) -> list[mx.array]:
+    if seen is None:
+        seen = set()
+    if isinstance(value, mx.array):
+        return [value]
+    if value is None or isinstance(value, (str, bytes, int, float, bool)):
+        return []
+    identity = id(value)
+    if identity in seen:
+        return []
+    seen.add(identity)
+    if isinstance(value, dict):
+        return [
+            array for item in value.values() for array in _result_arrays(item, seen)
+        ]
+    if isinstance(value, (list, tuple)):
+        return [array for item in value for array in _result_arrays(item, seen)]
+    arrays: list[mx.array] = []
+    for name in ("logits", "hidden_states", "gdn_states"):
+        if hasattr(value, name):
+            arrays.extend(_result_arrays(getattr(value, name), seen))
+    return arrays
+
+
+_PATCH_LOCK = threading.RLock()
+_TARGETS: dict[int, tuple[weakref.ReferenceType[Any], Any]] = {}
+_PATCHED_CLASSES: dict[type, Callable[..., Any]] = {}
+
+
+def attach_execution_runtime(target: Any, runtime: Any) -> None:
+    """Route calls to one model instance through its streaming runtime."""
+
+    target_id = id(target)
+    target_class = type(target)
+    with _PATCH_LOCK:
+        if target_class not in _PATCHED_CLASSES:
+            original = target_class.__call__
+
+            def streaming_call(self, *args, **kwargs):
+                registered = _TARGETS.get(id(self))
+                if registered is None or registered[0]() is not self:
+                    return original(self, *args, **kwargs)
+                return registered[1].execute_call(
+                    self,
+                    lambda: original(self, *args, **kwargs),
+                    args,
+                    kwargs,
+                )
+
+            _PATCHED_CLASSES[target_class] = original
+            target_class.__call__ = streaming_call
+
+        def remove_target(_reference, *, identity=target_id):
+            with _PATCH_LOCK:
+                _TARGETS.pop(identity, None)
+
+        _TARGETS[target_id] = (weakref.ref(target, remove_target), runtime)
+
+
+def detach_execution_runtime(target: Any) -> None:
+    with _PATCH_LOCK:
+        _TARGETS.pop(id(target), None)
+
+
+class SpeculativeExecution:
+    """Execute resident hits as one MLX graph and retry exact on a miss."""
+
+    def __init__(self, runtime: Any, *, policy: str, max_retries: int = 1):
+        if policy not in {"checked", "speculative"}:
+            raise ValueError(
+                "Expert streaming execution policy must be checked or speculative"
+            )
+        self.runtime = runtime
+        self.policy = policy
+        self.max_retries = max(0, int(max_retries))
+        self.stats = ExpertExecutionStats()
+        self._has_checked_pass = False
+        self._executing = False
+        self._lock = threading.RLock()
+        self._targets: list[weakref.ReferenceType[Any]] = []
+
+    def attach(self, target: Any) -> None:
+        attach_execution_runtime(target, self)
+        self._targets.append(weakref.ref(target))
+
+    def close(self) -> None:
+        for reference in self._targets:
+            target = reference()
+            if target is not None:
+                detach_execution_runtime(target)
+        self._targets.clear()
+
+    def _set_mode(self, mode: str) -> None:
+        for pool in self.runtime.pools:
+            pool.set_execution_mode(mode)
+
+    @staticmethod
+    def _cache_from_call(args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
+        if "cache" in kwargs:
+            return kwargs["cache"]
+        return args[1] if len(args) > 1 else None
+
+    def _can_speculate(self, args: tuple[Any, ...], kwargs: dict[str, Any]) -> bool:
+        if self.policy != "speculative" or not self._has_checked_pass:
+            return False
+        if kwargs.get("inputs_embeds") is not None:
+            return False
+        if kwargs.get("vlm_extra_kwargs"):
+            return False
+        if not args or not isinstance(args[0], mx.array):
+            return False
+        return args[0].ndim >= 1 and args[0].shape[-1] == 1
+
+    def _checked(self, call: Callable[[], Any]) -> Any:
+        self._set_mode("checked")
+        result = call()
+        self.stats.checked_passes += 1
+        self._has_checked_pass = True
+        return result
+
+    def _collect_routes(self):
+        routes = []
+        for pool in self.runtime.pools:
+            for indices, missing in pool.take_speculative_routes():
+                routes.append((pool, indices, missing))
+        return routes
+
+    @staticmethod
+    def _evaluate(result: Any, routes: list[tuple[Any, mx.array, mx.array]]) -> None:
+        arrays = _result_arrays(result)
+        arrays.extend(indices for _, indices, _ in routes)
+        arrays.extend(missing for _, _, missing in routes)
+        if arrays:
+            mx.eval(*arrays)
+
+    def _inspect_routes(self, routes):
+        first_miss = None
+        for pool, indices, missing in routes:
+            values = tuple(
+                int(value) for value in np.asarray(indices.tolist()).reshape(-1)
+            )
+            pool.record_speculative_route(values)
+            if bool(mx.any(missing).item()):
+                first_miss = (pool, values)
+                # Downstream routing was computed from placeholder expert
+                # output and is not a valid analytical cache signal.
+                break
+        return first_miss
+
+    def _speculative(self, call: Callable[[], Any], cache: Any) -> Any:
+        snapshot = CacheSnapshot(cache)
+        for attempt in range(self.max_retries + 1):
+            self._set_mode("speculative")
+            result = call()
+            routes = self._collect_routes()
+            self._evaluate(result, routes)
+            self.stats.speculative_passes += 1
+            first_miss = self._inspect_routes(routes)
+            if first_miss is None:
+                self.stats.speculative_hits += 1
+                return result
+
+            snapshot.restore()
+            pool, values = first_miss
+            try:
+                pool.promote(values)
+            except RuntimeError:
+                break
+            if attempt < self.max_retries:
+                self.stats.speculative_retries += 1
+                continue
+            break
+
+        snapshot.restore()
+        self.stats.speculative_fallbacks += 1
+        return self._checked(call)
+
+    def execute_call(
+        self,
+        target: Any,
+        call: Callable[[], Any],
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
+        del target
+        with self._lock:
+            if self._executing:
+                return call()
+            self._executing = True
+            try:
+                if not self._can_speculate(args, kwargs):
+                    return self._checked(call)
+                return self._speculative(call, self._cache_from_call(args, kwargs))
+            except Exception:
+                self._set_mode("checked")
+                raise
+            finally:
+                self._executing = False

--- a/omlx/expert_streaming/execution.py
+++ b/omlx/expert_streaming/execution.py
@@ -18,6 +18,7 @@ import numpy as np
 @dataclass
 class ExpertExecutionStats:
     checked_passes: int = 0
+    fill_gated_passes: int = 0
     speculative_passes: int = 0
     speculative_hits: int = 0
     speculative_retries: int = 0
@@ -194,6 +195,7 @@ class SpeculativeExecution:
         self.max_retries = max(0, int(max_retries))
         self.stats = ExpertExecutionStats()
         self._has_checked_pass = False
+        self._cache_fill_ready = False
         self._executing = False
         self._lock = threading.RLock()
         self._targets: list[weakref.ReferenceType[Any]] = []
@@ -228,7 +230,18 @@ class SpeculativeExecution:
             return False
         if not args or not isinstance(args[0], mx.array):
             return False
-        return args[0].ndim >= 1 and args[0].shape[-1] == 1
+        if args[0].ndim < 1 or args[0].shape[-1] != 1:
+            return False
+        if not self._cache_ready_for_speculation():
+            self.stats.fill_gated_passes += 1
+            return False
+        return True
+
+    def _cache_ready_for_speculation(self) -> bool:
+        """Latch readiness once all dynamic caches have reached capacity."""
+        if not self._cache_fill_ready:
+            self._cache_fill_ready = all(pool.cache_full for pool in self.runtime.pools)
+        return self._cache_fill_ready
 
     def _checked(self, call: Callable[[], Any]) -> Any:
         self._set_mode("checked")

--- a/omlx/expert_streaming/fast_resource.py
+++ b/omlx/expert_streaming/fast_resource.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Metal Fast Resource Loading plans for row-addressable expert tensors."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Hashable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import mlx.core as mx
+import numpy as np
+
+from .safetensors import _NUMPY_DTYPES, TensorLocation
+
+
+@dataclass
+class FastExpertLoad:
+    ticket: Any
+    source_offsets: dict[Hashable, list[int]]
+    row_bytes: dict[Hashable, int]
+
+
+class FastExpertLoadFuture:
+    """Future-shaped handle used by the existing scratch prefetch pipeline."""
+
+    def __init__(self, load: FastExpertLoad):
+        self._load = load
+
+    def result(self, timeout: float | None = None) -> FastExpertLoad:
+        del timeout
+        return self._load
+
+
+class FastExpertLoader:
+    """Issue MTLIO reads and blit their payloads into evaluated MLX banks."""
+
+    def __init__(self):
+        from omlx.custom_kernels.fast_resource_loading import (
+            FastResourceLoader,
+            available,
+            import_error,
+        )
+
+        if not available() or FastResourceLoader is None:
+            raise RuntimeError(
+                "Fast Resource Loading native extension is unavailable"
+                + (f": {import_error()}" if import_error() else "")
+            )
+        self._native = FastResourceLoader()
+
+    @staticmethod
+    def _source(location: TensorLocation, expert: int) -> tuple[str, int, int]:
+        if location.row_sources is not None:
+            source = location.row_sources[expert]
+            if source.data_bytes != location.row_bytes:
+                raise ValueError(
+                    f"Fragmented expert row size mismatch for {location.name}"
+                )
+            return str(source.path), source.data_start, location.row_bytes
+
+        storage_row_bytes = location.storage_row_bytes or location.row_bytes
+        source_offset = location.data_start + expert * storage_row_bytes
+        if location.output_slice is not None:
+            if location.storage_shape is None:
+                raise ValueError(f"Missing storage shape for {location.name}")
+            start, _ = location.output_slice
+            item_size = np.dtype(_NUMPY_DTYPES[location.dtype]).itemsize
+            inner_elements = math.prod(location.storage_shape[2:])
+            source_offset += start * inner_elements * item_size
+        return str(location.path), source_offset, location.row_bytes
+
+    def begin(
+        self,
+        locations: Mapping[Hashable, TensorLocation],
+        expert_ids: list[int] | tuple[int, ...],
+        *,
+        max_gap_bytes: int = 64 * 1024,
+    ) -> FastExpertLoad:
+        requested = [int(expert) for expert in expert_ids]
+        if not requested:
+            raise ValueError("At least one expert row must be requested")
+        requests: list[tuple[str, int, int, int]] = []
+        offsets: dict[Hashable, list[int]] = {}
+        row_bytes: dict[Hashable, int] = {}
+        staging_offset = 0
+        for key, location in locations.items():
+            for expert in requested:
+                if not 0 <= expert < location.shape[0]:
+                    raise ValueError(f"Expert row outside tensor {location.name}")
+            if location.row_sources is not None:
+                component_offsets = []
+                for expert in requested:
+                    path, source_offset, size = self._source(location, expert)
+                    component_offsets.append(staging_offset)
+                    requests.append((path, source_offset, size, staging_offset))
+                    staging_offset += size
+                offsets[key] = component_offsets
+                row_bytes[key] = location.row_bytes
+                continue
+
+            storage_row_bytes = location.storage_row_bytes or location.row_bytes
+            rows = sorted(set(requested))
+            ranges: list[tuple[int, int]] = []
+            first = previous = rows[0]
+            for row in rows[1:]:
+                gap = (row - previous - 1) * storage_row_bytes
+                if gap > max_gap_bytes:
+                    ranges.append((first, previous + 1))
+                    first = row
+                previous = row
+            ranges.append((first, previous + 1))
+
+            selected_offsets: dict[int, int] = {}
+            slice_offset = 0
+            if location.output_slice is not None:
+                if location.storage_shape is None:
+                    raise ValueError(f"Missing storage shape for {location.name}")
+                start, _ = location.output_slice
+                item_size = np.dtype(_NUMPY_DTYPES[location.dtype]).itemsize
+                slice_offset = start * math.prod(location.storage_shape[2:]) * item_size
+            for first, stop in ranges:
+                size = (stop - first) * storage_row_bytes
+                requests.append(
+                    (
+                        str(location.path),
+                        location.data_start + first * storage_row_bytes,
+                        size,
+                        staging_offset,
+                    )
+                )
+                for row in rows:
+                    if first <= row < stop:
+                        selected_offsets[row] = (
+                            staging_offset
+                            + (row - first) * storage_row_bytes
+                            + slice_offset
+                        )
+                staging_offset += size
+            offsets[key] = [selected_offsets[expert] for expert in requested]
+            row_bytes[key] = location.row_bytes
+        return FastExpertLoad(self._native.begin(requests), offsets, row_bytes)
+
+    def finish_into(
+        self,
+        load: FastExpertLoad,
+        slots: list[int],
+        targets: Mapping[Hashable, tuple[mx.array, int]],
+    ) -> dict[str, int | float]:
+        copies: list[tuple[mx.array, int, int, int]] = []
+        arrays: list[mx.array] = []
+        seen: set[int] = set()
+        for target, _ in targets.values():
+            identity = id(target)
+            if identity not in seen:
+                arrays.append(target)
+                seen.add(identity)
+        mx.eval(*arrays)
+        for key, source_offsets in load.source_offsets.items():
+            target, inner_offset = targets[key]
+            target_row_bytes = int(target.nbytes) // int(target.shape[0])
+            size = load.row_bytes[key]
+            for slot, source_offset in zip(slots, source_offsets, strict=True):
+                copies.append(
+                    (
+                        target,
+                        int(slot) * target_row_bytes + int(inner_offset),
+                        source_offset,
+                        size,
+                    )
+                )
+        return dict(self._native.finish(load.ticket, copies))

--- a/omlx/expert_streaming/integrate.py
+++ b/omlx/expert_streaming/integrate.py
@@ -64,6 +64,7 @@ class ExpertStreamingRuntime:
                 "pinned_loads",
                 "cold_loads",
                 "expert_major_calls",
+                "qmm_calls",
                 "speculative_routes",
                 "speculative_misses",
                 "hotness_decays",
@@ -85,6 +86,18 @@ class ExpertStreamingRuntime:
             "manifest": str(self.manifest.source) if self.manifest.source else None,
             "cache_budget_bytes": self.cache_budget_bytes,
             "cache_slots_per_layer": self.cache_slots_per_layer,
+            "layer_count": len(self.pools),
+            "resident_experts": sum(
+                int(layer["resident_experts"]) for layer in layers
+            ),
+            "resident_capacity": sum(pool.pool_size for pool in self.pools),
+            # The current resident cache is also the QMM execution bank. Keep
+            # this explicit in benchmark telemetry so a future two-tier design
+            # can be compared without changing the result schema.
+            "execution_bank_slots": (
+                max((pool.pool_size for pool in self.pools), default=0)
+            ),
+            "execution_banks_per_layer": 1 if self.pools else 0,
             "substitution_threshold_percent": self.substitution_threshold_percent,
             "streaming_mode": self.streaming_mode,
             "cache_policy": "route_frequency",

--- a/omlx/expert_streaming/integrate.py
+++ b/omlx/expert_streaming/integrate.py
@@ -1,0 +1,245 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Install SSD-streamed expert banks into already-lazy MLX MoE models."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import mlx.core as mx
+
+from .execution import SpeculativeExecution
+from .manifest import SoftReapManifest, load_soft_reap_manifest
+from .pool import StreamingSwitchGLU
+from .routing import ResidentPreferredMoeBlock
+from .safetensors import PROJECTIONS, ExpertReader, SafetensorExpertIndex
+
+logger = logging.getLogger(__name__)
+
+
+def _main_layers(model: Any) -> list[Any]:
+    candidates = (
+        getattr(
+            getattr(getattr(model, "language_model", None), "model", None),
+            "layers",
+            None,
+        ),
+        getattr(getattr(model, "model", None), "layers", None),
+        getattr(model, "layers", None),
+    )
+    for layers in candidates:
+        if isinstance(layers, (list, tuple)) and layers:
+            return list(layers)
+    raise ValueError("Could not locate the model's routed MoE layers")
+
+
+def _projection_metadata(switch_mlp: Any) -> dict[str, dict[str, Any]]:
+    metadata: dict[str, dict[str, Any]] = {}
+    for projection in PROJECTIONS:
+        module = getattr(switch_mlp, projection, None)
+        if module is None or not all(
+            hasattr(module, name) for name in ("weight", "scales", "biases")
+        ):
+            raise ValueError(
+                "Expert streaming currently requires stacked affine-quantized SwitchGLU weights"
+            )
+        metadata[projection] = {
+            "group_size": int(getattr(module, "group_size", 64)),
+            "bits": int(getattr(module, "bits", 4)),
+            "mode": str(getattr(module, "mode", "affine")),
+        }
+    return metadata
+
+
+@dataclass
+class ExpertStreamingRuntime:
+    model_path: Path
+    manifest: SoftReapManifest
+    cache_budget_bytes: int
+    cache_slots_per_layer: int
+    substitution_threshold_percent: float
+    streaming_mode: str
+    execution_policy: str
+    reader: ExpertReader
+    pools: list[StreamingSwitchGLU]
+    execution: SpeculativeExecution | None = None
+
+    def attach_model(self, model: Any) -> None:
+        if self.execution is None:
+            self.execution = SpeculativeExecution(
+                self,
+                policy=self.execution_policy,
+            )
+        self.execution.attach(model)
+
+    def stats(self) -> dict[str, Any]:
+        layers = [pool.snapshot() for pool in self.pools]
+        totals = {
+            key: sum(int(layer[key]) for layer in layers)
+            for key in (
+                "route_lookups",
+                "pinned_hits",
+                "cache_hits",
+                "cache_misses",
+                "evictions",
+                "loads",
+                "pinned_loads",
+                "cold_loads",
+                "expert_major_calls",
+                "speculative_routes",
+                "speculative_misses",
+                "hotness_decays",
+            )
+        }
+        attempts = totals["pinned_hits"] + totals["cache_hits"] + totals["cache_misses"]
+        totals["hit_rate"] = (
+            (totals["pinned_hits"] + totals["cache_hits"]) / attempts
+            if attempts
+            else 1.0
+        )
+        return {
+            "enabled": True,
+            "manifest": str(self.manifest.source) if self.manifest.source else None,
+            "cache_budget_bytes": self.cache_budget_bytes,
+            "cache_slots_per_layer": self.cache_slots_per_layer,
+            "substitution_threshold_percent": self.substitution_threshold_percent,
+            "streaming_mode": self.streaming_mode,
+            "cache_policy": "route_frequency",
+            "execution_policy": self.execution_policy,
+            "execution": self.execution.stats.as_dict() if self.execution else {},
+            "ssd_bytes_read": self.reader.bytes_read,
+            "ssd_read_operations": self.reader.read_operations,
+            "ssd_preload_bytes_read": self.reader.direct_bytes_read,
+            "ssd_preload_read_operations": self.reader.direct_read_operations,
+            "ssd_cold_bytes_read": self.reader.file_cache_bytes_read,
+            "ssd_cold_read_operations": self.reader.file_cache_read_operations,
+            **totals,
+            "layers": layers,
+        }
+
+    def close(self) -> None:
+        if self.execution is not None:
+            self.execution.close()
+        self.reader.close()
+
+
+def install_expert_streaming(
+    model: Any,
+    model_path: str | Path,
+    manifest_path: str | Path | None,
+    *,
+    cache_experts: int = 32,
+    substitution_threshold_percent: float = 0.0,
+    execution_policy: str = "checked",
+    streaming_mode: str = "soft_reap",
+) -> ExpertStreamingRuntime:
+    """Replace main-layer SwitchGLUs before the lazy checkpoint is evaluated."""
+
+    substitution_threshold_percent = float(substitution_threshold_percent)
+    if not 0.0 <= substitution_threshold_percent <= 100.0:
+        raise ValueError("Expert substitution threshold must be between 0% and 100%")
+    execution_policy = str(execution_policy).strip().lower()
+    if execution_policy not in {"checked", "speculative"}:
+        raise ValueError(
+            "Expert streaming execution policy must be checked or speculative"
+        )
+    streaming_mode = str(streaming_mode).strip().lower()
+    if streaming_mode not in {"soft_reap", "cache_only"}:
+        raise ValueError("Expert streaming mode must be soft_reap or cache_only")
+    layers = _main_layers(model)
+    first_mlp = getattr(layers[0], "mlp", None)
+    num_experts = int(getattr(first_mlp, "num_experts", 0) or 0)
+    top_k = int(getattr(first_mlp, "top_k", 0) or 0)
+    if not num_experts or not top_k:
+        raise ValueError(
+            "The selected model does not expose compatible routed MoE geometry"
+        )
+    if streaming_mode == "soft_reap":
+        if not manifest_path:
+            raise ValueError("Soft-REAP mode requires an expert pin manifest")
+        manifest = load_soft_reap_manifest(
+            manifest_path,
+            num_layers=len(layers),
+            num_experts=num_experts,
+        )
+    else:
+        manifest = SoftReapManifest.empty(len(layers))
+    index = SafetensorExpertIndex(model_path)
+    expert_bytes_all_layers = sum(
+        index.expert_bytes(layer) for layer in range(len(layers))
+    )
+    minimum_cache_slots = max(
+        min(top_k, num_experts - len(manifest.experts_for_layer(layer)))
+        for layer in range(len(layers))
+    )
+    cache_slots = max(0, int(cache_experts), minimum_cache_slots)
+    cache_budget_bytes = cache_slots * expert_bytes_all_layers
+    reader = ExpertReader(index)
+    pools: list[StreamingSwitchGLU] = []
+    try:
+        for layer_idx, layer in enumerate(layers):
+            mlp = getattr(layer, "mlp", None)
+            original = getattr(mlp, "switch_mlp", None)
+            if original is None:
+                raise ValueError(f"Layer {layer_idx} has no switch_mlp")
+            logger.info(
+                "Expert streaming loading layer %d/%d (%d pinned experts, %d hot slots)",
+                layer_idx + 1,
+                len(layers),
+                len(manifest.experts_for_layer(layer_idx)),
+                cache_slots,
+            )
+            pool = StreamingSwitchGLU(
+                layer=layer_idx,
+                num_experts=num_experts,
+                top_k=top_k,
+                pinned_experts=manifest.experts_for_layer(layer_idx),
+                cache_slots=cache_slots,
+                locations=index.layer(layer_idx),
+                projection_metadata=_projection_metadata(original),
+                activation=original.activation,
+                reader=reader,
+                cache_policy="route_frequency",
+            )
+            mlp.switch_mlp = pool
+            if substitution_threshold_percent > 0:
+                layer.mlp = ResidentPreferredMoeBlock(
+                    mlp,
+                    threshold_percent=substitution_threshold_percent,
+                )
+            pools.append(pool)
+            mx.clear_cache()
+    except Exception:
+        reader.close()
+        raise
+
+    runtime = ExpertStreamingRuntime(
+        model_path=Path(model_path).expanduser().resolve(),
+        manifest=manifest,
+        cache_budget_bytes=cache_budget_bytes,
+        cache_slots_per_layer=int(cache_slots),
+        substitution_threshold_percent=float(substitution_threshold_percent),
+        streaming_mode=streaming_mode,
+        execution_policy=execution_policy,
+        reader=reader,
+        pools=pools,
+    )
+    model._omlx_expert_streaming_runtime = runtime
+    runtime.attach_model(model)
+    language_model = getattr(model, "language_model", None)
+    if language_model is not None and language_model is not model:
+        language_model._omlx_expert_streaming_runtime = runtime
+        runtime.attach_model(language_model)
+    logger.info(
+        "Expert streaming ready: mode=%s, %d layers, pinned range %s, "
+        "%d hot slots/layer, %.2f GiB bank",
+        streaming_mode,
+        len(layers),
+        manifest.pinned_count_range,
+        pools[0].cache_slots if pools else 0,
+        sum(pool.pool_size * index.expert_bytes(pool.layer) for pool in pools)
+        / 1024**3,
+    )
+    return runtime

--- a/omlx/expert_streaming/integrate.py
+++ b/omlx/expert_streaming/integrate.py
@@ -3,7 +3,12 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
+import os
+import tempfile
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -31,6 +36,10 @@ class ExpertStreamingRuntime:
     execution_policy: str
     reader: ExpertReader
     pools: list[StreamingSwitchGLU]
+    hotlist_profile_path: Path | None = None
+    hotlist_fingerprint: str | None = None
+    hotlist_preloaded: int = 0
+    hotlist_profile_error: str | None = None
     execution: SpeculativeExecution | None = None
 
     def attach_model(self, model: Any) -> None:
@@ -58,7 +67,12 @@ class ExpertStreamingRuntime:
                 "speculative_routes",
                 "speculative_misses",
                 "hotness_decays",
+                "warm_start_loads",
             )
+        }
+        timing_totals = {
+            key: sum(float(layer[key]) for layer in layers)
+            for key in ("bank_bind_seconds", "bank_materialize_seconds")
         }
         attempts = totals["pinned_hits"] + totals["cache_hits"] + totals["cache_misses"]
         totals["hit_rate"] = (
@@ -82,14 +96,107 @@ class ExpertStreamingRuntime:
             "ssd_preload_read_operations": self.reader.direct_read_operations,
             "ssd_cold_bytes_read": self.reader.file_cache_bytes_read,
             "ssd_cold_read_operations": self.reader.file_cache_read_operations,
+            "ssd_io_seconds": self.reader.io_seconds,
+            "ssd_decode_seconds": self.reader.decode_seconds,
+            "ssd_readahead_descriptors": self.reader.readahead_descriptors,
+            "ssd_no_cache_descriptors": self.reader.no_cache_descriptors,
+            "hotlist_profile": (
+                str(self.hotlist_profile_path) if self.hotlist_profile_path else None
+            ),
+            "hotlist_preloaded": self.hotlist_preloaded,
+            "hotlist_profile_error": self.hotlist_profile_error,
             **totals,
+            **timing_totals,
             "layers": layers,
         }
 
+    def _save_hotlist(self) -> None:
+        if self.hotlist_profile_path is None or self.hotlist_fingerprint is None:
+            return
+        payload = {
+            "version": 1,
+            "fingerprint": self.hotlist_fingerprint,
+            "num_experts": self.pools[0].num_experts if self.pools else 0,
+            "layers": {
+                str(pool.layer): [list(entry) for entry in pool.hotlist()]
+                for pool in self.pools
+            },
+        }
+        try:
+            self.hotlist_profile_path.parent.mkdir(parents=True, exist_ok=True)
+            fd, temporary = tempfile.mkstemp(
+                prefix=f".{self.hotlist_profile_path.name}.",
+                dir=self.hotlist_profile_path.parent,
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                    json.dump(payload, handle, separators=(",", ":"))
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                os.replace(temporary, self.hotlist_profile_path)
+            except Exception:
+                with suppress(OSError):
+                    os.unlink(temporary)
+                raise
+        except (OSError, TypeError, ValueError) as exc:
+            self.hotlist_profile_error = f"save: {exc}"
+            logger.warning("Could not save expert hotlist profile: %s", exc)
+
     def close(self) -> None:
+        self._save_hotlist()
         if self.execution is not None:
             self.execution.close()
         self.reader.close()
+
+
+def _hotlist_identity(
+    model_path: Path, profile_dir: str | Path | None
+) -> tuple[Path | None, str | None]:
+    if profile_dir is None:
+        return None, None
+    index_path = model_path / "model.safetensors.index.json"
+    stat = index_path.stat()
+    identity = f"{model_path}\0{stat.st_size}\0{stat.st_mtime_ns}".encode()
+    fingerprint = hashlib.sha256(identity).hexdigest()
+    profile_path = Path(profile_dir).expanduser() / f"{fingerprint[:24]}.json"
+    return profile_path, fingerprint
+
+
+def _load_hotlist(
+    profile_path: Path | None,
+    fingerprint: str | None,
+    pools: list[StreamingSwitchGLU],
+) -> tuple[int, str | None]:
+    if profile_path is None or fingerprint is None or not profile_path.is_file():
+        return 0, None
+    try:
+        payload = json.loads(profile_path.read_text())
+        if payload.get("version") != 1 or payload.get("fingerprint") != fingerprint:
+            return 0, None
+        expected_experts = pools[0].num_experts if pools else 0
+        if int(payload.get("num_experts", -1)) != expected_experts:
+            return 0, None
+        layers = payload.get("layers")
+        if not isinstance(layers, dict):
+            raise ValueError("layers must be an object")
+        parsed: dict[int, list[tuple[int, int]]] = {}
+        for pool in pools:
+            raw_entries = layers.get(str(pool.layer), [])
+            if not isinstance(raw_entries, list):
+                raise ValueError(f"layer {pool.layer} must be a list")
+            entries: list[tuple[int, int]] = []
+            for entry in raw_entries:
+                if not isinstance(entry, list) or len(entry) != 2:
+                    raise ValueError(f"invalid layer {pool.layer} hotlist entry")
+                entries.append((int(entry[0]), int(entry[1])))
+            parsed[pool.layer] = entries
+    except (OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "Ignoring invalid expert hotlist profile %s: %s", profile_path, exc
+        )
+        return 0, f"load: {exc}"
+    preloaded = sum(pool.preload_hotlist(parsed[pool.layer]) for pool in pools)
+    return preloaded, None
 
 
 def install_expert_streaming(
@@ -101,6 +208,7 @@ def install_expert_streaming(
     substitution_threshold_percent: float = 0.0,
     execution_policy: str = "checked",
     streaming_mode: str = "soft_reap",
+    hotlist_profile_dir: str | Path | None = None,
 ) -> ExpertStreamingRuntime:
     """Replace main-layer SwitchGLUs before the lazy checkpoint is evaluated."""
 
@@ -130,6 +238,10 @@ def install_expert_streaming(
     else:
         manifest = SoftReapManifest.empty(layer_ids=layer_ids)
     index = SafetensorExpertIndex(model_path)
+    resolved_model_path = Path(model_path).expanduser().resolve()
+    hotlist_profile_path, hotlist_fingerprint = _hotlist_identity(
+        resolved_model_path, hotlist_profile_dir
+    )
     resolved: dict[int, tuple[dict[str, dict[str, Any]], dict]] = {}
     expert_bytes_all_layers = 0
     for target in targets:
@@ -205,8 +317,16 @@ def install_expert_streaming(
         reader.close()
         raise
 
+    try:
+        hotlist_preloaded, hotlist_profile_error = _load_hotlist(
+            hotlist_profile_path, hotlist_fingerprint, pools
+        )
+    except Exception:
+        reader.close()
+        raise
+
     runtime = ExpertStreamingRuntime(
-        model_path=Path(model_path).expanduser().resolve(),
+        model_path=resolved_model_path,
         manifest=manifest,
         cache_budget_bytes=cache_budget_bytes,
         cache_slots_per_layer=int(cache_slots),
@@ -215,6 +335,10 @@ def install_expert_streaming(
         execution_policy=execution_policy,
         reader=reader,
         pools=pools,
+        hotlist_profile_path=hotlist_profile_path,
+        hotlist_fingerprint=hotlist_fingerprint,
+        hotlist_preloaded=hotlist_preloaded,
+        hotlist_profile_error=hotlist_profile_error,
     )
     model._omlx_expert_streaming_runtime = runtime
     runtime.attach_model(model)

--- a/omlx/expert_streaming/integrate.py
+++ b/omlx/expert_streaming/integrate.py
@@ -39,6 +39,7 @@ class ExpertStreamingRuntime:
     hotlist_profile_path: Path | None = None
     hotlist_fingerprint: str | None = None
     hotlist_preloaded: int = 0
+    optimistic_preloaded: int = 0
     hotlist_profile_error: str | None = None
     execution: SpeculativeExecution | None = None
 
@@ -117,6 +118,7 @@ class ExpertStreamingRuntime:
                 str(self.hotlist_profile_path) if self.hotlist_profile_path else None
             ),
             "hotlist_preloaded": self.hotlist_preloaded,
+            "optimistic_preloaded": self.optimistic_preloaded,
             "hotlist_profile_error": self.hotlist_profile_error,
             **totals,
             **timing_totals,
@@ -179,16 +181,26 @@ def _load_hotlist(
     profile_path: Path | None,
     fingerprint: str | None,
     pools: list[StreamingSwitchGLU],
-) -> tuple[int, str | None]:
+) -> tuple[int, int, str | None]:
+    def fill(entries: dict[int, list[tuple[int, int]]] | None = None):
+        loaded = [
+            pool.preload_hotlist(entries.get(pool.layer, []) if entries else [])
+            for pool in pools
+        ]
+        return sum(value[0] for value in loaded), sum(value[1] for value in loaded)
+
     if profile_path is None or fingerprint is None or not profile_path.is_file():
-        return 0, None
+        learned, optimistic = fill()
+        return learned, optimistic, None
     try:
         payload = json.loads(profile_path.read_text())
         if payload.get("version") != 1 or payload.get("fingerprint") != fingerprint:
-            return 0, None
+            learned, optimistic = fill()
+            return learned, optimistic, None
         expected_experts = pools[0].num_experts if pools else 0
         if int(payload.get("num_experts", -1)) != expected_experts:
-            return 0, None
+            learned, optimistic = fill()
+            return learned, optimistic, None
         layers = payload.get("layers")
         if not isinstance(layers, dict):
             raise ValueError("layers must be an object")
@@ -207,9 +219,10 @@ def _load_hotlist(
         logger.warning(
             "Ignoring invalid expert hotlist profile %s: %s", profile_path, exc
         )
-        return 0, f"load: {exc}"
-    preloaded = sum(pool.preload_hotlist(parsed[pool.layer]) for pool in pools)
-    return preloaded, None
+        learned, optimistic = fill()
+        return learned, optimistic, f"load: {exc}"
+    learned, optimistic = fill(parsed)
+    return learned, optimistic, None
 
 
 def install_expert_streaming(
@@ -331,7 +344,7 @@ def install_expert_streaming(
         raise
 
     try:
-        hotlist_preloaded, hotlist_profile_error = _load_hotlist(
+        hotlist_preloaded, optimistic_preloaded, hotlist_profile_error = _load_hotlist(
             hotlist_profile_path, hotlist_fingerprint, pools
         )
     except Exception:
@@ -351,6 +364,7 @@ def install_expert_streaming(
         hotlist_profile_path=hotlist_profile_path,
         hotlist_fingerprint=hotlist_fingerprint,
         hotlist_preloaded=hotlist_preloaded,
+        optimistic_preloaded=optimistic_preloaded,
         hotlist_profile_error=hotlist_profile_error,
     )
     model._omlx_expert_streaming_runtime = runtime
@@ -361,11 +375,14 @@ def install_expert_streaming(
         runtime.attach_model(language_model)
     logger.info(
         "Expert streaming ready: mode=%s, %d layers, pinned range %s, "
-        "%d hot slots/layer, %.2f GiB bank",
+        "%d hot slots/layer, learned preload=%d, optimistic preload=%d, "
+        "%.2f GiB bank",
         streaming_mode,
         len(targets),
         manifest.pinned_count_range,
         pools[0].cache_slots if pools else 0,
+        hotlist_preloaded,
+        optimistic_preloaded,
         sum(
             pool.pool_size
             * sum(location.row_bytes for location in pool.locations.values())

--- a/omlx/expert_streaming/integrate.py
+++ b/omlx/expert_streaming/integrate.py
@@ -36,6 +36,8 @@ class ExpertStreamingRuntime:
     substitution_threshold_percent: float
     streaming_mode: str
     execution_policy: str
+    fast_resource_loading: bool
+    fast_resource_loading_scope: str
     reader: ExpertReader
     pools: list[StreamingSwitchGLU]
     hotlist_profile_path: Path | None = None
@@ -118,6 +120,8 @@ class ExpertStreamingRuntime:
             "streaming_mode": self.streaming_mode,
             "cache_policy": "route_frequency",
             "execution_policy": self.execution_policy,
+            "fast_resource_loading": self.fast_resource_loading,
+            "fast_resource_loading_scope": self.fast_resource_loading_scope,
             "execution": self.execution.stats.as_dict() if self.execution else {},
             "ssd_bytes_read": self.reader.bytes_read,
             "ssd_read_operations": self.reader.read_operations,
@@ -129,6 +133,11 @@ class ExpertStreamingRuntime:
             "ssd_decode_seconds": self.reader.decode_seconds,
             "ssd_readahead_descriptors": self.reader.readahead_descriptors,
             "ssd_no_cache_descriptors": self.reader.no_cache_descriptors,
+            "frl_loads": self.reader.fast_loads,
+            "frl_bytes_read": self.reader.fast_bytes_read,
+            "frl_read_operations": self.reader.fast_read_operations,
+            "frl_io_wait_seconds": self.reader.fast_io_wait_seconds,
+            "frl_copy_seconds": self.reader.fast_copy_seconds,
             "hotlist_profile": (
                 str(self.hotlist_profile_path) if self.hotlist_profile_path else None
             ),
@@ -251,6 +260,7 @@ def install_expert_streaming(
     execution_policy: str = "checked",
     streaming_mode: str = "soft_reap",
     hotlist_profile_dir: str | Path | None = None,
+    fast_resource_loading: bool | str = False,
 ) -> ExpertStreamingRuntime:
     """Replace main-layer SwitchGLUs before the lazy checkpoint is evaluated."""
 
@@ -316,7 +326,7 @@ def install_expert_streaming(
     cache_slots = max(0, int(cache_experts), minimum_cache_slots)
     cache_budget_bytes = cache_slots * expert_bytes_all_layers
     scratch_slots = max(0, int(scratch_experts))
-    reader = ExpertReader(index)
+    reader = ExpertReader(index, fast_resource_loading=fast_resource_loading)
     pools: list[StreamingSwitchGLU] = []
     try:
         for ordinal, target in enumerate(targets):
@@ -387,6 +397,8 @@ def install_expert_streaming(
         substitution_threshold_percent=float(substitution_threshold_percent),
         streaming_mode=streaming_mode,
         execution_policy=execution_policy,
+        fast_resource_loading=reader.fast_resource_loading,
+        fast_resource_loading_scope=reader.fast_resource_loading_scope,
         reader=reader,
         pools=pools,
         hotlist_profile_path=hotlist_profile_path,

--- a/omlx/expert_streaming/integrate.py
+++ b/omlx/expert_streaming/integrate.py
@@ -31,6 +31,8 @@ class ExpertStreamingRuntime:
     manifest: SoftReapManifest
     cache_budget_bytes: int
     cache_slots_per_layer: int
+    scratch_budget_bytes: int
+    scratch_slots_per_layer: int
     substitution_threshold_percent: float
     streaming_mode: str
     execution_policy: str
@@ -64,8 +66,13 @@ class ExpertStreamingRuntime:
                 "loads",
                 "pinned_loads",
                 "cold_loads",
+                "scratch_loads",
+                "scratch_prefetch_requests",
                 "expert_major_calls",
                 "qmm_calls",
+                "sorted_prefill_groups",
+                "sorted_prefill_routes",
+                "sorted_qmm_calls",
                 "speculative_routes",
                 "speculative_misses",
                 "hotness_decays",
@@ -74,7 +81,12 @@ class ExpertStreamingRuntime:
         }
         timing_totals = {
             key: sum(float(layer[key]) for layer in layers)
-            for key in ("bank_bind_seconds", "bank_materialize_seconds")
+            for key in (
+                "bank_bind_seconds",
+                "bank_materialize_seconds",
+                "scratch_prefetch_wait_seconds",
+                "scratch_mlx_materialize_seconds",
+            )
         }
         attempts = totals["pinned_hits"] + totals["cache_hits"] + totals["cache_misses"]
         totals["hit_rate"] = (
@@ -87,18 +99,21 @@ class ExpertStreamingRuntime:
             "manifest": str(self.manifest.source) if self.manifest.source else None,
             "cache_budget_bytes": self.cache_budget_bytes,
             "cache_slots_per_layer": self.cache_slots_per_layer,
+            "scratch_budget_bytes": self.scratch_budget_bytes,
+            "scratch_slots_per_layer": self.scratch_slots_per_layer,
             "layer_count": len(self.pools),
             "resident_experts": sum(
                 int(layer["resident_experts"]) for layer in layers
             ),
             "resident_capacity": sum(pool.pool_size for pool in self.pools),
-            # The current resident cache is also the QMM execution bank. Keep
-            # this explicit in benchmark telemetry so a future two-tier design
-            # can be compared without changing the result schema.
             "execution_bank_slots": (
-                max((pool.pool_size for pool in self.pools), default=0)
+                max((pool.bank_size for pool in self.pools), default=0)
             ),
             "execution_banks_per_layer": 1 if self.pools else 0,
+            "fused_gate_up": bool(self.pools)
+            and all(bool(layer["fused_gate_up"]) for layer in layers),
+            "sorted_prefill": bool(self.pools)
+            and all(bool(layer["sorted_prefill"]) for layer in layers),
             "substitution_threshold_percent": self.substitution_threshold_percent,
             "streaming_mode": self.streaming_mode,
             "cache_policy": "route_frequency",
@@ -231,6 +246,7 @@ def install_expert_streaming(
     manifest_path: str | Path | None,
     *,
     cache_experts: int = 32,
+    scratch_experts: int = 32,
     substitution_threshold_percent: float = 0.0,
     execution_policy: str = "checked",
     streaming_mode: str = "soft_reap",
@@ -299,6 +315,7 @@ def install_expert_streaming(
     )
     cache_slots = max(0, int(cache_experts), minimum_cache_slots)
     cache_budget_bytes = cache_slots * expert_bytes_all_layers
+    scratch_slots = max(0, int(scratch_experts))
     reader = ExpertReader(index)
     pools: list[StreamingSwitchGLU] = []
     try:
@@ -307,11 +324,13 @@ def install_expert_streaming(
             original = target.switch_mlp
             schema, locations = resolved[layer_idx]
             logger.info(
-                "Expert streaming loading layer %d/%d (%d pinned experts, %d hot slots)",
+                "Expert streaming loading layer %d/%d (%d pinned experts, "
+                "%d hot slots, %d scratch slots)",
                 ordinal + 1,
                 len(targets),
                 len(manifest.experts_for_layer(layer_idx)),
                 cache_slots,
+                scratch_slots,
             )
             pool = StreamingSwitchGLU(
                 layer=layer_idx,
@@ -319,6 +338,7 @@ def install_expert_streaming(
                 top_k=top_k,
                 pinned_experts=manifest.experts_for_layer(layer_idx),
                 cache_slots=cache_slots,
+                scratch_slots=scratch_slots,
                 locations=locations,
                 projection_metadata=schema,
                 activation=original.activation,
@@ -351,11 +371,19 @@ def install_expert_streaming(
         reader.close()
         raise
 
+    scratch_budget_bytes = sum(
+        pool.scratch_slots
+        * sum(location.row_bytes for location in pool.locations.values())
+        for pool in pools
+    )
+    actual_scratch_slots = max((pool.scratch_slots for pool in pools), default=0)
     runtime = ExpertStreamingRuntime(
         model_path=resolved_model_path,
         manifest=manifest,
         cache_budget_bytes=cache_budget_bytes,
         cache_slots_per_layer=int(cache_slots),
+        scratch_budget_bytes=scratch_budget_bytes,
+        scratch_slots_per_layer=actual_scratch_slots,
         substitution_threshold_percent=float(substitution_threshold_percent),
         streaming_mode=streaming_mode,
         execution_policy=execution_policy,
@@ -375,16 +403,18 @@ def install_expert_streaming(
         runtime.attach_model(language_model)
     logger.info(
         "Expert streaming ready: mode=%s, %d layers, pinned range %s, "
-        "%d hot slots/layer, learned preload=%d, optimistic preload=%d, "
+        "%d hot slots/layer, %d scratch slots/layer, learned preload=%d, "
+        "optimistic preload=%d, "
         "%.2f GiB bank",
         streaming_mode,
         len(targets),
         manifest.pinned_count_range,
         pools[0].cache_slots if pools else 0,
+        pools[0].scratch_slots if pools else 0,
         hotlist_preloaded,
         optimistic_preloaded,
         sum(
-            pool.pool_size
+            pool.bank_size
             * sum(location.row_bytes for location in pool.locations.values())
             for pool in pools
         )

--- a/omlx/expert_streaming/integrate.py
+++ b/omlx/expert_streaming/integrate.py
@@ -10,47 +10,14 @@ from typing import Any
 
 import mlx.core as mx
 
+from .adapters import discover_moe_layers, projection_schema
 from .execution import SpeculativeExecution
 from .manifest import SoftReapManifest, load_soft_reap_manifest
 from .pool import StreamingSwitchGLU
 from .routing import ResidentPreferredMoeBlock
-from .safetensors import PROJECTIONS, ExpertReader, SafetensorExpertIndex
+from .safetensors import ExpertReader, SafetensorExpertIndex
 
 logger = logging.getLogger(__name__)
-
-
-def _main_layers(model: Any) -> list[Any]:
-    candidates = (
-        getattr(
-            getattr(getattr(model, "language_model", None), "model", None),
-            "layers",
-            None,
-        ),
-        getattr(getattr(model, "model", None), "layers", None),
-        getattr(model, "layers", None),
-    )
-    for layers in candidates:
-        if isinstance(layers, (list, tuple)) and layers:
-            return list(layers)
-    raise ValueError("Could not locate the model's routed MoE layers")
-
-
-def _projection_metadata(switch_mlp: Any) -> dict[str, dict[str, Any]]:
-    metadata: dict[str, dict[str, Any]] = {}
-    for projection in PROJECTIONS:
-        module = getattr(switch_mlp, projection, None)
-        if module is None or not all(
-            hasattr(module, name) for name in ("weight", "scales", "biases")
-        ):
-            raise ValueError(
-                "Expert streaming currently requires stacked affine-quantized SwitchGLU weights"
-            )
-        metadata[projection] = {
-            "group_size": int(getattr(module, "group_size", 64)),
-            "bits": int(getattr(module, "bits", 4)),
-            "mode": str(getattr(module, "mode", "affine")),
-        }
-    return metadata
 
 
 @dataclass
@@ -148,46 +115,63 @@ def install_expert_streaming(
     streaming_mode = str(streaming_mode).strip().lower()
     if streaming_mode not in {"soft_reap", "cache_only"}:
         raise ValueError("Expert streaming mode must be soft_reap or cache_only")
-    layers = _main_layers(model)
-    first_mlp = getattr(layers[0], "mlp", None)
-    num_experts = int(getattr(first_mlp, "num_experts", 0) or 0)
-    top_k = int(getattr(first_mlp, "top_k", 0) or 0)
-    if not num_experts or not top_k:
-        raise ValueError(
-            "The selected model does not expose compatible routed MoE geometry"
-        )
+    targets = discover_moe_layers(model)
+    layer_ids = [target.layer_id for target in targets]
+    num_experts = targets[0].num_experts
+    top_k = targets[0].top_k
     if streaming_mode == "soft_reap":
         if not manifest_path:
             raise ValueError("Soft-REAP mode requires an expert pin manifest")
         manifest = load_soft_reap_manifest(
             manifest_path,
-            num_layers=len(layers),
+            layer_ids=layer_ids,
             num_experts=num_experts,
         )
     else:
-        manifest = SoftReapManifest.empty(len(layers))
+        manifest = SoftReapManifest.empty(layer_ids=layer_ids)
     index = SafetensorExpertIndex(model_path)
-    expert_bytes_all_layers = sum(
-        index.expert_bytes(layer) for layer in range(len(layers))
-    )
+    resolved: dict[int, tuple[dict[str, dict[str, Any]], dict]] = {}
+    expert_bytes_all_layers = 0
+    for target in targets:
+        schema = projection_schema(target.switch_mlp)
+        locations = index.layer(
+            target.layer_id,
+            container_name=target.container_name,
+            schema=schema,
+            num_experts=target.num_experts,
+        )
+        # ``arrays`` are only shape/dtype descriptors for checkpoint indexing.
+        # Never retain them in the runtime schema: they are the original full
+        # expert banks that streaming is meant to replace.
+        runtime_schema = {
+            projection: {
+                key: value
+                for key, value in metadata.items()
+                if key != "arrays"
+            }
+            for projection, metadata in schema.items()
+        }
+        resolved[target.layer_id] = (runtime_schema, locations)
+        expert_bytes_all_layers += sum(
+            location.row_bytes for location in locations.values()
+        )
     minimum_cache_slots = max(
         min(top_k, num_experts - len(manifest.experts_for_layer(layer)))
-        for layer in range(len(layers))
+        for layer in layer_ids
     )
     cache_slots = max(0, int(cache_experts), minimum_cache_slots)
     cache_budget_bytes = cache_slots * expert_bytes_all_layers
     reader = ExpertReader(index)
     pools: list[StreamingSwitchGLU] = []
     try:
-        for layer_idx, layer in enumerate(layers):
-            mlp = getattr(layer, "mlp", None)
-            original = getattr(mlp, "switch_mlp", None)
-            if original is None:
-                raise ValueError(f"Layer {layer_idx} has no switch_mlp")
+        for ordinal, target in enumerate(targets):
+            layer_idx = target.layer_id
+            original = target.switch_mlp
+            schema, locations = resolved[layer_idx]
             logger.info(
                 "Expert streaming loading layer %d/%d (%d pinned experts, %d hot slots)",
-                layer_idx + 1,
-                len(layers),
+                ordinal + 1,
+                len(targets),
                 len(manifest.experts_for_layer(layer_idx)),
                 cache_slots,
             )
@@ -197,18 +181,24 @@ def install_expert_streaming(
                 top_k=top_k,
                 pinned_experts=manifest.experts_for_layer(layer_idx),
                 cache_slots=cache_slots,
-                locations=index.layer(layer_idx),
-                projection_metadata=_projection_metadata(original),
+                locations=locations,
+                projection_metadata=schema,
                 activation=original.activation,
                 reader=reader,
                 cache_policy="route_frequency",
             )
-            mlp.switch_mlp = pool
+            target.replace_switch(pool)
             if substitution_threshold_percent > 0:
-                layer.mlp = ResidentPreferredMoeBlock(
-                    mlp,
+                module_name = type(target.moe).__module__.lower()
+                if "qwen" not in module_name:
+                    raise ValueError(
+                        "Resident substitution is currently available only for "
+                        "Qwen-family MoE routers"
+                    )
+                setattr(target.layer, target.container_name, ResidentPreferredMoeBlock(
+                    target.moe,
                     threshold_percent=substitution_threshold_percent,
-                )
+                ))
             pools.append(pool)
             mx.clear_cache()
     except Exception:
@@ -236,10 +226,14 @@ def install_expert_streaming(
         "Expert streaming ready: mode=%s, %d layers, pinned range %s, "
         "%d hot slots/layer, %.2f GiB bank",
         streaming_mode,
-        len(layers),
+        len(targets),
         manifest.pinned_count_range,
         pools[0].cache_slots if pools else 0,
-        sum(pool.pool_size * index.expert_bytes(pool.layer) for pool in pools)
+        sum(
+            pool.pool_size
+            * sum(location.row_bytes for location in pool.locations.values())
+            for pool in pools
+        )
         / 1024**3,
     )
     return runtime

--- a/omlx/expert_streaming/manifest.py
+++ b/omlx/expert_streaming/manifest.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Validation and normalization for Soft-REAP expert pin manifests."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SoftReapManifest:
+    """Original expert IDs that remain resident for every routed layer."""
+
+    layers: dict[int, tuple[int, ...]]
+    source: Path | None = None
+
+    @property
+    def layer_count(self) -> int:
+        return len(self.layers)
+
+    @property
+    def pinned_count_range(self) -> tuple[int, int]:
+        counts = [len(experts) for experts in self.layers.values()]
+        return (min(counts), max(counts)) if counts else (0, 0)
+
+    def experts_for_layer(self, layer: int) -> tuple[int, ...]:
+        try:
+            return self.layers[layer]
+        except KeyError as exc:
+            raise ValueError(
+                f"Soft-REAP manifest has no entry for layer {layer}"
+            ) from exc
+
+    @classmethod
+    def empty(cls, num_layers: int) -> SoftReapManifest:
+        """Build a manifest-free residency map for cache-only streaming."""
+
+        return cls(layers={layer: () for layer in range(num_layers)})
+
+
+def _unwrap_layers(data: Any) -> Any:
+    if not isinstance(data, Mapping):
+        return data
+    for key in ("layers", "pinned_experts", "kept_experts"):
+        value = data.get(key)
+        if value is not None:
+            return value
+    return data
+
+
+def _normalize_layers(
+    data: Any,
+    *,
+    num_layers: int | None,
+    num_experts: int | None,
+) -> dict[int, tuple[int, ...]]:
+    data = _unwrap_layers(data)
+    if isinstance(data, list):
+        if not data or not all(isinstance(value, int) for value in data):
+            raise ValueError("Soft-REAP expert list must contain integer expert IDs")
+        if num_layers is None:
+            raise ValueError("A shared expert list requires the model layer count")
+        data = {str(layer): data for layer in range(num_layers)}
+    if not isinstance(data, Mapping) or not data:
+        raise ValueError("Soft-REAP manifest must contain a non-empty layer mapping")
+
+    normalized: dict[int, tuple[int, ...]] = {}
+    for raw_layer, raw_experts in data.items():
+        try:
+            layer = int(raw_layer)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Invalid Soft-REAP layer ID: {raw_layer!r}") from exc
+        if layer < 0:
+            raise ValueError(f"Soft-REAP layer ID must be non-negative: {layer}")
+        if not isinstance(raw_experts, list) or not raw_experts:
+            raise ValueError(f"Layer {layer} must contain a non-empty expert list")
+        if not all(
+            isinstance(expert, int) and not isinstance(expert, bool)
+            for expert in raw_experts
+        ):
+            raise ValueError(f"Layer {layer} contains a non-integer expert ID")
+        experts = tuple(sorted(set(raw_experts)))
+        if len(experts) != len(raw_experts):
+            raise ValueError(f"Layer {layer} contains duplicate expert IDs")
+        if experts[0] < 0:
+            raise ValueError(f"Layer {layer} contains a negative expert ID")
+        if num_experts is not None and experts[-1] >= num_experts:
+            raise ValueError(
+                f"Layer {layer} expert {experts[-1]} exceeds model range 0-{num_experts - 1}"
+            )
+        normalized[layer] = experts
+
+    if num_layers is not None:
+        expected = set(range(num_layers))
+        present = set(normalized)
+        missing = sorted(expected - present)
+        extra = sorted(present - expected)
+        if missing or extra:
+            details = []
+            if missing:
+                details.append(f"missing layers {missing}")
+            if extra:
+                details.append(f"unexpected layers {extra}")
+            raise ValueError("Soft-REAP manifest layer mismatch: " + ", ".join(details))
+    return dict(sorted(normalized.items()))
+
+
+def load_soft_reap_manifest(
+    path: str | Path,
+    *,
+    num_layers: int | None = None,
+    num_experts: int | None = None,
+) -> SoftReapManifest:
+    """Load official REAP maps and the wrapped Soft-REAP manifest form."""
+
+    manifest_path = Path(path).expanduser().resolve()
+    if not manifest_path.is_file():
+        raise ValueError(f"Soft-REAP manifest does not exist: {manifest_path}")
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Could not read Soft-REAP manifest: {exc}") from exc
+    layers = _normalize_layers(
+        data,
+        num_layers=num_layers,
+        num_experts=num_experts,
+    )
+    return SoftReapManifest(layers=layers, source=manifest_path)
+
+
+def validate_soft_reap_manifest_data(
+    data: Any,
+    *,
+    num_layers: int | None = None,
+    num_experts: int | None = None,
+) -> SoftReapManifest:
+    """Validate uploaded JSON before it is persisted by the admin API."""
+
+    return SoftReapManifest(
+        layers=_normalize_layers(
+            data,
+            num_layers=num_layers,
+            num_experts=num_experts,
+        )
+    )

--- a/omlx/expert_streaming/manifest.py
+++ b/omlx/expert_streaming/manifest.py
@@ -35,10 +35,19 @@ class SoftReapManifest:
             ) from exc
 
     @classmethod
-    def empty(cls, num_layers: int) -> SoftReapManifest:
+    def empty(
+        cls,
+        num_layers: int | None = None,
+        *,
+        layer_ids: list[int] | tuple[int, ...] | None = None,
+    ) -> SoftReapManifest:
         """Build a manifest-free residency map for cache-only streaming."""
 
-        return cls(layers={layer: () for layer in range(num_layers)})
+        if layer_ids is None:
+            if num_layers is None:
+                raise ValueError("Empty manifest requires layer IDs or a layer count")
+            layer_ids = tuple(range(num_layers))
+        return cls(layers={int(layer): () for layer in layer_ids})
 
 
 def _unwrap_layers(data: Any) -> Any:
@@ -55,15 +64,17 @@ def _normalize_layers(
     data: Any,
     *,
     num_layers: int | None,
+    layer_ids: list[int] | tuple[int, ...] | None,
     num_experts: int | None,
 ) -> dict[int, tuple[int, ...]]:
     data = _unwrap_layers(data)
     if isinstance(data, list):
         if not data or not all(isinstance(value, int) for value in data):
             raise ValueError("Soft-REAP expert list must contain integer expert IDs")
-        if num_layers is None:
+        if num_layers is None and layer_ids is None:
             raise ValueError("A shared expert list requires the model layer count")
-        data = {str(layer): data for layer in range(num_layers)}
+        targets = layer_ids if layer_ids is not None else range(int(num_layers))
+        data = {str(layer): data for layer in targets}
     if not isinstance(data, Mapping) or not data:
         raise ValueError("Soft-REAP manifest must contain a non-empty layer mapping")
 
@@ -93,8 +104,12 @@ def _normalize_layers(
             )
         normalized[layer] = experts
 
-    if num_layers is not None:
-        expected = set(range(num_layers))
+    if layer_ids is not None or num_layers is not None:
+        expected = (
+            {int(layer) for layer in layer_ids}
+            if layer_ids is not None
+            else set(range(int(num_layers)))
+        )
         present = set(normalized)
         missing = sorted(expected - present)
         extra = sorted(present - expected)
@@ -112,6 +127,7 @@ def load_soft_reap_manifest(
     path: str | Path,
     *,
     num_layers: int | None = None,
+    layer_ids: list[int] | tuple[int, ...] | None = None,
     num_experts: int | None = None,
 ) -> SoftReapManifest:
     """Load official REAP maps and the wrapped Soft-REAP manifest form."""
@@ -126,6 +142,7 @@ def load_soft_reap_manifest(
     layers = _normalize_layers(
         data,
         num_layers=num_layers,
+        layer_ids=layer_ids,
         num_experts=num_experts,
     )
     return SoftReapManifest(layers=layers, source=manifest_path)
@@ -135,6 +152,7 @@ def validate_soft_reap_manifest_data(
     data: Any,
     *,
     num_layers: int | None = None,
+    layer_ids: list[int] | tuple[int, ...] | None = None,
     num_experts: int | None = None,
 ) -> SoftReapManifest:
     """Validate uploaded JSON before it is persisted by the admin API."""
@@ -143,6 +161,7 @@ def validate_soft_reap_manifest_data(
         layers=_normalize_layers(
             data,
             num_layers=num_layers,
+            layer_ids=layer_ids,
             num_experts=num_experts,
         )
     )

--- a/omlx/expert_streaming/pool.py
+++ b/omlx/expert_streaming/pool.py
@@ -325,8 +325,8 @@ class StreamingSwitchGLU(nn.Module):
             )
             return [(expert, int(self._route_counts[expert])) for expert in experts]
 
-    def preload_hotlist(self, entries: list[tuple[int, int]]) -> int:
-        """Fill evictable slots from a prior run's learned route profile."""
+    def preload_hotlist(self, entries: list[tuple[int, int]]) -> tuple[int, int]:
+        """Populate every configured hot slot, prioritizing learned experts."""
         with self._lock:
             valid: list[tuple[int, int]] = []
             seen: set[int] = set()
@@ -346,11 +346,19 @@ class StreamingSwitchGLU(nn.Module):
             for expert, count in valid:
                 self._route_counts[expert] = min(count, int(np.iinfo(np.uint64).max))
             selected = valid[: self.cache_slots]
+            selected_experts = {expert for expert, _ in selected}
+            if len(selected) < self.cache_slots:
+                selected.extend(
+                    (expert, 0)
+                    for expert in range(self.num_experts)
+                    if expert not in self._pinned_set and expert not in selected_experts
+                )
+                selected = selected[: self.cache_slots]
             missing = [
                 expert for expert, _ in selected if expert not in self._expert_to_slot
             ]
             if not missing:
-                return 0
+                return 0, 0
             slots = self._allocate_misses(missing)
             self._load_into_slots(missing, slots, load_kind="warm_start")
             counts = dict(selected)
@@ -369,7 +377,8 @@ class StreamingSwitchGLU(nn.Module):
             self.stats.bank_materialize_seconds += (
                 time.perf_counter() - materialize_started
             )
-            return len(missing)
+            learned = sum(1 for expert in missing if counts[expert] > 0)
+            return learned, len(missing) - learned
 
     def _eviction_victim(self, protected: set[int]) -> tuple[int, int]:
         candidates = [

--- a/omlx/expert_streaming/pool.py
+++ b/omlx/expert_streaming/pool.py
@@ -36,6 +36,7 @@ class ExpertPoolStats:
     pinned_loads: int = 0
     cold_loads: int = 0
     expert_major_calls: int = 0
+    qmm_calls: int = 0
     speculative_routes: int = 0
     speculative_misses: int = 0
     hotness_decays: int = 0
@@ -55,6 +56,7 @@ class ExpertPoolStats:
             "pinned_loads": self.pinned_loads,
             "cold_loads": self.cold_loads,
             "expert_major_calls": self.expert_major_calls,
+            "qmm_calls": self.qmm_calls,
             "speculative_routes": self.speculative_routes,
             "speculative_misses": self.speculative_misses,
             "hotness_decays": self.hotness_decays,
@@ -140,11 +142,7 @@ class StreamingSwitchGLU(nn.Module):
         for projection in PROJECTIONS:
             self.projection_metadata[projection].setdefault(
                 "parts",
-                tuple(
-                    part
-                    for candidate, part in locations
-                    if candidate == projection
-                ),
+                tuple(part for candidate, part in locations if candidate == projection),
             )
         self.activation = activation
         self._reader = reader
@@ -214,6 +212,11 @@ class StreamingSwitchGLU(nn.Module):
     @property
     def execution_mode(self) -> str:
         return self._execution_mode
+
+    @property
+    def cache_full(self) -> bool:
+        """Whether every evictable expert slot has been populated."""
+        return len(self._dynamic_lru) >= self.cache_slots
 
     def set_execution_mode(self, mode: str) -> None:
         if mode not in {"checked", "speculative"}:
@@ -320,9 +323,7 @@ class StreamingSwitchGLU(nn.Module):
                 ),
                 reverse=True,
             )
-            return [
-                (expert, int(self._route_counts[expert])) for expert in experts
-            ]
+            return [(expert, int(self._route_counts[expert])) for expert in experts]
 
     def preload_hotlist(self, entries: list[tuple[int, int]]) -> int:
         """Fill evictable slots from a prior run's learned route profile."""
@@ -343,9 +344,7 @@ class StreamingSwitchGLU(nn.Module):
                 valid.append((expert, count))
             valid.sort(key=lambda entry: entry[1], reverse=True)
             for expert, count in valid:
-                self._route_counts[expert] = min(
-                    count, int(np.iinfo(np.uint64).max)
-                )
+                self._route_counts[expert] = min(count, int(np.iinfo(np.uint64).max))
             selected = valid[: self.cache_slots]
             missing = [
                 expert for expert, _ in selected if expert not in self._expert_to_slot
@@ -493,7 +492,7 @@ class StreamingSwitchGLU(nn.Module):
                     self._dynamic_lru.move_to_end(expert)
 
     def promote(self, values: tuple[int, ...]) -> None:
-        """Load every currently-cold expert in ``values`` into the hot tier."""
+        """Load cold experts while deferring bank materialization to the retry."""
         with self._lock:
             unique = list(dict.fromkeys(values))
             dynamic_working_set = [
@@ -511,12 +510,11 @@ class StreamingSwitchGLU(nn.Module):
             if missing:
                 slots = self._allocate_misses(missing, protected=set(unique))
                 self._load_into_slots(missing, slots)
-                arrays = [
-                    self._array(projection, part)
-                    for projection in PROJECTIONS
-                    for part in self.projection_metadata[projection]["parts"]
-                ]
-                mx.eval(*arrays, self._slot_map, self._resident_mask)
+                # The retried QMM immediately consumes the updated banks, so
+                # forcing every projection here only materializes the same
+                # writes twice. Commit the tiny routing maps now and let the
+                # retry evaluate each bank update with its first consumer.
+                mx.eval(self._slot_map, self._resident_mask)
             self._last_indices = None
             self._last_slots = None
 
@@ -529,6 +527,7 @@ class StreamingSwitchGLU(nn.Module):
 
     def project(self, projection: str, x: mx.array, slot_indices: mx.array) -> mx.array:
         metadata = self.projection_metadata[projection]
+        self.stats.qmm_calls += 1
         output = mx.gather_qmm(
             x,
             self._array(projection, "weight"),
@@ -736,6 +735,7 @@ class StreamingSwitchGLU(nn.Module):
                 "cache_slots": self.cache_slots,
                 "cache_policy": self.cache_policy,
                 "resident_slots": self.pool_size,
+                "resident_experts": len(self._expert_to_slot),
                 "expert_bytes": sum(
                     location.row_bytes for location in self.locations.values()
                 ),

--- a/omlx/expert_streaming/pool.py
+++ b/omlx/expert_streaming/pool.py
@@ -1,0 +1,619 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fixed resident/cached expert banks for compile-stable MLX execution."""
+
+from __future__ import annotations
+
+import threading
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from .safetensors import PARTS, PROJECTIONS, ExpertReader, TensorLocation
+
+_MLX_DTYPES = {
+    "U32": mx.uint32,
+    "F32": mx.float32,
+    "F16": mx.float16,
+    "BF16": mx.bfloat16,
+}
+
+
+@dataclass
+class ExpertPoolStats:
+    route_lookups: int = 0
+    pinned_hits: int = 0
+    cache_hits: int = 0
+    cache_misses: int = 0
+    evictions: int = 0
+    loads: int = 0
+    pinned_loads: int = 0
+    cold_loads: int = 0
+    expert_major_calls: int = 0
+    speculative_routes: int = 0
+    speculative_misses: int = 0
+    hotness_decays: int = 0
+
+    def as_dict(self) -> dict[str, int | float]:
+        total = self.pinned_hits + self.cache_hits + self.cache_misses
+        return {
+            "route_lookups": self.route_lookups,
+            "pinned_hits": self.pinned_hits,
+            "cache_hits": self.cache_hits,
+            "cache_misses": self.cache_misses,
+            "evictions": self.evictions,
+            "loads": self.loads,
+            "pinned_loads": self.pinned_loads,
+            "cold_loads": self.cold_loads,
+            "expert_major_calls": self.expert_major_calls,
+            "speculative_routes": self.speculative_routes,
+            "speculative_misses": self.speculative_misses,
+            "hotness_decays": self.hotness_decays,
+            "hit_rate": (self.pinned_hits + self.cache_hits) / total if total else 1.0,
+        }
+
+
+class StreamingQuantizedSwitchLinear:
+    """Projection-compatible facade used by Qwen target-verify helpers."""
+
+    def __init__(self, owner: StreamingSwitchGLU, projection: str):
+        self._owner = owner
+        self._projection_name = projection
+        metadata = owner.projection_metadata[projection]
+        self.group_size = metadata["group_size"]
+        self.bits = metadata["bits"]
+        self.mode = metadata["mode"]
+
+    @property
+    def weight(self) -> mx.array:
+        return self._owner._array(self._projection_name, "weight")
+
+    @property
+    def scales(self) -> mx.array:
+        return self._owner._array(self._projection_name, "scales")
+
+    @property
+    def biases(self) -> mx.array:
+        return self._owner._array(self._projection_name, "biases")
+
+    @property
+    def input_dims(self) -> int:
+        return self.scales.shape[2] * self.group_size
+
+    @property
+    def output_dims(self) -> int:
+        return self.weight.shape[1]
+
+    @property
+    def num_experts(self) -> int:
+        return self._owner.num_experts
+
+    def __call__(self, x, indices, sorted_indices=False):
+        del sorted_indices
+        return self._owner.project_indices(self._projection_name, x, indices)
+
+
+class StreamingSwitchGLU(nn.Module):
+    """SwitchGLU whose stable bank contains pinned rows plus a hot tier."""
+
+    _omlx_expert_streaming = True
+
+    def __init__(
+        self,
+        *,
+        layer: int,
+        num_experts: int,
+        top_k: int,
+        pinned_experts: tuple[int, ...],
+        cache_slots: int,
+        locations: dict[tuple[str, str], TensorLocation],
+        projection_metadata: dict[str, dict[str, Any]],
+        activation: Any,
+        reader: ExpertReader,
+        cache_policy: str = "route_frequency",
+    ):
+        super().__init__()
+        self.layer = int(layer)
+        self.num_experts = int(num_experts)
+        self.top_k = int(top_k)
+        self.pinned_experts = tuple(int(value) for value in pinned_experts)
+        self._pinned_set = frozenset(self.pinned_experts)
+        self.pinned_count = len(self.pinned_experts)
+        cold_count = self.num_experts - self.pinned_count
+        minimum_working_set = min(self.top_k, cold_count)
+        self.cache_slots = min(cold_count, max(int(cache_slots), minimum_working_set))
+        self.pool_size = self.pinned_count + self.cache_slots
+        self.locations = locations
+        self.projection_metadata = projection_metadata
+        self.activation = activation
+        self._reader = reader
+        if cache_policy not in {"lru", "route_frequency"}:
+            raise ValueError(f"Unknown expert cache policy: {cache_policy}")
+        self.cache_policy = cache_policy
+        self._lock = threading.RLock()
+        self._expert_to_slot: dict[int, int] = {
+            expert: slot for slot, expert in enumerate(self.pinned_experts)
+        }
+        mask = np.zeros(self.num_experts, dtype=np.bool_)
+        mask[list(self.pinned_experts)] = True
+        slot_map = np.zeros(self.num_experts, dtype=np.int32)
+        for expert, slot in self._expert_to_slot.items():
+            slot_map[expert] = slot
+        self._slot_map_np = slot_map
+        self._resident_mask_np = mask
+        self._slot_map = mx.array(slot_map)
+        self._resident_mask = mx.array(mask)
+        self._dynamic_lru: OrderedDict[int, int] = OrderedDict()
+        self._route_hotness = np.zeros(self.num_experts, dtype=np.uint64)
+        self._last_used = np.zeros(self.num_experts, dtype=np.uint64)
+        self._route_tokens = 0
+        self._hotness_decay_interval = 16
+        self._next_hotness_decay = self._hotness_decay_interval
+        self._access_clock = 0
+        self._free_slots = list(range(self.pinned_count, self.pool_size))
+        self._last_indices: mx.array | None = None
+        self._last_slots: mx.array | None = None
+        self._execution_mode = "checked"
+        self._speculative_routes: list[tuple[mx.array, mx.array]] = []
+        self.stats = ExpertPoolStats()
+
+        for projection in PROJECTIONS:
+            for part in PARTS:
+                location = locations[(projection, part)]
+                setattr(
+                    self,
+                    self._array_name(projection, part),
+                    mx.zeros(
+                        (self.pool_size, *location.shape[1:]),
+                        dtype=_MLX_DTYPES[location.dtype],
+                    ),
+                )
+
+        self.gate_proj = StreamingQuantizedSwitchLinear(self, "gate_proj")
+        self.up_proj = StreamingQuantizedSwitchLinear(self, "up_proj")
+        self.down_proj = StreamingQuantizedSwitchLinear(self, "down_proj")
+        self._load_into_slots(self.pinned_experts, list(range(self.pinned_count)))
+
+    @staticmethod
+    def _array_name(projection: str, part: str) -> str:
+        return f"_bank_{projection}_{part}"
+
+    def _array(self, projection: str, part: str) -> mx.array:
+        return getattr(self, self._array_name(projection, part))
+
+    @property
+    def resident_mask(self) -> mx.array:
+        return self._resident_mask
+
+    @property
+    def execution_mode(self) -> str:
+        return self._execution_mode
+
+    def set_execution_mode(self, mode: str) -> None:
+        if mode not in {"checked", "speculative"}:
+            raise ValueError(f"Unknown expert streaming execution mode: {mode}")
+        with self._lock:
+            self._execution_mode = mode
+            self._last_indices = None
+            self._last_slots = None
+            if mode == "speculative":
+                self._speculative_routes.clear()
+
+    def take_speculative_routes(self) -> list[tuple[mx.array, mx.array]]:
+        with self._lock:
+            routes = self._speculative_routes
+            self._speculative_routes = []
+            return routes
+
+    def _load_into_slots(
+        self, experts: tuple[int, ...] | list[int], slots: list[int]
+    ) -> None:
+        if not experts:
+            return
+        preload = bool(slots) and max(slots) < self.pinned_count
+        # Pinned preload stays component-at-a-time to cap transient memory.
+        # Dynamic misses are small and benefit from one flat I/O queue.
+        components = (
+            None
+            if preload
+            else self._reader.read_many(
+                self.locations,
+                experts,
+                use_file_cache=True,
+            )
+        )
+        for projection in PROJECTIONS:
+            for part in PARTS:
+                rows = (
+                    self._reader.read_rows(
+                        self.locations[(projection, part)],
+                        experts,
+                        use_file_cache=False,
+                    )
+                    if components is None
+                    else components[(projection, part)]
+                )
+                target = self._array(projection, part)
+                target[slots] = rows
+                if preload:
+                    # Pinned construction can stage hundreds of rows, so commit
+                    # one component at a time and release it immediately.
+                    mx.eval(target)
+                # Dynamic updates deliberately remain lazy. The layer's QMM
+                # consumes the updated bank immediately, and the next layer's
+                # router evaluation provides the required synchronization.
+        self.stats.loads += len(experts)
+        if preload:
+            self.stats.pinned_loads += len(experts)
+        else:
+            self.stats.cold_loads += len(experts)
+
+    @staticmethod
+    def _flatten_indices(indices: mx.array) -> tuple[int, ...]:
+        return tuple(int(value) for value in np.asarray(indices.tolist()).reshape(-1))
+
+    def _note_route(self, values: tuple[int, ...]) -> None:
+        route_tokens = max(1, (len(values) + self.top_k - 1) // self.top_k)
+        self._route_tokens += route_tokens
+        while self._route_tokens >= self._next_hotness_decay:
+            self._route_hotness >>= 1
+            self._next_hotness_decay += self._hotness_decay_interval
+            self.stats.hotness_decays += 1
+        for expert in values:
+            if self._route_hotness[expert] < np.iinfo(np.uint64).max:
+                self._route_hotness[expert] += 1
+            self._access_clock += 1
+            self._last_used[expert] = self._access_clock
+
+    def _eviction_victim(self, protected: set[int]) -> tuple[int, int]:
+        candidates = [
+            (expert, slot)
+            for expert, slot in self._dynamic_lru.items()
+            if expert not in protected
+        ]
+        if not candidates:
+            raise RuntimeError(
+                f"Layer {self.layer} cannot evict a cache slot without replacing "
+                "an expert used by the current route"
+            )
+        if self.cache_policy == "lru":
+            return candidates[0]
+        return min(
+            candidates,
+            key=lambda item: (
+                int(self._route_hotness[item[0]]),
+                int(self._last_used[item[0]]),
+            ),
+        )
+
+    def _allocate_misses(
+        self, missing: list[int], *, protected: set[int] | None = None
+    ) -> list[int]:
+        protected = protected or set()
+        slots: list[int] = []
+        for expert in missing:
+            if self._free_slots:
+                slot = self._free_slots.pop(0)
+            else:
+                evicted, slot = self._eviction_victim(protected)
+                del self._dynamic_lru[evicted]
+                del self._expert_to_slot[evicted]
+                self._resident_mask_np[evicted] = False
+                self._slot_map_np[evicted] = 0
+                self.stats.evictions += 1
+            self._expert_to_slot[expert] = slot
+            self._resident_mask_np[expert] = True
+            self._slot_map_np[expert] = slot
+            self._dynamic_lru[expert] = slot
+            slots.append(slot)
+        self._resident_mask = mx.array(self._resident_mask_np)
+        self._slot_map = mx.array(self._slot_map_np)
+        return slots
+
+    def _ensure_values(self, values: tuple[int, ...]) -> list[int]:
+        unique = list(dict.fromkeys(values))
+        dynamic_working_set = [
+            expert for expert in unique if expert not in self._pinned_set
+        ]
+        if len(dynamic_working_set) > self.cache_slots:
+            raise RuntimeError(
+                f"Layer {self.layer} needs {len(dynamic_working_set)} unpinned "
+                f"experts concurrently but has only {self.cache_slots} "
+                "streaming slots"
+            )
+        self._note_route(values)
+        missing = [expert for expert in unique if expert not in self._expert_to_slot]
+        self.stats.route_lookups += len(values)
+        self.stats.pinned_hits += sum(
+            1
+            for expert in values
+            if self._expert_to_slot.get(expert, self.pinned_count) < self.pinned_count
+        )
+        self.stats.cache_hits += sum(
+            1 for expert in values if expert in self._dynamic_lru
+        )
+        self.stats.cache_misses += sum(1 for expert in values if expert in missing)
+
+        for expert in unique:
+            if expert in self._dynamic_lru and expert not in missing:
+                self._dynamic_lru.move_to_end(expert)
+        if missing:
+            slots = self._allocate_misses(missing, protected=set(unique))
+            self._load_into_slots(missing, slots)
+        return [self._expert_to_slot[expert] for expert in values]
+
+    def ensure(self, indices: mx.array) -> mx.array:
+        with self._lock:
+            if indices is self._last_indices and self._last_slots is not None:
+                return self._last_slots
+            if self._execution_mode == "speculative":
+                mapped = self._slot_map[indices]
+                missing = mx.logical_not(self._resident_mask[indices])
+                self._speculative_routes.append((indices, missing))
+                self._last_indices = indices
+                self._last_slots = mapped
+                return mapped
+            values = self._flatten_indices(indices)
+            slots = self._ensure_values(values)
+            mapped = mx.array(slots, dtype=mx.int32).reshape(indices.shape)
+            self._last_indices = indices
+            self._last_slots = mapped
+            return mapped
+
+    def record_speculative_route(self, values: tuple[int, ...]) -> None:
+        """Account for a graph-native route after its arrays are evaluated."""
+        with self._lock:
+            self._note_route(values)
+            self.stats.speculative_routes += 1
+            self.stats.route_lookups += len(values)
+            self.stats.pinned_hits += sum(
+                1
+                for expert in values
+                if self._expert_to_slot.get(expert, self.pinned_count)
+                < self.pinned_count
+            )
+            self.stats.cache_hits += sum(
+                1 for expert in values if expert in self._dynamic_lru
+            )
+            missing = {
+                expert for expert in values if expert not in self._expert_to_slot
+            }
+            misses = sum(1 for expert in values if expert in missing)
+            self.stats.cache_misses += misses
+            self.stats.speculative_misses += misses
+            for expert in dict.fromkeys(values):
+                if expert in self._dynamic_lru:
+                    self._dynamic_lru.move_to_end(expert)
+
+    def promote(self, values: tuple[int, ...]) -> None:
+        """Load every currently-cold expert in ``values`` into the hot tier."""
+        with self._lock:
+            unique = list(dict.fromkeys(values))
+            dynamic_working_set = [
+                expert for expert in unique if expert not in self._pinned_set
+            ]
+            if len(dynamic_working_set) > self.cache_slots:
+                raise RuntimeError(
+                    f"Layer {self.layer} needs {len(dynamic_working_set)} unpinned "
+                    f"experts concurrently but has only {self.cache_slots} "
+                    "streaming slots"
+                )
+            missing = [
+                expert for expert in unique if expert not in self._expert_to_slot
+            ]
+            if missing:
+                slots = self._allocate_misses(missing, protected=set(unique))
+                self._load_into_slots(missing, slots)
+                arrays = [
+                    self._array(projection, part)
+                    for projection in PROJECTIONS
+                    for part in PARTS
+                ]
+                mx.eval(*arrays, self._slot_map, self._resident_mask)
+            self._last_indices = None
+            self._last_slots = None
+
+    def _map_known_values(self, indices: mx.array, values: tuple[int, ...]) -> mx.array:
+        slots = self._ensure_values(values)
+        mapped = mx.array(slots, dtype=mx.int32).reshape(indices.shape)
+        self._last_indices = indices
+        self._last_slots = mapped
+        return mapped
+
+    def project(self, projection: str, x: mx.array, slot_indices: mx.array) -> mx.array:
+        metadata = self.projection_metadata[projection]
+        return mx.gather_qmm(
+            x,
+            self._array(projection, "weight"),
+            self._array(projection, "scales"),
+            self._array(projection, "biases"),
+            rhs_indices=slot_indices,
+            transpose=True,
+            group_size=metadata["group_size"],
+            bits=metadata["bits"],
+            mode=metadata["mode"],
+            sorted_indices=False,
+        )
+
+    def _forward_projection_expert_major(
+        self,
+        projection: str,
+        x: mx.array,
+        indices: mx.array,
+        values: tuple[int, ...],
+    ) -> mx.array:
+        """Materialize one projection in cache-sized expert groups.
+
+        This is a safety path for helpers which call ``gate_proj``, ``up_proj``
+        and ``down_proj`` directly instead of invoking the owning SwitchGLU.
+        Whole-GLU expert-major execution is preferred because it only streams
+        each group once.
+        """
+        self.stats.expert_major_calls += 1
+        unique = list(dict.fromkeys(values))
+        pinned = [expert for expert in unique if expert in self._pinned_set]
+        dynamic = [expert for expert in unique if expert not in self._pinned_set]
+        groups: list[list[int]] = []
+        if pinned:
+            groups.append(pinned)
+        groups.extend(
+            dynamic[offset : offset + self.cache_slots]
+            for offset in range(0, len(dynamic), self.cache_slots)
+        )
+
+        k = indices.shape[-1]
+        input_dims = x.shape[-1]
+        vectors = x.reshape(-1, input_dims)
+        flat_indices = np.asarray(values, dtype=np.int32)
+        metadata = self.projection_metadata[projection]
+        output_dims = self._array(projection, "weight").shape[1]
+        flat_output = mx.zeros((len(values), output_dims), dtype=x.dtype)
+        route_specific_input = vectors.shape[0] == len(values)
+
+        for group in groups:
+            mask = np.isin(flat_indices, np.asarray(group, dtype=np.int32))
+            positions_np = np.nonzero(mask)[0].astype(np.int32)
+            if positions_np.size == 0:
+                continue
+            logical_np = flat_indices[positions_np]
+            logical = mx.array(logical_np, dtype=mx.int32)
+            slots = self._map_known_values(
+                logical, tuple(int(value) for value in logical_np)
+            )
+            vector_positions = (
+                positions_np if route_specific_input else positions_np // k
+            )
+            selected = vectors[mx.array(vector_positions, dtype=mx.int32)][:, None, :]
+            output = mx.gather_qmm(
+                selected,
+                self._array(projection, "weight"),
+                self._array(projection, "scales"),
+                self._array(projection, "biases"),
+                rhs_indices=slots,
+                transpose=True,
+                group_size=metadata["group_size"],
+                bits=metadata["bits"],
+                mode=metadata["mode"],
+                sorted_indices=False,
+            ).squeeze(-2)
+            # The next group can overwrite the same bank slots.
+            mx.eval(output)
+            flat_output[mx.array(positions_np, dtype=mx.int32)] = output
+
+        return flat_output.reshape((*indices.shape, 1, output_dims))
+
+    def project_indices(
+        self, projection: str, x: mx.array, indices: mx.array
+    ) -> mx.array:
+        """Project logical expert indices, chunking oversized routed sets."""
+        with self._lock:
+            if self._execution_mode == "speculative":
+                slots = self.ensure(indices)
+                return self.project(projection, x, slots)
+            values = self._flatten_indices(indices)
+            dynamic_working_set = {
+                expert for expert in values if expert not in self._pinned_set
+            }
+            if len(dynamic_working_set) > self.cache_slots:
+                return self._forward_projection_expert_major(
+                    projection, x, indices, values
+                )
+            slots = self.ensure(indices)
+            # Router-order sorting does not imply slot-order sorting after
+            # remapping, so streamed banks always use unsorted slot indices.
+            return self.project(projection, x, slots)
+
+    def _forward_resident_set(
+        self, x: mx.array, indices: mx.array, values: tuple[int, ...]
+    ) -> mx.array:
+        slots = self._map_known_values(indices, values)
+        expanded = mx.expand_dims(x, (-2, -3))
+        up = self.project("up_proj", expanded, slots)
+        gate = self.project("gate_proj", expanded, slots)
+        output = self.project("down_proj", self.activation(up, gate), slots)
+        return output.squeeze(-2)
+
+    def _forward_expert_major(
+        self,
+        x: mx.array,
+        indices: mx.array,
+        values: tuple[int, ...],
+    ) -> mx.array:
+        self.stats.expert_major_calls += 1
+        unique = list(dict.fromkeys(values))
+        pinned = [
+            expert
+            for expert in unique
+            if expert in self._expert_to_slot and expert not in self._dynamic_lru
+        ]
+        cold = [expert for expert in unique if expert not in pinned]
+        groups: list[list[int]] = []
+        if pinned:
+            groups.append(pinned)
+        groups.extend(
+            cold[offset : offset + self.cache_slots]
+            for offset in range(0, len(cold), self.cache_slots)
+        )
+
+        k = indices.shape[-1]
+        hidden = x.shape[-1]
+        flat_x = x.reshape(-1, hidden)
+        flat_indices = np.asarray(values, dtype=np.int32)
+        flat_output = mx.zeros((len(values), hidden), dtype=x.dtype)
+        for group in groups:
+            mask = np.isin(flat_indices, np.asarray(group, dtype=np.int32))
+            positions_np = np.nonzero(mask)[0].astype(np.int32)
+            if positions_np.size == 0:
+                continue
+            logical_np = flat_indices[positions_np]
+            logical = mx.array(logical_np, dtype=mx.int32)
+            slots = self._map_known_values(
+                logical, tuple(int(value) for value in logical_np)
+            )
+            token_positions = mx.array(positions_np // k, dtype=mx.int32)
+            selected = flat_x[token_positions][:, None, :]
+            up = self.project("up_proj", selected, slots)
+            gate = self.project("gate_proj", selected, slots)
+            output = self.project(
+                "down_proj", self.activation(up, gate), slots
+            ).squeeze(-2)
+            # Evaluate before the next group mutates dynamic bank slots.
+            mx.eval(output)
+            flat_output[mx.array(positions_np, dtype=mx.int32)] = output
+        return flat_output.reshape((*indices.shape, hidden))
+
+    def __call__(self, x: mx.array, indices: mx.array) -> mx.array:
+        with self._lock:
+            if self._execution_mode == "speculative":
+                slots = self.ensure(indices)
+                expanded = mx.expand_dims(x, (-2, -3))
+                up = self.project("up_proj", expanded, slots)
+                gate = self.project("gate_proj", expanded, slots)
+                output = self.project("down_proj", self.activation(up, gate), slots)
+                return output.squeeze(-2)
+            values = self._flatten_indices(indices)
+            dynamic_working_set = {
+                expert for expert in values if expert not in self._pinned_set
+            }
+            if len(dynamic_working_set) > self.cache_slots:
+                return self._forward_expert_major(x, indices, values)
+            return self._forward_resident_set(x, indices, values)
+
+    def snapshot(self) -> dict[str, Any]:
+        result = self.stats.as_dict()
+        result.update(
+            {
+                "layer": self.layer,
+                "pinned_experts": self.pinned_count,
+                "cache_slots": self.cache_slots,
+                "cache_policy": self.cache_policy,
+                "resident_slots": self.pool_size,
+                "expert_bytes": sum(
+                    location.row_bytes for location in self.locations.values()
+                ),
+            }
+        )
+        return result

--- a/omlx/expert_streaming/pool.py
+++ b/omlx/expert_streaming/pool.py
@@ -14,6 +14,7 @@ import mlx.nn as nn
 import numpy as np
 from mlx_lm.models.switch_layers import _gather_sort, _scatter_unsort
 
+from .fast_resource import FastExpertLoad
 from .safetensors import PROJECTIONS, ExpertReader, TensorLocation
 
 _MLX_DTYPES = {
@@ -310,7 +311,9 @@ class StreamingSwitchGLU(nn.Module):
         slots: list[int],
         *,
         load_kind: str = "cold",
-        preloaded_components: dict[tuple[str, str], mx.array] | None = None,
+        preloaded_components: dict[tuple[str, str], mx.array]
+        | FastExpertLoad
+        | None = None,
     ) -> None:
         if not experts:
             return
@@ -318,6 +321,49 @@ class StreamingSwitchGLU(nn.Module):
         # Pinned preload stays component-at-a-time to cap transient memory.
         # Dynamic misses are small and benefit from one flat I/O queue.
         components = preloaded_components
+        use_fast_resource_loading = (
+            self._reader.fast_resource_loading
+            and not preload
+            and (
+                load_kind == "scratch"
+                or self._reader.fast_resource_loading_scope == "all"
+            )
+        )
+        if use_fast_resource_loading:
+            fast_load = (
+                components
+                if isinstance(components, FastExpertLoad)
+                else self._reader.begin_fast_many(self.locations, experts)
+            )
+            targets: dict[tuple[str, str], tuple[mx.array, int]] = {}
+            for projection in PROJECTIONS:
+                for part in self.projection_metadata[projection]["parts"]:
+                    target_projection = (
+                        "gate_up_proj"
+                        if self._fused_gate_up
+                        and projection in {"gate_proj", "up_proj"}
+                        else projection
+                    )
+                    target = self._array(target_projection, part)
+                    inner_offset = 0
+                    if target_projection == "gate_up_proj" and projection == "up_proj":
+                        target_row_bytes = int(target.nbytes) // int(target.shape[0])
+                        inner_offset = target_row_bytes // 2
+                    targets[(projection, part)] = (target, inner_offset)
+            fast_stats = self._reader.finish_fast_many(fast_load, slots, targets)
+            if load_kind == "scratch":
+                self.stats.scratch_prefetch_wait_seconds += float(
+                    fast_stats["io_wait_seconds"]
+                )
+            self.stats.bank_bind_seconds += float(fast_stats["copy_seconds"])
+            self.stats.loads += len(experts)
+            if load_kind == "warm_start":
+                self.stats.warm_start_loads += len(experts)
+            else:
+                self.stats.cold_loads += len(experts)
+                if load_kind == "scratch":
+                    self.stats.scratch_loads += len(experts)
+            return
         if components is None and not preload:
             components = self._reader.read_many(
                 self.locations,
@@ -914,13 +960,16 @@ class StreamingSwitchGLU(nn.Module):
                 self.stats.scratch_prefetch_wait_seconds += (
                     time.perf_counter() - wait_started
                 )
-                materialize_started = time.perf_counter()
-                components = self._reader.materialize_many(
-                    self.locations, cpu_components
-                )
-                self.stats.scratch_mlx_materialize_seconds += (
-                    time.perf_counter() - materialize_started
-                )
+                if isinstance(cpu_components, FastExpertLoad):
+                    components = cpu_components
+                else:
+                    materialize_started = time.perf_counter()
+                    components = self._reader.materialize_many(
+                        self.locations, cpu_components
+                    )
+                    self.stats.scratch_mlx_materialize_seconds += (
+                        time.perf_counter() - materialize_started
+                    )
                 prefetched_index += 1
                 if prefetched_index < len(cold_groups):
                     prefetched = self._reader.read_many_async(

--- a/omlx/expert_streaming/pool.py
+++ b/omlx/expert_streaming/pool.py
@@ -12,10 +12,12 @@ import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 
-from .safetensors import PARTS, PROJECTIONS, ExpertReader, TensorLocation
+from .safetensors import PROJECTIONS, ExpertReader, TensorLocation
 
 _MLX_DTYPES = {
     "U32": mx.uint32,
+    "U8": mx.uint8,
+    "I8": mx.int8,
     "F32": mx.float32,
     "F16": mx.float16,
     "BF16": mx.bfloat16,
@@ -76,7 +78,7 @@ class StreamingQuantizedSwitchLinear:
         return self._owner._array(self._projection_name, "scales")
 
     @property
-    def biases(self) -> mx.array:
+    def biases(self) -> mx.array | None:
         return self._owner._array(self._projection_name, "biases")
 
     @property
@@ -128,6 +130,15 @@ class StreamingSwitchGLU(nn.Module):
         self.pool_size = self.pinned_count + self.cache_slots
         self.locations = locations
         self.projection_metadata = projection_metadata
+        for projection in PROJECTIONS:
+            self.projection_metadata[projection].setdefault(
+                "parts",
+                tuple(
+                    part
+                    for candidate, part in locations
+                    if candidate == projection
+                ),
+            )
         self.activation = activation
         self._reader = reader
         if cache_policy not in {"lru", "route_frequency"}:
@@ -161,7 +172,7 @@ class StreamingSwitchGLU(nn.Module):
         self.stats = ExpertPoolStats()
 
         for projection in PROJECTIONS:
-            for part in PARTS:
+            for part in self.projection_metadata[projection]["parts"]:
                 location = locations[(projection, part)]
                 setattr(
                     self,
@@ -181,8 +192,8 @@ class StreamingSwitchGLU(nn.Module):
     def _array_name(projection: str, part: str) -> str:
         return f"_bank_{projection}_{part}"
 
-    def _array(self, projection: str, part: str) -> mx.array:
-        return getattr(self, self._array_name(projection, part))
+    def _array(self, projection: str, part: str) -> mx.array | None:
+        return getattr(self, self._array_name(projection, part), None)
 
     @property
     def resident_mask(self) -> mx.array:
@@ -226,7 +237,7 @@ class StreamingSwitchGLU(nn.Module):
             )
         )
         for projection in PROJECTIONS:
-            for part in PARTS:
+            for part in self.projection_metadata[projection]["parts"]:
                 rows = (
                     self._reader.read_rows(
                         self.locations[(projection, part)],
@@ -410,7 +421,7 @@ class StreamingSwitchGLU(nn.Module):
                 arrays = [
                     self._array(projection, part)
                     for projection in PROJECTIONS
-                    for part in PARTS
+                    for part in self.projection_metadata[projection]["parts"]
                 ]
                 mx.eval(*arrays, self._slot_map, self._resident_mask)
             self._last_indices = None
@@ -425,7 +436,7 @@ class StreamingSwitchGLU(nn.Module):
 
     def project(self, projection: str, x: mx.array, slot_indices: mx.array) -> mx.array:
         metadata = self.projection_metadata[projection]
-        return mx.gather_qmm(
+        output = mx.gather_qmm(
             x,
             self._array(projection, "weight"),
             self._array(projection, "scales"),
@@ -437,6 +448,10 @@ class StreamingSwitchGLU(nn.Module):
             mode=metadata["mode"],
             sorted_indices=False,
         )
+        bias = self._array(projection, "bias")
+        if bias is not None:
+            output = output + mx.expand_dims(bias[slot_indices], -2)
+        return output
 
     def _forward_projection_expert_major(
         self,
@@ -499,6 +514,9 @@ class StreamingSwitchGLU(nn.Module):
                 mode=metadata["mode"],
                 sorted_indices=False,
             ).squeeze(-2)
+            bias = self._array(projection, "bias")
+            if bias is not None:
+                output = output + bias[slots]
             # The next group can overwrite the same bank slots.
             mx.eval(output)
             flat_output[mx.array(positions_np, dtype=mx.int32)] = output
@@ -585,7 +603,14 @@ class StreamingSwitchGLU(nn.Module):
             flat_output[mx.array(positions_np, dtype=mx.int32)] = output
         return flat_output.reshape((*indices.shape, hidden))
 
-    def __call__(self, x: mx.array, indices: mx.array) -> mx.array:
+    def __call__(
+        self,
+        x: mx.array,
+        indices: mx.array,
+        scores: mx.array | None = None,
+        weighted_sum: bool = False,
+        **_kwargs,
+    ) -> mx.array:
         with self._lock:
             if self._execution_mode == "speculative":
                 slots = self.ensure(indices)
@@ -593,14 +618,21 @@ class StreamingSwitchGLU(nn.Module):
                 up = self.project("up_proj", expanded, slots)
                 gate = self.project("gate_proj", expanded, slots)
                 output = self.project("down_proj", self.activation(up, gate), slots)
-                return output.squeeze(-2)
+                output = output.squeeze(-2)
+                if weighted_sum and scores is not None:
+                    output = (output * scores[..., None].astype(output.dtype)).sum(-2)
+                return output
             values = self._flatten_indices(indices)
             dynamic_working_set = {
                 expert for expert in values if expert not in self._pinned_set
             }
             if len(dynamic_working_set) > self.cache_slots:
-                return self._forward_expert_major(x, indices, values)
-            return self._forward_resident_set(x, indices, values)
+                output = self._forward_expert_major(x, indices, values)
+            else:
+                output = self._forward_resident_set(x, indices, values)
+            if weighted_sum and scores is not None:
+                output = (output * scores[..., None].astype(output.dtype)).sum(-2)
+            return output
 
     def snapshot(self) -> dict[str, Any]:
         result = self.stats.as_dict()

--- a/omlx/expert_streaming/pool.py
+++ b/omlx/expert_streaming/pool.py
@@ -12,6 +12,7 @@ from typing import Any
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
+from mlx_lm.models.switch_layers import _gather_sort, _scatter_unsort
 
 from .safetensors import PROJECTIONS, ExpertReader, TensorLocation
 
@@ -35,6 +36,7 @@ class ExpertPoolStats:
     loads: int = 0
     pinned_loads: int = 0
     cold_loads: int = 0
+    scratch_loads: int = 0
     expert_major_calls: int = 0
     qmm_calls: int = 0
     speculative_routes: int = 0
@@ -43,6 +45,12 @@ class ExpertPoolStats:
     warm_start_loads: int = 0
     bank_bind_seconds: float = 0.0
     bank_materialize_seconds: float = 0.0
+    scratch_prefetch_wait_seconds: float = 0.0
+    scratch_prefetch_requests: int = 0
+    scratch_mlx_materialize_seconds: float = 0.0
+    sorted_prefill_groups: int = 0
+    sorted_prefill_routes: int = 0
+    sorted_qmm_calls: int = 0
 
     def as_dict(self) -> dict[str, int | float]:
         total = self.pinned_hits + self.cache_hits + self.cache_misses
@@ -55,6 +63,7 @@ class ExpertPoolStats:
             "loads": self.loads,
             "pinned_loads": self.pinned_loads,
             "cold_loads": self.cold_loads,
+            "scratch_loads": self.scratch_loads,
             "expert_major_calls": self.expert_major_calls,
             "qmm_calls": self.qmm_calls,
             "speculative_routes": self.speculative_routes,
@@ -63,6 +72,12 @@ class ExpertPoolStats:
             "warm_start_loads": self.warm_start_loads,
             "bank_bind_seconds": self.bank_bind_seconds,
             "bank_materialize_seconds": self.bank_materialize_seconds,
+            "scratch_prefetch_wait_seconds": self.scratch_prefetch_wait_seconds,
+            "scratch_prefetch_requests": self.scratch_prefetch_requests,
+            "scratch_mlx_materialize_seconds": self.scratch_mlx_materialize_seconds,
+            "sorted_prefill_groups": self.sorted_prefill_groups,
+            "sorted_prefill_routes": self.sorted_prefill_routes,
+            "sorted_qmm_calls": self.sorted_qmm_calls,
             "hit_rate": (self.pinned_hits + self.cache_hits) / total if total else 1.0,
         }
 
@@ -125,6 +140,9 @@ class StreamingSwitchGLU(nn.Module):
         activation: Any,
         reader: ExpertReader,
         cache_policy: str = "route_frequency",
+        fuse_gate_up: bool = True,
+        scratch_slots: int = 0,
+        sort_prefill: bool = True,
     ):
         super().__init__()
         self.layer = int(layer)
@@ -137,6 +155,10 @@ class StreamingSwitchGLU(nn.Module):
         minimum_working_set = min(self.top_k, cold_count)
         self.cache_slots = min(cold_count, max(int(cache_slots), minimum_working_set))
         self.pool_size = self.pinned_count + self.cache_slots
+        self.scratch_slots = min(
+            max(0, cold_count - self.cache_slots), max(0, int(scratch_slots))
+        )
+        self.bank_size = self.pool_size + self.scratch_slots
         self.locations = locations
         self.projection_metadata = projection_metadata
         for projection in PROJECTIONS:
@@ -149,6 +171,7 @@ class StreamingSwitchGLU(nn.Module):
         if cache_policy not in {"lru", "route_frequency"}:
             raise ValueError(f"Unknown expert cache policy: {cache_policy}")
         self.cache_policy = cache_policy
+        self._sort_prefill = bool(sort_prefill)
         self._lock = threading.RLock()
         self._expert_to_slot: dict[int, int] = {
             expert: slot for slot, expert in enumerate(self.pinned_experts)
@@ -177,20 +200,57 @@ class StreamingSwitchGLU(nn.Module):
         self._speculative_routes: list[tuple[mx.array, mx.array]] = []
         self.stats = ExpertPoolStats()
 
-        for projection in PROJECTIONS:
+        gate_metadata = self.projection_metadata["gate_proj"]
+        up_metadata = self.projection_metadata["up_proj"]
+        gate_parts = tuple(gate_metadata["parts"])
+        up_parts = tuple(up_metadata["parts"])
+        self._fused_gate_up = bool(fuse_gate_up) and (
+            gate_parts == up_parts
+            and (gate_metadata["group_size"], gate_metadata["bits"], gate_metadata["mode"])
+            == (up_metadata["group_size"], up_metadata["bits"], up_metadata["mode"])
+            and all(
+                locations[("gate_proj", part)].dtype
+                == locations[("up_proj", part)].dtype
+                and locations[("gate_proj", part)].shape[1:]
+                == locations[("up_proj", part)].shape[1:]
+                for part in gate_parts
+            )
+        )
+        if self._fused_gate_up:
+            self.projection_metadata["gate_up_proj"] = {
+                **gate_metadata,
+                "parts": gate_parts,
+            }
+
+        allocated_projections = (
+            ("gate_up_proj", "down_proj")
+            if self._fused_gate_up
+            else PROJECTIONS
+        )
+        for projection in allocated_projections:
             for part in self.projection_metadata[projection]["parts"]:
-                location = locations[(projection, part)]
+                source_projection = (
+                    "gate_proj" if projection == "gate_up_proj" else projection
+                )
+                location = locations[(source_projection, part)]
+                shape = location.shape[1:]
+                if projection == "gate_up_proj":
+                    shape = (shape[0] * 2, *shape[1:])
                 setattr(
                     self,
                     self._array_name(projection, part),
                     mx.zeros(
-                        (self.pool_size, *location.shape[1:]),
+                        (self.bank_size, *shape),
                         dtype=_MLX_DTYPES[location.dtype],
                     ),
                 )
 
         self.gate_proj = StreamingQuantizedSwitchLinear(self, "gate_proj")
         self.up_proj = StreamingQuantizedSwitchLinear(self, "up_proj")
+        if self._fused_gate_up:
+            self.gate_up_proj = StreamingQuantizedSwitchLinear(
+                self, "gate_up_proj"
+            )
         self.down_proj = StreamingQuantizedSwitchLinear(self, "down_proj")
         self._load_into_slots(
             self.pinned_experts,
@@ -203,6 +263,16 @@ class StreamingSwitchGLU(nn.Module):
         return f"_bank_{projection}_{part}"
 
     def _array(self, projection: str, part: str) -> mx.array | None:
+        if self._fused_gate_up and projection in {"gate_proj", "up_proj"}:
+            fused = getattr(self, self._array_name("gate_up_proj", part), None)
+            if fused is None:
+                return None
+            midpoint = fused.shape[1] // 2
+            return (
+                fused[:, :midpoint]
+                if projection == "gate_proj"
+                else fused[:, midpoint:]
+            )
         return getattr(self, self._array_name(projection, part), None)
 
     @property
@@ -240,21 +310,20 @@ class StreamingSwitchGLU(nn.Module):
         slots: list[int],
         *,
         load_kind: str = "cold",
+        preloaded_components: dict[tuple[str, str], mx.array] | None = None,
     ) -> None:
         if not experts:
             return
         preload = load_kind == "pinned"
         # Pinned preload stays component-at-a-time to cap transient memory.
         # Dynamic misses are small and benefit from one flat I/O queue.
-        components = (
-            None
-            if preload
-            else self._reader.read_many(
+        components = preloaded_components
+        if components is None and not preload:
+            components = self._reader.read_many(
                 self.locations,
                 experts,
                 use_file_cache=True,
             )
-        )
         for projection in PROJECTIONS:
             for part in self.projection_metadata[projection]["parts"]:
                 rows = (
@@ -266,9 +335,24 @@ class StreamingSwitchGLU(nn.Module):
                     if components is None
                     else components[(projection, part)]
                 )
-                target = self._array(projection, part)
+                target_projection = (
+                    "gate_up_proj"
+                    if self._fused_gate_up
+                    and projection in {"gate_proj", "up_proj"}
+                    else projection
+                )
+                target = self._array(target_projection, part)
                 bind_started = time.perf_counter()
-                target[slots] = rows
+                if target_projection == "gate_up_proj":
+                    midpoint = target.shape[1] // 2
+                    output_slice = (
+                        slice(0, midpoint)
+                        if projection == "gate_proj"
+                        else slice(midpoint, None)
+                    )
+                    target[slots, output_slice] = rows
+                else:
+                    target[slots] = rows
                 self.stats.bank_bind_seconds += time.perf_counter() - bind_started
                 if preload:
                     # Pinned construction can stage hundreds of rows, so commit
@@ -288,6 +372,8 @@ class StreamingSwitchGLU(nn.Module):
             self.stats.warm_start_loads += len(experts)
         else:
             self.stats.cold_loads += len(experts)
+            if load_kind == "scratch":
+                self.stats.scratch_loads += len(experts)
 
     @staticmethod
     def _flatten_indices(indices: mx.array) -> tuple[int, ...]:
@@ -534,9 +620,17 @@ class StreamingSwitchGLU(nn.Module):
         self._last_slots = mapped
         return mapped
 
-    def project(self, projection: str, x: mx.array, slot_indices: mx.array) -> mx.array:
+    def project(
+        self,
+        projection: str,
+        x: mx.array,
+        slot_indices: mx.array,
+        *,
+        sorted_indices: bool = False,
+    ) -> mx.array:
         metadata = self.projection_metadata[projection]
         self.stats.qmm_calls += 1
+        self.stats.sorted_qmm_calls += int(sorted_indices)
         output = mx.gather_qmm(
             x,
             self._array(projection, "weight"),
@@ -547,12 +641,44 @@ class StreamingSwitchGLU(nn.Module):
             group_size=metadata["group_size"],
             bits=metadata["bits"],
             mode=metadata["mode"],
-            sorted_indices=False,
+            sorted_indices=sorted_indices,
         )
         bias = self._array(projection, "bias")
         if bias is not None:
             output = output + mx.expand_dims(bias[slot_indices], -2)
         return output
+
+    def _project_gate_up(
+        self,
+        x: mx.array,
+        slot_indices: mx.array,
+        *,
+        sorted_indices: bool = False,
+    ) -> tuple[mx.array, mx.array]:
+        if not self._fused_gate_up:
+            return (
+                self.project(
+                    "gate_proj", x, slot_indices, sorted_indices=sorted_indices
+                ),
+                self.project(
+                    "up_proj", x, slot_indices, sorted_indices=sorted_indices
+                ),
+            )
+        gate_up = self.project(
+            "gate_up_proj", x, slot_indices, sorted_indices=sorted_indices
+        )
+        return tuple(mx.split(gate_up, 2, axis=-1))
+
+    def _sort_group_for_qmm(
+        self, selected: mx.array, slots: mx.array
+    ) -> tuple[mx.array, mx.array, mx.array | None]:
+        """Sort route rows by physical bank slot for large gather QMMs."""
+        if not self._sort_prefill or slots.size < 64:
+            return selected, slots, None
+        order = mx.argsort(slots)
+        self.stats.sorted_prefill_groups += 1
+        self.stats.sorted_prefill_routes += int(slots.size)
+        return selected[order], slots[order], mx.argsort(order)
 
     def _forward_projection_expert_major(
         self,
@@ -584,7 +710,6 @@ class StreamingSwitchGLU(nn.Module):
         input_dims = x.shape[-1]
         vectors = x.reshape(-1, input_dims)
         flat_indices = np.asarray(values, dtype=np.int32)
-        metadata = self.projection_metadata[projection]
         output_dims = self._array(projection, "weight").shape[1]
         flat_output = mx.zeros((len(values), output_dims), dtype=x.dtype)
         route_specific_input = vectors.shape[0] == len(values)
@@ -603,21 +728,15 @@ class StreamingSwitchGLU(nn.Module):
                 positions_np if route_specific_input else positions_np // k
             )
             selected = vectors[mx.array(vector_positions, dtype=mx.int32)][:, None, :]
-            output = mx.gather_qmm(
+            selected, slots, inv_order = self._sort_group_for_qmm(selected, slots)
+            output = self.project(
+                projection,
                 selected,
-                self._array(projection, "weight"),
-                self._array(projection, "scales"),
-                self._array(projection, "biases"),
-                rhs_indices=slots,
-                transpose=True,
-                group_size=metadata["group_size"],
-                bits=metadata["bits"],
-                mode=metadata["mode"],
-                sorted_indices=False,
+                slots,
+                sorted_indices=inv_order is not None,
             ).squeeze(-2)
-            bias = self._array(projection, "bias")
-            if bias is not None:
-                output = output + bias[slots]
+            if inv_order is not None:
+                output = output[inv_order]
             # The next group can overwrite the same bank slots.
             mx.eval(output)
             flat_output[mx.array(positions_np, dtype=mx.int32)] = output
@@ -650,9 +769,23 @@ class StreamingSwitchGLU(nn.Module):
     ) -> mx.array:
         slots = self._map_known_values(indices, values)
         expanded = mx.expand_dims(x, (-2, -3))
-        up = self.project("up_proj", expanded, slots)
-        gate = self.project("gate_proj", expanded, slots)
-        output = self.project("down_proj", self.activation(up, gate), slots)
+        inv_order = None
+        if self._sort_prefill and slots.size >= 64:
+            expanded, slots, inv_order = _gather_sort(expanded, slots)
+            self.stats.sorted_prefill_groups += 1
+            self.stats.sorted_prefill_routes += int(slots.size)
+        sorted_indices = inv_order is not None
+        gate, up = self._project_gate_up(
+            expanded, slots, sorted_indices=sorted_indices
+        )
+        output = self.project(
+            "down_proj",
+            self.activation(up, gate),
+            slots,
+            sorted_indices=sorted_indices,
+        )
+        if inv_order is not None:
+            output = _scatter_unsort(output, inv_order, indices.shape)
         return output.squeeze(-2)
 
     def _forward_expert_major(
@@ -661,6 +794,8 @@ class StreamingSwitchGLU(nn.Module):
         indices: mx.array,
         values: tuple[int, ...],
     ) -> mx.array:
+        if self.scratch_slots:
+            return self._forward_expert_major_scratch(x, indices, values)
         self.stats.expert_major_calls += 1
         unique = list(dict.fromkeys(values))
         pinned = [
@@ -694,14 +829,136 @@ class StreamingSwitchGLU(nn.Module):
             )
             token_positions = mx.array(positions_np // k, dtype=mx.int32)
             selected = flat_x[token_positions][:, None, :]
-            up = self.project("up_proj", selected, slots)
-            gate = self.project("gate_proj", selected, slots)
+            selected, slots, inv_order = self._sort_group_for_qmm(selected, slots)
+            sorted_indices = inv_order is not None
+            gate, up = self._project_gate_up(
+                selected, slots, sorted_indices=sorted_indices
+            )
             output = self.project(
-                "down_proj", self.activation(up, gate), slots
+                "down_proj",
+                self.activation(up, gate),
+                slots,
+                sorted_indices=sorted_indices,
             ).squeeze(-2)
+            if inv_order is not None:
+                output = output[inv_order]
             # Evaluate before the next group mutates dynamic bank slots.
             mx.eval(output)
             flat_output[mx.array(positions_np, dtype=mx.int32)] = output
+        return flat_output.reshape((*indices.shape, hidden))
+
+    def _forward_expert_major_scratch(
+        self,
+        x: mx.array,
+        indices: mx.array,
+        values: tuple[int, ...],
+    ) -> mx.array:
+        """Execute one-shot cold experts without replacing hot-cache rows."""
+
+        self.stats.expert_major_calls += 1
+        unique = list(dict.fromkeys(values))
+        resident = [expert for expert in unique if expert in self._expert_to_slot]
+        cold = [expert for expert in unique if expert not in self._expert_to_slot]
+
+        self._note_route(values)
+        self.stats.route_lookups += len(values)
+        self.stats.pinned_hits += sum(
+            1
+            for expert in values
+            if self._expert_to_slot.get(expert, self.pinned_count)
+            < self.pinned_count
+        )
+        self.stats.cache_hits += sum(
+            1 for expert in values if expert in self._dynamic_lru
+        )
+        cold_set = set(cold)
+        self.stats.cache_misses += sum(1 for expert in values if expert in cold_set)
+        for expert in dict.fromkeys(values):
+            if expert in self._dynamic_lru:
+                self._dynamic_lru.move_to_end(expert)
+
+        groups: list[tuple[list[int], bool]] = []
+        if resident:
+            groups.append((resident, False))
+        groups.extend(
+            (cold[offset : offset + self.scratch_slots], True)
+            for offset in range(0, len(cold), self.scratch_slots)
+        )
+
+        k = indices.shape[-1]
+        hidden = x.shape[-1]
+        flat_x = x.reshape(-1, hidden)
+        flat_indices = np.asarray(values, dtype=np.int32)
+        flat_output = mx.zeros((len(values), hidden), dtype=x.dtype)
+        scratch_base = self.pool_size
+        cold_groups = [group for group, is_scratch in groups if is_scratch]
+        prefetched = None
+        prefetched_index = 0
+        if cold_groups:
+            prefetched = self._reader.read_many_async(
+                self.locations,
+                cold_groups[0],
+                use_file_cache=True,
+            )
+            self.stats.scratch_prefetch_requests += 1
+
+        for group, is_scratch in groups:
+            mask = np.isin(flat_indices, np.asarray(group, dtype=np.int32))
+            positions_np = np.nonzero(mask)[0].astype(np.int32)
+            if positions_np.size == 0:
+                continue
+            logical_np = flat_indices[positions_np]
+            if is_scratch:
+                wait_started = time.perf_counter()
+                cpu_components = prefetched.result()
+                self.stats.scratch_prefetch_wait_seconds += (
+                    time.perf_counter() - wait_started
+                )
+                materialize_started = time.perf_counter()
+                components = self._reader.materialize_many(
+                    self.locations, cpu_components
+                )
+                self.stats.scratch_mlx_materialize_seconds += (
+                    time.perf_counter() - materialize_started
+                )
+                prefetched_index += 1
+                if prefetched_index < len(cold_groups):
+                    prefetched = self._reader.read_many_async(
+                        self.locations,
+                        cold_groups[prefetched_index],
+                        use_file_cache=True,
+                    )
+                    self.stats.scratch_prefetch_requests += 1
+                group_slots = list(range(scratch_base, scratch_base + len(group)))
+                self._load_into_slots(
+                    group,
+                    group_slots,
+                    load_kind="scratch",
+                    preloaded_components=components,
+                )
+                scratch_map = dict(zip(group, group_slots, strict=True))
+                slot_values = [scratch_map[int(expert)] for expert in logical_np]
+            else:
+                slot_values = [self._expert_to_slot[int(expert)] for expert in logical_np]
+            slots = mx.array(slot_values, dtype=mx.int32)
+            token_positions = mx.array(positions_np // k, dtype=mx.int32)
+            selected = flat_x[token_positions][:, None, :]
+            selected, slots, inv_order = self._sort_group_for_qmm(selected, slots)
+            sorted_indices = inv_order is not None
+            gate, up = self._project_gate_up(
+                selected, slots, sorted_indices=sorted_indices
+            )
+            output = self.project(
+                "down_proj",
+                self.activation(up, gate),
+                slots,
+                sorted_indices=sorted_indices,
+            ).squeeze(-2)
+            if inv_order is not None:
+                output = output[inv_order]
+            mx.eval(output)
+            flat_output[mx.array(positions_np, dtype=mx.int32)] = output
+
         return flat_output.reshape((*indices.shape, hidden))
 
     def __call__(
@@ -716,8 +973,7 @@ class StreamingSwitchGLU(nn.Module):
             if self._execution_mode == "speculative":
                 slots = self.ensure(indices)
                 expanded = mx.expand_dims(x, (-2, -3))
-                up = self.project("up_proj", expanded, slots)
-                gate = self.project("gate_proj", expanded, slots)
+                gate, up = self._project_gate_up(expanded, slots)
                 output = self.project("down_proj", self.activation(up, gate), slots)
                 output = output.squeeze(-2)
                 if weighted_sum and scores is not None:
@@ -744,7 +1000,11 @@ class StreamingSwitchGLU(nn.Module):
                 "cache_slots": self.cache_slots,
                 "cache_policy": self.cache_policy,
                 "resident_slots": self.pool_size,
+                "scratch_slots": self.scratch_slots,
+                "bank_slots": self.bank_size,
                 "resident_experts": len(self._expert_to_slot),
+                "fused_gate_up": self._fused_gate_up,
+                "sorted_prefill": self._sort_prefill,
                 "expert_bytes": sum(
                     location.row_bytes for location in self.locations.values()
                 ),

--- a/omlx/expert_streaming/pool.py
+++ b/omlx/expert_streaming/pool.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import threading
+import time
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any
@@ -38,6 +39,9 @@ class ExpertPoolStats:
     speculative_routes: int = 0
     speculative_misses: int = 0
     hotness_decays: int = 0
+    warm_start_loads: int = 0
+    bank_bind_seconds: float = 0.0
+    bank_materialize_seconds: float = 0.0
 
     def as_dict(self) -> dict[str, int | float]:
         total = self.pinned_hits + self.cache_hits + self.cache_misses
@@ -54,6 +58,9 @@ class ExpertPoolStats:
             "speculative_routes": self.speculative_routes,
             "speculative_misses": self.speculative_misses,
             "hotness_decays": self.hotness_decays,
+            "warm_start_loads": self.warm_start_loads,
+            "bank_bind_seconds": self.bank_bind_seconds,
+            "bank_materialize_seconds": self.bank_materialize_seconds,
             "hit_rate": (self.pinned_hits + self.cache_hits) / total if total else 1.0,
         }
 
@@ -159,6 +166,7 @@ class StreamingSwitchGLU(nn.Module):
         self._resident_mask = mx.array(mask)
         self._dynamic_lru: OrderedDict[int, int] = OrderedDict()
         self._route_hotness = np.zeros(self.num_experts, dtype=np.uint64)
+        self._route_counts = np.zeros(self.num_experts, dtype=np.uint64)
         self._last_used = np.zeros(self.num_experts, dtype=np.uint64)
         self._route_tokens = 0
         self._hotness_decay_interval = 16
@@ -186,7 +194,11 @@ class StreamingSwitchGLU(nn.Module):
         self.gate_proj = StreamingQuantizedSwitchLinear(self, "gate_proj")
         self.up_proj = StreamingQuantizedSwitchLinear(self, "up_proj")
         self.down_proj = StreamingQuantizedSwitchLinear(self, "down_proj")
-        self._load_into_slots(self.pinned_experts, list(range(self.pinned_count)))
+        self._load_into_slots(
+            self.pinned_experts,
+            list(range(self.pinned_count)),
+            load_kind="pinned",
+        )
 
     @staticmethod
     def _array_name(projection: str, part: str) -> str:
@@ -220,11 +232,15 @@ class StreamingSwitchGLU(nn.Module):
             return routes
 
     def _load_into_slots(
-        self, experts: tuple[int, ...] | list[int], slots: list[int]
+        self,
+        experts: tuple[int, ...] | list[int],
+        slots: list[int],
+        *,
+        load_kind: str = "cold",
     ) -> None:
         if not experts:
             return
-        preload = bool(slots) and max(slots) < self.pinned_count
+        preload = load_kind == "pinned"
         # Pinned preload stays component-at-a-time to cap transient memory.
         # Dynamic misses are small and benefit from one flat I/O queue.
         components = (
@@ -248,17 +264,25 @@ class StreamingSwitchGLU(nn.Module):
                     else components[(projection, part)]
                 )
                 target = self._array(projection, part)
+                bind_started = time.perf_counter()
                 target[slots] = rows
+                self.stats.bank_bind_seconds += time.perf_counter() - bind_started
                 if preload:
                     # Pinned construction can stage hundreds of rows, so commit
                     # one component at a time and release it immediately.
+                    materialize_started = time.perf_counter()
                     mx.eval(target)
+                    self.stats.bank_materialize_seconds += (
+                        time.perf_counter() - materialize_started
+                    )
                 # Dynamic updates deliberately remain lazy. The layer's QMM
                 # consumes the updated bank immediately, and the next layer's
                 # router evaluation provides the required synchronization.
         self.stats.loads += len(experts)
-        if preload:
+        if load_kind == "pinned":
             self.stats.pinned_loads += len(experts)
+        elif load_kind == "warm_start":
+            self.stats.warm_start_loads += len(experts)
         else:
             self.stats.cold_loads += len(experts)
 
@@ -276,8 +300,77 @@ class StreamingSwitchGLU(nn.Module):
         for expert in values:
             if self._route_hotness[expert] < np.iinfo(np.uint64).max:
                 self._route_hotness[expert] += 1
+            if self._route_counts[expert] < np.iinfo(np.uint64).max:
+                self._route_counts[expert] += 1
             self._access_clock += 1
             self._last_used[expert] = self._access_clock
+
+    def hotlist(self) -> list[tuple[int, int]]:
+        """Return non-pinned experts ranked by lifetime router selections."""
+        with self._lock:
+            experts = [
+                expert
+                for expert in range(self.num_experts)
+                if expert not in self._pinned_set and self._route_counts[expert] > 0
+            ]
+            experts.sort(
+                key=lambda expert: (
+                    int(self._route_counts[expert]),
+                    int(self._last_used[expert]),
+                ),
+                reverse=True,
+            )
+            return [
+                (expert, int(self._route_counts[expert])) for expert in experts
+            ]
+
+    def preload_hotlist(self, entries: list[tuple[int, int]]) -> int:
+        """Fill evictable slots from a prior run's learned route profile."""
+        with self._lock:
+            valid: list[tuple[int, int]] = []
+            seen: set[int] = set()
+            for expert, count in entries:
+                expert = int(expert)
+                count = int(count)
+                if (
+                    expert in seen
+                    or expert in self._pinned_set
+                    or not 0 <= expert < self.num_experts
+                    or count <= 0
+                ):
+                    continue
+                seen.add(expert)
+                valid.append((expert, count))
+            valid.sort(key=lambda entry: entry[1], reverse=True)
+            for expert, count in valid:
+                self._route_counts[expert] = min(
+                    count, int(np.iinfo(np.uint64).max)
+                )
+            selected = valid[: self.cache_slots]
+            missing = [
+                expert for expert, _ in selected if expert not in self._expert_to_slot
+            ]
+            if not missing:
+                return 0
+            slots = self._allocate_misses(missing)
+            self._load_into_slots(missing, slots, load_kind="warm_start")
+            counts = dict(selected)
+            for expert in missing:
+                score = min(counts[expert], int(np.iinfo(np.uint64).max))
+                self._route_hotness[expert] = score
+                self._access_clock += 1
+                self._last_used[expert] = self._access_clock
+            arrays = [
+                self._array(projection, part)
+                for projection in PROJECTIONS
+                for part in self.projection_metadata[projection]["parts"]
+            ]
+            materialize_started = time.perf_counter()
+            mx.eval(*arrays, self._slot_map, self._resident_mask)
+            self.stats.bank_materialize_seconds += (
+                time.perf_counter() - materialize_started
+            )
+            return len(missing)
 
     def _eviction_victim(self, protected: set[int]) -> tuple[int, int]:
         candidates = [

--- a/omlx/expert_streaming/residency.py
+++ b/omlx/expert_streaming/residency.py
@@ -20,6 +20,7 @@ class ExpertStreamingEstimate:
     fixed_bytes: int
     pinned_bytes: int
     cache_bytes: int
+    scratch_bytes: int
     resident_bytes: int
     cache_slots_per_layer: int
 
@@ -54,6 +55,9 @@ def estimate_for_model_settings(
         path,
         manifest,
         cache_experts=int(getattr(settings, "expert_streaming_cache_experts", 32)),
+        scratch_experts=int(
+            getattr(settings, "expert_streaming_scratch_experts", 32)
+        ),
         num_layers=num_layers,
         num_experts=num_experts,
         top_k=top_k,
@@ -66,6 +70,7 @@ def estimate_expert_streaming_residency(
     manifest_path: str | Path | None,
     *,
     cache_experts: int,
+    scratch_experts: int = 32,
     num_layers: int,
     num_experts: int,
     top_k: int,
@@ -106,13 +111,28 @@ def estimate_expert_streaming_residency(
     )
     cache_slots = max(requested_slots, minimum_slots)
     cache_bytes = cache_slots * one_slot_all_layers
-    resident_bytes = int((fixed_bytes + pinned_bytes + cache_bytes) * _OVERHEAD_FACTOR)
+    available_scratch = max(
+        0,
+        min(
+            num_experts
+            - len(manifest.experts_for_layer(layer))
+            - cache_slots
+            for layer in layers
+        ),
+    )
+    scratch_slots = min(max(0, int(scratch_experts)), available_scratch)
+    scratch_bytes = scratch_slots * one_slot_all_layers
+    resident_bytes = int(
+        (fixed_bytes + pinned_bytes + cache_bytes + scratch_bytes)
+        * _OVERHEAD_FACTOR
+    )
     return ExpertStreamingEstimate(
         checkpoint_bytes=checkpoint_bytes,
         streamed_tensor_bytes=streamed_tensor_bytes,
         fixed_bytes=fixed_bytes,
         pinned_bytes=pinned_bytes,
         cache_bytes=cache_bytes,
+        scratch_bytes=scratch_bytes,
         resident_bytes=resident_bytes,
         cache_slots_per_layer=cache_slots,
     )

--- a/omlx/expert_streaming/residency.py
+++ b/omlx/expert_streaming/residency.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Header-only resident-memory estimates for Soft-REAP admission control."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from .manifest import SoftReapManifest, load_soft_reap_manifest
+from .safetensors import SafetensorExpertIndex
+
+_OVERHEAD_FACTOR = 1.05
+
+
+@dataclass(frozen=True)
+class ExpertStreamingEstimate:
+    checkpoint_bytes: int
+    streamed_tensor_bytes: int
+    fixed_bytes: int
+    pinned_bytes: int
+    cache_bytes: int
+    resident_bytes: int
+    cache_slots_per_layer: int
+
+
+def estimate_for_model_settings(
+    model_path: str | Path,
+    settings: object | None,
+) -> ExpertStreamingEstimate | None:
+    """Resolve a configured estimate, returning ``None`` when disabled."""
+
+    if settings is None or not getattr(settings, "expert_streaming_enabled", False):
+        return None
+    streaming_mode = str(
+        getattr(settings, "expert_streaming_mode", "soft_reap")
+    ).lower()
+    if streaming_mode not in {"soft_reap", "cache_only"}:
+        raise ValueError("Expert streaming mode must be soft_reap or cache_only")
+    manifest = getattr(settings, "expert_streaming_manifest", None)
+    if streaming_mode == "soft_reap" and not manifest:
+        raise ValueError("Expert streaming is enabled without a Soft-REAP manifest")
+    path = Path(model_path).expanduser().resolve()
+    config = json.loads((path / "config.json").read_text(encoding="utf-8"))
+    text = config.get("text_config") or config
+    num_layers = int(text.get("num_hidden_layers", 0) or 0)
+    num_experts = int(text.get("num_experts", text.get("n_routed_experts", 0)) or 0)
+    top_k = int(
+        text.get("num_experts_per_tok", text.get("num_experts_per_token", 0)) or 0
+    )
+    if not num_layers or not num_experts or not top_k:
+        raise ValueError("Model config does not declare compatible MoE geometry")
+    return estimate_expert_streaming_residency(
+        path,
+        manifest,
+        cache_experts=int(getattr(settings, "expert_streaming_cache_experts", 32)),
+        num_layers=num_layers,
+        num_experts=num_experts,
+        top_k=top_k,
+        streaming_mode=streaming_mode,
+    )
+
+
+def estimate_expert_streaming_residency(
+    model_path: str | Path,
+    manifest_path: str | Path | None,
+    *,
+    cache_experts: int,
+    num_layers: int,
+    num_experts: int,
+    top_k: int,
+    streaming_mode: str = "soft_reap",
+) -> ExpertStreamingEstimate:
+    path = Path(model_path).expanduser().resolve()
+    if streaming_mode == "soft_reap":
+        if not manifest_path:
+            raise ValueError("Soft-REAP mode requires an expert pin manifest")
+        manifest = load_soft_reap_manifest(
+            manifest_path,
+            num_layers=num_layers,
+            num_experts=num_experts,
+        )
+    elif streaming_mode == "cache_only":
+        manifest = SoftReapManifest.empty(num_layers)
+    else:
+        raise ValueError("Expert streaming mode must be soft_reap or cache_only")
+    index = SafetensorExpertIndex(path)
+    layers = list(range(num_layers))
+    checkpoint_bytes = sum(file.stat().st_size for file in path.glob("*.safetensors"))
+    streamed_tensor_bytes = index.tensor_bytes(layers)
+    fixed_bytes = max(0, checkpoint_bytes - streamed_tensor_bytes)
+    per_layer_expert_bytes = [index.expert_bytes(layer) for layer in layers]
+    pinned_bytes = sum(
+        len(manifest.experts_for_layer(layer)) * per_layer_expert_bytes[layer]
+        for layer in layers
+    )
+    one_slot_all_layers = sum(per_layer_expert_bytes)
+    requested_slots = max(0, int(cache_experts))
+    minimum_slots = max(
+        min(top_k, num_experts - len(manifest.experts_for_layer(layer)))
+        for layer in layers
+    )
+    cache_slots = max(requested_slots, minimum_slots)
+    cache_bytes = cache_slots * one_slot_all_layers
+    resident_bytes = int((fixed_bytes + pinned_bytes + cache_bytes) * _OVERHEAD_FACTOR)
+    return ExpertStreamingEstimate(
+        checkpoint_bytes=checkpoint_bytes,
+        streamed_tensor_bytes=streamed_tensor_bytes,
+        fixed_bytes=fixed_bytes,
+        pinned_bytes=pinned_bytes,
+        cache_bytes=cache_bytes,
+        resident_bytes=resident_bytes,
+        cache_slots_per_layer=cache_slots,
+    )

--- a/omlx/expert_streaming/residency.py
+++ b/omlx/expert_streaming/residency.py
@@ -72,29 +72,33 @@ def estimate_expert_streaming_residency(
     streaming_mode: str = "soft_reap",
 ) -> ExpertStreamingEstimate:
     path = Path(model_path).expanduser().resolve()
+    index = SafetensorExpertIndex(path)
+    layers = index.expert_layer_ids()
+    if not layers:
+        raise ValueError("Checkpoint contains no indexed routed-expert tensors")
     if streaming_mode == "soft_reap":
         if not manifest_path:
             raise ValueError("Soft-REAP mode requires an expert pin manifest")
         manifest = load_soft_reap_manifest(
             manifest_path,
-            num_layers=num_layers,
+            layer_ids=layers,
             num_experts=num_experts,
         )
     elif streaming_mode == "cache_only":
-        manifest = SoftReapManifest.empty(num_layers)
+        manifest = SoftReapManifest.empty(layer_ids=layers)
     else:
         raise ValueError("Expert streaming mode must be soft_reap or cache_only")
-    index = SafetensorExpertIndex(path)
-    layers = list(range(num_layers))
     checkpoint_bytes = sum(file.stat().st_size for file in path.glob("*.safetensors"))
-    streamed_tensor_bytes = index.tensor_bytes(layers)
+    streamed_tensor_bytes = sum(index.streamed_storage_bytes(layer) for layer in layers)
     fixed_bytes = max(0, checkpoint_bytes - streamed_tensor_bytes)
-    per_layer_expert_bytes = [index.expert_bytes(layer) for layer in layers]
+    per_layer_expert_bytes = {
+        layer: index.expert_storage_bytes(layer) for layer in layers
+    }
     pinned_bytes = sum(
         len(manifest.experts_for_layer(layer)) * per_layer_expert_bytes[layer]
         for layer in layers
     )
-    one_slot_all_layers = sum(per_layer_expert_bytes)
+    one_slot_all_layers = sum(per_layer_expert_bytes.values())
     requested_slots = max(0, int(cache_experts))
     minimum_slots = max(
         min(top_k, num_experts - len(manifest.experts_for_layer(layer)))

--- a/omlx/expert_streaming/routing.py
+++ b/omlx/expert_streaming/routing.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Resident-aware approximate routing for Soft-REAP expert banks."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_vlm.models.qwen3_5_moe.language import (
+    _target_verify_linear,
+    _target_verify_switch_glu,
+)
+
+
+def resident_preferred_topk(
+    gates: mx.array,
+    resident_mask: mx.array,
+    *,
+    top_k: int,
+    threshold_percent: float,
+) -> tuple[mx.array, mx.array]:
+    """Route near-ties to resident experts, retaining original gate weights.
+
+    A resident expert may displace a cold expert when its unmodified router
+    probability is within ``threshold_percent`` of the cold probability.
+    """
+
+    threshold = min(100.0, max(0.0, float(threshold_percent))) / 100.0
+    if threshold >= 1.0:
+        adjusted = mx.where(resident_mask, gates, -mx.inf)
+    elif threshold > 0.0:
+        adjusted = mx.where(resident_mask, gates / (1.0 - threshold), gates)
+    else:
+        adjusted = gates
+    indices = mx.argpartition(adjusted, kth=-top_k, axis=-1)[..., -top_k:]
+    scores = mx.take_along_axis(gates, indices, axis=-1)
+    return indices, scores / scores.sum(axis=-1, keepdims=True)
+
+
+class ResidentPreferredMoeBlock(nn.Module):
+    """Qwen3.5/3.8 MoE block with optional resident-near-tie routing."""
+
+    def __init__(self, original: Any, *, threshold_percent: float):
+        super().__init__()
+        self.num_experts = int(original.num_experts)
+        self.top_k = int(original.top_k)
+        self.gate = original.gate
+        self.switch_mlp = original.switch_mlp
+        self.shared_expert = original.shared_expert
+        self.shared_expert_gate = original.shared_expert_gate
+        self.threshold_percent = float(threshold_percent)
+
+    def __call__(self, x: mx.array, target_verify: bool = False) -> mx.array:
+        gates = _target_verify_linear(self.gate, x, target_verify)
+        gates = mx.softmax(gates, axis=-1, precise=True)
+        indices, scores = resident_preferred_topk(
+            gates,
+            self.switch_mlp.resident_mask,
+            top_k=self.top_k,
+            threshold_percent=self.threshold_percent,
+        )
+        # The streaming pool owns cache-sized expert-major chunking. Calling
+        # mlx-vlm's target-verify helper directly would bypass that whole-GLU
+        # path and stream each projection separately for a wide verify batch.
+        if getattr(self.switch_mlp, "_omlx_expert_streaming", False):
+            routed = self.switch_mlp(x, indices)
+        else:
+            routed = _target_verify_switch_glu(
+                self.switch_mlp, x, indices, target_verify
+            )
+        routed = (routed * scores[..., None]).sum(axis=-2)
+        shared = self.shared_expert(x, target_verify)
+        shared = (
+            mx.sigmoid(_target_verify_linear(self.shared_expert_gate, x, target_verify))
+            * shared
+        )
+        return routed + shared

--- a/omlx/expert_streaming/safetensors.py
+++ b/omlx/expert_streaming/safetensors.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import struct
 from collections.abc import Hashable, Mapping
 from concurrent.futures import ThreadPoolExecutor
@@ -19,10 +20,22 @@ PARTS = ("weight", "scales", "biases")
 
 _NUMPY_DTYPES = {
     "U32": np.uint32,
+    "U8": np.uint8,
+    "I8": np.int8,
     "F32": np.float32,
     "F16": np.float16,
     "BF16": np.uint16,
 }
+
+
+@dataclass(frozen=True)
+class TensorRowSource:
+    name: str
+    path: Path
+    dtype: str
+    shape: tuple[int, ...]
+    data_start: int
+    data_bytes: int
 
 
 @dataclass(frozen=True)
@@ -33,6 +46,11 @@ class TensorLocation:
     shape: tuple[int, ...]
     data_start: int
     row_bytes: int
+    storage_dtype: str | None = None
+    storage_shape: tuple[int, ...] | None = None
+    storage_row_bytes: int | None = None
+    row_sources: tuple[TensorRowSource, ...] | None = None
+    output_slice: tuple[int, int] | None = None
 
     @property
     def tensor_bytes(self) -> int:
@@ -52,7 +70,9 @@ class SafetensorExpertIndex:
         except (OSError, KeyError, json.JSONDecodeError) as exc:
             raise ValueError(f"Invalid safetensors index: {exc}") from exc
         self._headers: dict[str, tuple[int, dict]] = {}
-        self._layer_locations: dict[int, dict[tuple[str, str], TensorLocation]] = {}
+        self._layer_locations: dict[
+            tuple[int, str], dict[tuple[str, str], TensorLocation]
+        ] = {}
 
     def _header(self, filename: str) -> tuple[int, dict]:
         cached = self._headers.get(filename)
@@ -69,11 +89,284 @@ class SafetensorExpertIndex:
         self._headers[filename] = cached
         return cached
 
-    def layer(self, layer: int) -> dict[tuple[str, str], TensorLocation]:
-        cached = self._layer_locations.get(layer)
+    @staticmethod
+    def _mlx_dtype_name(array) -> str:
+        if array.dtype == mx.uint32:
+            return "U32"
+        if array.dtype == mx.uint8:
+            return "U8"
+        if array.dtype == mx.int8:
+            return "I8"
+        if array.dtype == mx.float32:
+            return "F32"
+        if array.dtype == mx.float16:
+            return "F16"
+        if array.dtype == mx.bfloat16:
+            return "BF16"
+        raise ValueError(f"Unsupported streamed MLX dtype: {array.dtype}")
+
+    @staticmethod
+    def _projection_aliases(projection: str) -> tuple[str, ...]:
+        aliases = {
+            "gate_proj": ("gate_proj", "w1"),
+            "down_proj": ("down_proj", "w2"),
+            "up_proj": ("up_proj", "w3"),
+        }
+        return aliases[projection]
+
+    @staticmethod
+    def _part_aliases(part: str) -> tuple[str, ...]:
+        return ("scales", "scale") if part == "scales" else (part,)
+
+    def _source(self, name: str, filename: str) -> TensorRowSource:
+        data_base, header = self._header(filename)
+        meta = header.get(name)
+        if meta is None:
+            raise ValueError(f"Tensor {name} is absent from {filename}")
+        dtype = str(meta["dtype"])
+        if dtype not in _NUMPY_DTYPES:
+            raise ValueError(f"Unsupported streamed tensor dtype {dtype}: {name}")
+        shape = tuple(int(value) for value in meta["shape"])
+        start, end = (int(value) for value in meta["data_offsets"])
+        return TensorRowSource(
+            name=name,
+            path=self.model_path / filename,
+            dtype=dtype,
+            shape=shape,
+            data_start=data_base + start,
+            data_bytes=end - start,
+        )
+
+    @staticmethod
+    def _is_backbone_expert_name(name: str, layer: int) -> bool:
+        if name.startswith("mtp.") or ".mtp." in name:
+            return False
+        if f"layers.{layer}." not in name or ".shared_experts." in name:
+            return False
+        return ".switch_mlp." in name or ".experts." in name
+
+    def expert_layer_ids(self) -> list[int]:
+        result: set[int] = set()
+        for name in self.weight_map:
+            if name.startswith("mtp.") or ".mtp." in name or ".shared_experts." in name:
+                continue
+            match = re.search(r"(?:^|\.)layers\.(\d+)\.(?:mlp|ffn)\.", name)
+            if match and (".switch_mlp." in name or ".experts." in name):
+                result.add(int(match.group(1)))
+        return sorted(result)
+
+    def _tensor_storage_bytes(self, name: str, filename: str) -> int:
+        return self._source(name, filename).data_bytes
+
+    def streamed_storage_bytes(self, layer: int) -> int:
+        """Checkpoint bytes occupied by all routed tensors in one layer."""
+        names = [
+            (name, filename)
+            for name, filename in self.weight_map.items()
+            if self._is_backbone_expert_name(name, layer)
+        ]
+        stacked = [item for item in names if ".switch_mlp." in item[0]]
+        selected = stacked or [item for item in names if ".experts." in item[0]]
+        return sum(self._tensor_storage_bytes(*item) for item in selected)
+
+    def expert_storage_bytes(self, layer: int) -> int:
+        """Resident bytes for one routed expert, without loading payloads."""
+        total = self.streamed_storage_bytes(layer)
+        stacked_experts = None
+        for name, filename in self.weight_map.items():
+            if self._is_backbone_expert_name(name, layer) and ".switch_mlp." in name:
+                source = self._source(name, filename)
+                if source.shape:
+                    stacked_experts = source.shape[0]
+                    break
+        if stacked_experts:
+            return total // stacked_experts
+        expert_ids: set[int] = set()
+        marker = re.compile(rf"layers\.{layer}\.(?:mlp|ffn)\.experts\.(\d+)\.")
+        for name in self.weight_map:
+            match = marker.search(name)
+            if match and self._is_backbone_expert_name(name, layer):
+                expert_ids.add(int(match.group(1)))
+        if not expert_ids:
+            raise ValueError(f"Layer {layer} has no indexed routed experts")
+        return total // len(expert_ids)
+
+    def _stacked_location(
+        self,
+        *,
+        layer: int,
+        container_name: str,
+        projection: str,
+        part: str,
+        metadata: dict,
+        num_experts: int,
+    ) -> TensorLocation | None:
+        source_projection = str(metadata.get("source_projection", projection))
+        projection_names = [source_projection]
+        if source_projection == "gate_up_proj":
+            projection_names.extend(self._projection_aliases(projection))
+        else:
+            projection_names.extend(self._projection_aliases(projection))
+        seen: set[str] = set()
+        projection_names = [
+            value for value in projection_names if not (value in seen or seen.add(value))
+        ]
+        for name, filename in self.weight_map.items():
+            if name.startswith("mtp.") or ".mtp." in name:
+                continue
+            if f"layers.{layer}.{container_name}.switch_mlp." not in name:
+                continue
+            matched_projection = next(
+                (
+                    candidate
+                    for candidate in projection_names
+                    if any(
+                        name.endswith(f".{candidate}.{alias}")
+                        for alias in self._part_aliases(part)
+                    )
+                ),
+                None,
+            )
+            if matched_projection is None:
+                continue
+            source = self._source(name, filename)
+            if len(source.shape) < 2 or source.shape[0] != num_experts:
+                raise ValueError(f"Expert tensor is not row-addressable: {name}")
+            output_slice = None
+            logical_shape = tuple(int(v) for v in metadata["arrays"][part].shape)
+            if metadata.get("fused_half"):
+                logical_shape = (
+                    logical_shape[0],
+                    logical_shape[1] // 2,
+                    *logical_shape[2:],
+                )
+            if matched_projection == "gate_up_proj":
+                midpoint = source.shape[1] // 2
+                output_slice = (
+                    (0, midpoint)
+                    if metadata.get("fused_half") == "gate"
+                    else (midpoint, source.shape[1])
+                )
+            logical_dtype = self._mlx_dtype_name(metadata["arrays"][part])
+            logical_bytes = (
+                int(np.prod(logical_shape[1:]))
+                * np.dtype(_NUMPY_DTYPES[logical_dtype]).itemsize
+            )
+            return TensorLocation(
+                name=name,
+                path=source.path,
+                dtype=logical_dtype,
+                shape=logical_shape,
+                data_start=source.data_start,
+                row_bytes=logical_bytes,
+                storage_dtype=source.dtype,
+                storage_shape=source.shape,
+                storage_row_bytes=source.data_bytes // num_experts,
+                output_slice=output_slice,
+            )
+        return None
+
+    def _fragmented_location(
+        self,
+        *,
+        layer: int,
+        container_name: str,
+        projection: str,
+        part: str,
+        metadata: dict,
+        num_experts: int,
+    ) -> TensorLocation | None:
+        sources: list[TensorRowSource] = []
+        aliases = self._projection_aliases(projection)
+        for expert in range(num_experts):
+            marker = f"layers.{layer}.{container_name}.experts.{expert}."
+            found = None
+            for name, filename in self.weight_map.items():
+                if name.startswith("mtp.") or ".mtp." in name or marker not in name:
+                    continue
+                if any(
+                    name.endswith(f".{candidate}.{part_alias}")
+                    for candidate in aliases
+                    for part_alias in self._part_aliases(part)
+                ):
+                    found = self._source(name, filename)
+                    break
+            if found is None:
+                return None
+            sources.append(found)
+        logical_array = metadata["arrays"][part]
+        logical_dtype = self._mlx_dtype_name(logical_array)
+        logical_shape = tuple(int(value) for value in logical_array.shape)
+        if metadata.get("fused_half"):
+            logical_shape = (
+                logical_shape[0],
+                logical_shape[1] // 2,
+                *logical_shape[2:],
+            )
+        row_bytes = (
+            int(np.prod(logical_shape[1:]))
+            * np.dtype(_NUMPY_DTYPES[logical_dtype]).itemsize
+        )
+        for source in sources:
+            if source.data_bytes != row_bytes:
+                raise ValueError(
+                    f"Expert tensor {source.name} has {source.data_bytes} bytes; "
+                    f"expected {row_bytes}"
+                )
+        return TensorLocation(
+            name=f"layers.{layer}.{container_name}.experts.*.{projection}.{part}",
+            path=sources[0].path,
+            dtype=logical_dtype,
+            shape=logical_shape,
+            data_start=0,
+            row_bytes=row_bytes,
+            row_sources=tuple(sources),
+        )
+
+    def layer(
+        self,
+        layer: int,
+        *,
+        container_name: str = "mlp",
+        schema: dict[str, dict] | None = None,
+        num_experts: int | None = None,
+    ) -> dict[tuple[str, str], TensorLocation]:
+        cache_key = (layer, container_name)
+        cached = self._layer_locations.get(cache_key)
         if cached is not None:
             return cached
-        marker = f"layers.{layer}.mlp.switch_mlp."
+        if schema is not None:
+            if num_experts is None:
+                raise ValueError("A projection schema requires the expert count")
+            locations: dict[tuple[str, str], TensorLocation] = {}
+            for projection in PROJECTIONS:
+                metadata = schema[projection]
+                for part in metadata["parts"]:
+                    location = self._stacked_location(
+                        layer=layer,
+                        container_name=container_name,
+                        projection=projection,
+                        part=part,
+                        metadata=metadata,
+                        num_experts=num_experts,
+                    ) or self._fragmented_location(
+                        layer=layer,
+                        container_name=container_name,
+                        projection=projection,
+                        part=part,
+                        metadata=metadata,
+                        num_experts=num_experts,
+                    )
+                    if location is None:
+                        raise ValueError(
+                            f"Layer {layer} lacks {container_name} expert tensor "
+                            f"{projection}.{part}"
+                        )
+                    locations[(projection, part)] = location
+            self._layer_locations[cache_key] = locations
+            return locations
+
+        marker = f"layers.{layer}.{container_name}.switch_mlp."
         locations: dict[tuple[str, str], TensorLocation] = {}
         for name, filename in self.weight_map.items():
             # MTP checkpoints can contain ``mtp.layers.0`` alongside the
@@ -111,14 +404,21 @@ class SafetensorExpertIndex:
                         shape=shape,
                         data_start=data_base + start,
                         row_bytes=total // shape[0],
+                        storage_dtype=dtype,
+                        storage_shape=shape,
+                        storage_row_bytes=total // shape[0],
                     )
-        required = {(projection, part) for projection in PROJECTIONS for part in PARTS}
+        required = {
+            (projection, part)
+            for projection in PROJECTIONS
+            for part in ("weight", "scales")
+        }
         missing = required - set(locations)
         if missing:
             raise ValueError(
                 f"Layer {layer} lacks stacked quantized expert tensors: {sorted(missing)}"
             )
-        self._layer_locations[layer] = locations
+        self._layer_locations[cache_key] = locations
         return locations
 
     def expert_bytes(self, layer: int) -> int:
@@ -209,22 +509,38 @@ class ExpertReader:
         if not requested:
             raise ValueError("At least one expert row must be requested")
         rows = sorted(set(requested))
-        tasks: list[tuple[Hashable, TensorLocation, int, int, int]] = []
+        tasks: list[
+            tuple[Hashable, TensorLocation, int, int, int, TensorRowSource | None]
+        ] = []
         for key, location in locations.items():
             if min(requested) < 0 or max(requested) >= location.shape[0]:
                 raise ValueError(f"Expert row outside tensor {location.name}")
-            fd = self._fd(location.path, use_file_cache=use_file_cache)
-            for first, stop in self._ranges(rows, location.row_bytes, max_gap_bytes):
-                tasks.append((key, location, fd, first, stop))
+            if location.row_sources is not None:
+                for row in rows:
+                    source = location.row_sources[row]
+                    fd = self._fd(source.path, use_file_cache=use_file_cache)
+                    tasks.append((key, location, fd, row, row + 1, source))
+            else:
+                fd = self._fd(location.path, use_file_cache=use_file_cache)
+                storage_row_bytes = location.storage_row_bytes or location.row_bytes
+                for first, stop in self._ranges(
+                    rows, storage_row_bytes, max_gap_bytes
+                ):
+                    tasks.append((key, location, fd, first, stop, None))
 
         def read_range(task) -> tuple[Hashable, int, bytes]:
-            key, location, fd, first, stop = task
-            size = (stop - first) * location.row_bytes
-            payload = os.pread(
-                fd, size, location.data_start + first * location.row_bytes
-            )
+            key, location, fd, first, stop, source = task
+            if source is not None:
+                size = source.data_bytes
+                offset = source.data_start
+            else:
+                storage_row_bytes = location.storage_row_bytes or location.row_bytes
+                size = (stop - first) * storage_row_bytes
+                offset = location.data_start + first * storage_row_bytes
+            payload = os.pread(fd, size, offset)
             if len(payload) != size:
-                raise OSError(f"Short expert read from {location.path.name}")
+                path = source.path if source is not None else location.path
+                raise OSError(f"Short expert read from {path.name}")
             return key, first, payload
 
         chunks = list(self._pool.map(read_range, tasks))
@@ -250,10 +566,22 @@ class ExpertReader:
             dtype = _NUMPY_DTYPES[location.dtype]
             selected: dict[int, np.ndarray] = {}
             for first, payload in grouped[key]:
-                count = len(payload) // location.row_bytes
-                values = np.frombuffer(payload, dtype=dtype).reshape(
-                    (count, *row_shape)
+                storage_row_bytes = location.storage_row_bytes or location.row_bytes
+                count = (
+                    1
+                    if location.row_sources is not None
+                    else len(payload) // storage_row_bytes
                 )
+                values = np.frombuffer(payload, dtype=dtype)
+                if location.output_slice is not None:
+                    storage_shape = location.storage_shape
+                    if storage_shape is None:
+                        raise ValueError(f"Missing storage shape for {location.name}")
+                    values = values.reshape((count, *storage_shape[1:]))
+                    start, stop = location.output_slice
+                    values = values[:, start:stop]
+                else:
+                    values = values.reshape((count, *row_shape))
                 for row in rows:
                     if first <= row < first + count:
                         selected[row] = values[row - first]

--- a/omlx/expert_streaming/safetensors.py
+++ b/omlx/expert_streaming/safetensors.py
@@ -9,7 +9,7 @@ import re
 import struct
 import time
 from collections.abc import Hashable, Mapping
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -436,11 +436,21 @@ class SafetensorExpertIndex:
 class ExpertReader:
     """Read selected expert rows with ``pread`` and bounded parallelism."""
 
-    def __init__(self, index: SafetensorExpertIndex, workers: int = 9):
+    def __init__(
+        self,
+        index: SafetensorExpertIndex,
+        workers: int = 9,
+        *,
+        cold_max_gap_bytes: int = 64 * 1024,
+    ):
         self.index = index
+        self.cold_max_gap_bytes = max(0, int(cold_max_gap_bytes))
         self._fds: dict[tuple[Path, bool], int] = {}
         self._pool = ThreadPoolExecutor(
             max_workers=max(1, workers), thread_name_prefix="expert-ssd"
+        )
+        self._request_pool = ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="expert-prefetch"
         )
         self.bytes_read = 0
         self.direct_bytes_read = 0
@@ -501,7 +511,7 @@ class ExpertReader:
         location: TensorLocation,
         expert_ids: list[int] | tuple[int, ...],
         *,
-        max_gap_bytes: int = 0,
+        max_gap_bytes: int | None = None,
         use_file_cache: bool = False,
     ) -> mx.array:
         return self.read_many(
@@ -511,20 +521,22 @@ class ExpertReader:
             use_file_cache=use_file_cache,
         )["rows"]
 
-    def read_many(
+    def _read_many_numpy(
         self,
         locations: Mapping[Hashable, TensorLocation],
         expert_ids: list[int] | tuple[int, ...],
         *,
-        max_gap_bytes: int = 0,
+        max_gap_bytes: int | None = None,
         use_file_cache: bool = False,
-    ) -> dict[Hashable, mx.array]:
-        """Read several expert components through one flat parallel I/O queue."""
+    ) -> dict[Hashable, np.ndarray]:
+        """Read and decode components without creating thread-bound MLX arrays."""
 
         requested = [int(value) for value in expert_ids]
         if not requested:
             raise ValueError("At least one expert row must be requested")
         rows = sorted(set(requested))
+        if max_gap_bytes is None:
+            max_gap_bytes = self.cold_max_gap_bytes if use_file_cache else 0
         tasks: list[
             tuple[Hashable, TensorLocation, int, int, int, TensorRowSource | None]
         ] = []
@@ -579,7 +591,7 @@ class ExpertReader:
             grouped[key].append((first, payload))
 
         decode_started = time.perf_counter()
-        result: dict[Hashable, mx.array] = {}
+        result: dict[Hashable, np.ndarray] = {}
         for key, location in locations.items():
             row_shape = location.shape[1:]
             dtype = _NUMPY_DTYPES[location.dtype]
@@ -605,17 +617,66 @@ class ExpertReader:
                     if first <= row < first + count:
                         selected[row] = values[row - first]
             output = np.stack([selected[row] for row in requested])
-            array = mx.array(output)
-            if location.dtype == "BF16":
-                array = array.view(mx.bfloat16)
-            result[key] = array
+            result[key] = output
         self.decode_seconds += time.perf_counter() - decode_started
         return result
+
+    @staticmethod
+    def materialize_many(
+        locations: Mapping[Hashable, TensorLocation],
+        components: Mapping[Hashable, np.ndarray],
+    ) -> dict[Hashable, mx.array]:
+        """Create MLX arrays on the caller's inference thread."""
+
+        result: dict[Hashable, mx.array] = {}
+        for key, output in components.items():
+            array = mx.array(output)
+            if locations[key].dtype == "BF16":
+                array = array.view(mx.bfloat16)
+            result[key] = array
+        return result
+
+    def read_many(
+        self,
+        locations: Mapping[Hashable, TensorLocation],
+        expert_ids: list[int] | tuple[int, ...],
+        *,
+        max_gap_bytes: int | None = None,
+        use_file_cache: bool = False,
+    ) -> dict[Hashable, mx.array]:
+        """Read components and materialize them on the calling thread."""
+
+        components = self._read_many_numpy(
+            locations,
+            expert_ids,
+            max_gap_bytes=max_gap_bytes,
+            use_file_cache=use_file_cache,
+        )
+        return self.materialize_many(locations, components)
+
+    def read_many_async(
+        self,
+        locations: Mapping[Hashable, TensorLocation],
+        expert_ids: list[int] | tuple[int, ...],
+        *,
+        max_gap_bytes: int | None = None,
+        use_file_cache: bool = False,
+    ) -> Future[dict[Hashable, np.ndarray]]:
+        """Submit bounded CPU-only I/O and decoding for Metal overlap."""
+
+        return self._request_pool.submit(
+            self._read_many_numpy,
+            locations,
+            expert_ids,
+            max_gap_bytes=max_gap_bytes,
+            use_file_cache=use_file_cache,
+        )
 
     def close(self) -> None:
         if self._closed:
             return
         self._closed = True
+        self._request_pool.shutdown(wait=True, cancel_futures=True)
         self._pool.shutdown(wait=True, cancel_futures=True)
         for fd in self._fds.values():
             os.close(fd)

--- a/omlx/expert_streaming/safetensors.py
+++ b/omlx/expert_streaming/safetensors.py
@@ -12,9 +12,13 @@ from collections.abc import Hashable, Mapping
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import mlx.core as mx
 import numpy as np
+
+if TYPE_CHECKING:
+    from .fast_resource import FastExpertLoad, FastExpertLoader, FastExpertLoadFuture
 
 PROJECTIONS = ("gate_proj", "up_proj", "down_proj")
 PARTS = ("weight", "scales", "biases")
@@ -442,6 +446,7 @@ class ExpertReader:
         workers: int = 9,
         *,
         cold_max_gap_bytes: int = 64 * 1024,
+        fast_resource_loading: bool | str = False,
     ):
         self.index = index
         self.cold_max_gap_bytes = max(0, int(cold_max_gap_bytes))
@@ -463,6 +468,60 @@ class ExpertReader:
         self.readahead_descriptors = 0
         self.no_cache_descriptors = 0
         self._closed = False
+        self.fast_resource_loading = False
+        self.fast_resource_loading_scope = "off"
+        self._fast_loader: FastExpertLoader | None = None
+        self.fast_loads = 0
+        self.fast_bytes_read = 0
+        self.fast_read_operations = 0
+        self.fast_io_wait_seconds = 0.0
+        self.fast_copy_seconds = 0.0
+        scope = (
+            "all"
+            if fast_resource_loading is True
+            else str(fast_resource_loading).lower()
+        )
+        if scope not in {"off", "false", "scratch", "all"}:
+            raise ValueError("Fast Resource Loading scope must be off, scratch, or all")
+        if scope in {"scratch", "all"}:
+            from .fast_resource import FastExpertLoader
+
+            self._fast_loader = FastExpertLoader()
+            self.fast_resource_loading = True
+            self.fast_resource_loading_scope = scope
+
+    def begin_fast_many(
+        self,
+        locations: Mapping[Hashable, TensorLocation],
+        expert_ids: list[int] | tuple[int, ...],
+    ) -> FastExpertLoad:
+        if self._fast_loader is None:
+            raise RuntimeError("Fast Resource Loading is not enabled")
+        return self._fast_loader.begin(
+            locations,
+            expert_ids,
+            max_gap_bytes=self.cold_max_gap_bytes,
+        )
+
+    def finish_fast_many(
+        self,
+        load: FastExpertLoad,
+        slots: list[int],
+        targets: Mapping[Hashable, tuple[mx.array, int]],
+    ) -> dict[str, int | float]:
+        if self._fast_loader is None:
+            raise RuntimeError("Fast Resource Loading is not enabled")
+        stats = self._fast_loader.finish_into(load, slots, targets)
+        self.fast_loads += 1
+        self.fast_bytes_read += int(stats["bytes"])
+        self.fast_read_operations += int(stats["commands"])
+        self.fast_io_wait_seconds += float(stats["io_wait_seconds"])
+        self.fast_copy_seconds += float(stats["copy_seconds"])
+        self.bytes_read += int(stats["bytes"])
+        self.read_operations += int(stats["commands"])
+        self.file_cache_bytes_read += int(stats["bytes"])
+        self.file_cache_read_operations += int(stats["commands"])
+        return stats
 
     def _fd(self, path: Path, *, use_file_cache: bool) -> int:
         key = (path, use_file_cache)
@@ -661,8 +720,13 @@ class ExpertReader:
         *,
         max_gap_bytes: int | None = None,
         use_file_cache: bool = False,
-    ) -> Future[dict[Hashable, np.ndarray]]:
+    ) -> Future[dict[Hashable, np.ndarray]] | FastExpertLoadFuture:
         """Submit bounded CPU-only I/O and decoding for Metal overlap."""
+
+        if self.fast_resource_loading:
+            from .fast_resource import FastExpertLoadFuture
+
+            return FastExpertLoadFuture(self.begin_fast_many(locations, expert_ids))
 
         return self._request_pool.submit(
             self._read_many_numpy,

--- a/omlx/expert_streaming/safetensors.py
+++ b/omlx/expert_streaming/safetensors.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import struct
+import time
 from collections.abc import Hashable, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
@@ -447,6 +448,10 @@ class ExpertReader:
         self.read_operations = 0
         self.direct_read_operations = 0
         self.file_cache_read_operations = 0
+        self.io_seconds = 0.0
+        self.decode_seconds = 0.0
+        self.readahead_descriptors = 0
+        self.no_cache_descriptors = 0
         self._closed = False
 
     def _fd(self, path: Path, *, use_file_cache: bool) -> int:
@@ -455,14 +460,25 @@ class ExpertReader:
         if fd is None:
             fd = os.open(path, os.O_RDONLY)
             self._fds[key] = fd
-            no_cache = getattr(os, "F_NOCACHE", None)
-            if not use_file_cache and no_cache is not None:
-                try:
-                    import fcntl
+            try:
+                import fcntl
 
-                    fcntl.fcntl(fd, no_cache, 1)
-                except OSError:
-                    pass
+                if use_file_cache:
+                    read_ahead = getattr(fcntl, "F_RDAHEAD", None)
+                    if read_ahead is not None:
+                        fcntl.fcntl(fd, read_ahead, 1)
+                        self.readahead_descriptors += 1
+                else:
+                    no_cache = getattr(
+                        fcntl, "F_NOCACHE", getattr(os, "F_NOCACHE", None)
+                    )
+                    if no_cache is not None:
+                        fcntl.fcntl(fd, no_cache, 1)
+                        self.no_cache_descriptors += 1
+            except OSError:
+                # These are advisory Darwin hints. Unsupported filesystems and
+                # non-Darwin platforms should retain ordinary pread semantics.
+                pass
         return fd
 
     @staticmethod
@@ -543,7 +559,9 @@ class ExpertReader:
                 raise OSError(f"Short expert read from {path.name}")
             return key, first, payload
 
+        io_started = time.perf_counter()
         chunks = list(self._pool.map(read_range, tasks))
+        self.io_seconds += time.perf_counter() - io_started
         bytes_read = sum(len(payload) for _, _, payload in chunks)
         operations = len(chunks)
         self.bytes_read += bytes_read
@@ -560,6 +578,7 @@ class ExpertReader:
         for key, first, payload in chunks:
             grouped[key].append((first, payload))
 
+        decode_started = time.perf_counter()
         result: dict[Hashable, mx.array] = {}
         for key, location in locations.items():
             row_shape = location.shape[1:]
@@ -590,6 +609,7 @@ class ExpertReader:
             if location.dtype == "BF16":
                 array = array.view(mx.bfloat16)
             result[key] = array
+        self.decode_seconds += time.perf_counter() - decode_started
         return result
 
     def close(self) -> None:

--- a/omlx/expert_streaming/safetensors.py
+++ b/omlx/expert_streaming/safetensors.py
@@ -1,0 +1,274 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Small row-addressable safetensors reader used by expert streaming."""
+
+from __future__ import annotations
+
+import json
+import os
+import struct
+from collections.abc import Hashable, Mapping
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+
+import mlx.core as mx
+import numpy as np
+
+PROJECTIONS = ("gate_proj", "up_proj", "down_proj")
+PARTS = ("weight", "scales", "biases")
+
+_NUMPY_DTYPES = {
+    "U32": np.uint32,
+    "F32": np.float32,
+    "F16": np.float16,
+    "BF16": np.uint16,
+}
+
+
+@dataclass(frozen=True)
+class TensorLocation:
+    name: str
+    path: Path
+    dtype: str
+    shape: tuple[int, ...]
+    data_start: int
+    row_bytes: int
+
+    @property
+    def tensor_bytes(self) -> int:
+        return self.row_bytes * self.shape[0]
+
+
+class SafetensorExpertIndex:
+    """Index stacked ``switch_mlp`` tensors without mapping their payloads."""
+
+    def __init__(self, model_path: str | Path):
+        self.model_path = Path(model_path).expanduser().resolve()
+        index_path = self.model_path / "model.safetensors.index.json"
+        if not index_path.is_file():
+            raise ValueError("Expert streaming requires model.safetensors.index.json")
+        try:
+            self.weight_map = json.loads(index_path.read_text())["weight_map"]
+        except (OSError, KeyError, json.JSONDecodeError) as exc:
+            raise ValueError(f"Invalid safetensors index: {exc}") from exc
+        self._headers: dict[str, tuple[int, dict]] = {}
+        self._layer_locations: dict[int, dict[tuple[str, str], TensorLocation]] = {}
+
+    def _header(self, filename: str) -> tuple[int, dict]:
+        cached = self._headers.get(filename)
+        if cached is not None:
+            return cached
+        path = self.model_path / filename
+        with path.open("rb") as handle:
+            raw = handle.read(8)
+            if len(raw) != 8:
+                raise ValueError(f"Invalid safetensors header: {path}")
+            header_size = struct.unpack("<Q", raw)[0]
+            header = json.loads(handle.read(header_size))
+        cached = (8 + header_size, header)
+        self._headers[filename] = cached
+        return cached
+
+    def layer(self, layer: int) -> dict[tuple[str, str], TensorLocation]:
+        cached = self._layer_locations.get(layer)
+        if cached is not None:
+            return cached
+        marker = f"layers.{layer}.mlp.switch_mlp."
+        locations: dict[tuple[str, str], TensorLocation] = {}
+        for name, filename in self.weight_map.items():
+            # MTP checkpoints can contain ``mtp.layers.0`` alongside the
+            # backbone's real layer 0. Soft-REAP manifests describe backbone
+            # experts only, so never let the auxiliary predictor overwrite
+            # those locations.
+            if marker not in name or name.startswith("mtp.") or ".mtp." in name:
+                continue
+            for projection in PROJECTIONS:
+                for part in PARTS:
+                    if not name.endswith(f".{projection}.{part}"):
+                        continue
+                    data_base, header = self._header(filename)
+                    meta = header.get(name)
+                    if meta is None:
+                        raise ValueError(f"Tensor {name} is absent from {filename}")
+                    dtype = str(meta["dtype"])
+                    if dtype not in _NUMPY_DTYPES:
+                        raise ValueError(
+                            f"Unsupported streamed tensor dtype {dtype}: {name}"
+                        )
+                    shape = tuple(int(value) for value in meta["shape"])
+                    if len(shape) < 2 or shape[0] <= 0:
+                        raise ValueError(
+                            f"Expert tensor is not row-addressable: {name}"
+                        )
+                    start, end = (int(value) for value in meta["data_offsets"])
+                    total = end - start
+                    if total % shape[0]:
+                        raise ValueError(f"Expert tensor rows are uneven: {name}")
+                    locations[(projection, part)] = TensorLocation(
+                        name=name,
+                        path=self.model_path / filename,
+                        dtype=dtype,
+                        shape=shape,
+                        data_start=data_base + start,
+                        row_bytes=total // shape[0],
+                    )
+        required = {(projection, part) for projection in PROJECTIONS for part in PARTS}
+        missing = required - set(locations)
+        if missing:
+            raise ValueError(
+                f"Layer {layer} lacks stacked quantized expert tensors: {sorted(missing)}"
+            )
+        self._layer_locations[layer] = locations
+        return locations
+
+    def expert_bytes(self, layer: int) -> int:
+        return sum(location.row_bytes for location in self.layer(layer).values())
+
+    def tensor_bytes(self, layers: list[int] | tuple[int, ...]) -> int:
+        return sum(
+            location.tensor_bytes
+            for layer in layers
+            for location in self.layer(layer).values()
+        )
+
+
+class ExpertReader:
+    """Read selected expert rows with ``pread`` and bounded parallelism."""
+
+    def __init__(self, index: SafetensorExpertIndex, workers: int = 9):
+        self.index = index
+        self._fds: dict[tuple[Path, bool], int] = {}
+        self._pool = ThreadPoolExecutor(
+            max_workers=max(1, workers), thread_name_prefix="expert-ssd"
+        )
+        self.bytes_read = 0
+        self.direct_bytes_read = 0
+        self.file_cache_bytes_read = 0
+        self.read_operations = 0
+        self.direct_read_operations = 0
+        self.file_cache_read_operations = 0
+        self._closed = False
+
+    def _fd(self, path: Path, *, use_file_cache: bool) -> int:
+        key = (path, use_file_cache)
+        fd = self._fds.get(key)
+        if fd is None:
+            fd = os.open(path, os.O_RDONLY)
+            self._fds[key] = fd
+            no_cache = getattr(os, "F_NOCACHE", None)
+            if not use_file_cache and no_cache is not None:
+                try:
+                    import fcntl
+
+                    fcntl.fcntl(fd, no_cache, 1)
+                except OSError:
+                    pass
+        return fd
+
+    @staticmethod
+    def _ranges(
+        rows: list[int], row_bytes: int, max_gap_bytes: int
+    ) -> list[tuple[int, int]]:
+        ranges: list[tuple[int, int]] = []
+        start = previous = rows[0]
+        for row in rows[1:]:
+            gap = (row - previous - 1) * row_bytes
+            if gap > max_gap_bytes:
+                ranges.append((start, previous + 1))
+                start = row
+            previous = row
+        ranges.append((start, previous + 1))
+        return ranges
+
+    def read_rows(
+        self,
+        location: TensorLocation,
+        expert_ids: list[int] | tuple[int, ...],
+        *,
+        max_gap_bytes: int = 0,
+        use_file_cache: bool = False,
+    ) -> mx.array:
+        return self.read_many(
+            {"rows": location},
+            expert_ids,
+            max_gap_bytes=max_gap_bytes,
+            use_file_cache=use_file_cache,
+        )["rows"]
+
+    def read_many(
+        self,
+        locations: Mapping[Hashable, TensorLocation],
+        expert_ids: list[int] | tuple[int, ...],
+        *,
+        max_gap_bytes: int = 0,
+        use_file_cache: bool = False,
+    ) -> dict[Hashable, mx.array]:
+        """Read several expert components through one flat parallel I/O queue."""
+
+        requested = [int(value) for value in expert_ids]
+        if not requested:
+            raise ValueError("At least one expert row must be requested")
+        rows = sorted(set(requested))
+        tasks: list[tuple[Hashable, TensorLocation, int, int, int]] = []
+        for key, location in locations.items():
+            if min(requested) < 0 or max(requested) >= location.shape[0]:
+                raise ValueError(f"Expert row outside tensor {location.name}")
+            fd = self._fd(location.path, use_file_cache=use_file_cache)
+            for first, stop in self._ranges(rows, location.row_bytes, max_gap_bytes):
+                tasks.append((key, location, fd, first, stop))
+
+        def read_range(task) -> tuple[Hashable, int, bytes]:
+            key, location, fd, first, stop = task
+            size = (stop - first) * location.row_bytes
+            payload = os.pread(
+                fd, size, location.data_start + first * location.row_bytes
+            )
+            if len(payload) != size:
+                raise OSError(f"Short expert read from {location.path.name}")
+            return key, first, payload
+
+        chunks = list(self._pool.map(read_range, tasks))
+        bytes_read = sum(len(payload) for _, _, payload in chunks)
+        operations = len(chunks)
+        self.bytes_read += bytes_read
+        self.read_operations += operations
+        if use_file_cache:
+            self.file_cache_bytes_read += bytes_read
+            self.file_cache_read_operations += operations
+        else:
+            self.direct_bytes_read += bytes_read
+            self.direct_read_operations += operations
+        grouped: dict[Hashable, list[tuple[int, bytes]]] = {
+            key: [] for key in locations
+        }
+        for key, first, payload in chunks:
+            grouped[key].append((first, payload))
+
+        result: dict[Hashable, mx.array] = {}
+        for key, location in locations.items():
+            row_shape = location.shape[1:]
+            dtype = _NUMPY_DTYPES[location.dtype]
+            selected: dict[int, np.ndarray] = {}
+            for first, payload in grouped[key]:
+                count = len(payload) // location.row_bytes
+                values = np.frombuffer(payload, dtype=dtype).reshape(
+                    (count, *row_shape)
+                )
+                for row in rows:
+                    if first <= row < first + count:
+                        selected[row] = values[row - first]
+            output = np.stack([selected[row] for row in requested])
+            array = mx.array(output)
+            if location.dtype == "BF16":
+                array = array.view(mx.bfloat16)
+            result[key] = array
+        return result
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._pool.shutdown(wait=True, cancel_futures=True)
+        for fd in self._fds.values():
+            os.close(fd)
+        self._fds.clear()

--- a/omlx/model_profiles.py
+++ b/omlx/model_profiles.py
@@ -87,6 +87,12 @@ MODEL_SPECIFIC_PROFILE_FIELDS = (
     "specprefill_keep_pct",
     "specprefill_threshold",
     "index_cache_freq",
+    "expert_streaming_enabled",
+    "expert_streaming_mode",
+    "expert_streaming_manifest",
+    "expert_streaming_cache_experts",
+    "expert_streaming_substitution_threshold_percent",
+    "expert_streaming_execution_policy",
 )
 
 # Excluded — never stored in a profile or template.

--- a/omlx/model_profiles.py
+++ b/omlx/model_profiles.py
@@ -92,6 +92,7 @@ MODEL_SPECIFIC_PROFILE_FIELDS = (
     "expert_streaming_manifest",
     "expert_streaming_cache_experts",
     "expert_streaming_scratch_experts",
+    "expert_streaming_fast_resource_loading",
     "expert_streaming_substitution_threshold_percent",
     "expert_streaming_execution_policy",
 )

--- a/omlx/model_profiles.py
+++ b/omlx/model_profiles.py
@@ -91,6 +91,7 @@ MODEL_SPECIFIC_PROFILE_FIELDS = (
     "expert_streaming_mode",
     "expert_streaming_manifest",
     "expert_streaming_cache_experts",
+    "expert_streaming_scratch_experts",
     "expert_streaming_substitution_threshold_percent",
     "expert_streaming_execution_policy",
 )

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -227,6 +227,7 @@ class ModelSettings:
     expert_streaming_manifest: Optional[str] = None
     expert_streaming_cache_experts: int = 32
     expert_streaming_scratch_experts: int = 32
+    expert_streaming_fast_resource_loading: bool = False
     expert_streaming_substitution_threshold_percent: float = 0.0
     expert_streaming_execution_policy: str = "checked"
     preserve_thinking: Optional[bool] = (

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -220,6 +220,14 @@ class ModelSettings:
     # through mmap. The runtime may force this on when resident loading cannot
     # fit under the configured model-memory ceiling but mmap loading can.
     qwen4_ple_ssd_offload: bool = False
+    # Soft-REAP: keep manifest-selected routed experts resident and stream all
+    # remaining stacked quantized experts from their safetensor shards.
+    expert_streaming_enabled: bool = False
+    expert_streaming_mode: str = "soft_reap"
+    expert_streaming_manifest: Optional[str] = None
+    expert_streaming_cache_experts: int = 32
+    expert_streaming_substitution_threshold_percent: float = 0.0
+    expert_streaming_execution_policy: str = "checked"
     preserve_thinking: Optional[bool] = (
         None  # Keep <think> blocks in historical turns (None = auto, True when template supports it)
     )

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -226,6 +226,7 @@ class ModelSettings:
     expert_streaming_mode: str = "soft_reap"
     expert_streaming_manifest: Optional[str] = None
     expert_streaming_cache_experts: int = 32
+    expert_streaming_scratch_experts: int = 32
     expert_streaming_substitution_threshold_percent: float = 0.0
     expert_streaming_execution_policy: str = "checked"
     preserve_thinking: Optional[bool] = (

--- a/omlx/patches/qwen35_moe_router.py
+++ b/omlx/patches/qwen35_moe_router.py
@@ -206,9 +206,14 @@ def apply_qwen35_moe_router_patch() -> bool:
                 gates = mx.softmax(gates, axis=-1, precise=True)
                 inds, scores = fused_router_topk(gates, self.top_k)
 
-                y = vlm_moe._target_verify_switch_glu(
-                    self.switch_mlp, x, inds, target_verify
-                )
+                if getattr(self.switch_mlp, "_omlx_expert_streaming", False):
+                    # The streaming pool chunks wide MTP verification routes
+                    # as a whole GLU so each expert group is loaded once.
+                    y = self.switch_mlp(x, inds)
+                else:
+                    y = vlm_moe._target_verify_switch_glu(
+                        self.switch_mlp, x, inds, target_verify
+                    )
                 y = (y * scores[..., None]).sum(axis=-2)
 
                 shared_y = self.shared_expert(x, target_verify)

--- a/omlx/patches/qwen35_moe_weighted_sum.py
+++ b/omlx/patches/qwen35_moe_weighted_sum.py
@@ -62,6 +62,8 @@ def _should_route(self: Any, x: mx.array, target_verify: bool, min_tokens: int) 
     switch_mlp = getattr(self, "switch_mlp", None)
     if switch_mlp is None or not hasattr(switch_mlp, "down_proj"):
         return False
+    if getattr(switch_mlp, "_omlx_expert_streaming", False):
+        return False
     # Either the stock split projections or the omlx gate+up fused layout
     # (qwen35_moe_gate_up patch, issue #2238).
     return hasattr(switch_mlp, "gate_up_proj") or (

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,10 @@ def _custom_kernel_build_kwargs() -> dict:
     return {
         "ext_modules": [
             extension.CMakeExtension(
+                "omlx.custom_kernels.fast_resource_loading._ext",
+                sourcedir="omlx/custom_kernels/fast_resource_loading/csrc",
+            ),
+            extension.CMakeExtension(
                 "omlx.custom_kernels.bonsai._ext",
                 sourcedir="omlx/custom_kernels/bonsai/csrc",
             ),

--- a/tests/test_admin_model_settings.py
+++ b/tests/test_admin_model_settings.py
@@ -138,6 +138,20 @@ async def test_expert_streaming_execution_policy_is_persisted():
 
 
 @pytest.mark.asyncio
+async def test_expert_streaming_scratch_experts_is_persisted():
+    pool, _ = _failed_pool()
+    settings = ModelSettings()
+
+    await _update_settings(
+        pool,
+        settings,
+        admin_routes.ModelSettingsRequest(expert_streaming_scratch_experts=48),
+    )
+
+    assert settings.expert_streaming_scratch_experts == 48
+
+
+@pytest.mark.asyncio
 async def test_cache_only_streaming_does_not_require_manifest():
     pool, _ = _failed_pool()
     settings = ModelSettings()

--- a/tests/test_admin_model_settings.py
+++ b/tests/test_admin_model_settings.py
@@ -152,6 +152,22 @@ async def test_expert_streaming_scratch_experts_is_persisted():
 
 
 @pytest.mark.asyncio
+async def test_expert_streaming_fast_resource_loading_is_persisted():
+    pool, _ = _failed_pool()
+    settings = ModelSettings()
+
+    await _update_settings(
+        pool,
+        settings,
+        admin_routes.ModelSettingsRequest(
+            expert_streaming_fast_resource_loading=True
+        ),
+    )
+
+    assert settings.expert_streaming_fast_resource_loading is True
+
+
+@pytest.mark.asyncio
 async def test_cache_only_streaming_does_not_require_manifest():
     pool, _ = _failed_pool()
     settings = ModelSettings()

--- a/tests/test_admin_model_settings.py
+++ b/tests/test_admin_model_settings.py
@@ -122,6 +122,46 @@ async def test_sampling_setting_change_keeps_cached_failure():
 
 
 @pytest.mark.asyncio
+async def test_expert_streaming_execution_policy_is_persisted():
+    pool, _ = _failed_pool()
+    settings = ModelSettings()
+
+    await _update_settings(
+        pool,
+        settings,
+        admin_routes.ModelSettingsRequest(
+            expert_streaming_execution_policy="speculative"
+        ),
+    )
+
+    assert settings.expert_streaming_execution_policy == "speculative"
+
+
+@pytest.mark.asyncio
+async def test_cache_only_streaming_does_not_require_manifest():
+    pool, _ = _failed_pool()
+    settings = ModelSettings()
+
+    with patch(
+        "omlx.expert_streaming.residency.estimate_for_model_settings"
+    ) as estimate:
+        await _update_settings(
+            pool,
+            settings,
+            admin_routes.ModelSettingsRequest(
+                expert_streaming_enabled=True,
+                expert_streaming_mode="cache_only",
+                expert_streaming_manifest=None,
+            ),
+        )
+
+    assert settings.expert_streaming_enabled is True
+    assert settings.expert_streaming_mode == "cache_only"
+    assert settings.expert_streaming_manifest is None
+    estimate.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_qwen_ane_prefill_settings_are_persisted():
     pool, entry = _failed_pool()
     entry.config_model_type = "qwen3_5"
@@ -264,9 +304,7 @@ async def test_qwen_ane_prefill_rejects_invalid_block_size():
         await _update_settings(
             pool,
             ModelSettings(),
-            admin_routes.ModelSettingsRequest(
-                qwen35_ane_prefill_sequence_length=2000
-            ),
+            admin_routes.ModelSettingsRequest(qwen35_ane_prefill_sequence_length=2000),
         )
 
 
@@ -298,9 +336,7 @@ async def test_qwen_ane_prefill_rejects_fused_down_above_half_fraction():
         await _update_settings(
             pool,
             settings,
-            admin_routes.ModelSettingsRequest(
-                qwen35_ane_prefill_fused_down=True
-            ),
+            admin_routes.ModelSettingsRequest(qwen35_ane_prefill_fused_down=True),
         )
 
 

--- a/tests/test_admin_model_settings_template.py
+++ b/tests/test_admin_model_settings_template.py
@@ -167,6 +167,8 @@ def test_model_settings_feature_i18n_keys_exist_in_every_locale():
         "modal.model_settings.qwen_ane_tune_test",
         "modal.model_settings.qwen_ane_tune_throughput",
         "modal.model_settings.qwen_ane_tail_padding",
+        "modal.model_settings.expert_scratch",
+        "modal.model_settings.expert_scratch_hint",
     }
 
     for locale_path in sorted(i18n_dir.glob("*.json")):
@@ -202,6 +204,17 @@ def test_qwen_ane_model_specific_controls_are_fully_wired():
     assert 'placeholder="0.53"' in html
     assert 'placeholder="0.5"' in html
     assert "measured optimum" not in html
+
+
+def test_expert_streaming_cold_execution_bank_is_fully_wired():
+    html = _model_settings_template()
+    script = _dashboard_script()
+    field = "expert_streaming_scratch_experts"
+
+    assert f'modelSettings.{field}' in html
+    assert script.count(f"{field}:") >= 2
+    assert f"s.{field} ?? 32" in script
+    assert f"Number(this.modelSettings.{field}) || 0" in script
 
 
 def test_qwen_ane_numeric_controls_accept_arbitrary_valid_values():

--- a/tests/test_admin_model_settings_template.py
+++ b/tests/test_admin_model_settings_template.py
@@ -169,6 +169,8 @@ def test_model_settings_feature_i18n_keys_exist_in_every_locale():
         "modal.model_settings.qwen_ane_tail_padding",
         "modal.model_settings.expert_scratch",
         "modal.model_settings.expert_scratch_hint",
+        "modal.model_settings.expert_fast_resource_loading",
+        "modal.model_settings.expert_fast_resource_loading_hint",
     }
 
     for locale_path in sorted(i18n_dir.glob("*.json")):
@@ -215,6 +217,17 @@ def test_expert_streaming_cold_execution_bank_is_fully_wired():
     assert script.count(f"{field}:") >= 2
     assert f"s.{field} ?? 32" in script
     assert f"Number(this.modelSettings.{field}) || 0" in script
+
+
+def test_expert_streaming_fast_resource_loading_is_fully_wired():
+    html = _model_settings_template()
+    script = _dashboard_script()
+    field = "expert_streaming_fast_resource_loading"
+
+    assert f"modelSettings.{field}" in html
+    assert script.count(f"{field}:") >= 2
+    assert f"s.{field} === true" in script
+    assert f"!!this.modelSettings.{field}" in script
 
 
 def test_qwen_ane_numeric_controls_accept_arbitrary_valid_values():

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -505,6 +505,75 @@ class TestRunSingleTest:
         assert metrics["gen_tps"] < 1000.0
 
     @pytest.mark.asyncio
+    async def test_records_per_trial_expert_streaming_and_metal_metrics(self):
+        class InstrumentedEngine:
+            def __init__(self):
+                self.lookups = 100
+
+            def get_stats(self):
+                result = {
+                    "cache_slots_per_layer": 128,
+                    "layer_count": 48,
+                    "resident_experts": 6144,
+                    "resident_capacity": 6144,
+                    "execution_bank_slots": 32,
+                    "execution_banks_per_layer": 4,
+                    "hotlist_preloaded": 1536,
+                    "route_lookups": self.lookups,
+                    "cache_hits": self.lookups - 10,
+                    "cache_misses": 10,
+                    "evictions": 4,
+                    "loads": 10,
+                    "ssd_bytes_read": 4096,
+                    "ssd_io_seconds": 0.25,
+                    "bank_materialize_seconds": 0.5,
+                    "bank_group_calls": 12,
+                    "qmm_calls": 36,
+                }
+                return {"expert_streaming": result}
+
+            async def stream_generate(self, **kwargs):
+                self.lookups = 140
+                yield SimpleNamespace(
+                    completion_tokens=2,
+                    prompt_tokens=32,
+                    cached_tokens=0,
+                    new_text="xx",
+                    finished=True,
+                    finish_reason="length",
+                    prompt_tps=16.0,
+                    generation_tps=2.0,
+                )
+
+        with (
+            patch("omlx.admin.benchmark.mx.get_active_memory", side_effect=[11, 22]),
+            patch("omlx.admin.benchmark.mx.get_peak_memory", return_value=33),
+        ):
+            metrics = await _run_single_test(
+                InstrumentedEngine(),
+                prompt=[0] * 32,
+                max_tokens=2,
+                pp_len=32,
+            )
+
+        streaming = metrics["expert_streaming"]
+        assert streaming["route_lookups"] == 40
+        assert streaming["cache_hits"] == 40
+        assert streaming["cache_misses"] == 0
+        assert streaming["hit_rate"] == 1.0
+        assert streaming["cache_slots_per_layer"] == 128
+        assert streaming["execution_bank_slots"] == 32
+        assert streaming["execution_banks_per_layer"] == 4
+        assert streaming["hotlist_preloaded"] == 1536
+        assert streaming["resident_fill_rate"] == 1.0
+        assert streaming["hotlist_preload_fill_rate"] == 0.25
+        assert metrics["metal_memory"] == {
+            "active_start_bytes": 11,
+            "active_end_bytes": 22,
+            "peak_bytes": 33,
+        }
+
+    @pytest.mark.asyncio
     async def test_uses_diffusion_canvas_metrics_when_eos_stops_early(self):
         """Diffusion benchmark TG should measure canvas work, not early EOS text."""
 
@@ -617,7 +686,26 @@ class TestRunBatchTest:
                 )
 
         core = Core()
-        engine = SimpleNamespace(_engine=core)
+
+        class Engine:
+            _engine = core
+
+            def __init__(self):
+                self.snapshots = 0
+
+            def get_stats(self):
+                value = self.snapshots * 4
+                self.snapshots += 1
+                return {
+                    "expert_streaming": {
+                        "cache_slots_per_layer": 32,
+                        "cache_hits": value,
+                        "cache_misses": 0,
+                        "qmm_calls": value * 3,
+                    }
+                }
+
+        engine = Engine()
         prompts = [[row] * 1024 for row in (1, 2)]
 
         metrics = await _run_batch_test(
@@ -631,6 +719,9 @@ class TestRunBatchTest:
         assert list(core.prompts.values()) == prompts
         assert core.skip_cache_store == [True, True]
         assert metrics["batch_size"] == 2
+        assert metrics["expert_streaming"]["cache_hits"] == 4
+        assert metrics["expert_streaming"]["qmm_calls"] == 12
+        assert metrics["metal_memory"]["peak_bytes"] >= 0
 
     @pytest.mark.asyncio
     async def test_rejects_mismatched_prompt_before_submission(self):

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -519,6 +519,7 @@ class TestRunSingleTest:
                     "execution_bank_slots": 32,
                     "execution_banks_per_layer": 4,
                     "hotlist_preloaded": 1536,
+                    "optimistic_preloaded": 0,
                     "route_lookups": self.lookups,
                     "cache_hits": self.lookups - 10,
                     "cache_misses": 10,
@@ -565,8 +566,10 @@ class TestRunSingleTest:
         assert streaming["execution_bank_slots"] == 32
         assert streaming["execution_banks_per_layer"] == 4
         assert streaming["hotlist_preloaded"] == 1536
+        assert streaming["optimistic_preloaded"] == 0
         assert streaming["resident_fill_rate"] == 1.0
         assert streaming["hotlist_preload_fill_rate"] == 0.25
+        assert streaming["startup_preload_fill_rate"] == 0.25
         assert metrics["metal_memory"] == {
             "active_start_bytes": 11,
             "active_end_bytes": 22,

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -1378,6 +1378,27 @@ class TestEnginePoolAsync:
         assert pool._engine_runtime_signature("model-a", dflash) != pure_signature
         assert pool._engine_runtime_signature("model-a", vlm_mtp) != pure_signature
 
+    def test_fast_resource_loading_changes_expert_streaming_runtime_signature(
+        self, pool_with_mock_engines
+    ):
+        from omlx.model_settings import ModelSettings
+
+        pool = pool_with_mock_engines
+        baseline = ModelSettings(
+            expert_streaming_enabled=True,
+            expert_streaming_mode="cache_only",
+            expert_streaming_fast_resource_loading=False,
+        )
+        accelerated = ModelSettings(
+            expert_streaming_enabled=True,
+            expert_streaming_mode="cache_only",
+            expert_streaming_fast_resource_loading=True,
+        )
+
+        assert pool._engine_runtime_signature(
+            "model-a", baseline
+        ) != pool._engine_runtime_signature("model-a", accelerated)
+
     @pytest.mark.asyncio
     async def test_base_request_reloads_after_profile_variant(
         self, pool_with_mock_engines

--- a/tests/test_expert_streaming.py
+++ b/tests/test_expert_streaming.py
@@ -312,6 +312,39 @@ def test_cache_only_install_requires_no_manifest(tmp_path):
         runtime.close()
 
 
+def test_fast_resource_loading_writes_exact_preallocated_bank_rows(tmp_path):
+    from omlx.custom_kernels.fast_resource_loading import available
+
+    if not available():
+        pytest.skip("Fast Resource Loading native extension is not built")
+    full = _checkpoint(tmp_path)
+    model = _streamable_test_model()
+    runtime = install_expert_streaming(
+        model,
+        tmp_path,
+        None,
+        cache_experts=2,
+        scratch_experts=2,
+        streaming_mode="cache_only",
+        fast_resource_loading=True,
+    )
+    try:
+        indices = mx.array([[[4, 5]]], dtype=mx.int32)
+        x = mx.random.normal((1, 1, 64)).astype(mx.float16)
+        output = runtime.pools[0](x, indices)
+        expected = _reference(full, x, indices)
+        mx.eval(output, expected)
+        assert bool(mx.all(output == expected).item())
+        stats = runtime.stats()
+        assert stats["fast_resource_loading"] is True
+        assert stats["frl_loads"] >= 2
+        assert stats["frl_bytes_read"] > 0
+        assert stats["frl_read_operations"] > 0
+        assert stats["frl_copy_seconds"] >= 0
+    finally:
+        runtime.close()
+
+
 def test_learned_hotlist_warm_starts_evictable_cache(tmp_path):
     model_path = tmp_path / "model"
     profile_dir = tmp_path / "profiles"
@@ -423,10 +456,24 @@ def test_invalid_hotlist_profile_is_ignored(tmp_path):
 
 
 @pytest.mark.parametrize(
-    ("fragmented", "fused_gate_up"),
-    [(False, False), (True, False), (False, True)],
+    ("fragmented", "fused_gate_up", "fast_resource_loading"),
+    [
+        (False, False, False),
+        (True, False, False),
+        (False, True, False),
+        (False, False, True),
+        (True, False, True),
+        (False, True, True),
+    ],
 )
-def test_cross_family_ffn_mxfp4_streaming_is_exact(tmp_path, fragmented, fused_gate_up):
+def test_cross_family_ffn_mxfp4_streaming_is_exact(
+    tmp_path, fragmented, fused_gate_up, fast_resource_loading
+):
+    if fast_resource_loading:
+        from omlx.custom_kernels.fast_resource_loading import available
+
+        if not available():
+            pytest.skip("Fast Resource Loading native extension is not built")
     projections, modules = _family_checkpoint(
         tmp_path,
         container="ffn",
@@ -455,6 +502,7 @@ def test_cross_family_ffn_mxfp4_streaming_is_exact(tmp_path, fragmented, fused_g
         None,
         cache_experts=2,
         streaming_mode="cache_only",
+        fast_resource_loading=fast_resource_loading,
     )
     try:
         assert [pool.layer for pool in runtime.pools] == [1]

--- a/tests/test_expert_streaming.py
+++ b/tests/test_expert_streaming.py
@@ -10,6 +10,7 @@ import mlx.core as mx
 import pytest
 from mlx_lm.models.switch_layers import SwiGLU
 
+from omlx.expert_streaming.adapters import discover_moe_layers
 from omlx.expert_streaming.execution import CacheSnapshot, SpeculativeExecution
 from omlx.expert_streaming.integrate import install_expert_streaming
 from omlx.expert_streaming.manifest import (
@@ -71,6 +72,98 @@ def _reference(full, x, indices):
     up = projection("up_proj", expanded)
     gate = projection("gate_proj", expanded)
     return projection("down_proj", SwiGLU()(up, gate)).squeeze(-2)
+
+
+def _quantized_projection(dense, *, group_size, bits, mode):
+    weight, scales, *biases = mx.quantize(
+        dense, group_size=group_size, bits=bits, mode=mode
+    )
+    return SimpleNamespace(
+        weight=weight,
+        scales=scales,
+        biases=biases[0] if biases else None,
+        group_size=group_size,
+        bits=bits,
+        mode=mode,
+    )
+
+
+def _family_checkpoint(
+    path: Path,
+    *,
+    container: str,
+    fragmented: bool = False,
+    fused_gate_up: bool = False,
+):
+    experts = 4
+    projections = {}
+    for name, output, inputs in (
+        ("gate_proj", 32, 64),
+        ("up_proj", 32, 64),
+        ("down_proj", 64, 32),
+    ):
+        dense = mx.random.normal((experts, output, inputs)).astype(mx.float16)
+        projections[name] = _quantized_projection(
+            dense, group_size=32, bits=4, mode="mxfp4"
+        )
+    tensors = {}
+    if fused_gate_up:
+        gate = projections["gate_proj"]
+        up = projections["up_proj"]
+        fused = SimpleNamespace(
+            weight=mx.concatenate([gate.weight, up.weight], axis=1),
+            scales=mx.concatenate([gate.scales, up.scales], axis=1),
+            biases=None,
+            group_size=32,
+            bits=4,
+            mode="mxfp4",
+        )
+        modules = {"gate_up_proj": fused, "down_proj": projections["down_proj"]}
+    else:
+        modules = projections
+    if fragmented:
+        aliases = {"gate_proj": "w1", "down_proj": "w2", "up_proj": "w3"}
+        for projection, module in projections.items():
+            for expert in range(experts):
+                prefix = (
+                    f"model.layers.1.{container}.experts.{expert}."
+                    f"{aliases[projection]}"
+                )
+                tensors[f"{prefix}.weight"] = module.weight[expert]
+                tensors[f"{prefix}.scale"] = module.scales[expert]
+    else:
+        for projection, module in modules.items():
+            prefix = f"model.layers.1.{container}.switch_mlp.{projection}"
+            tensors[f"{prefix}.weight"] = module.weight
+            tensors[f"{prefix}.scales"] = module.scales
+    shard = "model-00001-of-00001.safetensors"
+    mx.save_safetensors(str(path / shard), tensors, metadata={"format": "mlx"})
+    (path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {key: shard for key in tensors}})
+    )
+    return projections, modules
+
+
+def _family_reference(projections, x, indices):
+    expanded = mx.expand_dims(x, (-2, -3))
+
+    def project(name, value):
+        module = projections[name]
+        return mx.gather_qmm(
+            value,
+            module.weight,
+            module.scales,
+            module.biases,
+            rhs_indices=indices,
+            transpose=True,
+            group_size=module.group_size,
+            bits=module.bits,
+            mode=module.mode,
+        )
+
+    up = project("up_proj", expanded)
+    gate = project("gate_proj", expanded)
+    return project("down_proj", SwiGLU()(up, gate)).squeeze(-2)
 
 
 def test_official_reap_layer_mapping_shape(tmp_path):
@@ -144,6 +237,97 @@ def test_cache_only_install_requires_no_manifest(tmp_path):
         assert runtime.pools[0].pinned_count == 0
     finally:
         runtime.close()
+
+
+@pytest.mark.parametrize(
+    ("fragmented", "fused_gate_up"),
+    [(False, False), (True, False), (False, True)],
+)
+def test_cross_family_ffn_mxfp4_streaming_is_exact(
+    tmp_path, fragmented, fused_gate_up
+):
+    projections, modules = _family_checkpoint(
+        tmp_path,
+        container="ffn",
+        fragmented=fragmented,
+        fused_gate_up=fused_gate_up,
+    )
+    switch = SimpleNamespace(activation=SwiGLU(), **modules)
+    moe = SimpleNamespace(
+        switch_mlp=switch,
+        gate=SimpleNamespace(top_k=2, num_experts=4),
+        config=SimpleNamespace(n_routed_experts=4, num_experts_per_tok=2),
+    )
+
+    class Model:
+        def __init__(self):
+            self.layers = [SimpleNamespace(ffn=object()), SimpleNamespace(ffn=moe)]
+
+        def __call__(self, inputs, cache=None):
+            del cache
+            return inputs
+
+    model = Model()
+    runtime = install_expert_streaming(
+        model,
+        tmp_path,
+        None,
+        cache_experts=2,
+        streaming_mode="cache_only",
+    )
+    try:
+        assert [pool.layer for pool in runtime.pools] == [1]
+        assert runtime.manifest.layers == {1: ()}
+        pool = runtime.pools[0]
+        assert all(
+            "arrays" not in metadata
+            for metadata in pool.projection_metadata.values()
+        )
+        indices = mx.array([[[0, 3]]], dtype=mx.int32)
+        x = mx.random.normal((1, 1, 64)).astype(mx.float16)
+        output = pool(x, indices)
+        expected = _family_reference(projections, x, indices)
+        mx.eval(output, expected)
+        assert bool(mx.all(output == expected).item())
+
+        scores = mx.array([[[0.25, 0.75]]], dtype=mx.float32)
+        combined = pool(x, indices, scores=scores, weighted_sum=True)
+        expected_combined = (
+            expected * scores[..., None].astype(expected.dtype)
+        ).sum(-2)
+        mx.eval(combined, expected_combined)
+        assert bool(mx.all(combined == expected_combined).item())
+    finally:
+        runtime.close()
+
+
+def test_adapter_discovers_common_moe_geometry_and_skips_dense_layers():
+    projection = SimpleNamespace(
+        weight=mx.zeros((8, 4, 2), dtype=mx.uint32),
+        scales=mx.zeros((8, 4, 1), dtype=mx.float16),
+        biases=mx.zeros((8, 4, 1), dtype=mx.float16),
+    )
+    switch = SimpleNamespace(
+        gate_proj=projection,
+        up_proj=projection,
+        down_proj=projection,
+    )
+    moe = SimpleNamespace(
+        switch_mlp=switch,
+        num_experts_per_tok=3,
+        router=SimpleNamespace(num_experts=8),
+    )
+    model = SimpleNamespace(
+        layers=[SimpleNamespace(mlp=object()), SimpleNamespace(mlp=moe)]
+    )
+
+    targets = discover_moe_layers(model)
+
+    assert len(targets) == 1
+    assert targets[0].layer_id == 1
+    assert targets[0].container_name == "mlp"
+    assert targets[0].num_experts == 8
+    assert targets[0].top_k == 3
 
 
 def test_resident_substitution_uses_relative_router_threshold():

--- a/tests/test_expert_streaming.py
+++ b/tests/test_expert_streaming.py
@@ -244,6 +244,10 @@ def test_cache_only_install_requires_no_manifest(tmp_path):
         assert runtime.streaming_mode == "cache_only"
         assert runtime.manifest.pinned_count_range == (0, 0)
         assert runtime.pools[0].pinned_count == 0
+        assert runtime.hotlist_preloaded == 0
+        assert runtime.optimistic_preloaded == 2
+        assert sum(runtime.pools[0].resident_mask.tolist()) == 2
+        assert not any(runtime.pools[0]._route_hotness)
     finally:
         runtime.close()
 
@@ -284,6 +288,7 @@ def test_learned_hotlist_warm_starts_evictable_cache(tmp_path):
     try:
         resident = second.pools[0].resident_mask.tolist()
         assert second.hotlist_preloaded == 2
+        assert second.optimistic_preloaded == 0
         assert second.pools[0].pinned_count == 0
         assert resident[4] is True
         assert resident[1] is True
@@ -340,8 +345,17 @@ def test_invalid_hotlist_profile_is_ignored(tmp_path):
     )
     try:
         assert second.hotlist_preloaded == 0
+        assert second.optimistic_preloaded == 2
         assert second.hotlist_profile_error.startswith("load:")
-        assert not any(second.pools[0].resident_mask.tolist())
+        assert second.pools[0].resident_mask.tolist() == [
+            True,
+            True,
+            False,
+            False,
+            False,
+            False,
+        ]
+        assert not any(second.pools[0]._route_hotness)
     finally:
         second.close()
 

--- a/tests/test_expert_streaming.py
+++ b/tests/test_expert_streaming.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import json
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 
 import mlx.core as mx
 import pytest
-from mlx_lm.models.switch_layers import SwiGLU
+from mlx_lm.models.switch_layers import SwiGLU, _gather_sort, _scatter_unsort
 
 from omlx.expert_streaming.adapters import discover_moe_layers
 from omlx.expert_streaming.execution import CacheSnapshot, SpeculativeExecution
@@ -52,8 +53,12 @@ def _checkpoint(path: Path, *, experts: int = 6, layers: int = 1):
     return full
 
 
-def _reference(full, x, indices):
+def _reference(full, x, indices, *, sort_routes=False):
     expanded = mx.expand_dims(x, (-2, -3))
+    routed_indices = indices
+    inv_order = None
+    if sort_routes:
+        expanded, routed_indices, inv_order = _gather_sort(expanded, indices)
 
     def projection(name, value):
         weight, scales, biases = full[(0, name)]
@@ -62,16 +67,20 @@ def _reference(full, x, indices):
             weight,
             scales,
             biases,
-            rhs_indices=indices,
+            rhs_indices=routed_indices,
             transpose=True,
             group_size=32,
             bits=4,
             mode="affine",
+            sorted_indices=sort_routes,
         )
 
     up = projection("up_proj", expanded)
     gate = projection("gate_proj", expanded)
-    return projection("down_proj", SwiGLU()(up, gate)).squeeze(-2)
+    output = projection("down_proj", SwiGLU()(up, gate))
+    if inv_order is not None:
+        output = _scatter_unsort(output, inv_order, indices.shape)
+    return output.squeeze(-2)
 
 
 def _quantized_projection(dense, *, group_size, bits, mode):
@@ -230,6 +239,57 @@ def test_cache_only_residency_requires_no_manifest(tmp_path):
     assert estimate.cache_slots_per_layer == 2
 
 
+def test_cold_reader_coalesces_small_gaps_without_affecting_direct_preload(tmp_path):
+    _checkpoint(tmp_path)
+    index = SafetensorExpertIndex(tmp_path)
+    cold = ExpertReader(index)
+    direct = ExpertReader(index)
+    try:
+        cold_rows = cold.read_many(index.layer(0), [0, 2], use_file_cache=True)
+        direct_rows = direct.read_many(index.layer(0), [0, 2], use_file_cache=False)
+        mx.eval(*cold_rows.values(), *direct_rows.values())
+        assert all(
+            bool(mx.all(cold_rows[key] == direct_rows[key]).item())
+            for key in cold_rows
+        )
+        assert cold.read_operations < direct.read_operations
+        assert cold.bytes_read > direct.bytes_read
+    finally:
+        cold.close()
+        direct.close()
+
+
+def test_async_reader_materializes_mlx_only_on_inference_thread(
+    tmp_path, monkeypatch
+):
+    _checkpoint(tmp_path)
+    index = SafetensorExpertIndex(tmp_path)
+    reader = ExpertReader(index)
+    inference_thread = threading.get_ident()
+    original_array = mx.array
+
+    def inference_thread_array(*args, **kwargs):
+        assert threading.get_ident() == inference_thread
+        return original_array(*args, **kwargs)
+
+    monkeypatch.setattr(mx, "array", inference_thread_array)
+    try:
+        locations = index.layer(0)
+        cpu_components = reader.read_many_async(
+            locations, [0, 2], use_file_cache=True
+        ).result()
+        assert all(type(value).__module__ == "numpy" for value in cpu_components.values())
+
+        arrays = reader.materialize_many(locations, cpu_components)
+        expected = reader.read_many(locations, [0, 2], use_file_cache=True)
+        mx.eval(*arrays.values(), *expected.values())
+        assert all(
+            bool(mx.all(arrays[key] == expected[key]).item()) for key in arrays
+        )
+    finally:
+        reader.close()
+
+
 def test_cache_only_install_requires_no_manifest(tmp_path):
     _checkpoint(tmp_path)
     model = _streamable_test_model()
@@ -308,9 +368,11 @@ def test_learned_hotlist_warm_starts_evictable_cache(tmp_path):
         assert stats["ssd_decode_seconds"] >= 0
         assert stats["bank_bind_seconds"] >= 0
         assert stats["bank_materialize_seconds"] >= 0
-        assert stats["qmm_calls"] == 3
-        assert stats["execution_bank_slots"] == 2
+        assert stats["qmm_calls"] == 2
+        assert stats["fused_gate_up"] is True
+        assert stats["execution_bank_slots"] == 6
         assert stats["execution_banks_per_layer"] == 1
+        assert stats["scratch_slots_per_layer"] == 4
         assert stats["resident_experts"] == 2
         assert stats["resident_capacity"] == 2
     finally:
@@ -530,6 +592,41 @@ def test_streaming_switch_glu_is_bit_exact(tmp_path, expert_major):
         reader.close()
 
 
+def test_resident_prefill_sorts_physical_slots_and_remains_bit_exact(tmp_path):
+    full = _checkpoint(tmp_path)
+    index = SafetensorExpertIndex(tmp_path)
+    reader = ExpertReader(index)
+    try:
+        pool = StreamingSwitchGLU(
+            layer=0,
+            num_experts=6,
+            top_k=2,
+            pinned_experts=(5, 2, 0, 4, 1, 3),
+            cache_slots=0,
+            locations=index.layer(0),
+            projection_metadata={
+                name: {"group_size": 32, "bits": 4, "mode": "affine"}
+                for name in ("gate_proj", "up_proj", "down_proj")
+            },
+            activation=SwiGLU(),
+            reader=reader,
+        )
+        route = [value % 6 for value in range(64)]
+        indices = mx.array(route, dtype=mx.int32).reshape(1, 32, 2)
+        x = mx.random.normal((1, 32, 64)).astype(mx.float16)
+
+        output = pool(x, indices)
+        expected = _reference(full, x, indices, sort_routes=True)
+        mx.eval(output, expected)
+
+        assert bool(mx.all(output == expected).item())
+        assert pool.stats.sorted_prefill_groups == 1
+        assert pool.stats.sorted_prefill_routes == 64
+        assert pool.stats.sorted_qmm_calls == 2
+    finally:
+        reader.close()
+
+
 def test_cache_only_switch_glu_is_bit_exact(tmp_path):
     full = _checkpoint(tmp_path)
     index = SafetensorExpertIndex(tmp_path)
@@ -593,6 +690,44 @@ def test_route_larger_than_hot_cache_chunks_without_evicting_itself(tmp_path):
 
         assert bool(mx.all(output == expected).item())
         assert pool.stats.expert_major_calls == 1
+    finally:
+        reader.close()
+
+
+def test_scratch_bank_executes_cold_prefill_without_polluting_hot_cache(tmp_path):
+    full = _checkpoint(tmp_path)
+    index = SafetensorExpertIndex(tmp_path)
+    reader = ExpertReader(index)
+    try:
+        pool = StreamingSwitchGLU(
+            layer=0,
+            num_experts=6,
+            top_k=2,
+            pinned_experts=(),
+            cache_slots=2,
+            scratch_slots=2,
+            locations=index.layer(0),
+            projection_metadata={
+                name: {"group_size": 32, "bits": 4, "mode": "affine"}
+                for name in ("gate_proj", "up_proj", "down_proj")
+            },
+            activation=SwiGLU(),
+            reader=reader,
+        )
+        pool.preload_hotlist([(0, 2), (1, 1)])
+        before = tuple(pool._dynamic_lru)
+        indices = mx.array([[[0, 1], [2, 3], [4, 5]]], dtype=mx.int32)
+        x = mx.random.normal((1, 3, 64)).astype(mx.float16)
+        output = pool(x, indices)
+        expected = _reference(full, x, indices)
+        mx.eval(output, expected)
+        assert bool(mx.all(output == expected).item())
+        assert tuple(pool._dynamic_lru) == before
+        assert pool.stats.scratch_loads == 4
+        assert pool.stats.evictions == 0
+        assert pool.stats.cache_hits == 2
+        assert pool.stats.cache_misses == 4
+        assert pool.bank_size == 4
     finally:
         reader.close()
 

--- a/tests/test_expert_streaming.py
+++ b/tests/test_expert_streaming.py
@@ -88,6 +88,40 @@ def _quantized_projection(dense, *, group_size, bits, mode):
     )
 
 
+def _streamable_test_model(*, experts: int = 6, top_k: int = 2):
+    projections = {}
+    for name, output, inputs in (
+        ("gate_proj", 32, 64),
+        ("up_proj", 32, 64),
+        ("down_proj", 64, 32),
+    ):
+        projections[name] = _quantized_projection(
+            mx.zeros((experts, output, inputs), dtype=mx.float16),
+            group_size=32,
+            bits=4,
+            mode="affine",
+        )
+    switch = SimpleNamespace(
+        **projections,
+        activation=SwiGLU(),
+    )
+    mlp = SimpleNamespace(
+        num_experts=experts,
+        top_k=top_k,
+        switch_mlp=switch,
+    )
+
+    class Model:
+        def __init__(self):
+            self.layers = [SimpleNamespace(mlp=mlp)]
+
+        def __call__(self, inputs, cache=None):
+            del cache
+            return inputs
+
+    return Model()
+
+
 def _family_checkpoint(
     path: Path,
     *,
@@ -199,31 +233,7 @@ def test_cache_only_residency_requires_no_manifest(tmp_path):
 
 def test_cache_only_install_requires_no_manifest(tmp_path):
     _checkpoint(tmp_path)
-
-    class Model:
-        def __init__(self):
-            projection = SimpleNamespace(
-                weight=mx.zeros((1, 1)),
-                scales=mx.zeros((1, 1)),
-                biases=mx.zeros((1, 1)),
-                group_size=32,
-                bits=4,
-                mode="affine",
-            )
-            switch = SimpleNamespace(
-                gate_proj=projection,
-                up_proj=projection,
-                down_proj=projection,
-                activation=SwiGLU(),
-            )
-            mlp = SimpleNamespace(num_experts=6, top_k=2, switch_mlp=switch)
-            self.layers = [SimpleNamespace(mlp=mlp)]
-
-        def __call__(self, inputs, cache=None):
-            del cache
-            return inputs
-
-    model = Model()
+    model = _streamable_test_model()
     runtime = install_expert_streaming(
         model,
         tmp_path,
@@ -237,6 +247,99 @@ def test_cache_only_install_requires_no_manifest(tmp_path):
         assert runtime.pools[0].pinned_count == 0
     finally:
         runtime.close()
+
+
+def test_learned_hotlist_warm_starts_evictable_cache(tmp_path):
+    model_path = tmp_path / "model"
+    profile_dir = tmp_path / "profiles"
+    model_path.mkdir()
+    full = _checkpoint(model_path)
+
+    first = install_expert_streaming(
+        _streamable_test_model(),
+        model_path,
+        None,
+        cache_experts=2,
+        streaming_mode="cache_only",
+        hotlist_profile_dir=profile_dir,
+    )
+    try:
+        for _ in range(5):
+            mx.eval(first.pools[0].ensure(mx.array([4], dtype=mx.int32)))
+        for _ in range(2):
+            mx.eval(first.pools[0].ensure(mx.array([1], dtype=mx.int32)))
+        mx.eval(first.pools[0].ensure(mx.array([3], dtype=mx.int32)))
+    finally:
+        first.close()
+
+    profiles = list(profile_dir.glob("*.json"))
+    assert len(profiles) == 1
+    second = install_expert_streaming(
+        _streamable_test_model(),
+        model_path,
+        None,
+        cache_experts=2,
+        streaming_mode="cache_only",
+        hotlist_profile_dir=profile_dir,
+    )
+    try:
+        resident = second.pools[0].resident_mask.tolist()
+        assert second.hotlist_preloaded == 2
+        assert second.pools[0].pinned_count == 0
+        assert resident[4] is True
+        assert resident[1] is True
+        assert second.pools[0].stats.warm_start_loads == 2
+        assert second.pools[0].stats.route_lookups == 0
+        bytes_after_preload = second.reader.bytes_read
+        indices = mx.array([[[4, 1]]], dtype=mx.int32)
+        x = mx.random.normal((1, 1, 64)).astype(mx.float16)
+        output = second.pools[0](x, indices)
+        expected = _reference(full, x, indices)
+        mx.eval(output, expected)
+        assert bool(mx.all(output == expected).item())
+        assert second.reader.bytes_read == bytes_after_preload
+        assert second.pools[0].stats.cache_hits == 2
+        stats = second.stats()
+        assert stats["ssd_io_seconds"] >= 0
+        assert stats["ssd_decode_seconds"] >= 0
+        assert stats["bank_bind_seconds"] >= 0
+        assert stats["bank_materialize_seconds"] >= 0
+    finally:
+        second.close()
+
+
+def test_invalid_hotlist_profile_is_ignored(tmp_path):
+    model_path = tmp_path / "model"
+    profile_dir = tmp_path / "profiles"
+    model_path.mkdir()
+    _checkpoint(model_path)
+    first = install_expert_streaming(
+        _streamable_test_model(),
+        model_path,
+        None,
+        cache_experts=2,
+        streaming_mode="cache_only",
+        hotlist_profile_dir=profile_dir,
+    )
+    profile_path = first.hotlist_profile_path
+    first.close()
+    assert profile_path is not None
+    profile_path.write_text("not json")
+
+    second = install_expert_streaming(
+        _streamable_test_model(),
+        model_path,
+        None,
+        cache_experts=2,
+        streaming_mode="cache_only",
+        hotlist_profile_dir=profile_dir,
+    )
+    try:
+        assert second.hotlist_preloaded == 0
+        assert second.hotlist_profile_error.startswith("load:")
+        assert not any(second.pools[0].resident_mask.tolist())
+    finally:
+        second.close()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_expert_streaming.py
+++ b/tests/test_expert_streaming.py
@@ -1,0 +1,451 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+from mlx_lm.models.switch_layers import SwiGLU
+
+from omlx.expert_streaming.execution import CacheSnapshot, SpeculativeExecution
+from omlx.expert_streaming.integrate import install_expert_streaming
+from omlx.expert_streaming.manifest import (
+    load_soft_reap_manifest,
+    validate_soft_reap_manifest_data,
+)
+from omlx.expert_streaming.pool import StreamingSwitchGLU
+from omlx.expert_streaming.residency import estimate_expert_streaming_residency
+from omlx.expert_streaming.routing import resident_preferred_topk
+from omlx.expert_streaming.safetensors import (
+    ExpertReader,
+    SafetensorExpertIndex,
+)
+
+
+def _checkpoint(path: Path, *, experts: int = 6, layers: int = 1):
+    tensors = {}
+    full = {}
+    for layer in range(layers):
+        for projection, output, inputs in (
+            ("gate_proj", 32, 64),
+            ("up_proj", 32, 64),
+            ("down_proj", 64, 32),
+        ):
+            dense = mx.random.normal((experts, output, inputs)).astype(mx.float16)
+            weight, scales, biases = mx.quantize(
+                dense, group_size=32, bits=4, mode="affine"
+            )
+            prefix = f"language_model.model.layers.{layer}.mlp.switch_mlp.{projection}"
+            tensors[f"{prefix}.weight"] = weight
+            tensors[f"{prefix}.scales"] = scales
+            tensors[f"{prefix}.biases"] = biases
+            full[(layer, projection)] = (weight, scales, biases)
+    shard = "model-00001-of-00001.safetensors"
+    mx.save_safetensors(str(path / shard), tensors, metadata={"format": "mlx"})
+    (path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {key: shard for key in tensors}})
+    )
+    return full
+
+
+def _reference(full, x, indices):
+    expanded = mx.expand_dims(x, (-2, -3))
+
+    def projection(name, value):
+        weight, scales, biases = full[(0, name)]
+        return mx.gather_qmm(
+            value,
+            weight,
+            scales,
+            biases,
+            rhs_indices=indices,
+            transpose=True,
+            group_size=32,
+            bits=4,
+            mode="affine",
+        )
+
+    up = projection("up_proj", expanded)
+    gate = projection("gate_proj", expanded)
+    return projection("down_proj", SwiGLU()(up, gate)).squeeze(-2)
+
+
+def test_official_reap_layer_mapping_shape(tmp_path):
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps({"0": [4, 1, 3], "1": [0, 2, 5]}))
+    manifest = load_soft_reap_manifest(path, num_layers=2, num_experts=6)
+    assert manifest.layers == {0: (1, 3, 4), 1: (0, 2, 5)}
+    assert manifest.pinned_count_range == (3, 3)
+
+
+def test_manifest_rejects_duplicates_and_missing_layers():
+    with pytest.raises(ValueError, match="duplicate"):
+        validate_soft_reap_manifest_data({"0": [1, 1]}, num_layers=1, num_experts=2)
+    with pytest.raises(ValueError, match="missing layers"):
+        validate_soft_reap_manifest_data({"0": [1]}, num_layers=2, num_experts=2)
+
+
+def test_cache_only_residency_requires_no_manifest(tmp_path):
+    _checkpoint(tmp_path)
+    estimate = estimate_expert_streaming_residency(
+        tmp_path,
+        None,
+        cache_experts=2,
+        num_layers=1,
+        num_experts=6,
+        top_k=2,
+        streaming_mode="cache_only",
+    )
+
+    assert estimate.pinned_bytes == 0
+    assert estimate.cache_slots_per_layer == 2
+
+
+def test_cache_only_install_requires_no_manifest(tmp_path):
+    _checkpoint(tmp_path)
+
+    class Model:
+        def __init__(self):
+            projection = SimpleNamespace(
+                weight=mx.zeros((1, 1)),
+                scales=mx.zeros((1, 1)),
+                biases=mx.zeros((1, 1)),
+                group_size=32,
+                bits=4,
+                mode="affine",
+            )
+            switch = SimpleNamespace(
+                gate_proj=projection,
+                up_proj=projection,
+                down_proj=projection,
+                activation=SwiGLU(),
+            )
+            mlp = SimpleNamespace(num_experts=6, top_k=2, switch_mlp=switch)
+            self.layers = [SimpleNamespace(mlp=mlp)]
+
+        def __call__(self, inputs, cache=None):
+            del cache
+            return inputs
+
+    model = Model()
+    runtime = install_expert_streaming(
+        model,
+        tmp_path,
+        None,
+        cache_experts=2,
+        streaming_mode="cache_only",
+    )
+    try:
+        assert runtime.streaming_mode == "cache_only"
+        assert runtime.manifest.pinned_count_range == (0, 0)
+        assert runtime.pools[0].pinned_count == 0
+    finally:
+        runtime.close()
+
+
+def test_resident_substitution_uses_relative_router_threshold():
+    gates = mx.array([[0.40, 0.35, 0.20, 0.05]], dtype=mx.float32)
+    resident = mx.array([False, True, True, False])
+
+    below, _ = resident_preferred_topk(gates, resident, top_k=1, threshold_percent=10)
+    above, scores = resident_preferred_topk(
+        gates, resident, top_k=1, threshold_percent=15
+    )
+    resident_only, _ = resident_preferred_topk(
+        gates, resident, top_k=2, threshold_percent=100
+    )
+    mx.eval(below, above, scores, resident_only)
+
+    assert int(below.item()) == 0
+    assert int(above.item()) == 1
+    assert float(scores.item()) == pytest.approx(1.0)
+    assert set(resident_only.tolist()[0]) == {1, 2}
+
+
+def test_reader_returns_exact_selected_rows(tmp_path):
+    full = _checkpoint(tmp_path)
+    index = SafetensorExpertIndex(tmp_path)
+    reader = ExpertReader(index)
+    try:
+        rows = reader.read_rows(index.layer(0)[("gate_proj", "weight")], [5, 0, 3])
+        expected = full[(0, "gate_proj")][0][[5, 0, 3]]
+        mx.eval(rows, expected)
+        assert bool(mx.all(rows == expected).item())
+    finally:
+        reader.close()
+
+
+def test_index_ignores_mtp_layer_zero_experts(tmp_path):
+    _checkpoint(tmp_path)
+    index_path = tmp_path / "model.safetensors.index.json"
+    weight_map = json.loads(index_path.read_text())["weight_map"]
+    shard = next(iter(weight_map.values()))
+    for projection in ("gate_proj", "up_proj", "down_proj"):
+        for part in ("weight", "scales", "biases"):
+            weight_map[f"mtp.layers.0.mlp.switch_mlp.{projection}.{part}"] = shard
+    index_path.write_text(json.dumps({"weight_map": weight_map}))
+
+    locations = SafetensorExpertIndex(tmp_path).layer(0)
+
+    assert all(not location.name.startswith("mtp.") for location in locations.values())
+
+
+@pytest.mark.parametrize("expert_major", [False, True])
+def test_streaming_switch_glu_is_bit_exact(tmp_path, expert_major):
+    full = _checkpoint(tmp_path)
+    index = SafetensorExpertIndex(tmp_path)
+    reader = ExpertReader(index)
+    try:
+        pool = StreamingSwitchGLU(
+            layer=0,
+            num_experts=6,
+            top_k=2,
+            pinned_experts=(0,),
+            cache_slots=2 if expert_major else 5,
+            locations=index.layer(0),
+            projection_metadata={
+                name: {"group_size": 32, "bits": 4, "mode": "affine"}
+                for name in ("gate_proj", "up_proj", "down_proj")
+            },
+            activation=SwiGLU(),
+            reader=reader,
+        )
+        indices = (
+            mx.array([[[0, 1], [2, 3], [4, 5]]], dtype=mx.int32)
+            if expert_major
+            else mx.array([[[0, 1], [2, 3]]], dtype=mx.int32)
+        )
+        x = mx.random.normal((*indices.shape[:-1], 64)).astype(mx.float16)
+        output = pool(x, indices)
+        expected = _reference(full, x, indices)
+        mx.eval(output, expected)
+        assert bool(mx.all(output == expected).item())
+        assert pool.stats.expert_major_calls == int(expert_major)
+    finally:
+        reader.close()
+
+
+def test_cache_only_switch_glu_is_bit_exact(tmp_path):
+    full = _checkpoint(tmp_path)
+    index = SafetensorExpertIndex(tmp_path)
+    reader = ExpertReader(index)
+    try:
+        pool = StreamingSwitchGLU(
+            layer=0,
+            num_experts=6,
+            top_k=2,
+            pinned_experts=(),
+            cache_slots=2,
+            locations=index.layer(0),
+            projection_metadata={
+                name: {"group_size": 32, "bits": 4, "mode": "affine"}
+                for name in ("gate_proj", "up_proj", "down_proj")
+            },
+            activation=SwiGLU(),
+            reader=reader,
+        )
+        indices = mx.array([[[2, 5]]], dtype=mx.int32)
+        x = mx.random.normal((1, 1, 64)).astype(mx.float16)
+        output = pool(x, indices)
+        expected = _reference(full, x, indices)
+        mx.eval(output, expected)
+
+        assert pool.pinned_count == 0
+        assert bool(mx.all(output == expected).item())
+    finally:
+        reader.close()
+
+
+def test_route_larger_than_hot_cache_chunks_without_evicting_itself(tmp_path):
+    full = _checkpoint(tmp_path)
+    index = SafetensorExpertIndex(tmp_path)
+    reader = ExpertReader(index)
+    try:
+        pool = StreamingSwitchGLU(
+            layer=0,
+            num_experts=6,
+            top_k=2,
+            pinned_experts=(),
+            cache_slots=2,
+            locations=index.layer(0),
+            projection_metadata={
+                name: {"group_size": 32, "bits": 4, "mode": "affine"}
+                for name in ("gate_proj", "up_proj", "down_proj")
+            },
+            activation=SwiGLU(),
+            reader=reader,
+        )
+        # Prime two experts so the next route has only two misses, but needs
+        # four unpinned experts in total. The old miss-count check evicted an
+        # expert protected by this same route and then raised KeyError.
+        mx.eval(pool.ensure(mx.array([[0, 1]], dtype=mx.int32)))
+        indices = mx.array([[[0, 1], [2, 3]]], dtype=mx.int32)
+        x = mx.random.normal((1, 2, 64)).astype(mx.float16)
+
+        output = pool(x, indices)
+        expected = _reference(full, x, indices)
+        mx.eval(output, expected)
+
+        assert bool(mx.all(output == expected).item())
+        assert pool.stats.expert_major_calls == 1
+    finally:
+        reader.close()
+
+
+def test_direct_projection_helper_chunks_oversized_route(tmp_path):
+    full = _checkpoint(tmp_path)
+    index = SafetensorExpertIndex(tmp_path)
+    reader = ExpertReader(index)
+    try:
+        pool = StreamingSwitchGLU(
+            layer=0,
+            num_experts=6,
+            top_k=2,
+            pinned_experts=(),
+            cache_slots=2,
+            locations=index.layer(0),
+            projection_metadata={
+                name: {"group_size": 32, "bits": 4, "mode": "affine"}
+                for name in ("gate_proj", "up_proj", "down_proj")
+            },
+            activation=SwiGLU(),
+            reader=reader,
+        )
+        mx.eval(pool.ensure(mx.array([[0, 1]], dtype=mx.int32)))
+        indices = mx.array([[[0, 1], [2, 3]]], dtype=mx.int32)
+        x = mx.random.normal((1, 2, 64)).astype(mx.float16)
+        flat_indices = indices.reshape(2, 2)
+        flat_x = mx.expand_dims(x.reshape(2, 64), (-2, -3))
+
+        up = pool.up_proj(flat_x, flat_indices, sorted_indices=False)
+        gate = pool.gate_proj(flat_x, flat_indices, sorted_indices=False)
+        output = pool.down_proj(
+            pool.activation(up, gate), flat_indices, sorted_indices=False
+        ).squeeze(-2).reshape(1, 2, 2, -1)
+        expected = _reference(full, x, indices)
+        mx.eval(output, expected)
+
+        assert bool(mx.all(output == expected).item())
+        assert pool.stats.expert_major_calls == 3
+    finally:
+        reader.close()
+
+
+def test_route_frequency_cache_retains_frequent_expert(tmp_path):
+    _checkpoint(tmp_path)
+    index = SafetensorExpertIndex(tmp_path)
+    reader = ExpertReader(index)
+    try:
+        pool = StreamingSwitchGLU(
+            layer=0,
+            num_experts=6,
+            top_k=1,
+            pinned_experts=(),
+            cache_slots=2,
+            locations=index.layer(0),
+            projection_metadata={
+                name: {"group_size": 32, "bits": 4, "mode": "affine"}
+                for name in ("gate_proj", "up_proj", "down_proj")
+            },
+            activation=SwiGLU(),
+            reader=reader,
+            cache_policy="route_frequency",
+        )
+        for _ in range(5):
+            mx.eval(pool.ensure(mx.array([0], dtype=mx.int32)))
+        mx.eval(pool.ensure(mx.array([1], dtype=mx.int32)))
+        mx.eval(pool.ensure(mx.array([2], dtype=mx.int32)))
+
+        resident = pool.resident_mask.tolist()
+        assert resident[0] is True
+        assert resident[1] is False
+        assert resident[2] is True
+    finally:
+        reader.close()
+
+
+def test_cache_snapshot_restores_nested_cache_metadata():
+    class Cache:
+        def __init__(self):
+            self.offset = 7
+            self.cache = [mx.array([1]), mx.array([2])]
+
+    cache = Cache()
+    original = cache.cache[0]
+    caches = [cache]
+    snapshot = CacheSnapshot(caches)
+    cache.offset = 8
+    cache.cache[0] = mx.array([99])
+    caches[0] = object()
+
+    snapshot.restore()
+
+    assert cache.offset == 7
+    assert cache.cache[0] is original
+    assert caches == [cache]
+
+
+def test_speculative_miss_rolls_back_promotes_and_retries_exactly(tmp_path):
+    full = _checkpoint(tmp_path)
+    index = SafetensorExpertIndex(tmp_path)
+    reader = ExpertReader(index)
+    pool = StreamingSwitchGLU(
+        layer=0,
+        num_experts=6,
+        top_k=2,
+        pinned_experts=(0,),
+        cache_slots=2,
+        locations=index.layer(0),
+        projection_metadata={
+            name: {"group_size": 32, "bits": 4, "mode": "affine"}
+            for name in ("gate_proj", "up_proj", "down_proj")
+        },
+        activation=SwiGLU(),
+        reader=reader,
+    )
+
+    class Cache:
+        offset = 0
+
+    class Model:
+        def __init__(self):
+            self.indices = mx.array([[[0, 0]]], dtype=mx.int32)
+            self.x = mx.random.normal((1, 1, 64)).astype(mx.float16)
+
+        def __call__(self, input_ids, cache=None):
+            del input_ids
+            if cache is not None:
+                cache.offset += 1
+            return pool(self.x, self.indices)
+
+    class Runtime:
+        pools = [pool]
+
+    model = Model()
+    cache = Cache()
+    execution = SpeculativeExecution(Runtime(), policy="speculative")
+    execution.attach(model)
+    try:
+        # The first pass is intentionally checked so a one-token prompt cannot
+        # trigger a cascade of speculative cold misses.
+        mx.eval(model(mx.array([[1]]), cache=cache))
+        assert cache.offset == 1
+
+        model.indices = mx.array([[[0, 5]]], dtype=mx.int32)
+        result = model(mx.array([[2]]), cache=cache)
+        expected = _reference(full, model.x, model.indices)
+        mx.eval(result, expected)
+
+        assert bool(mx.all(result == expected).item())
+        assert cache.offset == 2
+        assert execution.stats.speculative_passes == 2
+        assert execution.stats.speculative_retries == 1
+        assert execution.stats.speculative_hits == 1
+        assert execution.stats.speculative_fallbacks == 0
+        assert pool.stats.cold_loads == 1
+    finally:
+        execution.close()
+        reader.close()

--- a/tests/test_expert_streaming.py
+++ b/tests/test_expert_streaming.py
@@ -160,8 +160,7 @@ def _family_checkpoint(
         for projection, module in projections.items():
             for expert in range(experts):
                 prefix = (
-                    f"model.layers.1.{container}.experts.{expert}."
-                    f"{aliases[projection]}"
+                    f"model.layers.1.{container}.experts.{expert}.{aliases[projection]}"
                 )
                 tensors[f"{prefix}.weight"] = module.weight[expert]
                 tensors[f"{prefix}.scale"] = module.scales[expert]
@@ -304,6 +303,11 @@ def test_learned_hotlist_warm_starts_evictable_cache(tmp_path):
         assert stats["ssd_decode_seconds"] >= 0
         assert stats["bank_bind_seconds"] >= 0
         assert stats["bank_materialize_seconds"] >= 0
+        assert stats["qmm_calls"] == 3
+        assert stats["execution_bank_slots"] == 2
+        assert stats["execution_banks_per_layer"] == 1
+        assert stats["resident_experts"] == 2
+        assert stats["resident_capacity"] == 2
     finally:
         second.close()
 
@@ -346,9 +350,7 @@ def test_invalid_hotlist_profile_is_ignored(tmp_path):
     ("fragmented", "fused_gate_up"),
     [(False, False), (True, False), (False, True)],
 )
-def test_cross_family_ffn_mxfp4_streaming_is_exact(
-    tmp_path, fragmented, fused_gate_up
-):
+def test_cross_family_ffn_mxfp4_streaming_is_exact(tmp_path, fragmented, fused_gate_up):
     projections, modules = _family_checkpoint(
         tmp_path,
         container="ffn",
@@ -383,8 +385,7 @@ def test_cross_family_ffn_mxfp4_streaming_is_exact(
         assert runtime.manifest.layers == {1: ()}
         pool = runtime.pools[0]
         assert all(
-            "arrays" not in metadata
-            for metadata in pool.projection_metadata.values()
+            "arrays" not in metadata for metadata in pool.projection_metadata.values()
         )
         indices = mx.array([[[0, 3]]], dtype=mx.int32)
         x = mx.random.normal((1, 1, 64)).astype(mx.float16)
@@ -395,9 +396,9 @@ def test_cross_family_ffn_mxfp4_streaming_is_exact(
 
         scores = mx.array([[[0.25, 0.75]]], dtype=mx.float32)
         combined = pool(x, indices, scores=scores, weighted_sum=True)
-        expected_combined = (
-            expected * scores[..., None].astype(expected.dtype)
-        ).sum(-2)
+        expected_combined = (expected * scores[..., None].astype(expected.dtype)).sum(
+            -2
+        )
         mx.eval(combined, expected_combined)
         assert bool(mx.all(combined == expected_combined).item())
     finally:
@@ -609,9 +610,13 @@ def test_direct_projection_helper_chunks_oversized_route(tmp_path):
 
         up = pool.up_proj(flat_x, flat_indices, sorted_indices=False)
         gate = pool.gate_proj(flat_x, flat_indices, sorted_indices=False)
-        output = pool.down_proj(
-            pool.activation(up, gate), flat_indices, sorted_indices=False
-        ).squeeze(-2).reshape(1, 2, 2, -1)
+        output = (
+            pool.down_proj(
+                pool.activation(up, gate), flat_indices, sorted_indices=False
+            )
+            .squeeze(-2)
+            .reshape(1, 2, 2, -1)
+        )
         expected = _reference(full, x, indices)
         mx.eval(output, expected)
 
@@ -716,23 +721,36 @@ def test_speculative_miss_rolls_back_promotes_and_retries_exactly(tmp_path):
     execution = SpeculativeExecution(Runtime(), policy="speculative")
     execution.attach(model)
     try:
-        # The first pass is intentionally checked so a one-token prompt cannot
-        # trigger a cascade of speculative cold misses.
+        # Speculation remains gated while the dynamic cache is only partially
+        # populated, even after the mandatory first checked pass.
+        model.indices = mx.array([[[0, 1]]], dtype=mx.int32)
         mx.eval(model(mx.array([[1]]), cache=cache))
         assert cache.offset == 1
 
+        model.indices = mx.array([[[0, 2]]], dtype=mx.int32)
+        mx.eval(model(mx.array([[2]]), cache=cache))
+        assert cache.offset == 2
+        assert pool.cache_full is True
+        assert execution.stats.checked_passes == 2
+        assert execution.stats.fill_gated_passes == 1
+
         model.indices = mx.array([[[0, 5]]], dtype=mx.int32)
-        result = model(mx.array([[2]]), cache=cache)
+        cold_loads = pool.stats.cold_loads
+        materialize_seconds = pool.stats.bank_materialize_seconds
+        result = model(mx.array([[3]]), cache=cache)
         expected = _reference(full, model.x, model.indices)
         mx.eval(result, expected)
 
         assert bool(mx.all(result == expected).item())
-        assert cache.offset == 2
+        assert cache.offset == 3
         assert execution.stats.speculative_passes == 2
         assert execution.stats.speculative_retries == 1
         assert execution.stats.speculative_hits == 1
         assert execution.stats.speculative_fallbacks == 0
-        assert pool.stats.cold_loads == 1
+        assert pool.stats.cold_loads == cold_loads + 1
+        # Promotion commits only routing maps. The retry consumes the lazy bank
+        # writes without a redundant explicit bank materialization.
+        assert pool.stats.bank_materialize_seconds == materialize_seconds
     finally:
         execution.close()
         reader.close()


### PR DESCRIPTION
# SSD Expert Streaming and Soft-REAP for MoE models

## Summary

This branch adds SSD Expert Streaming for quantized Mixture-of-Experts models. Routed experts are held in fixed, preallocated MLX banks containing manifest-pinned experts plus a configurable number of evictable hot experts. Experts outside those banks remain in their original safetensor shards and are loaded on demand.

Two residency modes are available:

- **Soft-REAP pinning** keeps the experts selected by an uploaded REAP manifest permanently resident and uses the remaining bank slots as a hot cache.
- **Analytical cache only** pins no routed experts and manages the entire bank from observed router selections.

At a `0%` substitution threshold, the streamed path preserves the model's original expert routing and produces bit-exact expert outputs.

## Runtime and storage

- Adds a row-addressable safetensor index and SSD reader that accesses expert weights, scales, quantization biases, and explicit biases without mapping complete expert tensors into memory.
- Supports stacked and per-expert checkpoint layouts, separate and fused gate/up projections, projection aliases such as `w1`/`w2`/`w3`, and affine, MXFP4, and NVFP4 quantization metadata.
- Preallocates fixed-shape per-layer expert banks so cache promotion and eviction do not change MLX graph shapes or allocate replacement banks.
- Configures cache capacity as an expert count per layer and always reserves at least the model's routed top-k working set.
- Uses expert-major chunking when a routed batch requires more non-pinned experts than the hot tier can hold concurrently.
- Fully populates the user-configured hot tier at model load. Learned hotlist experts are loaded first; unused capacity is filled optimistically with zero-hotness, fully evictable experts so additional RAM immediately provides route coverage without creating implicit pins or narrowing execution.
- Provides checked and speculative execution policies. Speculation remains checked until every layer's hot tier reaches capacity, then keeps resident-hit routing in the MLX graph and transactionally restores KV/SSM cache state before promoting a missed expert and retrying. Readiness is latched, and promoted bank writes are materialized lazily by the retry's first QMM rather than by a redundant eager bank commit.
- Adds optional Qwen-family resident substitution: a resident expert may replace an unloaded expert when its original router weight is within the configured percentage threshold. Selected router weights are retained and renormalized.
- Records runtime statistics for hits, misses, promotions, evictions, fill-gated passes, speculative retries, QMM projection invocations, SSD bytes and operations, SSD I/O time, payload decoding, bank binding, and materialization.

## Model support

- Discovers routed layers under both `mlp` and `ffn`, preserves physical model-layer IDs, and skips dense layers.
- Normalizes expert count and top-k geometry across common router and configuration field names.
- Supports the SwitchGLU layouts used by Qwen 3.5/3.8/4-Exp, DeepSeek V3.2/V4, GLM MoE/GLM5, MiMo-v2, Hy-v3, Laguna, Bailing Hybrid, compatible MiniMax variants, and related models using the same layouts.
- Integrates streamed execution with Qwen target-verification and weighted-sum router paths so MTP and wide verification batches use the cache-aware whole-GLU path.

## Cache management and DwarfStar attribution

The following cache and SSD-I/O optimisations are adapted from [DwarfStar by stefandsl](https://github.com/stefandsl/DwarfStar/tree/80ebbc3):

- Decayed route-frequency scoring with recency as an eviction tie-break.
- Accounting for selected experts on both cache hits and misses.
- Protection of experts used by the current route from eviction.
- Reuse of fixed cache slots and a persistent parallel `pread` worker pool.
- Darwin read-ahead hints for cacheable cold reads.
- Learned per-layer popularity hotlists that warm ordinary evictable slots on later model loads.

Hotlist profiles are compact, checkpoint-fingerprinted, and written atomically to the configured SSD cache directory. Missing, stale, or malformed profiles use optimistic zero-hotness entries to fill the configured capacity. Loading never changes the configured expert count, pins additional experts, or increases the preallocated resident bank size.

## Settings and administration

- Adds **SSD Expert Streaming** to both the web and native Swift model settings with controls for residency mode, manifest upload, hot experts per layer, execution policy, substitution threshold, and projected resident memory.
- Validates uploaded manifests against the checkpoint's routed layer IDs, expert range, tensor layout, duplicate IDs, and a 2 MiB upload limit before storing them by content hash.
- Accepts official REAP layer maps and the wrapped `layers`, `pinned_experts`, and `kept_experts` forms.
- Adds header-only residency estimates for the fixed model state, pinned experts, and hot cache, including the minimum safe cache size.
- Uses the projected streamed residency in engine admission and model-memory-ceiling decisions, including Qwen4 PLE residency handling.
- Includes the new settings in model profiles and load-affecting engine signatures.
- Adds localized UI strings for every existing dashboard locale.

## Documentation and validation

- Adds `docs/soft_reap.md` covering residency modes, manifests, supported layouts, routing behavior, execution policies, memory estimates, and runtime metrics.
- Adds `benchmarks/soft_reap_streaming.py` for checkpoint residency, load, generation, and streaming-stat measurements.
- Adds a bounded synthetic microbenchmark for lazy promotion, fill-gated speculation, cache-capacity scaling, optimistic preload, and prefill expert-group behavior. It exercises the real safetensor reader, quantized expert banks, streaming cache, and speculative executor while checking exact outputs and reporting latency, throughput, retries, SSD traffic, and peak Metal memory without loading a production checkpoint.
- Adds per-trial SSD Expert Streaming telemetry to local throughput benchmarks. Single-request and batch results contain counter deltas for cache hits and misses, evictions, expert loads, SSD traffic and timing, bank update timing, expert-major and QMM calls, resident fill, learned and optimistic preload coverage, and active/peak Metal memory. Logs explicitly warn when an analytical-cache benchmark has incomplete learned coverage so unlike cache states are not compared as equivalent runs.
- Adds synthetic checkpoint tests for manifest validation, cache-only operation, fixed-bank streaming, exact outputs, expert-major execution, route-frequency eviction, speculative rollback/retry, learned hotlist persistence, malformed-profile handling, fused projections, fragmented checkpoints, and cross-family adapters.
- The relevant regression suite passes **372 tests** across expert streaming, throughput benchmarking, DeepSeek V4, GLM MoE/DSA, MiMo-v2, Hy-v3, Laguna, Qwen MoE, and Qwen4 residency coverage.
- The focused native model-settings suite passes **18 tests**, including wire-format and profile-assembly coverage for Soft-REAP and cache-only modes.
