### PR TITLE
feat(glm5): add exact DFlash2 speculative decoding

### DIFF
--- a/docs/experimental/dflash_mlx_integration.md
+++ b/docs/experimental/dflash_mlx_integration.md
@@ -129,7 +129,9 @@ DSA `CacheList(KVCache, PoolingCache)`. Image/video requests retain the normal
 evict-and-VLM-fallback behavior. DDTree, target KV quantization, specialized
 verify linears, and DFlash L1/L2 prefix snapshots are disabled for this target
 until their GLM composite-cache and numerical-parity suites pass. Adaptive
-linear DFlash verification remains available. The published checkpoint is
+linear DFlash verification remains available. Cold prefill still follows the
+runtime `prefill_step_size`; chunking is kept independent from snapshot
+hydration or publication for this target. The published checkpoint is
 CC BY-NC-ND 4.0; oMLX neither bundles nor automatically downloads its weights.
 
 ### Per-model settings

--- a/docs/experimental/dflash_mlx_integration.md
+++ b/docs/experimental/dflash_mlx_integration.md
@@ -64,16 +64,17 @@ DFlashEngine is a `BaseEngine` implementation that:
 | `omlx/admin/benchmark.py` | Batch test skip guard for DFlashEngine |
 | `tests/test_dflash_engine.py` | DFlash engine and routing tests |
 | `tests/test_dflash_laguna.py` | Laguna adapter parity, cache rollback, config, and checkpoint-layout tests |
+| `tests/test_dflash_glm5.py` | GLM-5.3 MHC capture, KDA/DSA rollback, loader, and lifecycle tests |
 
 ### Dependency
 
-- `dflash-mlx` pinned to `jundot/dflash-mlx` (v0.1.10+omlx.4)
+- `dflash-mlx` pinned to `jundot/dflash-mlx` (v0.1.10+omlx.7)
 - Listed as required dependency in `pyproject.toml`; the mac-app release
   lockfiles are regenerated from it by the packaging pipeline
 
 ### Supported models
 
-DFlash registers `QwenGdnTargetOps`, `Gemma4TargetOps`, and `MuseGlimmerTargetOps`. oMLX also registers a Laguna backend and the `DFlashLagunaForCausalLM` drafter used by Poolside's official checkpoints:
+DFlash registers `QwenGdnTargetOps`, `Gemma4TargetOps`, and `MuseGlimmerTargetOps`. oMLX also registers Laguna and GLM-5.3 target backends. The pinned runtime already contains the generic `DFlash2DraftModel` required by GLM-5.3:
 
 | Target model | Draft checkpoint |
 |--------------|-----------------|
@@ -95,6 +96,7 @@ DFlash registers `QwenGdnTargetOps`, `Gemma4TargetOps`, and `MuseGlimmerTargetOp
 | poolside/Laguna-S-2.1 | poolside/Laguna-S-2.1-DFlash |
 | poolside/Laguna-S-2.1-NVFP4-mlx | poolside/Laguna-S-2.1-DFlash-NVFP4 |
 | meta-models/Muse-Glimmer-30B | meta-models/Muse-Glimmer-30B-assistant |
+| zai-org/GLM-5.3-Flash (and matched MLX quantizations) | incoai/GLM-5.3-Flash-DFlash2 |
 
 Other model families (Llama, Gemma3, etc.) are not supported — they require both a trained DFlash draft checkpoint and a compatible target adapter in dflash-mlx.
 
@@ -119,6 +121,16 @@ numerical-parity coverage; ordinary adaptive DFlash verification remains
 available.
 
 Note: the `-DFlash` suffix is specific to DFlash draft checkpoints. Gemma4 also ships an `-assistant` variant (e.g. `gemma-4-26B-A4B-it-assistant`) that targets MTP speculative decoding via mlx-vlm — do not mix these in the DFlash toggle. Meta breaks this naming convention: `Muse-Glimmer-30B-assistant` IS a DFlash drafter (block-diffusion, `block_size` 16), not an MTP checkpoint. Drafter routing therefore keys on `config_model_type` (`muse_glimmer_assistant` is in the dashboard's DFlash drafter set), not on the checkpoint name. The Muse Glimmer target is a VLM: DFlash drives its text backbone through dflash-mlx's bundled text-only mlx-lm module, and image requests divert to the VLM fallback engine as usual.
+
+GLM-5.3 uses the text backbone for speculative generation. Its MHC hidden
+streams are contracted before the five configured target-layer captures, and
+rejected verify tokens are rolled back across both recurrent KDA state and the
+DSA `CacheList(KVCache, PoolingCache)`. Image/video requests retain the normal
+evict-and-VLM-fallback behavior. DDTree, target KV quantization, specialized
+verify linears, and DFlash L1/L2 prefix snapshots are disabled for this target
+until their GLM composite-cache and numerical-parity suites pass. Adaptive
+linear DFlash verification remains available. The published checkpoint is
+CC BY-NC-ND 4.0; oMLX neither bundles nor automatically downloads its weights.
 
 ### Per-model settings
 
@@ -215,7 +227,7 @@ DFlash effectiveness degrades with long contexts:
 
 ### 3. Model support
 
-Qwen, Gemma4, and Laguna have compatible target adapters and published draft checkpoints. Each additional model family still requires:
+Qwen, Gemma4, Laguna, Muse Glimmer, and GLM-5.3 have compatible target adapters and published draft checkpoints. Each additional model family still requires:
 - A trained DFlash draft checkpoint (block diffusion model matching target hidden dimensions)
 - Support in dflash-mlx's target model handling (hidden state extraction, cache rollback)
 
@@ -310,6 +322,7 @@ DFlash context fallback: 5120 >= 4096, evicting dflash models and switching to v
 - DFlashEngine: properties, stats, cache stats
 - EnginePool routing: disabled/enabled/draft model checks
 - Laguna: native-forward parity, hidden-state capture, full/rotating-cache rollback, gated draft forward, target binding, and fused-QKV checkpoint loading
+- GLM-5.3: MHC-contracted capture, repeated KDA rejection replay, DSA pooling-boundary rollback, VLM/oQ loader routing, and lifecycle cleanup
 
 ### Manual testing
 

--- a/docs/experimental/dflash_mlx_integration.md
+++ b/docs/experimental/dflash_mlx_integration.md
@@ -133,6 +133,9 @@ linear DFlash verification remains available. Cold prefill still follows the
 runtime `prefill_step_size`; chunking is kept independent from snapshot
 hydration or publication for this target. The published checkpoint is
 CC BY-NC-ND 4.0; oMLX neither bundles nor automatically downloads its weights.
+The mlx-vlm fallback target is constructed eagerly, matching normal
+`VLMEngine` startup, and then passes through the same bounded whole-tree
+materialization gate. Custom oQ checkpoints retain their dedicated loader.
 
 ### Per-model settings
 

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -2149,6 +2149,14 @@ async def load_model(
     entry = engine_pool.get_entry(model_id)
     if entry is None:
         raise HTTPException(status_code=404, detail=f"Model not found: {model_id}")
+    if bool(getattr(entry, "is_helper", False)):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "DFlash helper models load automatically with their target model. "
+                "Load the target model and enable DFlash instead."
+            ),
+        )
     if entry.engine is not None:
         return {
             "status": "ok",

--- a/omlx/admin/templates/dashboard/_settings.html
+++ b/omlx/admin/templates/dashboard/_settings.html
@@ -1518,7 +1518,7 @@
                                                 </span>
                                             </template>
                                             <!-- Ready state -->
-                                            <template x-if="!model.virtual && !model.is_loading && !model.loaded">
+                                            <template x-if="!model.virtual && !model.is_helper && !model.is_loading && !model.loaded">
                                                 <button @click="loadModel(model.id)"
                                                         :class="hover
                                                             ? 'bg-green-100 text-green-700 border-green-200 cursor-pointer'
@@ -1527,6 +1527,11 @@
                                                     <span :class="hover ? 'bg-green-500' : 'bg-neutral-400'" class="w-1.5 h-1.5 rounded-full"></span>
                                                     <span x-text="hover ? window.t('settings.models.table.status_load') : window.t('settings.models.table.status_ready')"></span>
                                                 </button>
+                                            </template>
+                                            <!-- DFlash helpers are owned by their target engine. -->
+                                            <template x-if="!model.virtual && model.is_helper && !model.is_loading && !model.loaded">
+                                                <span class="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full gap-1 bg-amber-50 text-amber-700 border border-amber-200"
+                                                      x-text="window.t('settings.models.table.helper_badge')"></span>
                                             </template>
                                         </div>
 

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/bindings.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/bindings.cpp
@@ -89,6 +89,23 @@ NB_MODULE(_ext, m) {
       "topk_length"_a = nb::none(),
       "causal_prefix_rows"_a = 0,
       "stream"_a = nb::none());
+  // Separate ABI name lets Python fail closed when code is paired with an
+  // older extension that only accepts the historical D_PE=64 geometry.
+  m.def(
+      "glm_dsa_nope_sparse_mla_attention",
+      &omlx::glm_kernels::glm_dsa_nope_sparse_mla_attention,
+      "q_latent"_a,
+      "q_pe"_a,
+      "kv_latent"_a,
+      "k_pe"_a,
+      "topk_indices"_a,
+      "scale"_a,
+      "causal"_a = true,
+      "topk_valid_prefix"_a = false,
+      "causal_prefix_indices"_a = false,
+      "topk_length"_a = nb::none(),
+      "causal_prefix_rows"_a = 0,
+      "stream"_a = nb::none());
   m.def(
       "glm_dsa_exact_block_attention",
       &omlx::glm_kernels::glm_dsa_exact_block_attention,

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.cpp
@@ -132,7 +132,6 @@ class DSAIndexerScoresPrimitive : public Primitive {
 
     out.set_data(allocator::malloc(out.nbytes()));
 
-    constexpr int bm = 64;
     constexpr int bk = 16;
 
     const int B = q.shape(0);
@@ -148,9 +147,11 @@ class DSAIndexerScoresPrimitive : public Primitive {
     // slower at P=125k and ~11% slower at P=2.5k — the kernel is
     // compute/barrier-bound (Q and pooled-K panels are largely
     // L2-resident), so the traffic reduction does not pay. bn=64/wm2/wn2
-    // is the fixed configuration.
+    // remains the prefill configuration; an M=1 decode row uses the exact
+    // BM8/wm1 specialization from the same Steel kernel.
+    const int bm = M == 1 ? 8 : 64;
     const int bn = 64;
-    const int wm = 2;
+    const int wm = M == 1 ? 1 : 2;
     const int wn = 2;
 
     const int tiles_m = (M + bm - 1) / bm;

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.metal
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.metal
@@ -45,6 +45,13 @@ struct OMLXDSATopKParams {
 instantiate_dsa_indexer_score(float16, half, 64, 64, 16, 2, 2);
 instantiate_dsa_indexer_score(bfloat16, bfloat16_t, 64, 64, 16, 2, 2);
 
+// Decode has one query row.  Keep the exact Steel MMA arithmetic used by the
+// historical BM64 score kernel, but reduce the minimum M tile to one 8-row
+// simdgroup fragment.  BK=16 and the simdgroup matmul sequence are unchanged,
+// so retained row 0 is bit-identical; the other seven fragment rows are safe
+// loaded as zero and never stored.
+instantiate_dsa_indexer_score(float16, half, 8, 64, 16, 1, 2);
+instantiate_dsa_indexer_score(bfloat16, bfloat16_t, 8, 64, 16, 1, 2);
 instantiate_dsa_topk_indices(float16, half, 2048, 1024);
 instantiate_dsa_topk_indices(bfloat16, bfloat16_t, 2048, 1024);
 instantiate_dsa_topk_indices(float16, half, 512, 1024);

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/sparse_mla.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/sparse_mla.cpp
@@ -115,7 +115,8 @@ class GlmDsaSparseMlaAttentionPrimitive : public Primitive {
       return true;
     }
     if (q_latent.shape(3) != 512 || kv_latent.shape(3) != 512 ||
-        q_pe.shape(3) != 64 || k_pe.shape(3) != 64) {
+        q_pe.shape(3) != k_pe.shape(3) ||
+        (q_pe.shape(3) != 0 && q_pe.shape(3) != 64)) {
       return true;
     }
     if (q_latent.shape(2) <= 1 || topk_indices.shape(3) < 16 ||
@@ -182,7 +183,7 @@ class GlmDsaSparseMlaAttentionPrimitive : public Primitive {
     const int bk = (q_latent.shape(1) == 32) ? 128 : 256;
     constexpr int dc = 32;
     constexpr int d_latent = 512;
-    constexpr int d_pe = 64;
+    const int d_pe = q_pe.shape(3);
 
     const int B = q_latent.shape(0);
     const int H = q_latent.shape(1);
@@ -461,6 +462,42 @@ array glm_dsa_sparse_mla_attention(
           topk_length.has_value(),
           causal_prefix_rows),
       std::move(inputs));
+}
+
+array glm_dsa_nope_sparse_mla_attention(
+    const array& q_latent,
+    const array& q_pe,
+    const array& kv_latent,
+    const array& k_pe,
+    const array& topk_indices,
+    float scale,
+    bool causal,
+    bool topk_valid_prefix,
+    bool causal_prefix_indices,
+    const std::optional<array>& topk_length,
+    int causal_prefix_rows,
+    StreamOrDevice s) {
+  if (q_pe.ndim() != 4 || k_pe.ndim() != 4 || q_pe.shape(3) != 0 ||
+      k_pe.shape(3) != 0) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.glm_dsa_nope_sparse_mla_attention] expected "
+           "zero-width q_pe and k_pe, got "
+        << q_pe.shape() << " and " << k_pe.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  return glm_dsa_sparse_mla_attention(
+      q_latent,
+      q_pe,
+      kv_latent,
+      k_pe,
+      topk_indices,
+      scale,
+      causal,
+      topk_valid_prefix,
+      causal_prefix_indices,
+      topk_length,
+      causal_prefix_rows,
+      s);
 }
 
 } // namespace omlx::glm_kernels

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/sparse_mla.h
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/sparse_mla.h
@@ -24,4 +24,18 @@ mx::array glm_dsa_sparse_mla_attention(
     int causal_prefix_rows = 0,
     mx::StreamOrDevice s = {});
 
+mx::array glm_dsa_nope_sparse_mla_attention(
+    const mx::array& q_latent,
+    const mx::array& q_pe,
+    const mx::array& kv_latent,
+    const mx::array& k_pe,
+    const mx::array& topk_indices,
+    float scale,
+    bool causal = true,
+    bool topk_valid_prefix = false,
+    bool causal_prefix_indices = false,
+    const std::optional<mx::array>& topk_length = std::nullopt,
+    int causal_prefix_rows = 0,
+    mx::StreamOrDevice s = {});
+
 } // namespace omlx::glm_kernels

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/sparse_mla.metal
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/sparse_mla.metal
@@ -19,6 +19,11 @@
 
 instantiate_sparse_mla(float16, half, 256, 32, 64, 512, 64, 8);
 instantiate_sparse_mla(bfloat16, bfloat16_t, 256, 32, 64, 512, 64, 8);
+// GLM-5.3 is NoPE. Avoid two QK chunks that load and multiply an all-zero
+// 64-wide positional lane. The latent path and FP32 accumulation order are
+// unchanged, so this specialization is bitwise-equivalent to D_PE=64 zeros.
+instantiate_sparse_mla(float16, half, 256, 32, 64, 512, 0, 8);
+instantiate_sparse_mla(bfloat16, bfloat16_t, 256, 32, 64, 512, 0, 8);
 // 32-head variant for tensor-sharded (multi-device) runs: each shard holds
 // H=32 of the 64 MLA heads. wm=4 keeps TQ = H / (wm * 8) = 1.
 instantiate_sparse_mla(float16, half, 256, 32, 32, 512, 64, 4);

--- a/omlx/custom_kernels/glm_moe_dsa/fast.py
+++ b/omlx/custom_kernels/glm_moe_dsa/fast.py
@@ -105,6 +105,7 @@ NATIVE_SYMBOLS = (
     "dspark_fp32_topk_indices",
     "dspark_exact_mxfp8_qmv_pair",
     "glm_dsa_sparse_mla_attention",
+    "glm_dsa_nope_sparse_mla_attention",
     "glm_dsa_exact_block_attention",
     "deepseek_v4_sparse_attention",
     "dspark_ring_gemm",
@@ -361,6 +362,40 @@ def glm_dsa_sparse_mla_attention(
         topk_length=topk_length,
         causal_prefix_rows=causal_prefix_rows,
         stream=stream or mx.gpu,
+    )
+
+
+def glm_dsa_nope_sparse_mla_attention(
+    q_latent: mx.array,
+    q_pe: mx.array,
+    kv_latent: mx.array,
+    k_pe: mx.array,
+    topk_indices: mx.array,
+    scale: float,
+    causal: bool = True,
+    topk_valid_prefix: bool = False,
+    causal_prefix_indices: bool = False,
+    topk_length: mx.array | None = None,
+    causal_prefix_rows: int = 0,
+    *,
+    stream=None,
+) -> mx.array:
+    """Strict GLM-5.3 NoPE sparse-MLA ABI (D_PE must be zero)."""
+    if _ext is None or not hasattr(_ext, "glm_dsa_nope_sparse_mla_attention"):
+        raise RuntimeError("GLM-5.3 NoPE sparse-MLA kernel is unavailable")
+    return _ext.glm_dsa_nope_sparse_mla_attention(
+        q_latent,
+        q_pe,
+        kv_latent,
+        k_pe,
+        topk_indices,
+        scale,
+        causal=causal,
+        topk_valid_prefix=topk_valid_prefix,
+        causal_prefix_indices=causal_prefix_indices,
+        topk_length=topk_length,
+        causal_prefix_rows=causal_prefix_rows,
+        **_native_stream_kwargs(stream),
     )
 
 

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -880,6 +880,19 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                 logger.warning(f"DFlash prefill guard init failed: {exc}")
                 self._prefill_guard = None
 
+        # GLM-5.3's first DFlash request compiles the target prefill, recurrent
+        # rollback, draft, and block-verification graphs.  That cold compile can
+        # take long enough that an OpenAI client sees only keepalives and the
+        # admin UI paints the request as stalled, even though model loading was
+        # already reported complete.  Compile against a disposable request
+        # before publishing readiness so the first real request behaves like
+        # every subsequent one.
+        if self._requires_load_warmup():
+            await loop.run_in_executor(
+                get_mlx_executor(),
+                self._warmup_dflash_sync,
+            )
+
         self._loaded = True
         self._in_fallback_mode = False
         max_ctx_display = (
@@ -1327,6 +1340,87 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         tag = getattr(self._tokenizer_obj, "think_start", "<think>")
         return f"{tag}\n"
 
+    def _requires_load_warmup(self) -> bool:
+        """Return whether this backend needs a readiness-gated cold compile."""
+        return getattr(self._target_ops, "backend_name", "") == "glm5_next"
+
+    def _build_load_warmup_prompt_tokens(self, prompt_len: int = 64) -> list[int]:
+        """Build a non-stop-token prompt for the disposable GLM warmup."""
+        tokenizer = self._executor_tokenizer
+        try:
+            encoded = tokenizer.encode(
+                "oMLX DFlash readiness warmup. Reply with ready.",
+                add_special_tokens=False,
+            )
+        except TypeError:
+            encoded = tokenizer.encode(
+                "oMLX DFlash readiness warmup. Reply with ready."
+            )
+
+        stop_ids = set(
+            _get_dflash_stop_token_ids(tokenizer, self._generation_config_eos)
+        )
+        usable = [
+            int(token_id)
+            for token_id in encoded
+            if int(token_id) not in stop_ids
+            and int(token_id) not in self._suppress_token_ids
+        ]
+        if not usable:
+            vocab_size = int(getattr(tokenizer, "vocab_size", 0) or 0)
+            search_limit = vocab_size if vocab_size > 0 else 4096
+            usable = [
+                token_id
+                for token_id in range(search_limit)
+                if token_id not in stop_ids and token_id not in self._suppress_token_ids
+            ][:1]
+        if not usable:
+            raise RuntimeError("DFlash load warmup could not find a safe prompt token")
+        repeats = (prompt_len + len(usable) - 1) // len(usable)
+        return (usable * repeats)[:prompt_len]
+
+    def _warmup_dflash_sync(self) -> None:
+        """Compile GLM DFlash before the engine is advertised as ready."""
+        from dflash_mlx.engine.events import SummaryEvent
+
+        prompt_tokens = self._build_load_warmup_prompt_tokens()
+        max_tokens = max(8, int(self._block_size or 8))
+        started = time.perf_counter()
+        event_iter = None
+        summary = None
+        try:
+            event_iter, _, _ = self._stream_dflash_events(
+                prompt_tokens=prompt_tokens,
+                max_tokens=max_tokens,
+                temperature=0.0,
+                top_p=1.0,
+                top_k=0,
+                min_p=0.0,
+                repetition_penalty=1.0,
+                repetition_context_size=20,
+                use_prefix_cache=False,
+            )
+            for event in event_iter:
+                if isinstance(event, SummaryEvent):
+                    summary = event
+        finally:
+            close = getattr(event_iter, "close", None)
+            if callable(close):
+                close()
+
+        if summary is None:
+            raise RuntimeError("GLM DFlash load warmup ended without a summary")
+        if int(summary.cycles_completed) < 1:
+            raise RuntimeError("GLM DFlash load warmup completed no verify cycles")
+        logger.info(
+            "GLM DFlash load warmup completed: prompt=%d tokens=%d "
+            "elapsed=%.2fs acceptance=%.1f%%",
+            len(prompt_tokens),
+            int(summary.generation_tokens),
+            time.perf_counter() - started,
+            float(summary.acceptance_ratio) * 100.0,
+        )
+
     def _stream_dflash_events(
         self,
         prompt_tokens: list[int],
@@ -1337,6 +1431,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         min_p: float = 0.0,
         repetition_penalty: float = 1.0,
         repetition_context_size: int = 20,
+        use_prefix_cache: bool = True,
     ):
         """Build the dflash event iterator with prefix cache plumbed in."""
         from dflash_mlx.runtime import stream_dflash_generate
@@ -1360,14 +1455,19 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             tokenizer = self._executor_tokenizer
             cli_args = None
 
-        prefix_flow = PrefixCacheFlow.for_request(
-            model_provider=_ModelProviderShim(),
-            draft_model=self._draft_model,
-            tokenizer=self._executor_tokenizer,
-            prompt=prompt_tokens,
-            max_new_tokens=max_tokens,
-            runtime_context=self._runtime_context,
-        )
+        if use_prefix_cache:
+            prefix_flow = PrefixCacheFlow.for_request(
+                model_provider=_ModelProviderShim(),
+                draft_model=self._draft_model,
+                tokenizer=self._executor_tokenizer,
+                prompt=prompt_tokens,
+                max_new_tokens=max_tokens,
+                runtime_context=self._runtime_context,
+            )
+        else:
+            # Load warmups must not become user-visible prefix snapshots or
+            # affect cache hit/miss telemetry.
+            prefix_flow = PrefixCacheFlow(cache_manager=None)
 
         event_iter = stream_dflash_generate(
             target_model=self._target_model,

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -49,6 +49,31 @@ from .base import (
 logger = logging.getLogger(__name__)
 
 
+def _get_dflash_stop_token_ids(tokenizer: Any) -> list[int]:
+    """Normalize tokenizer EOS metadata for the DFlash runtime.
+
+    Some mlx-vlm tokenizers expose ``eos_token_ids`` as a scalar while
+    dflash-mlx currently assumes it is iterable.  Keep the compatibility at
+    the oMLX boundary instead of mutating the tokenizer object shared with
+    chat-template and detokenization code.
+    """
+    raw_ids = getattr(tokenizer, "eos_token_ids", None)
+    if raw_ids is None:
+        stop_ids: list[int] = []
+    elif isinstance(raw_ids, int):
+        stop_ids = [int(raw_ids)]
+    else:
+        try:
+            stop_ids = [int(token_id) for token_id in raw_ids]
+        except TypeError:
+            stop_ids = [int(raw_ids)]
+
+    eos_token_id = getattr(tokenizer, "eos_token_id", None)
+    if eos_token_id is not None and int(eos_token_id) not in stop_ids:
+        stop_ids.append(int(eos_token_id))
+    return stop_ids
+
+
 def is_dflash_compatible(model_path: str | Path) -> tuple[bool, str]:
     """Decide whether ``model_path`` can run on the current dflash backend.
 
@@ -1176,10 +1201,10 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         repetition_context_size: int = 20,
     ):
         """Build the dflash event iterator with prefix cache plumbed in."""
-        from dflash_mlx.runtime import get_stop_token_ids, stream_dflash_generate
+        from dflash_mlx.runtime import stream_dflash_generate
         from dflash_mlx.server.prefix_cache_flow import PrefixCacheFlow
 
-        stop_ids = get_stop_token_ids(self._executor_tokenizer)
+        stop_ids = _get_dflash_stop_token_ids(self._executor_tokenizer)
 
         # Build a minimal model_provider shim for the prefix cache flow.
         # ``model_key`` is consumed as a tuple where index 0 = target id and

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -74,6 +74,26 @@ def _get_dflash_stop_token_ids(tokenizer: Any) -> list[int]:
     return stop_ids
 
 
+def _process_output_parser_token(result: Any) -> tuple[str, str, bool, bool]:
+    """Normalize the scheduler-facing parser token contract."""
+    is_stop = bool(getattr(result, "is_stop", False))
+    record_token = getattr(result, "record_token", None)
+    should_record = bool(record_token) if record_token is not None else not is_stop
+    return result.stream_text, result.visible_text, is_stop, should_record
+
+
+def _finalize_output_parser(
+    parser_session: Any,
+    visible_parts: list[str],
+) -> tuple[Any, str]:
+    """Finalize once and return Scheduler-compatible cumulative output text."""
+    final = parser_session.finalize()
+    if final.visible_text:
+        visible_parts.append(final.visible_text)
+    prefix = getattr(final, "output_text_prefix", "") or ""
+    return final, prefix + "".join(visible_parts)
+
+
 def is_dflash_compatible(model_path: str | Path) -> tuple[bool, str]:
     """Decide whether ``model_path`` can run on the current dflash backend.
 
@@ -1388,6 +1408,54 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
 
         event_iter = None
         cache_manager = None
+        prefix_flow = None
+        parser_session = None
+        parser_final = None
+        parser_output_text = ""
+        parser_finalized = False
+        final_enqueued = False
+        recorded_completion = 0
+        parsed_visible_parts: list[str] = []
+        last_acceptance_ratio = 0.0
+        last_cycles_completed = 0
+
+        def enqueue(item: tuple[str, list[int], bool, dict[str, Any] | None]) -> None:
+            asyncio.run_coroutine_threadsafe(queue.put(item), loop)
+
+        def finalize_parser_once():
+            nonlocal parser_final, parser_finalized, parser_output_text
+            if parser_session is None or parser_finalized:
+                return parser_final
+            # Mark first so a failing parser finalizer is never invoked twice
+            # from the error/finally cleanup paths.
+            parser_finalized = True
+            parser_final, parser_output_text = _finalize_output_parser(
+                parser_session, parsed_visible_parts
+            )
+            return parser_final
+
+        def add_parser_final_metrics(metrics: dict[str, Any]) -> str:
+            final = finalize_parser_once()
+            if final is None:
+                return ""
+            metrics["output_text"] = parser_output_text
+            if final.tool_calls:
+                metrics["tool_calls"] = final.tool_calls
+            if final.finish_reason:
+                metrics["finish_reason"] = final.finish_reason
+            return final.stream_text or ""
+
+        def enqueue_final(
+            metrics: dict[str, Any],
+            *,
+            new_text: str = "",
+        ) -> None:
+            nonlocal final_enqueued
+            if final_enqueued:
+                return
+            final_enqueued = True
+            enqueue((new_text, [], True, metrics))
+
         try:
             self._record_prefill_guard_active_memory()
             if seed is not None:
@@ -1428,40 +1496,52 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
 
                 if isinstance(event, TokenEvent):
                     token_id = int(event.token_id)
+                    last_acceptance_ratio = float(event.acceptance_ratio)
+                    last_cycles_completed = int(event.cycles_completed)
                     # Skip EOS/stop tokens from output
                     if token_id in stop_ids:
                         continue
                     if parser_session is not None:
                         result = parser_session.process_token(token_id)
-                        text = result.stream_text
+                        (
+                            text,
+                            visible_text,
+                            is_parser_stop,
+                            should_record_token,
+                        ) = _process_output_parser_token(result)
+                        if visible_text:
+                            parsed_visible_parts.append(visible_text)
+                        if should_record_token:
+                            recorded_completion += 1
+                        chunk_tokens = (
+                            [token_id]
+                            if should_record_token and not is_parser_stop
+                            else []
+                        )
                     elif detokenizer is not None:
+                        recorded_completion += 1
                         detokenizer.add_token(token_id)
                         text = detokenizer.last_segment
+                        chunk_tokens = [token_id]
                     else:
+                        recorded_completion += 1
                         text = self._executor_tokenizer.decode([token_id])
+                        chunk_tokens = [token_id]
                     # Parser sessions can emit empty stream_text on protocol
                     # marker tokens — skip the chunk so clients don't see a
                     # flood of empty deltas.
-                    if not text:
-                        continue
-                    asyncio.run_coroutine_threadsafe(
-                        queue.put((text, [token_id], False, None)), loop
-                    )
+                    if text:
+                        enqueue((text, chunk_tokens, False, None))
+                    if parser_session is not None and is_parser_stop:
+                        logger.info(
+                            "DFlash streaming generation stopped by output parser "
+                            "after %d recorded token(s)",
+                            recorded_completion,
+                        )
+                        break
 
                 elif isinstance(event, SummaryEvent):
                     self._record_speculation_summary(event)
-                    # Flush any buffered tail from the parser (e.g. close an
-                    # unterminated <think> block) before the metrics chunk so
-                    # the client sees a well-formed final delta.
-                    parser_final = None
-                    if parser_session is not None:
-                        parser_final = parser_session.finalize()
-                        tail = parser_final.stream_text
-                        if tail:
-                            asyncio.run_coroutine_threadsafe(
-                                queue.put((tail, [], False, None)), loop
-                            )
-
                     gen_tokens = int(event.generation_tokens)
                     accept_ratio = float(event.acceptance_ratio)
                     cycles = int(event.cycles_completed)
@@ -1483,31 +1563,42 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                     )
                     metrics: dict[str, Any] = {
                         "prompt_tokens": int(event.prompt_token_count),
-                        "completion_tokens": gen_tokens,
+                        "completion_tokens": (
+                            recorded_completion
+                            if parser_session is not None
+                            else gen_tokens
+                        ),
                         "acceptance_ratio": accept_ratio,
                         "cycles_completed": cycles,
                         # Prefix-snapshot hit count, surfaced on the final
                         # (usage) chunk so the API reports cached_tokens (#1441).
                         "cached_tokens": self._cached_tokens_from_flow(prefix_flow),
                     }
-                    if parser_final is not None:
-                        if parser_final.tool_calls:
-                            metrics["tool_calls"] = parser_final.tool_calls
-                        if parser_final.finish_reason:
-                            metrics["finish_reason"] = parser_final.finish_reason
-                    asyncio.run_coroutine_threadsafe(
-                        queue.put(("", [], True, metrics)), loop
-                    )
+                    tail = add_parser_final_metrics(metrics)
+                    enqueue_final(metrics, new_text=tail)
+                    break
 
                 # Cycle, memory, prefill, and snapshot events are consumed by the
                 # runtime cache manager and metrics layers — omlx does not surface
                 # them so all other event types are intentionally ignored.
 
+            if not final_enqueued:
+                metrics = {
+                    "prompt_tokens": len(prompt_tokens),
+                    "completion_tokens": recorded_completion,
+                    "acceptance_ratio": last_acceptance_ratio,
+                    "cycles_completed": last_cycles_completed,
+                    "cached_tokens": self._cached_tokens_from_flow(prefix_flow),
+                    "aborted": stop_event.is_set(),
+                }
+                tail = ""
+                if not stop_event.is_set():
+                    tail = add_parser_final_metrics(metrics)
+                enqueue_final(metrics, new_text=tail)
+
         except Exception as e:
             logger.error(f"DFlash streaming generation error: {e}")
-            asyncio.run_coroutine_threadsafe(
-                queue.put(("", [], True, {"error": str(e)})), loop
-            )
+            enqueue_final({"error": str(e), "completion_tokens": recorded_completion})
         finally:
             # Closing the dflash generator throws GeneratorExit on its next
             # yield, releasing kernel state and any draft cache it holds.
@@ -1520,11 +1611,14 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                     except Exception as exc:
                         logger.debug(f"event_iter.close() raised: {exc}")
             self._end_runtime_cache_request(cache_manager)
-            # Always send a sentinel so the async consumer doesn't deadlock
-            # when an abort happened before the dflash summary was emitted.
-            asyncio.run_coroutine_threadsafe(
-                queue.put(("", [], True, {"aborted": stop_event.is_set()})),
-                loop,
+            # Exactly one terminal queue item is required: the async consumer
+            # otherwise either deadlocks (no SummaryEvent after parser stop) or
+            # observes two finals (SummaryEvent plus an unconditional sentinel).
+            enqueue_final(
+                {
+                    "completion_tokens": recorded_completion,
+                    "aborted": stop_event.is_set(),
+                }
             )
             self._active_request = False
 
@@ -1636,37 +1730,59 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                 summary: SummaryEvent | None = None
                 first_token_at: float | None = None
                 parser_final = None
+                parser_output_text = ""
                 for event in event_iter:
                     if stop_event.is_set():
                         logger.info("DFlash generation aborted by client")
                         break
                     if isinstance(event, TokenEvent):
-                        if first_token_at is None:
-                            first_token_at = time.perf_counter()
                         token_id = int(event.token_id)
                         if token_id in stop_ids:
                             continue
-                        tokens.append(token_id)
-                        self._update_activity(activity_id, token_count=len(tokens))
                         if parser_session is not None:
                             result = parser_session.process_token(token_id)
-                            if result.visible_text:
-                                parsed_visible_parts.append(result.visible_text)
+                            (
+                                _,
+                                visible_text,
+                                is_parser_stop,
+                                should_record_token,
+                            ) = _process_output_parser_token(result)
+                            if visible_text:
+                                parsed_visible_parts.append(visible_text)
+                            if should_record_token:
+                                if first_token_at is None:
+                                    first_token_at = time.perf_counter()
+                                tokens.append(token_id)
+                                self._update_activity(
+                                    activity_id, token_count=len(tokens)
+                                )
+                            if is_parser_stop:
+                                logger.info(
+                                    "DFlash generation stopped by output parser "
+                                    "after %d recorded token(s)",
+                                    len(tokens),
+                                )
+                                break
+                        else:
+                            if first_token_at is None:
+                                first_token_at = time.perf_counter()
+                            tokens.append(token_id)
+                            self._update_activity(activity_id, token_count=len(tokens))
                     elif isinstance(event, SummaryEvent):
                         summary = event
                         self._record_speculation_summary(event)
                 if parser_session is not None:
-                    parser_final = parser_session.finalize()
-                    if parser_final.visible_text:
-                        parsed_visible_parts.append(parser_final.visible_text)
+                    parser_final, parser_output_text = _finalize_output_parser(
+                        parser_session, parsed_visible_parts
+                    )
                 return (
                     summary,
                     tokens,
                     parser_session,
                     parser_final,
-                    parsed_visible_parts,
                     prefix_flow,
                     first_token_at,
+                    parser_output_text,
                 )
             finally:
                 self._record_prefill_guard_active_memory()
@@ -1689,9 +1805,9 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                     generated,
                     parser_session,
                     parser_final,
-                    parsed_visible_parts,
                     prefix_flow,
                     first_token_at,
+                    parser_output_text,
                 ) = await asyncio.shield(asyncio.wrap_future(future))
             except asyncio.CancelledError:
                 stop_event.set()
@@ -1713,7 +1829,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             # and stripped channel marker tokens, so just join the visible
             # segments. Don't re-decode the raw token list — that would
             # reintroduce the raw markers and double-buffer detokenization.
-            text = "".join(parsed_visible_parts)
+            text = parser_output_text
         else:
             text = self._tokenizer_obj.decode(generated, skip_special_tokens=True)
             text = clean_special_tokens(text)
@@ -1735,8 +1851,19 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             if summary is not None
             else len(prompt_tokens)
         )
+        # Parser sessions decide whether a protocol/control token belongs to
+        # completion accounting.  Once a parser stop closes the DFlash event
+        # iterator there is no SummaryEvent, so the recorded token list is the
+        # scheduler-compatible source of truth.  Preserve the historical
+        # summary accounting for ordinary, parser-free generation.
         completion_token_count = (
-            int(summary.generation_tokens) if summary is not None else len(generated)
+            len(generated)
+            if parser_session is not None
+            else (
+                int(summary.generation_tokens)
+                if summary is not None
+                else len(generated)
+            )
         )
         return GenerationOutput(
             text=text,
@@ -1885,6 +2012,12 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                 if finished:
                     if metrics and metrics.get("completion_tokens") is not None:
                         total_completion = int(metrics["completion_tokens"])
+                    if metrics and metrics.get("output_text") is not None:
+                        # Protocol parsers maintain a visible-output channel
+                        # distinct from their streamed control/reasoning text.
+                        # Match Scheduler by exposing prefix + visible text as
+                        # the final cumulative GenerationOutput.text.
+                        total_text = str(metrics["output_text"])
                     if metrics and metrics.get("error"):
                         finish_reason = "error"
                     else:

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -1438,6 +1438,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         queue: asyncio.Queue,
         loop: asyncio.AbstractEventLoop,
         stop_event: threading.Event,
+        activity_id: str,
     ) -> None:
         """Run dflash generation with streaming on MLX executor thread.
 
@@ -1532,6 +1533,11 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                     detokenizer.reset()
 
             for event in event_iter:
+                # Prefill/cycle events are real forward progress even when no
+                # output token is ready yet. Keep the admin activity heartbeat
+                # fresh so long DFlash prefill is not painted amber/red as a
+                # stalled request.
+                self._update_activity(activity_id)
                 if stop_event.is_set():
                     logger.info("DFlash generation aborted by client")
                     break
@@ -1774,6 +1780,10 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                 parser_final = None
                 parser_output_text = ""
                 for event in event_iter:
+                    # DFlash emits prefill and cycle events between tokens.
+                    # Treat every event as activity so the dashboard's
+                    # last-progress indicator reflects compute, not token gaps.
+                    self._update_activity(activity_id)
                     if stop_event.is_set():
                         logger.info("DFlash generation aborted by client")
                         break
@@ -2032,6 +2042,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             queue,
             loop,
             stop_event,
+            activity_id,
         )
 
         total_text = ""

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -49,29 +49,55 @@ from .base import (
 logger = logging.getLogger(__name__)
 
 
-def _get_dflash_stop_token_ids(tokenizer: Any) -> list[int]:
-    """Normalize tokenizer EOS metadata for the DFlash runtime.
+def _get_dflash_stop_token_ids(
+    tokenizer: Any,
+    generation_config_eos: set[int] | None = None,
+) -> list[int]:
+    """Resolve Scheduler-compatible stop IDs for the DFlash runtime.
 
     Some mlx-vlm tokenizers expose ``eos_token_ids`` as a scalar while
-    dflash-mlx currently assumes it is iterable.  Keep the compatibility at
-    the oMLX boundary instead of mutating the tokenizer object shared with
-    chat-template and detokenization code.
+    dflash-mlx currently assumes it is iterable. Models such as GLM-5.3 also
+    publish additional turn terminators only in ``generation_config.json``.
+    Keep this normalization at the oMLX boundary instead of mutating the
+    tokenizer object shared with chat-template and detokenization code.
     """
-    raw_ids = getattr(tokenizer, "eos_token_ids", None)
-    if raw_ids is None:
-        stop_ids: list[int] = []
-    elif isinstance(raw_ids, int):
-        stop_ids = [int(raw_ids)]
-    else:
-        try:
-            stop_ids = [int(token_id) for token_id in raw_ids]
-        except TypeError:
-            stop_ids = [int(raw_ids)]
 
-    eos_token_id = getattr(tokenizer, "eos_token_id", None)
-    if eos_token_id is not None and int(eos_token_id) not in stop_ids:
-        stop_ids.append(int(eos_token_id))
-    return stop_ids
+    stop_ids: set[int] = set()
+
+    def add_ids(value: Any) -> None:
+        if value is None or isinstance(value, bool):
+            return
+        if isinstance(value, int):
+            stop_ids.add(int(value))
+            return
+        try:
+            values = iter(value)
+        except TypeError:
+            return
+        for token_id in values:
+            if isinstance(token_id, bool):
+                continue
+            try:
+                stop_ids.add(int(token_id))
+            except (TypeError, ValueError):
+                continue
+
+    add_ids(getattr(tokenizer, "eos_token_id", None))
+    add_ids(getattr(tokenizer, "eos_token_ids", None))
+
+    eot_token_id = getattr(tokenizer, "eot_token_id", None)
+    if eot_token_id is not None:
+        add_ids(eot_token_id)
+    else:
+        eot_token = getattr(tokenizer, "eot_token", None)
+        if eot_token:
+            try:
+                add_ids(tokenizer.encode(eot_token, add_special_tokens=False))
+            except Exception:
+                pass
+
+    add_ids(generation_config_eos)
+    return sorted(stop_ids)
 
 
 def _process_output_parser_token(result: Any) -> tuple[str, str, bool, bool]:
@@ -399,6 +425,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         self._old_wired_limit: int | None = None
         self._wired_limit_owned = False
         self._suppress_token_ids: set[int] = set()
+        self._generation_config_eos: set[int] = set()
         # Protocol-specific output parser factory (gemma4 / harmony).
         # Detected once in start() after the target model is loaded; None means
         # the streaming detokenizer is used as-is (qwen, llama, etc.).
@@ -799,6 +826,17 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         suppress_ref = (
             getattr(self._executor_tokenizer, "name_or_path", None) or self._model_name
         )
+        self._generation_config_eos = set()
+        for key in ("eos_token_id", "eos_token_ids"):
+            configured_ids = load_generation_config_token_ids(suppress_ref, key)
+            if configured_ids:
+                self._generation_config_eos.update(configured_ids)
+        if self._generation_config_eos:
+            logger.info(
+                "DFlash loaded %d EOS token(s) from generation_config.json: %s",
+                len(self._generation_config_eos),
+                self._generation_config_eos,
+            )
         suppress_ids = load_generation_config_token_ids(suppress_ref, "suppress_tokens")
         self._suppress_token_ids = suppress_ids or set()
         if self._suppress_token_ids:
@@ -1014,6 +1052,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         self._draft_backend = None
         self._tokenizer_obj = None
         self._executor_tokenizer = None
+        self._generation_config_eos.clear()
         self._output_parser_factory = None
         self._prefill_guard = None
         self._in_fallback_mode = False
@@ -1303,7 +1342,10 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         from dflash_mlx.runtime import stream_dflash_generate
         from dflash_mlx.server.prefix_cache_flow import PrefixCacheFlow
 
-        stop_ids = _get_dflash_stop_token_ids(self._executor_tokenizer)
+        stop_ids = _get_dflash_stop_token_ids(
+            self._executor_tokenizer,
+            self._generation_config_eos,
+        )
 
         # Build a minimal model_provider shim for the prefix cache flow.
         # ``model_key`` is consumed as a tuple where index 0 = target id and

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -374,6 +374,10 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         self._prefill_guard: _DFlashPrefillGuard | None = None
         self._runtime_context: Any | None = None
         self._dflash_prefix_cache: Any | None = None
+        # DFlash bypasses mlx-lm's BatchGenerator, which normally owns the
+        # process Metal wired-limit raise/restore lifecycle.
+        self._old_wired_limit: int | None = None
+        self._wired_limit_owned = False
         self._suppress_token_ids: set[int] = set()
         # Protocol-specific output parser factory (gemma4 / harmony).
         # Detected once in start() after the target model is loaded; None means
@@ -458,6 +462,57 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
     @property
     def model_type(self) -> str | None:
         return self._model_type_str
+
+    def _acquire_wired_limit(self) -> None:
+        """Mirror BatchGenerator's recommended working-set wired limit."""
+        if self._wired_limit_owned or not mx.metal.is_available():
+            return
+        recommended = int(
+            mx.device_info().get("max_recommended_working_set_size", 0) or 0
+        )
+        if recommended <= 0:
+            raise RuntimeError("MLX did not report a recommended working set size")
+        self._old_wired_limit = mx.set_wired_limit(recommended)
+        self._wired_limit_owned = True
+
+    def _restore_wired_limit(self) -> bool:
+        """Restore the pre-DFlash limit once, on the owning MLX thread."""
+        if not self._wired_limit_owned:
+            return False
+        previous = self._old_wired_limit
+        self._wired_limit_owned = False
+        self._old_wired_limit = None
+        try:
+            mx.synchronize()
+        finally:
+            if previous is not None:
+                mx.set_wired_limit(previous)
+        return True
+
+    def _load_with_wired_limit(self, loader):
+        """Acquire before loading and restore without masking load failures."""
+        try:
+            self._acquire_wired_limit()
+            return loader()
+        except BaseException:
+            try:
+                self._restore_wired_limit()
+            except Exception:
+                logger.warning(
+                    "DFlash wired-limit restore failed after load error",
+                    exc_info=True,
+                )
+            raise
+
+    async def _restore_wired_limit_async(self) -> bool:
+        if not self._wired_limit_owned:
+            return False
+        from ..engine_core import get_mlx_executor
+
+        loop = asyncio.get_running_loop()
+        return bool(
+            await loop.run_in_executor(get_mlx_executor(), self._restore_wired_limit)
+        )
 
     @staticmethod
     def _build_quant_spec(
@@ -550,13 +605,28 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
     async def start(self) -> None:
         if self._loaded:
             return
+        try:
+            await self._start_impl()
+        except BaseException:
+            try:
+                await asyncio.shield(self._restore_wired_limit_async())
+            except Exception:
+                logger.warning(
+                    "DFlash wired-limit restore failed after start error",
+                    exc_info=True,
+                )
+            raise
+
+    async def _start_impl(self) -> None:
+        if self._loaded:
+            return
 
         from ..engine_core import get_mlx_executor
 
         loop = asyncio.get_running_loop()
         runtime_context = self._build_runtime_context()
 
-        def _load_models():
+        def _load_models_owned():
             # Register oMLX-owned target extensions before importing the
             # dflash loader functions below. GLM-5.3 is mlx-vlm-only, so its
             # installer wraps ``load_target_bundle`` with a scoped VLM loader.
@@ -650,7 +720,11 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             draft_backend = EagerDraftBackend()
             return target_bundle, draft, draft_backend, draft_meta
 
-        result = await loop.run_in_executor(get_mlx_executor(), _load_models)
+        result = await loop.run_in_executor(
+            get_mlx_executor(),
+            self._load_with_wired_limit,
+            _load_models_owned,
+        )
         target_bundle, self._draft_model, self._draft_backend, draft_meta = result
         self._draft_window_size = self._resolve_draft_window_size(draft_meta)
         capabilities_for = getattr(target_bundle.target_ops, "capabilities_for", None)
@@ -822,6 +896,10 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         loop = asyncio.get_running_loop()
         pre_active = mx.get_active_memory()
 
+        # BatchGenerator would restore this in close(); DFlash owns the same
+        # lifecycle explicitly before its target allocations are released.
+        await self._restore_wired_limit_async()
+
         # Release dflash model and cache references
         shutdown_runtime_cache_manager()
         self._dflash_prefix_cache = None
@@ -903,6 +981,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         if self._fallback_engine is not None:
             await self._fallback_engine.stop()
             self._fallback_engine = None
+        await self._restore_wired_limit_async()
         try:
             shutdown_runtime_cache_manager()
         except Exception as exc:

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -3,8 +3,9 @@
 DFlash engine for block diffusion speculative decoding.
 
 This engine wraps dflash-mlx (>= 0.1.5) to provide faster decoding on Apple
-Silicon for Qwen, Gemma4, and Laguna model families. By default it serves all
-requests through dflash; setting ``model_settings.dflash_max_ctx`` opts into
+Silicon for Qwen, Gemma4, Laguna, Muse Glimmer, and GLM-5.3 model families. By
+default it serves all requests through dflash; setting
+``model_settings.dflash_max_ctx`` opts into
 evicting the dflash models and delegating long-context requests to omlx's
 BatchedEngine/VLMBatchedEngine (paged cache, SSD cache, continuous batching).
 """
@@ -92,9 +93,11 @@ def is_dflash_compatible(model_path: str | Path) -> tuple[bool, str]:
     is_gemma4 = model_type in ("gemma4", "gemma4_text", "gemma4_unified")
     is_laguna = model_type == "laguna"
     is_muse = model_type in ("muse_glimmer", "muse_glimmer_text")
-    if not (is_qwen or is_gemma4 or is_laguna or is_muse):
+    is_glm5 = model_type == "glm5_next"
+    if not (is_qwen or is_gemma4 or is_laguna or is_muse or is_glm5):
         return False, (
-            f"DFlash supports only Qwen, Gemma4, Laguna, and Muse Glimmer "
+            f"DFlash supports only Qwen, Gemma4, Laguna, Muse Glimmer, and "
+            f"GLM-5.3 "
             f"models (model_type='{cfg.get('model_type', '')}')"
         )
     return True, ""
@@ -529,6 +532,15 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         runtime_context = self._build_runtime_context()
 
         def _load_models():
+            # Register oMLX-owned target extensions before importing the
+            # dflash loader functions below. GLM-5.3 is mlx-vlm-only, so its
+            # installer wraps ``load_target_bundle`` with a scoped VLM loader.
+            from ..patches.dflash_glm5 import install_dflash_glm5_backend
+            from ..patches.dflash_laguna import install_dflash_laguna_backend
+
+            install_dflash_laguna_backend()
+            install_dflash_glm5_backend()
+
             from dflash_mlx.draft_backend import EagerDraftBackend
             from dflash_mlx.engine.target_ops import bind_draft_to_target
             from dflash_mlx.runtime.loading import (
@@ -545,13 +557,6 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             maybe_apply_pre_load_patches(
                 self._model_name, model_settings=self._model_settings
             )
-
-            # dflash-mlx 0.1.10 has no Laguna backend. Register oMLX's strict
-            # TargetOps plus the official gated Laguna drafter specialization
-            # before load_target_bundle resolves either architecture.
-            from ..patches.dflash_laguna import install_dflash_laguna_backend
-
-            install_dflash_laguna_backend()
 
             # Wrap dflash's hook installers so we can revert the class-level
             # __call__ patches when this engine stops. Without this, a later
@@ -605,6 +610,13 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                     else None
                 ),
             )
+            from ..patches.dflash_glm5 import validate_glm5_dflash_pair
+
+            validate_glm5_dflash_pair(
+                target_bundle.model,
+                draft,
+                draft_meta,
+            )
             bind_draft_to_target(
                 draft,
                 target_bundle.model,
@@ -616,6 +628,27 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         result = await loop.run_in_executor(get_mlx_executor(), _load_models)
         target_bundle, self._draft_model, self._draft_backend, draft_meta = result
         self._draft_window_size = self._resolve_draft_window_size(draft_meta)
+        capabilities_for = getattr(target_bundle.target_ops, "capabilities_for", None)
+        target_capabilities = (
+            capabilities_for(target_bundle.model)
+            if callable(capabilities_for)
+            else None
+        )
+        if (
+            self._in_memory_cache_enabled
+            and target_capabilities is not None
+            and not target_capabilities.supports_prefix_snapshot
+        ):
+            # Do not advertise or initialize an inert cache. GLM-5.3's DSA
+            # layers use CacheList(KVCache, PoolingCache), which the pinned
+            # dflash snapshot codec cannot serialize yet.
+            logger.warning(
+                "DFlash prefix snapshots are not supported by target backend %s; "
+                "disabling DFlash L1/L2 cache for this load",
+                getattr(target_bundle.target_ops, "backend_name", "unknown"),
+            )
+            self._in_memory_cache_enabled = False
+            self._ssd_cache_requested = False
         runtime_context = self._build_runtime_context()
         self._runtime_context = runtime_context
         self._target_model = target_bundle.model

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -269,7 +269,9 @@ class EnginePool:
             the `_get_final_ceiling` callback set by `server.init_server()`.
             When that reads 0 (memory guard disabled), the pool falls back
             to `enforcer.get_admission_ceiling()` via `_get_admission_ceiling`
-            for best-effort LRU eviction (#2290). Idle-model eviction
+            for process-safe admission and LRU eviction (#2290). Disabling
+            request-time memory throttling must not permit concurrent model
+            weights to exceed the physical residency budget. Idle-model eviction
             starts at `enforcer.get_admission_soft_target()` via
             `_get_admission_soft_target` so the old model is unloaded
             before the new weights allocate (#2319). Until the callbacks
@@ -454,7 +456,7 @@ class EnginePool:
             return 0
 
     def _fallback_admission_ceiling(self) -> int:
-        """Best-effort admission ceiling used when `_current_ceiling()` is 0.
+        """Process-safe admission ceiling when `_current_ceiling()` is 0.
 
         Wired to `enforcer.get_admission_ceiling`, which keeps returning
         the static ceiling while the memory guard is disabled so a model
@@ -1540,10 +1542,11 @@ class EnginePool:
             #
             # ceiling == 0 means the guard is disabled or the enforcer is
             # not wired up. Eviction on model swap must not die with the
-            # guard (#2290): fall back to the best-effort admission
-            # ceiling (static, guard-independent) and keep evicting, but
-            # never refuse the load under it — with the guard off the
-            # user opted out of hard limits.
+            # guard (#2290): fall back to the static, guard-independent
+            # admission ceiling and keep evicting. This fallback remains a
+            # hard *model residency* limit: the optional guard controls
+            # request-time throttling, not whether two large checkpoints may
+            # overcommit physical memory and crash the host.
             # A distributed coordinator admits only rank zero's planned shard,
             # not the complete model. A local VLM-shaped checkpoint served by
             # the text engine (force_lm or a model_type_override that flipped
@@ -1570,10 +1573,8 @@ class EnginePool:
             )
             admission_kind = "local shard" if deployment is not None else "model"
             ceiling = self._current_ceiling()
-            best_effort = False
             if ceiling <= 0:
                 ceiling = self._fallback_admission_ceiling()
-                best_effort = ceiling > 0
             if ceiling > 0:
                 soft_target = self._admission_soft_target()
                 evict_target = min(soft_target, ceiling) if soft_target > 0 else ceiling
@@ -1653,21 +1654,6 @@ class EnginePool:
                         failure_current = committed
                         failure_projected = committed_projected
                         failure_label = "committed"
-
-                    if best_effort:
-                        # Memory guard is off: evicting was all we could
-                        # do. Admit over the static ceiling instead of
-                        # refusing, matching the unguarded no-hard-limit
-                        # contract.
-                        logger.warning(
-                            f"Loading '{model_id}' past the static memory "
-                            f"ceiling with the memory guard disabled "
-                            f"(projected {format_size(failure_projected)} > "
-                            f"ceiling {format_size(ceiling)}, "
-                            f"{failure_label} baseline) and nothing left to "
-                            f"evict; the system may swap heavily."
-                        )
-                        break
 
                     # Still over budget under the applicable baseline. Use
                     # ModelTooLargeError when the model alone exceeds the

--- a/omlx/patches/dflash_glm5.py
+++ b/omlx/patches/dflash_glm5.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import json
 import time
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -40,6 +41,7 @@ from dflash_mlx.recurrent_rollback_cache import RecurrentRollbackCache
 _BACKEND_PATH = "omlx.patches.dflash_glm5:Glm5NextTargetOps"
 _ORIGINAL_TARGET_LOADER: Any | None = None
 _ORIGINAL_LINEAR_CALLS: dict[type, Any] = {}
+_ORIGINAL_PREFILL_RUNNER: Any | None = None
 
 
 def _config_value(config: Any, name: str, default: Any = None) -> Any:
@@ -161,13 +163,97 @@ def _install_glm5_recurrent_hook(linear_attn: Any) -> None:
     cls.__call__ = speculative_call
 
 
+def _install_glm5_prefill_chunking_bridge() -> bool:
+    """Chunk GLM prefill without claiming or activating snapshot support.
+
+    The pinned dflash runtime currently uses ``supports_prefix_snapshot`` for
+    two independent decisions: whether cache snapshots are legal *and* whether
+    cold prefill is split by ``prefill_step_size``.  GLM's composite DSA cache
+    is intentionally not serializable, but that must not turn a long prompt
+    into one monolithic target forward.
+
+    This scoped bridge temporarily enables only the runtime's chunk loop while
+    sanitizing every snapshot-bearing request field.  It then rewrites the
+    returned prefill result back to ``supports_prefix_snapshot=False``, so
+    decode and generation-snapshot paths continue to see the truthful target
+    capability.  Non-GLM sessions take the original method unchanged.
+    """
+    global _ORIGINAL_PREFILL_RUNNER
+
+    from dflash_mlx.engine.spec_epoch import SpeculativeSession
+
+    current = SpeculativeSession._run_prefill_events
+    if getattr(current, "_omlx_glm5_chunk_bridge", False):
+        return False
+    _ORIGINAL_PREFILL_RUNNER = current
+
+    def run_prefill_chunked(self, *, request, state, yield_pause):
+        if (
+            getattr(getattr(self, "target_ops", None), "backend_name", "")
+            != "glm5_next"
+        ):
+            return current(
+                self,
+                request=request,
+                state=state,
+                yield_pause=yield_pause,
+            )
+
+        # Session.open() already received the real False capability, so it
+        # cannot hydrate a prefix snapshot.  Scrub the request as a second,
+        # local fail-closed boundary before borrowing the chunk loop.
+        safe_request = replace(
+            request,
+            prefix_snapshot=None,
+            snapshot_service=None,
+            stable_prefix_len=None,
+            prefix_cache_active=False,
+            publish_generation_snapshot=False,
+            prefix_hit_kind="miss",
+        )
+
+        def iterate():
+            previous = bool(self.supports_prefix_snapshot)
+            self.supports_prefix_snapshot = True
+            try:
+                result = yield from current(
+                    self,
+                    request=safe_request,
+                    state=state,
+                    yield_pause=yield_pause,
+                )
+                return replace(result, supports_prefix_snapshot=False)
+            finally:
+                self.supports_prefix_snapshot = previous
+
+        return iterate()
+
+    run_prefill_chunked._omlx_glm5_chunk_bridge = True  # type: ignore[attr-defined]
+    run_prefill_chunked._omlx_original = current  # type: ignore[attr-defined]
+    SpeculativeSession._run_prefill_events = run_prefill_chunked
+    return True
+
+
 def restore_glm5_dflash_class_patches() -> int:
-    """Restore every GLM class changed by ``_install_glm5_recurrent_hook``."""
+    """Restore every process-global GLM DFlash runtime hook."""
+    global _ORIGINAL_PREFILL_RUNNER
+
     restored = 0
     for cls, original_call in tuple(_ORIGINAL_LINEAR_CALLS.items()):
         cls.__call__ = original_call
         restored += 1
     _ORIGINAL_LINEAR_CALLS.clear()
+
+    if _ORIGINAL_PREFILL_RUNNER is not None:
+        try:
+            from dflash_mlx.engine.spec_epoch import SpeculativeSession
+
+            current = SpeculativeSession._run_prefill_events
+            if getattr(current, "_omlx_glm5_chunk_bridge", False):
+                SpeculativeSession._run_prefill_events = _ORIGINAL_PREFILL_RUNNER
+                restored += 1
+        finally:
+            _ORIGINAL_PREFILL_RUNNER = None
     return restored
 
 
@@ -402,6 +488,15 @@ class Glm5NextTargetOps:
             delattr(cache_entry, "_omlx_glm5_verify")
         cache_entry.clear_transients()
 
+    @staticmethod
+    def _clear_composite_undo(cache_entry: Any) -> None:
+        """Drop accepted verify-block undo arrays retained by PoolingCache."""
+        for component in getattr(cache_entry, "caches", ()):
+            if hasattr(component, "_undo"):
+                component._undo = None
+            if hasattr(component, "_undo_chain"):
+                component._undo_chain = False
+
     @classmethod
     def _rollback_glm_recurrent(
         cls,
@@ -469,6 +564,8 @@ class Glm5NextTargetOps:
             offset = int(getattr(kv_cache, "offset", 0) or 0)
             trim_count = max(0, offset - int(target_len))
             if trim_count <= 0:
+                if fully_accepted:
+                    self._clear_composite_undo(cache_entry)
                 continue
             trim = getattr(cache_entry, "trim", None)
             if not callable(trim):
@@ -481,6 +578,7 @@ class Glm5NextTargetOps:
                     "GLM-5.3 DFlash composite-cache rollback failed: "
                     f"requested={trim_count}, trimmed={trimmed}"
                 )
+            self._clear_composite_undo(cache_entry)
             changed = True
         return time.perf_counter_ns() - started if changed else 0
 
@@ -549,6 +647,7 @@ def install_dflash_glm5_backend() -> bool:
     from dflash_mlx.runtime import loading
 
     changed = False
+    changed |= _install_glm5_prefill_chunking_bridge()
     if _BACKEND_PATH not in target_ops.TARGET_BACKENDS:
         target_ops.TARGET_BACKENDS.append(_BACKEND_PATH)
         changed = True

--- a/omlx/patches/dflash_glm5.py
+++ b/omlx/patches/dflash_glm5.py
@@ -610,7 +610,10 @@ def _load_glm5_target_bundle(
     from dflash_mlx.runtime.loading import LoadedTargetBundle
     from mlx_vlm.utils import load as vlm_load
 
-    from ..utils.model_loading import maybe_load_custom_quantization
+    from ..utils.model_loading import (
+        materialize_lazy_state,
+        maybe_load_custom_quantization,
+    )
     from .mlx_vlm_glm5_next_compat import apply_mlx_vlm_glm5_next_compat_patch
 
     apply_mlx_vlm_glm5_next_compat_patch()
@@ -619,6 +622,14 @@ def _load_glm5_target_bundle(
         model, processor = custom_loaded
     else:
         model, processor = vlm_load(str(model_ref), lazy=lazy, strict=True)
+    # The custom oQ loader intentionally leaves the target tree lazy. Normal
+    # VLMEngine startup materializes it before serving, but DFlash owns a
+    # separate loader and previously skipped that lifecycle step. The result
+    # looked like a 1-second/~200 MB load and every target verification paid
+    # the mmap/lazy-transform cost again. Force the exact same bounded model
+    # materialization here, on DFlash's loader/MLX-executor thread, before any
+    # speculative hook or request can observe the model.
+    materialize_lazy_state(model)
     target_ops = resolve_target_ops(model)
     target_ops.install_speculative_hooks(model)
     config_path = Path(model_ref) / "config.json"

--- a/omlx/patches/dflash_glm5.py
+++ b/omlx/patches/dflash_glm5.py
@@ -1,0 +1,585 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GLM-5.3 target adapter for the pinned dflash-mlx runtime.
+
+The published ``incoai/GLM-5.3-Flash-DFlash2`` checkpoint already uses the
+generic :class:`dflash_mlx.model.DFlash2DraftModel`.  The missing piece is the
+target contract: GLM-5.3 is loaded through mlx-vlm, carries multi-stream
+hyper-connection (MHC) hidden states, and combines recurrent KDA caches with
+``CacheList(KVCache, PoolingCache)`` sparse-attention caches.
+
+This module extends dflash-mlx through its backend registry and target-loader
+seam.  It intentionally fails closed:
+
+* only ``glm5_next`` targets paired with a DFlash2 checkpoint are accepted;
+* captured MHC states are contracted before reaching the drafter, matching
+  SGLang's official GLM-5.3 DFlash capture contract;
+* recurrent verification uses bounded replay through GLM's exact vector-gate
+  recurrence (the generic innovation tape drifts at tail-ULP after repeated
+  GLM rejection cycles);
+* composite DSA caches are trimmed explicitly after rejected draft tokens;
+* prefix snapshots and tree verification remain disabled until codecs for the
+  composite GLM cache are independently parity-proven.
+
+The installer is process-global and idempotent, like the existing Laguna
+adapter.  ``restore_glm5_dflash_class_patches`` is called by the shared DFlash
+lifecycle restore so a later normal/MTP GLM load cannot inherit speculative
+class hooks.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import mlx.core as mx
+from dflash_mlx.engine.target_ops import TargetCapabilities
+from dflash_mlx.recurrent_rollback_cache import RecurrentRollbackCache
+
+_BACKEND_PATH = "omlx.patches.dflash_glm5:Glm5NextTargetOps"
+_ORIGINAL_TARGET_LOADER: Any | None = None
+_ORIGINAL_LINEAR_CALLS: dict[type, Any] = {}
+
+
+def _config_value(config: Any, name: str, default: Any = None) -> Any:
+    if isinstance(config, dict):
+        return config.get(name, default)
+    return getattr(config, name, default)
+
+
+def _model_type(model: Any) -> str:
+    value = getattr(model, "model_type", None)
+    if value is not None:
+        return str(value).lower()
+    config = getattr(model, "config", None)
+    value = _config_value(config, "model_type")
+    if value is not None:
+        return str(value).lower()
+    language_model = getattr(model, "language_model", None)
+    args = getattr(language_model, "args", None)
+    return str(getattr(args, "model_type", "")).lower()
+
+
+def _is_glm5_config(config: dict[str, Any]) -> bool:
+    return str(config.get("model_type", "")).lower() == "glm5_next"
+
+
+def _contract_mhc_hidden(hidden: mx.array) -> mx.array:
+    """Contract GLM's ``[B, T, hc_mult, H]`` residual streams for DFlash."""
+    if hidden.ndim == 4:
+        return hidden.mean(axis=2)
+    if hidden.ndim != 3:
+        raise ValueError(f"Unexpected GLM hidden-state rank: {hidden.ndim}")
+    return hidden
+
+
+def validate_glm5_dflash_pair(
+    target_model: Any,
+    draft_model: Any,
+    draft_meta: Any,
+) -> None:
+    """Reject an unproven GLM target/draft pairing before generation starts."""
+    if _model_type(target_model) != "glm5_next":
+        return
+
+    config = draft_meta.get("config", {}) if isinstance(draft_meta, dict) else {}
+    architectures = tuple(str(v) for v in (config.get("architectures") or ()))
+    if "DFlash2DraftModel" not in architectures or not bool(
+        getattr(draft_model, "is_dflash2", False)
+    ):
+        raise ValueError("GLM-5.3 DFlash requires a DFlash2DraftModel checkpoint")
+
+    language_model = getattr(target_model, "language_model", None)
+    target_args = getattr(language_model, "args", None)
+    target_inner = getattr(language_model, "model", None)
+    draft_args = getattr(draft_model, "args", None)
+    if target_args is None or target_inner is None or draft_args is None:
+        raise ValueError("GLM-5.3 DFlash target/draft metadata is incomplete")
+
+    checks = (
+        ("hidden_size", int(getattr(target_args, "hidden_size", 0))),
+        ("vocab_size", int(getattr(target_args, "vocab_size", 0))),
+        ("num_target_layers", len(getattr(target_inner, "layers", ()))),
+    )
+    for draft_name, target_value in checks:
+        draft_value = int(getattr(draft_args, draft_name, 0) or 0)
+        if draft_value != target_value:
+            raise ValueError(
+                f"GLM-5.3 DFlash {draft_name} mismatch: "
+                f"draft={draft_value}, target={target_value}"
+            )
+
+    target_layer_ids = [int(v) for v in getattr(draft_model, "target_layer_ids", ())]
+    if (
+        not target_layer_ids
+        or target_layer_ids != sorted(set(target_layer_ids))
+        or target_layer_ids[0] < 0
+        or target_layer_ids[-1] >= len(target_inner.layers)
+    ):
+        raise ValueError(
+            "GLM-5.3 DFlash target_layer_ids must be unique, increasing, and "
+            "inside the target layer range"
+        )
+
+    if (
+        not bool(getattr(target_args, "mhc", False))
+        or int(getattr(target_args, "hc_mult", 0) or 0) <= 0
+    ):
+        raise ValueError("GLM-5.3 DFlash requires the checkpoint's MHC target")
+
+
+def _install_glm5_recurrent_hook(linear_attn: Any) -> None:
+    """Retain verify inputs so rejected KDA state can be replayed exactly.
+
+    The target forward itself remains the vendored GLM implementation. This is
+    important: a copied verify implementation can silently drift whenever the
+    GLM projection or recurrence kernels change. The wrapper records only the
+    already-computed layer input and delegates all arithmetic unchanged.
+    """
+    cls = type(linear_attn)
+    if cls in _ORIGINAL_LINEAR_CALLS:
+        return
+    original_call = cls.__call__
+    _ORIGINAL_LINEAR_CALLS[cls] = original_call
+
+    def speculative_call(
+        self,
+        inputs: mx.array,
+        mask: mx.array | None = None,
+        cache: Any | None = None,
+    ) -> mx.array:
+        if not isinstance(cache, RecurrentRollbackCache) or not getattr(
+            cache, "_armed", False
+        ):
+            return original_call(self, inputs, mask=mask, cache=cache)
+        output = original_call(self, inputs, mask=mask, cache=cache)
+        cache._omlx_glm5_verify = (self, inputs, mask)
+        return output
+
+    speculative_call._omlx_dflash_glm5 = True  # type: ignore[attr-defined]
+    cls.__call__ = speculative_call
+
+
+def restore_glm5_dflash_class_patches() -> int:
+    """Restore every GLM class changed by ``_install_glm5_recurrent_hook``."""
+    restored = 0
+    for cls, original_call in tuple(_ORIGINAL_LINEAR_CALLS.items()):
+        cls.__call__ = original_call
+        restored += 1
+    _ORIGINAL_LINEAR_CALLS.clear()
+    return restored
+
+
+class Glm5NextTargetOps:
+    """dflash-mlx target contract for GLM-5.3's KDA/DSA text backbone."""
+
+    backend_name = "glm5_next"
+
+    def model_type(self, target_model: Any) -> str:
+        return _model_type(target_model)
+
+    def supports_model(self, target_model: Any) -> bool:
+        if self.model_type(target_model) != "glm5_next":
+            return False
+        try:
+            inner = self.text_model(target_model)
+        except AttributeError:
+            return False
+        return (
+            hasattr(inner, "layers")
+            and hasattr(inner, "embed_tokens")
+            and hasattr(inner, "fa_idx")
+            and hasattr(inner, "ssm_idx")
+        )
+
+    def family(self, target_model: Any) -> str:
+        del target_model
+        return "glm5_next_kda_dsa"
+
+    def capabilities_for(self, target_model: Any) -> TargetCapabilities:
+        del target_model
+        return TargetCapabilities(
+            supports_dflash=True,
+            supports_recurrent_rollback=True,
+            supports_kv_trim=True,
+            # dflash-mlx's snapshot codec only supports bare KVCache and its
+            # own recurrent cache. GLM DSA uses CacheList(KV, Pooling).
+            supports_prefix_snapshot=False,
+            supports_rotating_cache_snapshot=False,
+            supports_shared_kv=False,
+            supports_target_hidden_capture=True,
+            # The Qwen verify-qmm kernels have not passed GLM parity gates.
+            supports_verify_linear=False,
+            supports_full_context_draft_layers=False,
+            supports_tree_verify=False,
+        )
+
+    def supports_tree_cache(self, cache_entries: list[Any]) -> bool:
+        del cache_entries
+        return False
+
+    def text_wrapper(self, target_model: Any) -> Any:
+        wrapper = getattr(target_model, "language_model", None)
+        if wrapper is None or not hasattr(wrapper, "model"):
+            raise AttributeError(
+                f"Unsupported GLM-5.3 model wrapper: {type(target_model)!r}"
+            )
+        return wrapper
+
+    def text_model(self, target_model: Any) -> Any:
+        return self.text_wrapper(target_model).model
+
+    def embed_tokens(self, target_model: Any) -> Any:
+        return self.text_model(target_model).embed_tokens
+
+    def logits_from_hidden(
+        self, target_model: Any, hidden_states: mx.array
+    ) -> mx.array:
+        from mlx_vlm.models.glm5_next.linear import linear_forward
+
+        wrapper = self.text_wrapper(target_model)
+        if bool(getattr(wrapper.args, "tie_word_embeddings", False)):
+            return wrapper.model.embed_tokens.as_linear(hidden_states)
+        return linear_forward(wrapper.lm_head, hidden_states)
+
+    def make_cache(
+        self,
+        target_model: Any,
+        *,
+        enable_speculative_linear_cache: bool,
+        quantize_kv_cache: bool = False,
+        target_fa_window: int | None = None,
+    ) -> list[Any]:
+        if not enable_speculative_linear_cache:
+            raise ValueError("GLM-5.3 DFlash requires recurrent rollback caches")
+        if quantize_kv_cache:
+            raise ValueError("GLM-5.3 DFlash target KV quantization is unproven")
+        if target_fa_window is not None and int(target_fa_window) > 0:
+            raise ValueError("GLM-5.3 DFlash does not support target_fa_window")
+
+        wrapper = self.text_wrapper(target_model)
+        caches = list(wrapper.make_cache())
+        inner = wrapper.model
+        if len(caches) != len(inner.layers):
+            raise ValueError("GLM-5.3 target cache/layer count mismatch")
+        for index, layer in enumerate(inner.layers):
+            if getattr(layer, "is_linear", False):
+                conv_kernel = int(layer.self_attn.conv_kernel_size)
+                caches[index] = RecurrentRollbackCache(
+                    size=2, conv_kernel_size=conv_kernel
+                )
+        return caches
+
+    def install_speculative_hooks(self, target_model: Any) -> None:
+        inner = self.text_model(target_model)
+        for layer in inner.layers:
+            if getattr(layer, "is_linear", False):
+                _install_glm5_recurrent_hook(layer.self_attn)
+
+    def forward_with_hidden_capture(
+        self,
+        target_model: Any,
+        *,
+        input_ids: mx.array | None = None,
+        cache: list[Any] | None = None,
+        input_embeddings: mx.array | None = None,
+        capture_layer_ids: set[int] | None = None,
+        logits_last_only: bool = False,
+    ) -> tuple[mx.array, list[mx.array] | dict[int, mx.array]]:
+        from mlx_vlm.models.base import create_attention_mask, create_ssm_mask
+
+        inner = self.text_model(target_model)
+        h = (
+            input_embeddings
+            if input_embeddings is not None
+            else inner.embed_tokens(input_ids)
+        )
+        if cache is None:
+            cache = [None] * len(inner.layers)
+        elif len(cache) != len(inner.layers):
+            raise ValueError("GLM-5.3 cache/layer count mismatch")
+
+        fa_cache = cache[inner.fa_idx]
+        fa_mask = create_attention_mask(
+            h,
+            fa_cache[0] if fa_cache is not None else None,
+            return_array=True,
+        )
+        ssm_mask = create_ssm_mask(h, cache[inner.ssm_idx])
+        h = mx.contiguous(
+            mx.broadcast_to(
+                h[:, :, None, :],
+                (h.shape[0], h.shape[1], inner.hc_mult, h.shape[2]),
+            )
+        )
+
+        capture_all = capture_layer_ids is None
+        if capture_all:
+            captured: list[mx.array] | dict[int, mx.array] = [_contract_mhc_hidden(h)]
+        else:
+            capture_layer_ids = set(capture_layer_ids)
+            captured = {0: _contract_mhc_hidden(h)} if 0 in capture_layer_ids else {}
+
+        for layer_index, (layer, layer_cache) in enumerate(
+            zip(inner.layers, cache, strict=True)
+        ):
+            mask = ssm_mask if getattr(layer, "is_linear", False) else fa_mask
+            h = layer(h, mask=mask, cache=layer_cache)
+            capture_key = layer_index + 1
+            if capture_all:
+                captured.append(_contract_mhc_hidden(h))
+            elif capture_layer_ids is not None and capture_key in capture_layer_ids:
+                captured[capture_key] = _contract_mhc_hidden(h)
+
+        normalized = inner.norm(_contract_mhc_hidden(h))
+        if logits_last_only and isinstance(captured, dict):
+            captured[-1] = normalized
+        logits_hidden = normalized[:, -1:, :] if logits_last_only else normalized
+        return self.logits_from_hidden(target_model, logits_hidden), captured
+
+    def verify_block(
+        self,
+        *,
+        target_model: Any,
+        verify_ids: mx.array,
+        target_cache: list[Any],
+        capture_layer_ids: set[int] | None = None,
+    ) -> tuple[mx.array, list[mx.array] | dict[int, mx.array]]:
+        if int(verify_ids.shape[1]) <= 0:
+            raise ValueError("verify block must contain at least one token")
+        # PoolingCache and any future rotating component only retain their
+        # cross-boundary undo record while this thread-local gate is armed.
+        from ..patches.mlx_lm_mtp import cache_rollback
+
+        cache_rollback.apply()
+        cache_rollback.set_undo_armed(True)
+        try:
+            return self.forward_with_hidden_capture(
+                target_model,
+                input_ids=verify_ids,
+                cache=target_cache,
+                capture_layer_ids=capture_layer_ids,
+            )
+        finally:
+            cache_rollback.set_undo_armed(False)
+
+    def verify_tree_block(
+        self,
+        *,
+        target_model: Any,
+        tree_inputs: Any,
+        target_cache: list[Any],
+        capture_layer_ids: set[int] | None = None,
+    ) -> tuple[mx.array, list[mx.array] | dict[int, mx.array]]:
+        del target_model, tree_inputs, target_cache, capture_layer_ids
+        raise NotImplementedError("GLM-5.3 DFlash tree verification is unproven")
+
+    def restore_after_tree_acceptance(
+        self, cache_entries: list[Any], *, accepted_tree_indices: list[int]
+    ) -> int:
+        del cache_entries, accepted_tree_indices
+        raise NotImplementedError("GLM-5.3 DFlash tree verification is unproven")
+
+    def extract_context_feature(
+        self,
+        captured_dict: dict[int, mx.array] | list[mx.array],
+        target_layer_ids: list[int],
+    ) -> mx.array:
+        return mx.concatenate(
+            [captured_dict[int(layer_id) + 1] for layer_id in target_layer_ids],
+            axis=-1,
+        )
+
+    def arm_rollback(self, cache_entries: list[Any], *, prefix_len: int) -> None:
+        for cache_entry in cache_entries:
+            if isinstance(cache_entry, RecurrentRollbackCache):
+                cache_entry.arm_rollback(prefix_len=prefix_len)
+
+    @staticmethod
+    def _clear_glm_recurrent_transients(cache_entry: Any) -> None:
+        if hasattr(cache_entry, "_omlx_glm5_verify"):
+            delattr(cache_entry, "_omlx_glm5_verify")
+        cache_entry.clear_transients()
+
+    @classmethod
+    def _rollback_glm_recurrent(
+        cls,
+        cache_entry: RecurrentRollbackCache,
+        *,
+        accepted_steps: int,
+    ) -> None:
+        snapshot = getattr(cache_entry, "_snapshot", None)
+        verify = getattr(cache_entry, "_omlx_glm5_verify", None)
+        if snapshot is None or verify is None:
+            cls._clear_glm_recurrent_transients(cache_entry)
+            raise RuntimeError("GLM-5.3 recurrent rollback state is missing")
+
+        attention, inputs, mask = verify
+        accepted_steps = max(0, min(int(accepted_steps), int(inputs.shape[1])))
+        cache_entry.cache = list(snapshot)
+        if accepted_steps > 0:
+            step_mask = (
+                mask[:, :accepted_steps]
+                if isinstance(mask, mx.array) and mask.ndim == 2
+                else None
+            )
+            original_call = _ORIGINAL_LINEAR_CALLS.get(type(attention))
+            if original_call is None:
+                cls._clear_glm_recurrent_transients(cache_entry)
+                raise RuntimeError("GLM-5.3 recurrent target hook is not installed")
+            # One bounded native call recreates both conv and KDA state using
+            # exactly the target implementation and the accepted-width shape.
+            original_call(
+                attention,
+                inputs[:, :accepted_steps],
+                mask=step_mask,
+                cache=cache_entry,
+            )
+        cls._clear_glm_recurrent_transients(cache_entry)
+
+    def restore_after_acceptance(
+        self,
+        cache_entries: list[Any],
+        *,
+        target_len: int,
+        acceptance_length: int,
+        drafted_tokens: int = 0,
+    ) -> int:
+        started = time.perf_counter_ns()
+        changed = False
+        fully_accepted = acceptance_length == drafted_tokens
+        for cache_entry in cache_entries:
+            if isinstance(cache_entry, RecurrentRollbackCache):
+                if fully_accepted:
+                    self._clear_glm_recurrent_transients(cache_entry)
+                else:
+                    self._rollback_glm_recurrent(
+                        cache_entry,
+                        accepted_steps=int(acceptance_length) + 1,
+                    )
+                changed = True
+                continue
+
+            # GLM DSA cache entries are CacheList(KVCache, PoolingCache).
+            try:
+                kv_cache = cache_entry[0]
+            except (IndexError, TypeError):
+                kv_cache = None
+            offset = int(getattr(kv_cache, "offset", 0) or 0)
+            trim_count = max(0, offset - int(target_len))
+            if trim_count <= 0:
+                continue
+            trim = getattr(cache_entry, "trim", None)
+            if not callable(trim):
+                raise RuntimeError(
+                    f"GLM-5.3 DFlash cannot trim {type(cache_entry).__name__}"
+                )
+            trimmed = int(trim(trim_count))
+            if trimmed != trim_count:
+                raise RuntimeError(
+                    "GLM-5.3 DFlash composite-cache rollback failed: "
+                    f"requested={trim_count}, trimmed={trimmed}"
+                )
+            changed = True
+        return time.perf_counter_ns() - started if changed else 0
+
+    def cleanup_generation_caches(
+        self, target_cache: list[Any], draft_cache: list[Any]
+    ) -> None:
+        for entry in target_cache:
+            if isinstance(entry, RecurrentRollbackCache):
+                self._clear_glm_recurrent_transients(entry)
+        draft_cache.clear()
+        target_cache.clear()
+
+
+def _load_glm5_target_bundle(
+    model_ref: str | Path | None,
+    *,
+    lazy: bool = True,
+    quantize_kv_cache: bool = False,
+    verify_config: Any | None = None,
+) -> Any:
+    """Load GLM through mlx-vlm while returning dflash-mlx's bundle type."""
+    del verify_config
+    if quantize_kv_cache:
+        raise ValueError("GLM-5.3 DFlash target KV quantization is unproven")
+    if model_ref is None:
+        raise ValueError("target model reference is required")
+
+    from dflash_mlx.engine.target_ops import resolve_target_ops
+    from dflash_mlx.runtime.loading import LoadedTargetBundle
+    from mlx_vlm.utils import load as vlm_load
+
+    from ..utils.model_loading import maybe_load_custom_quantization
+    from .mlx_vlm_glm5_next_compat import apply_mlx_vlm_glm5_next_compat_patch
+
+    apply_mlx_vlm_glm5_next_compat_patch()
+    custom_loaded = maybe_load_custom_quantization(str(model_ref), is_vlm=True)
+    if custom_loaded is not None:
+        model, processor = custom_loaded
+    else:
+        model, processor = vlm_load(str(model_ref), lazy=lazy, strict=True)
+    target_ops = resolve_target_ops(model)
+    target_ops.install_speculative_hooks(model)
+    config_path = Path(model_ref) / "config.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    tokenizer = getattr(processor, "tokenizer", processor)
+    return LoadedTargetBundle(
+        model=model,
+        tokenizer=tokenizer,
+        meta={
+            "resolved_model_ref": str(model_ref),
+            "config": config,
+            "quantize_kv_cache": False,
+            "target_family": target_ops.family(model),
+            "verify_linear_enabled": False,
+            "verify_mode": "disabled-glm5-parity-gate",
+        },
+        target_ops=target_ops,
+    )
+
+
+def install_dflash_glm5_backend() -> bool:
+    """Register GLM target ops and a scoped mlx-vlm target loader."""
+    global _ORIGINAL_TARGET_LOADER
+
+    from dflash_mlx.engine import target_ops
+    from dflash_mlx.runtime import loading
+
+    changed = False
+    if _BACKEND_PATH not in target_ops.TARGET_BACKENDS:
+        target_ops.TARGET_BACKENDS.append(_BACKEND_PATH)
+        changed = True
+
+    current = loading.load_target_bundle
+    if not getattr(current, "_omlx_glm5_target_loader", False):
+        _ORIGINAL_TARGET_LOADER = current
+
+        def load_target_bundle(model_ref=None, **kwargs):
+            candidate = Path(str(model_ref)).expanduser() if model_ref else None
+            config_path = candidate / "config.json" if candidate is not None else None
+            if config_path is None or not config_path.exists():
+                return current(model_ref, **kwargs)
+            try:
+                config = json.loads(config_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                return current(model_ref, **kwargs)
+            if not _is_glm5_config(config):
+                return current(model_ref, **kwargs)
+            return _load_glm5_target_bundle(model_ref, **kwargs)
+
+        load_target_bundle._omlx_glm5_target_loader = True  # type: ignore[attr-defined]
+        load_target_bundle._omlx_original = current  # type: ignore[attr-defined]
+        loading.load_target_bundle = load_target_bundle
+        changed = True
+    return changed
+
+
+__all__ = [
+    "Glm5NextTargetOps",
+    "install_dflash_glm5_backend",
+    "restore_glm5_dflash_class_patches",
+    "validate_glm5_dflash_pair",
+]

--- a/omlx/patches/dflash_glm5.py
+++ b/omlx/patches/dflash_glm5.py
@@ -599,8 +599,14 @@ def _load_glm5_target_bundle(
     quantize_kv_cache: bool = False,
     verify_config: Any | None = None,
 ) -> Any:
-    """Load GLM through mlx-vlm while returning dflash-mlx's bundle type."""
-    del verify_config
+    """Load GLM through mlx-vlm while returning dflash-mlx's bundle type.
+
+    The pinned DFlash loader requests lazy targets by default. GLM must follow
+    the regular VLMEngine contract instead: mlx-vlm constructs the fallback
+    target eagerly, then oMLX performs its bounded whole-tree materialization.
+    Custom oQ loading owns its own load policy and is deliberately unchanged.
+    """
+    del lazy, verify_config
     if quantize_kv_cache:
         raise ValueError("GLM-5.3 DFlash target KV quantization is unproven")
     if model_ref is None:
@@ -621,7 +627,7 @@ def _load_glm5_target_bundle(
     if custom_loaded is not None:
         model, processor = custom_loaded
     else:
-        model, processor = vlm_load(str(model_ref), lazy=lazy, strict=True)
+        model, processor = vlm_load(str(model_ref), lazy=False, strict=True)
     # The custom oQ loader intentionally leaves the target tree lazy. Normal
     # VLMEngine startup materializes it before serving, but DFlash owns a
     # separate loader and previously skipped that lifecycle step. The result

--- a/omlx/patches/dflash_glm5.py
+++ b/omlx/patches/dflash_glm5.py
@@ -604,7 +604,8 @@ def _load_glm5_target_bundle(
     The pinned DFlash loader requests lazy targets by default. GLM must follow
     the regular VLMEngine contract instead: mlx-vlm constructs the fallback
     target eagerly, then oMLX performs its bounded whole-tree materialization.
-    Custom oQ loading owns its own load policy and is deliberately unchanged.
+    Both routes run inside VLMEngine's pre-quantization sanitize scope; custom
+    oQ loading otherwise owns its existing load policy unchanged.
     """
     del lazy, verify_config
     if quantize_kv_cache:
@@ -616,6 +617,7 @@ def _load_glm5_target_bundle(
     from dflash_mlx.runtime.loading import LoadedTargetBundle
     from mlx_vlm.utils import load as vlm_load
 
+    from ..engine.vlm import _force_qwen4_exp_sanitize_on_load
     from ..utils.model_loading import (
         materialize_lazy_state,
         maybe_load_custom_quantization,
@@ -623,11 +625,12 @@ def _load_glm5_target_bundle(
     from .mlx_vlm_glm5_next_compat import apply_mlx_vlm_glm5_next_compat_patch
 
     apply_mlx_vlm_glm5_next_compat_patch()
-    custom_loaded = maybe_load_custom_quantization(str(model_ref), is_vlm=True)
-    if custom_loaded is not None:
-        model, processor = custom_loaded
-    else:
-        model, processor = vlm_load(str(model_ref), lazy=False, strict=True)
+    with _force_qwen4_exp_sanitize_on_load(Path(model_ref)):
+        custom_loaded = maybe_load_custom_quantization(str(model_ref), is_vlm=True)
+        if custom_loaded is not None:
+            model, processor = custom_loaded
+        else:
+            model, processor = vlm_load(str(model_ref), lazy=False, strict=True)
     # The custom oQ loader intentionally leaves the target tree lazy. Normal
     # VLMEngine startup materializes it before serving, but DFlash owns a
     # separate loader and previously skipped that lifecycle step. The result

--- a/omlx/patches/dflash_lifecycle.py
+++ b/omlx/patches/dflash_lifecycle.py
@@ -167,9 +167,6 @@ def restore_dflash_class_patches() -> None:
     DFlash engine load can re-install its hook freshly. Empties the
     backup table.
     """
-    if not _DFLASH_BACKUP:
-        return
-
     restored = 0
     for cls, info in list(_DFLASH_BACKUP.items()):
         try:
@@ -186,6 +183,14 @@ def restore_dflash_class_patches() -> None:
         restored += 1
 
     _DFLASH_BACKUP.clear()
+    # GLM-5.3's KDA adapter owns a separate hook because dflash-mlx has no
+    # upstream GLM module to wrap. Restore it at the same lifecycle boundary.
+    try:
+        from .dflash_glm5 import restore_glm5_dflash_class_patches
+
+        restored += restore_glm5_dflash_class_patches()
+    except Exception:
+        logger.debug("GLM-5.3 dflash class restore skipped", exc_info=True)
     logger.info("dflash class patches restored on %d class(es)", restored)
 
 

--- a/omlx/patches/glm_moe_dsa/generate_patch.py
+++ b/omlx/patches/glm_moe_dsa/generate_patch.py
@@ -31,14 +31,90 @@ class _AdaptivePrefillConfig:
     min_remaining: int
 
 
+_GLM5_NATIVE_PREFILL_SYMBOLS = (
+    "dsa_indexer_scores",
+    "dsa_topk_indices",
+    "glm_dsa_sparse_mla_attention",
+    "glm_dsa_exact_block_attention",
+    "glm_dsa_q8_vup_flat",
+)
+
+
+def _glm5_native_prefill_geometry(model: Any) -> bool:
+    config = getattr(model, "config", None)
+    candidates = (
+        getattr(config, "text_config", None),
+        getattr(getattr(model, "language_model", None), "config", None),
+        getattr(getattr(model, "_language_model", None), "config", None),
+        config,
+        getattr(model, "args", None),
+    )
+    text_config = next(
+        (
+            candidate
+            for candidate in candidates
+            if candidate is not None
+            and hasattr(candidate, "num_attention_heads")
+        ),
+        None,
+    )
+    if text_config is None:
+        return False
+
+    expected = {
+        "num_attention_heads": 64,
+        "kv_lora_rank": 512,
+        "index_topk": 2048,
+        "index_n_heads": 32,
+        "index_head_dim": 128,
+        "index_kpool": 4,
+        "linear_num_heads": 64,
+        "linear_head_dim": 128,
+    }
+    try:
+        geometry_matches = all(
+            int(getattr(text_config, name, -1)) == value
+            for name, value in expected.items()
+        )
+    except (TypeError, ValueError):
+        return False
+    if not geometry_matches:
+        return False
+    return bool(
+        getattr(text_config, "mla_use_nope", False)
+        or int(getattr(text_config, "qk_rope_head_dim", -1)) == 0
+    )
+
+
+def _glm5_native_sparse_available(model: Any) -> bool:
+    if not _glm5_native_prefill_geometry(model):
+        return False
+    try:
+        from ...custom_kernels.glm_moe_dsa import fast
+
+        return bool(
+            fast.is_native_available()
+            and not fast.missing_symbols(_GLM5_NATIVE_PREFILL_SYMBOLS)
+        )
+    except Exception:
+        return False
+
+
 def _glm_dsa_adaptive_prefill_config(
     model: Any, prefill_step_size: int
 ) -> _AdaptivePrefillConfig | None:
     model_type = getattr(model, "model_type", None) or getattr(
         getattr(model, "args", None), "model_type", None
     )
+    adaptive_env = os.environ.get("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP")
+    glm5_wide_prefill = adaptive_env == "1"
+    supported_type = model_type == "glm_moe_dsa" or (
+        model_type in {"glm5_next", "glm5_next_text"}
+        and glm5_wide_prefill
+        and _glm5_native_sparse_available(model)
+    )
     if (
-        model_type != "glm_moe_dsa"
+        not supported_type
         or prefill_step_size != 2048
         or os.environ.get("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP", "1") != "1"
     ):

--- a/omlx/patches/glm_moe_dsa/sparse_mla.py
+++ b/omlx/patches/glm_moe_dsa/sparse_mla.py
@@ -478,6 +478,86 @@ def sparse_mla_attention(
     )
 
 
+def sparse_mla_attention_nope(
+    q_latent: mx.array,
+    kv_latent: mx.array,
+    topk_indices: mx.array,
+    scale: float,
+    *,
+    topk_valid_prefix: bool = False,
+    causal_prefix_indices: bool = False,
+    topk_length: Optional[mx.array] = None,
+    causal_prefix_rows: int = 0,
+    stream: Optional[mx.Stream] = None,
+) -> Optional[mx.array]:
+    """Exact GLM-5.3 NoPE sparse MLA without the all-zero PE lane.
+
+    The dedicated ABI is deliberately narrower than ``sparse_mla_attention``:
+    it accepts only the published single-device GLM-5.3 geometry and creates
+    zero-width PE views internally. Older extension builds fail closed so the
+    caller can retain the historical D_PE=64-zero fallback.
+    """
+
+    if (
+        q_latent.ndim != 4
+        or kv_latent.ndim != 4
+        or topk_indices.ndim != 4
+        or kv_latent.shape[1] != 1
+    ):
+        return None
+
+    B, H, L, D_LATENT = q_latent.shape
+    K = kv_latent.shape[2]
+    topk_rows = topk_indices.shape[2]
+    compact_prefix = causal_prefix_rows > 0 and topk_rows != L
+    if (
+        L <= 1
+        or H != 64
+        or D_LATENT != 512
+        or kv_latent.shape != (B, 1, K, D_LATENT)
+        or topk_indices.shape[:2] != (B, 1)
+        or not (
+            topk_rows == L
+            or (
+                compact_prefix
+                and topk_rows + causal_prefix_rows == L
+                and causal_prefix_indices
+                and topk_valid_prefix
+            )
+        )
+        or q_latent.dtype not in (mx.float16, mx.bfloat16)
+        or kv_latent.dtype != q_latent.dtype
+        or not glm_fast.has("glm_dsa_nope_sparse_mla_attention")
+    ):
+        return None
+
+    topk = (
+        topk_indices
+        if topk_indices.dtype == mx.uint32
+        else topk_indices.astype(mx.uint32)
+    )
+    if topk_length is not None and topk_length.dtype != mx.uint32:
+        topk_length = topk_length.astype(mx.uint32)
+    q_pe = mx.zeros((B, H, L, 0), dtype=q_latent.dtype)
+    k_pe = mx.zeros((B, 1, K, 0), dtype=q_latent.dtype)
+    try:
+        return glm_fast.glm_dsa_nope_sparse_mla_attention(
+            q_latent,
+            q_pe,
+            kv_latent,
+            k_pe,
+            topk,
+            scale,
+            topk_valid_prefix=topk_valid_prefix,
+            causal_prefix_indices=causal_prefix_indices,
+            topk_length=topk_length,
+            causal_prefix_rows=causal_prefix_rows,
+            stream=stream or mx.gpu,
+        )
+    except (AttributeError, RuntimeError, TypeError, ValueError):
+        return None
+
+
 def q8_vup_flat(
     x: mx.array,
     unembed_out,

--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/gated_delta.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/gated_delta.py
@@ -26,14 +26,22 @@ def _make_gated_delta_kernel(has_mask=False, vectorized=False):
     if vectorized:
         g_comment = "// g: [B, T, Hv, Dk]"
         g_setup = "auto g_ = g + (b_idx * T * Hv + hv_idx) * Dk;"
-        g_access = "g_[s_idx]"
+        g_hoist = """
+            for (int i = 0; i < n_per_t; ++i) {
+              gt[i] = static_cast<float>(g_[n_per_t * dk_idx + i]);
+            }"""
+        g_decay = "state[r][i] * gt[i]"
         g_advance = "g_ += Hv * Dk;"
     else:
         g_comment = "// g: [B, T, Hv]"
         g_setup = "auto g_ = g + b_idx * T * Hv;"
-        g_access = "g_[hv_idx]"
+        g_hoist = "float gg = static_cast<float>(g_[hv_idx]);"
+        g_decay = "state[r][i] * gg"
         g_advance = "g_ += Hv;"
 
+    # One thread owns R consecutive value rows. GLM's vector gate is shared by
+    # those rows, as are q, k, and beta, so row blocking removes redundant
+    # loads while preserving the per-row arithmetic and reduction order.
     source = f"""
         auto n = thread_position_in_grid.z;
         auto b_idx = n / Hv;
@@ -50,16 +58,17 @@ def _make_gated_delta_kernel(has_mask=False, vectorized=False):
         y += b_idx * T * Hv * Dv + hv_idx * Dv;
 
         auto dk_idx = thread_position_in_threadgroup.x;
-        auto dv_idx = thread_position_in_grid.y;
+        auto dv0 = thread_position_in_grid.y * R;
 
         // state_in, state_out: [B, Hv, Dv, Dk]
-        auto i_state = state_in + (n * Dv + dv_idx) * Dk;
-        auto o_state = state_out + (n * Dv + dv_idx) * Dk;
+        auto i_state = state_in + (n * Dv + dv0) * Dk + n_per_t * dk_idx;
+        auto o_state = state_out + (n * Dv + dv0) * Dk + n_per_t * dk_idx;
 
-        float state[n_per_t];
-        for (int i = 0; i < n_per_t; ++i) {{
-          auto s_idx = n_per_t * dk_idx + i;
-          state[i] = static_cast<float>(i_state[s_idx]);
+        float state[R][n_per_t];
+        for (int r = 0; r < R; ++r) {{
+          for (int i = 0; i < n_per_t; ++i) {{
+            state[r][i] = static_cast<float>(i_state[r * Dk + i]);
+          }}
         }}
 
         {g_comment}
@@ -68,28 +77,41 @@ def _make_gated_delta_kernel(has_mask=False, vectorized=False):
 
         for (int t = 0; t < T; ++t) {{
           if ({mask_source}) {{
-            float kv_mem = 0.0f;
+            // q, k, vector-g, and beta are identical for all R value rows.
+            float kk[n_per_t];
+            float qq[n_per_t];
+            {"float gt[n_per_t];" if vectorized else ""}
             for (int i = 0; i < n_per_t; ++i) {{
-              auto s_idx = n_per_t * dk_idx + i;
-              state[i] = state[i] * {g_access};
-              kv_mem += state[i] * k_[s_idx];
+              kk[i] = static_cast<float>(k_[n_per_t * dk_idx + i]);
+              qq[i] = static_cast<float>(q_[n_per_t * dk_idx + i]);
             }}
-            kv_mem = simd_sum(kv_mem);
+            {g_hoist}
+            float bb = static_cast<float>(beta_[hv_idx]);
 
-            auto delta = (v_[dv_idx] - kv_mem) * beta_[hv_idx];
+            for (int r = 0; r < R; ++r) {{
+              float kv_mem = 0.0f;
+              for (int i = 0; i < n_per_t; ++i) {{
+                state[r][i] = {g_decay};
+                kv_mem += state[r][i] * kk[i];
+              }}
+              kv_mem = simd_sum(kv_mem);
 
-            float out = 0.0f;
-            for (int i = 0; i < n_per_t; ++i) {{
-              auto s_idx = n_per_t * dk_idx + i;
-              state[i] = state[i] + k_[s_idx] * delta;
-              out += state[i] * q_[s_idx];
-            }}
-            out = simd_sum(out);
-            if (thread_index_in_simdgroup == 0) {{
-              y[dv_idx] = static_cast<InT>(out);
+              auto delta = (static_cast<float>(v_[dv0 + r]) - kv_mem) * bb;
+
+              float out = 0.0f;
+              for (int i = 0; i < n_per_t; ++i) {{
+                state[r][i] = state[r][i] + kk[i] * delta;
+                out += state[r][i] * qq[i];
+              }}
+              out = simd_sum(out);
+              if (thread_index_in_simdgroup == 0) {{
+                y[dv0 + r] = static_cast<InT>(out);
+              }}
             }}
           }} else {{
-            y[dv_idx] = static_cast<InT>(0);
+            for (int r = 0; r < R; ++r) {{
+              y[dv0 + r] = static_cast<InT>(0);
+            }}
           }}
           // Increment data pointers to next time step
           q_ += Hk * Dk;
@@ -99,9 +121,10 @@ def _make_gated_delta_kernel(has_mask=False, vectorized=False):
           {g_advance}
           beta_ += Hv;
         }}
-        for (int i = 0; i < n_per_t; ++i) {{
-          auto s_idx = n_per_t * dk_idx + i;
-          o_state[s_idx] = static_cast<StT>(state[i]);
+        for (int r = 0; r < R; ++r) {{
+          for (int i = 0; i < n_per_t; ++i) {{
+            o_state[r * Dk + i] = static_cast<StT>(state[r][i]);
+          }}
         }}
     """
     inputs = ["q", "k", "v", "g", "beta", "state_in", "T"]
@@ -177,7 +200,7 @@ def _gated_delta_step_ops(
     return y.astype(q.dtype), state
 
 
-def gated_delta_kernel(
+def _gated_delta_kernel_rows(
     q: mx.array,
     k: mx.array,
     v: mx.array,
@@ -185,6 +208,9 @@ def gated_delta_kernel(
     beta: mx.array,
     state: mx.array,
     mask: Optional[mx.array] = None,
+    *,
+    rows_per_thread: int,
+    threadgroup_y: int,
 ) -> Tuple[mx.array, mx.array]:
     B, T, Hk, Dk = k.shape
     Hv, Dv = v.shape[2:]
@@ -203,6 +229,11 @@ def gated_delta_kernel(
             kernel = _gated_delta_kernel_masked
             inputs.append(mask)
 
+    if rows_per_thread < 1 or Dv % rows_per_thread != 0:
+        raise ValueError(
+            f"rows_per_thread={rows_per_thread} must divide value width {Dv}"
+        )
+
     return kernel(
         inputs=inputs,
         template=[
@@ -212,11 +243,37 @@ def gated_delta_kernel(
             ("Dv", Dv),
             ("Hk", Hk),
             ("Hv", Hv),
+            ("R", rows_per_thread),
         ],
-        grid=(32, Dv, B * Hv),
-        threadgroup=(32, 4, 1),
+        grid=(32, Dv // rows_per_thread, B * Hv),
+        threadgroup=(32, threadgroup_y, 1),
         output_shapes=[(B, T, Hv, Dv), state.shape],
         output_dtypes=[input_type, state_type],
+    )
+
+
+def gated_delta_kernel(
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+    g: mx.array,
+    beta: mx.array,
+    state: mx.array,
+    mask: Optional[mx.array] = None,
+) -> Tuple[mx.array, mx.array]:
+    Dv = v.shape[-1]
+    rows_per_thread = 4 if Dv % 4 == 0 else (2 if Dv % 2 == 0 else 1)
+    threadgroup_y = 2 if (Dv // rows_per_thread) % 2 == 0 else 1
+    return _gated_delta_kernel_rows(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        state,
+        mask,
+        rows_per_thread=rows_per_thread,
+        threadgroup_y=threadgroup_y,
     )
 
 

--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/language.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/language.py
@@ -351,6 +351,31 @@ class Glm5NextIndexer(nn.Module):
         try:
             from omlx.custom_kernels.glm_moe_dsa import fast
 
+            # Decode has exactly one query row.  Route it through the exact
+            # M=1 specialization of the same Steel MMA score kernel used by
+            # prefill.  This preserves the historical row-0 dot/reduction
+            # order bit-for-bit while avoiding both the 64-row input/output
+            # padding and 63 unused MMA rows.  Older extension builds safely
+            # accept M=1 with the historical BM64 implementation, so this is
+            # also an exact compatibility path rather than a new ABI.
+            if (
+                q.shape[1] == 1
+                and fast.has_symbol("dsa_indexer_scores")
+            ):
+                qt = q.transpose(0, 2, 1, 3)
+                try:
+                    scores = fast.dsa_indexer_scores(
+                        qt,
+                        pool_keys[:, None],
+                        weights,
+                        causal=False,
+                    )
+                    return scores[:, 0]
+                except (AttributeError, RuntimeError, TypeError, ValueError):
+                    # Preserve availability through the historical padded
+                    # route below if a packaged extension rejects M=1.
+                    pass
+
             if not fast.has_symbol("dsa_indexer_scores"):
                 return None
             qt = q.transpose(0, 2, 1, 3)

--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/language.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/language.py
@@ -22,6 +22,7 @@ from omlx.patches.glm_moe_dsa.sparse_mla import (
     exact_block_token_attention,
     q8_vup_flat,
     sparse_mla_attention,
+    sparse_mla_attention_nope,
 )
 from .config import ModelConfig, TextConfig
 from .gated_delta import gated_delta_update
@@ -613,18 +614,32 @@ class Glm5NextSparseAttention(nn.Module):
                 return self._gathered_attention(q, kv_latent, topk_indices)
             else:
                 q_latent = self.embed_q(q)
-                q_pe = mx.zeros(q_latent.shape[:-1] + (64,), dtype=q_latent.dtype)
-                k_pe = mx.zeros(kv_latent.shape[:-1] + (64,), dtype=kv_latent.dtype)
                 output = None
                 if Kv >= 4096:
-                    output = sparse_mla_attention(
+                    output = sparse_mla_attention_nope(
                         q_latent,
-                        q_pe,
                         kv_latent,
-                        k_pe,
                         topk_indices,
                         self.scale,
                     )
+                    # Compatibility with an older packaged extension: retain
+                    # the exact historical path until the dedicated NoPE ABI
+                    # is present, rather than silently demoting to dense MLA.
+                    if output is None:
+                        q_pe = mx.zeros(
+                            q_latent.shape[:-1] + (64,), dtype=q_latent.dtype
+                        )
+                        k_pe = mx.zeros(
+                            kv_latent.shape[:-1] + (64,), dtype=kv_latent.dtype
+                        )
+                        output = sparse_mla_attention(
+                            q_latent,
+                            q_pe,
+                            kv_latent,
+                            k_pe,
+                            topk_indices,
+                            self.scale,
+                        )
                 if output is not None:
                     output_flat = q8_vup_flat(
                         output,

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1767,18 +1767,6 @@ class Scheduler:
         # prefill step changes cache-ON from one forward into multiple forwards.
         self._qwen35_prefill_floor = self._detect_qwen35_prefill_floor()
 
-        # For strict RotatingKVCache reuse, align paged cache block size to
-        # the model's rotating window size when paged cache is enabled.
-        self._align_block_size_with_rotating_window()
-        # For ArraysCache-only models (no RotatingKVCache), use a larger block
-        # size to reduce boundary snapshot overhead during prefill.
-        self._enlarge_block_size_for_arrays_cache()
-
-        # TurboQuant KV cache (set by engine if model_settings has it enabled)
-        self._turboquant_kv_bits: float | None = None
-        self._turboquant_skip_last: bool = True
-        # Memoized MLA-architecture detection (see _model_uses_mla / #1613).
-        self._mla_model: bool | None = None
         self._glm_dsa_adaptive_prefill = None
         try:
             from .patches.glm_moe_dsa.generate_patch import (
@@ -1798,6 +1786,19 @@ class Scheduler:
                 self._glm_dsa_adaptive_prefill.after,
                 self._glm_dsa_adaptive_prefill.min_remaining,
             )
+
+        # For strict RotatingKVCache reuse, align paged cache block size to
+        # the model's rotating window size when paged cache is enabled.
+        self._align_block_size_with_rotating_window()
+        # For ArraysCache-only models (no RotatingKVCache), use a larger block
+        # size to reduce boundary snapshot overhead during prefill.
+        self._enlarge_block_size_for_arrays_cache()
+
+        # TurboQuant KV cache (set by engine if model_settings has it enabled)
+        self._turboquant_kv_bits: float | None = None
+        self._turboquant_skip_last: bool = True
+        # Memoized MLA-architecture detection (see _model_uses_mla / #1613).
+        self._mla_model: bool | None = None
         self._minimax_m3_adaptive_prefill = None
         try:
             from .patches.minimax_m3.generate_patch import (
@@ -2756,6 +2757,14 @@ class Scheduler:
             self._ARRAYS_CACHE_BLOCK_SIZE,
             int(self.config.prefill_step_size or 0),
             self._qwen35_prefill_floor,
+            int(
+                getattr(
+                    getattr(self, "_glm_dsa_adaptive_prefill", None),
+                    "step_size",
+                    0,
+                )
+                or 0
+            ),
         )
         if self.config.paged_cache_block_size >= target:
             return

--- a/tests/test_admin_unload.py
+++ b/tests/test_admin_unload.py
@@ -54,6 +54,25 @@ async def test_idle_model_unload_returns_completed():
 
 
 @pytest.mark.asyncio
+async def test_dflash_helper_cannot_be_loaded_directly():
+    entry = MagicMock()
+    entry.is_helper = True
+    entry.engine = None
+    pool = MagicMock()
+    pool.get_entry.return_value = entry
+
+    with (
+        patch.object(admin_routes, "_get_engine_pool", return_value=pool),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await admin_routes.load_model("glm-dflash-helper", is_admin=True)
+
+    assert exc_info.value.status_code == 400
+    assert "load automatically with their target" in exc_info.value.detail
+    pool.get_engine.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_lease_rejected_during_manual_unload_uses_unload_error():
     pool = MagicMock()
     pool.get_abort_requested_reason.return_value = "manual admin unload"

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -1727,6 +1727,7 @@ class TestDFlashOutputParserWiring:
         )
         queue = asyncio.Queue()
         loop = asyncio.get_running_loop()
+        engine._update_activity = MagicMock()
 
         await asyncio.to_thread(
             engine._run_generate_streaming,
@@ -1743,6 +1744,7 @@ class TestDFlashOutputParserWiring:
             queue,
             loop,
             threading.Event(),
+            "activity-id",
         )
         queued = []
         while True:
@@ -1763,6 +1765,8 @@ class TestDFlashOutputParserWiring:
         parser.finalize.assert_called_once_with()
         assert event_iter.close_calls == 1
         engine._end_runtime_cache_request.assert_called_once_with(cache_manager)
+        assert engine._update_activity.call_count == 2
+        engine._update_activity.assert_called_with("activity-id")
 
     @pytest.mark.asyncio
     async def test_streaming_without_parser_keeps_token_and_summary_behavior(

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -1960,6 +1960,94 @@ class TestDFlashPretokenizedPrompt:
         engine._tokenizer_obj.encode.assert_called_once_with("hello")
 
 
+class TestDFlashLoadWarmup:
+    def _engine(self):
+        from omlx.engine.dflash import DFlashEngine
+
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+            model_settings=ModelSettings(dflash_block_size=8),
+        )
+        engine._target_ops = SimpleNamespace(backend_name="glm5_next")
+        engine._executor_tokenizer = SimpleNamespace(
+            encode=lambda text, add_special_tokens=False: [2, 11, 12],
+            eos_token_id=2,
+            eos_token_ids=None,
+            eot_token_id=None,
+            vocab_size=100,
+        )
+        engine._generation_config_eos = set()
+        engine._suppress_token_ids = {12}
+        return engine
+
+    def test_only_glm_backend_requires_load_warmup(self):
+        engine = self._engine()
+        assert engine._requires_load_warmup() is True
+        engine._target_ops.backend_name = "qwen"
+        assert engine._requires_load_warmup() is False
+
+    def test_warmup_prompt_excludes_stop_and_suppress_tokens(self):
+        engine = self._engine()
+        prompt = engine._build_load_warmup_prompt_tokens(prompt_len=6)
+        assert prompt == [11] * 6
+
+    def test_warmup_consumes_summary_closes_iterator_and_disables_cache(self):
+        from dflash_mlx.engine.events import SummaryEvent
+
+        engine = self._engine()
+        summary = SummaryEvent(
+            elapsed_us=1000,
+            prompt_token_count=64,
+            generated_token_ids=(5,),
+            generation_tokens=1,
+            accepted_from_draft=1,
+            acceptance_ratio=1.0,
+            cycles_completed=1,
+            phase_timings_us={},
+        )
+
+        class TrackingIterator:
+            def __init__(self):
+                self.closed = False
+
+            def __iter__(self):
+                return iter([summary])
+
+            def close(self):
+                self.closed = True
+
+        events = TrackingIterator()
+        engine._stream_dflash_events = MagicMock(return_value=(events, None, []))
+
+        engine._warmup_dflash_sync()
+
+        assert events.closed is True
+        kwargs = engine._stream_dflash_events.call_args.kwargs
+        assert kwargs["use_prefix_cache"] is False
+        assert kwargs["max_tokens"] == 8
+
+    def test_warmup_fails_closed_without_summary_and_closes_iterator(self):
+        engine = self._engine()
+
+        class TrackingIterator:
+            def __init__(self):
+                self.closed = False
+
+            def __iter__(self):
+                return iter(())
+
+            def close(self):
+                self.closed = True
+
+        events = TrackingIterator()
+        engine._stream_dflash_events = MagicMock(return_value=(events, None, []))
+
+        with pytest.raises(RuntimeError, match="without a summary"):
+            engine._warmup_dflash_sync()
+        assert events.closed is True
+
+
 class TestDFlashActivityTracking:
     """DFlash bypasses the scheduler, so the admin Active Models card reads
     the engine's own activity snapshot (#2396)."""

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -3,7 +3,7 @@
 
 import json
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -169,6 +169,147 @@ class TestDFlashModelSettings:
 
 class TestDFlashEngineInit:
     """Test DFlashEngine initialization and configuration."""
+
+    def test_wired_limit_uses_recommended_working_set_and_is_idempotent(
+        self, monkeypatch
+    ):
+        from omlx.engine import dflash as dflash_mod
+        from omlx.engine.dflash import DFlashEngine
+
+        engine = DFlashEngine("target", "draft")
+        calls = []
+        synchronized = []
+        monkeypatch.setattr(dflash_mod.mx.metal, "is_available", lambda: True)
+        monkeypatch.setattr(
+            dflash_mod.mx,
+            "device_info",
+            lambda: {
+                "max_recommended_working_set_size": 96,
+                "memory_size": 256,
+            },
+        )
+
+        def set_wired_limit(value):
+            calls.append(value)
+            return 41
+
+        monkeypatch.setattr(dflash_mod.mx, "set_wired_limit", set_wired_limit)
+        monkeypatch.setattr(
+            dflash_mod.mx,
+            "synchronize",
+            lambda: synchronized.append(True),
+        )
+
+        engine._acquire_wired_limit()
+        engine._acquire_wired_limit()
+        assert calls == [96]
+        assert engine._old_wired_limit == 41
+        assert engine._wired_limit_owned is True
+
+        assert engine._restore_wired_limit() is True
+        assert engine._restore_wired_limit() is False
+        assert calls == [96, 41]
+        assert synchronized == [True]
+
+    def test_wired_limit_restores_when_start_loader_fails(self, monkeypatch):
+        from omlx.engine.dflash import DFlashEngine
+
+        engine = DFlashEngine("target", "draft")
+        events = []
+
+        def acquire():
+            engine._wired_limit_owned = True
+            events.append("acquire")
+
+        def restore():
+            engine._wired_limit_owned = False
+            events.append("restore")
+            return True
+
+        monkeypatch.setattr(engine, "_acquire_wired_limit", acquire)
+        monkeypatch.setattr(engine, "_restore_wired_limit", restore)
+
+        def fail_load():
+            events.append("load")
+            raise RuntimeError("load failed")
+
+        with pytest.raises(RuntimeError, match="load failed"):
+            engine._load_with_wired_limit(fail_load)
+        assert events == ["acquire", "load", "restore"]
+
+    @pytest.mark.asyncio
+    async def test_start_restores_wired_limit_after_finalize_failure(
+        self, monkeypatch
+    ):
+        from omlx.engine.dflash import DFlashEngine
+
+        engine = DFlashEngine("target", "draft")
+        monkeypatch.setattr(
+            engine,
+            "_start_impl",
+            AsyncMock(side_effect=RuntimeError("finalize failed")),
+        )
+        restore = AsyncMock(return_value=True)
+        monkeypatch.setattr(engine, "_restore_wired_limit_async", restore)
+
+        with pytest.raises(RuntimeError, match="finalize failed"):
+            await engine.start()
+        restore.assert_awaited_once_with()
+
+    @pytest.mark.asyncio
+    async def test_wired_limit_restores_before_fallback_teardown(self, monkeypatch):
+        from dflash_mlx.cache import manager as cache_manager
+
+        from omlx.engine import dflash as dflash_mod
+        from omlx.engine.dflash import DFlashEngine
+
+        engine = DFlashEngine("target", "draft")
+        restore = AsyncMock(return_value=True)
+        monkeypatch.setattr(engine, "_restore_wired_limit_async", restore)
+        monkeypatch.setattr(dflash_mod.mx, "get_active_memory", lambda: 0)
+
+        def stop_after_restore():
+            raise RuntimeError("stop after restore")
+
+        monkeypatch.setattr(
+            cache_manager,
+            "shutdown_runtime_cache_manager",
+            stop_after_restore,
+        )
+
+        with pytest.raises(RuntimeError, match="stop after restore"):
+            await engine._evict_dflash_and_start_fallback()
+        restore.assert_awaited_once_with()
+
+    @pytest.mark.asyncio
+    async def test_double_stop_restores_wired_limit_once(self, monkeypatch):
+        from dflash_mlx.cache import manager as cache_manager
+
+        from omlx import engine_core
+        from omlx.engine.dflash import DFlashEngine
+
+        engine = DFlashEngine("target", "draft")
+        engine._wired_limit_owned = True
+        restores = []
+
+        def restore():
+            if not engine._wired_limit_owned:
+                return False
+            engine._wired_limit_owned = False
+            restores.append(True)
+            return True
+
+        monkeypatch.setattr(engine, "_restore_wired_limit", restore)
+        monkeypatch.setattr(engine_core, "get_mlx_executor", lambda: None)
+        monkeypatch.setattr(
+            cache_manager,
+            "shutdown_runtime_cache_manager",
+            lambda: None,
+        )
+
+        await engine.stop()
+        await engine.stop()
+        assert restores == [True]
 
     def test_import_without_dflash_mlx(self):
         from omlx.engine import DFlashEngine  # noqa: F401

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -323,7 +323,12 @@ class TestDFlashEngineInit:
         snapshot = object()
         engine._target_model = target_model
         engine._target_ops = target_ops
-        engine._executor_tokenizer = object()
+        # GLM tokenizers expose eos_token_ids as a scalar; the oMLX boundary
+        # normalizes it without mutating the tokenizer.
+        engine._executor_tokenizer = SimpleNamespace(
+            eos_token_ids=2,
+            eos_token_id=3,
+        )
         engine._draft_model = object()
         engine._draft_backend = object()
         engine._runtime_context = object()
@@ -347,8 +352,6 @@ class TestDFlashEngineInit:
         monkeypatch.setattr(
             PrefixCacheFlow, "for_request", classmethod(fake_for_request)
         )
-        monkeypatch.setattr(dflash_runtime, "get_stop_token_ids", lambda tokenizer: [2])
-
         def fake_stream_dflash_generate(**kwargs):
             captured.update(kwargs)
             return iter(())
@@ -371,7 +374,7 @@ class TestDFlashEngineInit:
         )
 
         assert list(event_iter) == []
-        assert stop_ids == [2]
+        assert stop_ids == [2, 3]
         assert captured["suppress_token_ids"] == [258882, 258883]
         assert captured["prefix_snapshot"] is snapshot
         assert captured["prefix_hit_kind"] == "l2_prefix"

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for DFlash engine integration."""
 
+import asyncio
 import json
+import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -1475,6 +1477,120 @@ class TestDFlashOutputParserWiring:
         ]
         return engine, create_with_tools, tools, tool_calls
 
+    def _parser_stop_engine(self):
+        events = pytest.importorskip("dflash_mlx.engine.events")
+
+        from omlx.engine.dflash import DFlashEngine
+
+        class TrackingIterator:
+            def __init__(self, values):
+                self._values = iter(values)
+                self.next_calls = 0
+                self.close_calls = 0
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                self.next_calls += 1
+                return next(self._values)
+
+            def close(self):
+                self.close_calls += 1
+
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+            model_settings=ModelSettings(),
+        )
+        engine._loaded = True
+        engine._tokenizer_obj = SimpleNamespace(
+            encode=lambda text: [1, 2],
+            decode=lambda tokens, **kwargs: "".join(str(token) for token in tokens),
+        )
+        engine._executor_tokenizer = engine._tokenizer_obj
+        engine._should_fallback = lambda tokens: False
+        engine._detect_needs_think_prefix = lambda tokens: False
+
+        tool_calls = [
+            {
+                "name": "internal_search",
+                "arguments": '{"query":"maintenance contract"}',
+            }
+        ]
+        parser_session = MagicMock()
+
+        def process_token(token_id):
+            if token_id == 7:
+                return SimpleNamespace(
+                    stream_text="<think>streamed",
+                    visible_text="visible",
+                    is_stop=False,
+                    record_token=True,
+                )
+            if token_id == 8:
+                return SimpleNamespace(
+                    stream_text="",
+                    visible_text="",
+                    is_stop=True,
+                    record_token=False,
+                )
+            pytest.fail(f"parser processed token after stop: {token_id}")
+
+        parser_session.process_token.side_effect = process_token
+        parser_session.finalize.return_value = SimpleNamespace(
+            stream_text="</think>",
+            visible_text="-tail",
+            output_text_prefix="PREFIX:",
+            tool_calls=tool_calls,
+            finish_reason="tool_calls",
+        )
+        engine._output_parser_factory = SimpleNamespace(
+            create_session=MagicMock(return_value=parser_session),
+            create_session_with_tools=None,
+        )
+
+        token_1 = events.TokenEvent(
+            token_id=7,
+            generated_tokens=1,
+            acceptance_ratio=0.5,
+            cycles_completed=1,
+        )
+        stop_token = events.TokenEvent(
+            token_id=8,
+            generated_tokens=2,
+            acceptance_ratio=0.5,
+            cycles_completed=2,
+        )
+        forbidden_token = events.TokenEvent(
+            token_id=9,
+            generated_tokens=3,
+            acceptance_ratio=0.5,
+            cycles_completed=3,
+        )
+        summary = events.SummaryEvent(
+            elapsed_us=1000,
+            prompt_token_count=2,
+            generated_token_ids=(7, 8, 9),
+            generation_tokens=3,
+            accepted_from_draft=0,
+            acceptance_ratio=0.5,
+            cycles_completed=3,
+            phase_timings_us={},
+        )
+        event_iter = TrackingIterator([token_1, stop_token, forbidden_token, summary])
+        engine._stream_dflash_events = MagicMock(
+            return_value=(
+                event_iter,
+                SimpleNamespace(hit_tokens=0),
+                [],
+            )
+        )
+        cache_manager = object()
+        engine._begin_runtime_cache_request = MagicMock(return_value=cache_manager)
+        engine._end_runtime_cache_request = MagicMock()
+        return engine, parser_session, event_iter, cache_manager, tool_calls
+
     @pytest.mark.asyncio
     async def test_non_streaming_propagates_parser_tool_calls(self):
         engine, create_with_tools, tools, tool_calls = self._tool_parser_engine()
@@ -1504,6 +1620,151 @@ class TestDFlashOutputParserWiring:
         assert outputs[0].tool_calls == tool_calls
         assert outputs[0].finish_reason == "tool_calls"
         assert outputs[0].completion_tokens == 1
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_parser_stop_closes_iterator_and_keeps_clean_output(
+        self,
+    ):
+        engine, parser, event_iter, cache_manager, tool_calls = (
+            self._parser_stop_engine()
+        )
+
+        output = await engine.generate([1, 2])
+
+        assert parser.process_token.call_args_list == [((7,),), ((8,),)]
+        parser.finalize.assert_called_once_with()
+        assert event_iter.next_calls == 2
+        assert event_iter.close_calls == 1
+        engine._end_runtime_cache_request.assert_called_once_with(cache_manager)
+        assert output.tokens == [7]
+        assert output.completion_tokens == 1
+        assert output.text == "PREFIX:visible-tail"
+        assert output.tool_calls == tool_calls
+        assert output.finish_reason == "tool_calls"
+
+    @pytest.mark.asyncio
+    async def test_streaming_parser_stop_has_one_final_and_no_late_tokens(self):
+        engine, parser, event_iter, cache_manager, tool_calls = (
+            self._parser_stop_engine()
+        )
+
+        outputs = [output async for output in engine.stream_generate([1, 2])]
+
+        assert parser.process_token.call_args_list == [((7,),), ((8,),)]
+        parser.finalize.assert_called_once_with()
+        assert event_iter.next_calls == 2
+        assert event_iter.close_calls == 1
+        engine._end_runtime_cache_request.assert_called_once_with(cache_manager)
+        assert sum(output.finished for output in outputs) == 1
+        assert outputs[-1].finished is True
+        assert outputs[-1].new_text == "</think>"
+        assert outputs[-1].text == "PREFIX:visible-tail"
+        assert outputs[-1].completion_tokens == 1
+        assert outputs[-1].tool_calls == tool_calls
+        assert outputs[-1].finish_reason == "tool_calls"
+
+    @pytest.mark.asyncio
+    async def test_streaming_worker_enqueues_exactly_one_terminal_item(self):
+        engine, parser, event_iter, cache_manager, tool_calls = (
+            self._parser_stop_engine()
+        )
+        queue = asyncio.Queue()
+        loop = asyncio.get_running_loop()
+
+        await asyncio.to_thread(
+            engine._run_generate_streaming,
+            [1, 2],
+            32,
+            0.0,
+            1.0,
+            0,
+            0.0,
+            1.0,
+            20,
+            None,
+            None,
+            queue,
+            loop,
+            threading.Event(),
+        )
+        queued = []
+        while True:
+            item = await asyncio.wait_for(queue.get(), timeout=1.0)
+            queued.append(item)
+            if item[2]:
+                break
+        await asyncio.sleep(0)
+        while not queue.empty():
+            queued.append(queue.get_nowait())
+
+        finals = [item for item in queued if item[2]]
+        assert len(finals) == 1
+        assert finals[0][0] == "</think>"
+        assert finals[0][3]["output_text"] == "PREFIX:visible-tail"
+        assert finals[0][3]["completion_tokens"] == 1
+        assert finals[0][3]["tool_calls"] == tool_calls
+        parser.finalize.assert_called_once_with()
+        assert event_iter.close_calls == 1
+        engine._end_runtime_cache_request.assert_called_once_with(cache_manager)
+
+    @pytest.mark.asyncio
+    async def test_streaming_without_parser_keeps_token_and_summary_behavior(
+        self, monkeypatch
+    ):
+        events = pytest.importorskip("dflash_mlx.engine.events")
+        from omlx.engine import dflash as dflash_mod
+        from omlx.engine.dflash import DFlashEngine
+
+        engine = DFlashEngine("target", "draft")
+        engine._loaded = True
+        engine._tokenizer_obj = SimpleNamespace(
+            encode=lambda text: [1, 2],
+            decode=lambda tokens, **kwargs: "".join(
+                {7: "A", 8: "B"}[token] for token in tokens
+            ),
+        )
+        engine._executor_tokenizer = engine._tokenizer_obj
+        engine._should_fallback = lambda tokens: False
+        engine._detect_needs_think_prefix = lambda tokens: False
+        engine._output_parser_factory = None
+        monkeypatch.setattr(
+            dflash_mod, "create_streaming_detokenizer", lambda *a, **k: None
+        )
+
+        token_1 = events.TokenEvent(
+            token_id=7,
+            generated_tokens=1,
+            acceptance_ratio=1.0,
+            cycles_completed=1,
+        )
+        token_2 = events.TokenEvent(
+            token_id=8,
+            generated_tokens=2,
+            acceptance_ratio=1.0,
+            cycles_completed=2,
+        )
+        summary = events.SummaryEvent(
+            elapsed_us=1000,
+            prompt_token_count=2,
+            generated_token_ids=(7, 8),
+            generation_tokens=2,
+            accepted_from_draft=2,
+            acceptance_ratio=1.0,
+            cycles_completed=2,
+            phase_timings_us={},
+        )
+        engine._stream_dflash_events = MagicMock(
+            return_value=(iter([token_1, token_2, summary]), SimpleNamespace(), [])
+        )
+
+        outputs = [output async for output in engine.stream_generate([1, 2])]
+
+        assert [output.new_text for output in outputs] == ["A", "B", ""]
+        assert [output.tokens for output in outputs] == [[7], [8], []]
+        assert outputs[-1].text == "AB"
+        assert outputs[-1].completion_tokens == 2
+        assert outputs[-1].finish_reason == "stop"
+        assert sum(output.finished for output in outputs) == 1
 
 
 class TestDFlashCachedTokens:

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -172,6 +172,42 @@ class TestDFlashModelSettings:
 class TestDFlashEngineInit:
     """Test DFlashEngine initialization and configuration."""
 
+    def test_stop_ids_union_scalar_list_eot_and_generation_config(self):
+        from omlx.engine.dflash import _get_dflash_stop_token_ids
+
+        tokenizer = SimpleNamespace(
+            eos_token_id=[3, 4],
+            eos_token_ids=2,
+            eot_token_id=[4, 5],
+        )
+
+        assert _get_dflash_stop_token_ids(tokenizer, {2, 5, 6}) == [2, 3, 4, 5, 6]
+
+    def test_stop_ids_encode_eot_string_when_id_is_missing(self):
+        from omlx.engine.dflash import _get_dflash_stop_token_ids
+
+        encode = MagicMock(return_value=[7, 8])
+        tokenizer = SimpleNamespace(
+            eos_token_id=2,
+            eos_token_ids=None,
+            eot_token="<eot>",
+            encode=encode,
+        )
+
+        assert _get_dflash_stop_token_ids(tokenizer) == [2, 7, 8]
+        encode.assert_called_once_with("<eot>", add_special_tokens=False)
+
+    def test_stop_ids_are_unique_and_ignore_boolean_metadata(self):
+        from omlx.engine.dflash import _get_dflash_stop_token_ids
+
+        tokenizer = SimpleNamespace(
+            eos_token_id=[2, 2, True],
+            eos_token_ids=[2, 3, False],
+            eot_token_id=3,
+        )
+
+        assert _get_dflash_stop_token_ids(tokenizer, {3, 4}) == [2, 3, 4]
+
     def test_wired_limit_uses_recommended_working_set_and_is_idempotent(
         self, monkeypatch
     ):
@@ -470,12 +506,15 @@ class TestDFlashEngineInit:
         # normalizes it without mutating the tokenizer.
         engine._executor_tokenizer = SimpleNamespace(
             eos_token_ids=2,
-            eos_token_id=3,
+            eos_token_id=[3, 4],
+            eot_token_id=[4, 5],
         )
         engine._draft_model = object()
         engine._draft_backend = object()
         engine._runtime_context = object()
         engine._suppress_token_ids = {258883, 258882}
+        engine._generation_config_eos = {5, 6}
+        engine._output_parser_factory = SimpleNamespace(stop_token_ids={99})
 
         fake_flow = SimpleNamespace(
             snapshot=snapshot,
@@ -517,7 +556,8 @@ class TestDFlashEngineInit:
         )
 
         assert list(event_iter) == []
-        assert stop_ids == [2, 3]
+        assert stop_ids == [2, 3, 4, 5, 6]
+        assert 99 not in captured["stop_token_ids"]
         assert captured["suppress_token_ids"] == [258882, 258883]
         assert captured["prefix_snapshot"] is snapshot
         assert captured["prefix_hit_kind"] == "l2_prefix"
@@ -638,10 +678,20 @@ class TestDFlashEngineInit:
             "apply_qwen35_moe_gate_up_fusion",
             lambda model: captured.setdefault("fused_target", model),
         )
+        generation_config_calls = []
+
+        def fake_generation_config_token_ids(model_ref, key):
+            generation_config_calls.append((model_ref, key))
+            return {
+                "eos_token_id": {1, 2},
+                "eos_token_ids": {2, 3},
+                "suppress_tokens": set(),
+            }[key]
+
         monkeypatch.setattr(
             dflash_mod,
             "load_generation_config_token_ids",
-            lambda *args, **kwargs: set(),
+            fake_generation_config_token_ids,
         )
         monkeypatch.setattr(
             dflash_mod, "detect_output_parser", lambda *args, **kwargs: None
@@ -666,8 +716,15 @@ class TestDFlashEngineInit:
             assert captured["bound_target_ops"] is engine._target_ops
             assert engine._draft_window_size == 2048
             assert engine._runtime_context.runtime.draft_window_size == 2048
+            assert engine._generation_config_eos == {1, 2, 3}
+            assert generation_config_calls == [
+                ("fake-target", "eos_token_id"),
+                ("fake-target", "eos_token_ids"),
+                ("fake-target", "suppress_tokens"),
+            ]
         finally:
             await engine.stop()
+        assert engine._generation_config_eos == set()
 
     def test_should_fallback_unlimited_when_max_ctx_none(self):
         """A None threshold means dflash handles every prompt size."""

--- a/tests/test_dflash_glm5.py
+++ b/tests/test_dflash_glm5.py
@@ -595,6 +595,113 @@ def test_glm_target_loader_forces_eager_mlx_vlm_fallback(tmp_path, monkeypatch):
     }
 
 
+@pytest.mark.parametrize("use_custom_loader", [True, False])
+def test_glm_target_loader_scopes_prequant_sanitize_around_both_loaders(
+    tmp_path, monkeypatch, use_custom_loader
+):
+    from contextlib import contextmanager
+
+    import mlx_vlm.utils as vlm_utils
+
+    from omlx.engine import vlm as vlm_engine
+    from omlx.patches import dflash_glm5
+    from omlx.patches.dflash_glm5 import (
+        _load_glm5_target_bundle,
+        install_dflash_glm5_backend,
+    )
+    from omlx.utils import model_loading
+
+    (tmp_path / "config.json").write_text(
+        json.dumps({"model_type": "glm5_next"}), encoding="utf-8"
+    )
+    target = _fake_target()
+    processor = SimpleNamespace(tokenizer=object())
+    events = []
+
+    @contextmanager
+    def sanitize_scope(model_dir):
+        assert model_dir == tmp_path
+        events.append("enter")
+        try:
+            yield
+        finally:
+            events.append("exit")
+
+    def custom_loader(*_args, **_kwargs):
+        events.append("custom")
+        return (target, processor) if use_custom_loader else None
+
+    def fallback_loader(*_args, **_kwargs):
+        events.append("fallback")
+        return target, processor
+
+    monkeypatch.setattr(
+        vlm_engine,
+        "_force_qwen4_exp_sanitize_on_load",
+        sanitize_scope,
+    )
+    monkeypatch.setattr(model_loading, "maybe_load_custom_quantization", custom_loader)
+    monkeypatch.setattr(
+        model_loading,
+        "materialize_lazy_state",
+        lambda _model: events.append("materialize"),
+    )
+    monkeypatch.setattr(vlm_utils, "load", fallback_loader)
+    monkeypatch.setattr(
+        dflash_glm5.Glm5NextTargetOps,
+        "install_speculative_hooks",
+        lambda self, model: events.append("hooks"),
+    )
+    install_dflash_glm5_backend()
+
+    _load_glm5_target_bundle(tmp_path)
+    load_events = ["custom"] if use_custom_loader else ["custom", "fallback"]
+    assert events == ["enter", *load_events, "exit", "materialize", "hooks"]
+
+
+def test_glm_target_loader_restores_prequant_sanitize_after_load_error(
+    tmp_path, monkeypatch
+):
+    from contextlib import contextmanager
+
+    from omlx.engine import vlm as vlm_engine
+    from omlx.patches.dflash_glm5 import _load_glm5_target_bundle
+    from omlx.utils import model_loading
+
+    (tmp_path / "config.json").write_text(
+        json.dumps({"model_type": "glm5_next"}), encoding="utf-8"
+    )
+    events = []
+
+    @contextmanager
+    def sanitize_scope(_model_dir):
+        events.append("enter")
+        try:
+            yield
+        finally:
+            events.append("exit")
+
+    def fail_load(*_args, **_kwargs):
+        events.append("load")
+        raise RuntimeError("load failed")
+
+    monkeypatch.setattr(
+        vlm_engine,
+        "_force_qwen4_exp_sanitize_on_load",
+        sanitize_scope,
+    )
+    monkeypatch.setattr(model_loading, "maybe_load_custom_quantization", fail_load)
+    monkeypatch.setattr(
+        model_loading,
+        "materialize_lazy_state",
+        lambda _model: pytest.fail("materialize must not run after load failure"),
+    )
+
+    with pytest.raises(RuntimeError, match="load failed"):
+        _load_glm5_target_bundle(tmp_path)
+    assert events == ["enter", "load", "exit"]
+
+
 def test_glm_target_loader_fails_before_hooks_if_materialization_fails(
     tmp_path, monkeypatch
 ):

--- a/tests/test_dflash_glm5.py
+++ b/tests/test_dflash_glm5.py
@@ -1,0 +1,423 @@
+"""Contract tests for the GLM-5.3 DFlash2 target adapter."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+pytest.importorskip("dflash_mlx")
+
+
+def _fake_target(*, hidden_size=4096, vocab_size=154880, layers=45):
+    inner = SimpleNamespace(
+        layers=[SimpleNamespace() for _ in range(layers)],
+        embed_tokens=object(),
+        fa_idx=3,
+        ssm_idx=0,
+    )
+    language_model = SimpleNamespace(
+        args=SimpleNamespace(
+            model_type="glm5_next_text",
+            hidden_size=hidden_size,
+            vocab_size=vocab_size,
+            mhc=True,
+            hc_mult=4,
+        ),
+        model=inner,
+    )
+    return SimpleNamespace(model_type="glm5_next", language_model=language_model)
+
+
+def _fake_draft(*, hidden_size=4096, vocab_size=154880, layers=45):
+    args = SimpleNamespace(
+        hidden_size=hidden_size,
+        vocab_size=vocab_size,
+        num_target_layers=layers,
+    )
+    return SimpleNamespace(
+        args=args,
+        is_dflash2=True,
+        target_layer_ids=[5, 14, 24, 33, 42],
+    )
+
+
+def _draft_meta(architecture="DFlash2DraftModel"):
+    return {"config": {"architectures": [architecture]}}
+
+
+def test_glm5_target_gate_is_explicit(tmp_path):
+    from omlx.engine.dflash import is_dflash_compatible
+
+    (tmp_path / "config.json").write_text(
+        json.dumps({"model_type": "glm5_next"}), encoding="utf-8"
+    )
+    assert is_dflash_compatible(tmp_path) == (True, "")
+
+
+def test_dflash2_pair_validation_accepts_published_geometry():
+    from omlx.patches.dflash_glm5 import validate_glm5_dflash_pair
+
+    validate_glm5_dflash_pair(_fake_target(), _fake_draft(), _draft_meta())
+
+
+@pytest.mark.parametrize(
+    ("draft", "match"),
+    [
+        (_fake_draft(hidden_size=2048), "hidden_size mismatch"),
+        (_fake_draft(vocab_size=32000), "vocab_size mismatch"),
+        (_fake_draft(layers=44), "num_target_layers mismatch"),
+    ],
+)
+def test_dflash2_pair_validation_rejects_geometry_mismatch(draft, match):
+    from omlx.patches.dflash_glm5 import validate_glm5_dflash_pair
+
+    with pytest.raises(ValueError, match=match):
+        validate_glm5_dflash_pair(_fake_target(), draft, _draft_meta())
+
+
+def test_dflash2_pair_validation_rejects_non_dflash2():
+    from omlx.patches.dflash_glm5 import validate_glm5_dflash_pair
+
+    with pytest.raises(ValueError, match="DFlash2DraftModel"):
+        validate_glm5_dflash_pair(
+            _fake_target(), _fake_draft(), _draft_meta("DFlashDraftModel")
+        )
+
+
+def test_mhc_capture_contract_matches_official_serving_contract():
+    from omlx.patches.dflash_glm5 import _contract_mhc_hidden
+
+    hidden = mx.arange(48, dtype=mx.float32).reshape(1, 2, 4, 6)
+    actual = _contract_mhc_hidden(hidden)
+    expected = hidden.mean(axis=2)
+    mx.eval(actual, expected)
+    assert actual.shape == (1, 2, 6)
+    assert mx.array_equal(actual, expected).item()
+
+
+def test_hidden_extraction_maps_target_layer_k_to_capture_k_plus_one():
+    from omlx.patches.dflash_glm5 import Glm5NextTargetOps
+
+    captured = {
+        6: mx.full((1, 2, 3), 6),
+        15: mx.full((1, 2, 3), 15),
+        25: mx.full((1, 2, 3), 25),
+        34: mx.full((1, 2, 3), 34),
+        43: mx.full((1, 2, 3), 43),
+    }
+    feature = Glm5NextTargetOps().extract_context_feature(captured, [5, 14, 24, 33, 42])
+    mx.eval(feature)
+    assert feature.shape == (1, 2, 15)
+    assert feature[0, 0].tolist() == [
+        6,
+        6,
+        6,
+        15,
+        15,
+        15,
+        25,
+        25,
+        25,
+        34,
+        34,
+        34,
+        43,
+        43,
+        43,
+    ]
+
+
+def test_capabilities_fail_closed_for_unproven_paths():
+    from omlx.patches.dflash_glm5 import Glm5NextTargetOps
+
+    caps = Glm5NextTargetOps().capabilities_for(_fake_target())
+    assert caps.supports_dflash is True
+    assert caps.supports_recurrent_rollback is True
+    assert caps.supports_kv_trim is True
+    assert caps.supports_prefix_snapshot is False
+    assert caps.supports_verify_linear is False
+    assert caps.supports_tree_verify is False
+
+
+def test_composite_dsa_cache_rollback_uses_kv_offset_and_checks_trim():
+    from omlx.patches.dflash_glm5 import Glm5NextTargetOps
+
+    class Composite:
+        def __init__(self):
+            self.kv = SimpleNamespace(offset=18)
+            self.trimmed = 0
+
+        def __getitem__(self, index):
+            assert index == 0
+            return self.kv
+
+        def trim(self, count):
+            self.trimmed += count
+            self.kv.offset -= count
+            return count
+
+    cache = Composite()
+    elapsed = Glm5NextTargetOps().restore_after_acceptance(
+        [cache], target_len=15, acceptance_length=1, drafted_tokens=7
+    )
+    assert elapsed > 0
+    assert cache.trimmed == 3
+    assert cache.kv.offset == 15
+
+
+def test_composite_dsa_cache_rollback_fails_closed_on_partial_trim():
+    from omlx.patches.dflash_glm5 import Glm5NextTargetOps
+
+    class Composite:
+        def __getitem__(self, index):
+            return SimpleNamespace(offset=18)
+
+        def trim(self, count):
+            return count - 1
+
+    with pytest.raises(RuntimeError, match="rollback failed"):
+        Glm5NextTargetOps().restore_after_acceptance(
+            [Composite()], target_len=15, acceptance_length=1, drafted_tokens=7
+        )
+
+
+def test_actual_cache_list_rollback_crosses_pooling_boundary_exactly():
+    from mlx_lm.models.cache import CacheList, KVCache
+
+    from omlx.patches.deepseek_v4 import apply_pooling_cache_support
+    from omlx.patches.dflash_glm5 import Glm5NextTargetOps
+
+    apply_pooling_cache_support()
+    from mlx_lm.models.cache import PoolingCache
+
+    def append(cache, tokens, *, offset):
+        kv = mx.arange(tokens * 3, dtype=mx.float32).reshape(1, tokens, 3)
+        gate = mx.ones((1, tokens, 1), dtype=mx.float32)
+        ready_kv, _ready_gate, _ = cache[1].accumulate_windows(kv, gate, offset)
+        pooled = ready_kv[:, ::4] if ready_kv.shape[1] else ready_kv
+        cache[1].update_and_fetch(pooled)
+        keys = kv[:, None]
+        values = mx.zeros((1, 1, tokens, 0), dtype=mx.float32)
+        cache[0].update_and_fetch(keys, values)
+
+    actual = CacheList(KVCache(), PoolingCache(4))
+    append(actual, 3, offset=0)
+    append(actual, 4, offset=3)
+    Glm5NextTargetOps().restore_after_acceptance(
+        [actual], target_len=4, acceptance_length=0, drafted_tokens=3
+    )
+
+    reference = CacheList(KVCache(), PoolingCache(4))
+    append(reference, 3, offset=0)
+    append(reference, 1, offset=3)
+    mx.eval(
+        *[v for v in actual[0].state if v is not None],
+        *[v for v in reference[0].state if v is not None],
+        *[v for v in actual[1].state if v is not None],
+        *[v for v in reference[1].state if v is not None],
+    )
+    assert actual[0].offset == reference[0].offset == 4
+    assert actual[1].remainder == reference[1].remainder == 0
+    for lhs, rhs in zip(actual[0].state, reference[0].state, strict=True):
+        assert mx.array_equal(lhs, rhs).item()
+    for lhs, rhs in zip(actual[1].state, reference[1].state, strict=True):
+        if lhs is None or rhs is None:
+            assert lhs is rhs
+        else:
+            assert mx.array_equal(lhs, rhs).item()
+
+
+def test_backend_install_is_idempotent_and_registers_before_resolution():
+    from dflash_mlx.engine import target_ops
+
+    from omlx.patches.dflash_glm5 import (
+        _BACKEND_PATH,
+        install_dflash_glm5_backend,
+    )
+
+    install_dflash_glm5_backend()
+    install_dflash_glm5_backend()
+    assert target_ops.TARGET_BACKENDS.count(_BACKEND_PATH) == 1
+
+
+def test_verify_block_scopes_pooling_undo_gate_even_on_error(monkeypatch):
+    from omlx.patches.dflash_glm5 import Glm5NextTargetOps
+    from omlx.patches.mlx_lm_mtp import cache_rollback
+
+    ops = Glm5NextTargetOps()
+
+    def fail_while_armed(*args, **kwargs):
+        assert cache_rollback._is_undo_armed() is True
+        raise RuntimeError("verify failed")
+
+    monkeypatch.setattr(ops, "forward_with_hidden_capture", fail_while_armed)
+    with pytest.raises(RuntimeError, match="verify failed"):
+        ops.verify_block(
+            target_model=object(),
+            verify_ids=mx.zeros((1, 2), dtype=mx.int32),
+            target_cache=[],
+        )
+    assert cache_rollback._is_undo_armed() is False
+
+
+def test_shared_lifecycle_restore_removes_glm_hook_without_qwen_backups():
+    from omlx.patches.dflash_glm5 import _install_glm5_recurrent_hook
+    from omlx.patches.dflash_lifecycle import restore_dflash_class_patches
+
+    class Attention:
+        def __call__(self, inputs, mask=None, cache=None):
+            return inputs
+
+    original = Attention.__call__
+    _install_glm5_recurrent_hook(Attention())
+    assert Attention.__call__ is not original
+    restore_dflash_class_patches()
+    assert Attention.__call__ is original
+
+
+def test_glm_target_loader_prefers_omlx_custom_vlm_loader(tmp_path, monkeypatch):
+    import mlx_vlm.utils as vlm_utils
+
+    from omlx.patches.dflash_glm5 import (
+        _load_glm5_target_bundle,
+        install_dflash_glm5_backend,
+    )
+    from omlx.utils import model_loading
+
+    (tmp_path / "config.json").write_text(
+        json.dumps({"model_type": "glm5_next"}), encoding="utf-8"
+    )
+    target = _fake_target()
+    processor = SimpleNamespace(tokenizer=object())
+    seen = []
+
+    def custom_loader(model_ref, *, is_vlm):
+        seen.append((model_ref, is_vlm))
+        return target, processor
+
+    monkeypatch.setattr(model_loading, "maybe_load_custom_quantization", custom_loader)
+    monkeypatch.setattr(
+        vlm_utils,
+        "load",
+        lambda *args, **kwargs: pytest.fail("plain mlx-vlm loader must not run"),
+    )
+    install_dflash_glm5_backend()
+    bundle = _load_glm5_target_bundle(tmp_path)
+    assert bundle.model is target
+    assert bundle.tokenizer is processor.tokenizer
+    assert seen == [(str(tmp_path), True)]
+
+
+def test_recurrent_verify_hook_matches_target_and_replays_accepted_prefix():
+    """The vector-gate tape path must preserve target output and KDA state."""
+    from mlx_lm.models.cache import ArraysCache
+
+    from omlx.patches.mlx_vlm_glm5_next_compat import (
+        apply_mlx_vlm_glm5_next_compat_patch,
+    )
+
+    apply_mlx_vlm_glm5_next_compat_patch()
+    from dflash_mlx.recurrent_rollback_cache import RecurrentRollbackCache
+    from mlx_vlm.models.glm5_next.language import Glm5NextLinearAttention
+
+    from omlx.patches.dflash_glm5 import (
+        Glm5NextTargetOps,
+        _install_glm5_recurrent_hook,
+        restore_glm5_dflash_class_patches,
+    )
+
+    config = SimpleNamespace(
+        hidden_size=64,
+        linear_num_heads=2,
+        linear_head_dim=32,
+        linear_conv_kernel_dim=4,
+        rms_norm_eps=1e-6,
+        linear_lower_bound=-5.0,
+    )
+    mx.random.seed(7)
+    attention = Glm5NextLinearAttention(config)
+    prefix = mx.random.normal((1, 3, 64)).astype(mx.bfloat16)
+    verify = mx.random.normal((1, 4, 64)).astype(mx.bfloat16)
+
+    baseline_cache = ArraysCache(size=2)
+    attention(prefix, cache=baseline_cache)
+    expected = attention(verify, cache=baseline_cache)
+    mx.eval(expected, *[v for v in baseline_cache.state if v is not None])
+
+    rollback_cache = RecurrentRollbackCache(size=2, conv_kernel_size=4)
+    attention(prefix, cache=rollback_cache)
+    mx.eval(*[v for v in rollback_cache.state if v is not None])
+    rollback_cache.arm_rollback(prefix_len=3)
+    _install_glm5_recurrent_hook(attention)
+    try:
+        full_cache = RecurrentRollbackCache(size=2, conv_kernel_size=4)
+        attention(prefix, cache=full_cache)
+        full_cache.arm_rollback(prefix_len=3)
+        attention(verify, cache=full_cache)
+        full_state = [v for v in full_cache.state]
+        Glm5NextTargetOps().restore_after_acceptance(
+            [full_cache],
+            target_len=7,
+            acceptance_length=3,
+            drafted_tokens=3,
+        )
+        mx.eval(
+            *[v for v in full_cache.state if v is not None],
+            *[v for v in full_state if v is not None],
+        )
+        for retained, expected_retained in zip(
+            full_cache.state, full_state, strict=True
+        ):
+            assert mx.array_equal(retained, expected_retained).item()
+        assert not hasattr(full_cache, "_omlx_glm5_verify")
+
+        actual = attention(verify, cache=rollback_cache)
+        mx.eval(actual, *[v for v in rollback_cache.state if v is not None])
+        assert mx.array_equal(actual, expected).item()
+        assert rollback_cache._omlx_glm5_verify is not None
+
+        # acceptance_length=1 commits the target-owned first token plus one
+        # accepted draft token. Compare rollback with a serial two-token run.
+        Glm5NextTargetOps()._rollback_glm_recurrent(rollback_cache, accepted_steps=2)
+        reference_cache = ArraysCache(size=2)
+        attention(prefix, cache=reference_cache)
+        attention(verify[:, :2], cache=reference_cache)
+        mx.eval(
+            *[v for v in rollback_cache.state if v is not None],
+            *[v for v in reference_cache.state if v is not None],
+        )
+        for replayed, reference in zip(
+            rollback_cache.state, reference_cache.state, strict=True
+        ):
+            assert mx.array_equal(replayed, reference).item()
+
+        # A second rejection from the replayed state catches cumulative drift
+        # that a one-cycle snapshot test would miss.
+        verify_two = mx.random.normal((1, 4, 64)).astype(mx.bfloat16)
+        baseline_two = ArraysCache(size=2)
+        attention(prefix, cache=baseline_two)
+        attention(verify[:, :2], cache=baseline_two)
+        expected_two = attention(verify_two, cache=baseline_two)
+        rollback_cache.arm_rollback(prefix_len=5)
+        actual_two = attention(verify_two, cache=rollback_cache)
+        mx.eval(actual_two, expected_two)
+        assert mx.array_equal(actual_two, expected_two).item()
+        Glm5NextTargetOps()._rollback_glm_recurrent(rollback_cache, accepted_steps=1)
+
+        reference_two = ArraysCache(size=2)
+        attention(prefix, cache=reference_two)
+        attention(verify[:, :2], cache=reference_two)
+        attention(verify_two[:, :1], cache=reference_two)
+        mx.eval(
+            *[v for v in rollback_cache.state if v is not None],
+            *[v for v in reference_two.state if v is not None],
+        )
+        for replayed, reference in zip(
+            rollback_cache.state, reference_two.state, strict=True
+        ):
+            assert mx.array_equal(replayed, reference).item()
+    finally:
+        restore_glm5_dflash_class_patches()

--- a/tests/test_dflash_glm5.py
+++ b/tests/test_dflash_glm5.py
@@ -555,6 +555,46 @@ def test_glm_target_loader_prefers_omlx_custom_vlm_loader(tmp_path, monkeypatch)
     ]
 
 
+def test_glm_target_loader_forces_eager_mlx_vlm_fallback(tmp_path, monkeypatch):
+    import mlx_vlm.utils as vlm_utils
+
+    from omlx.patches import dflash_glm5
+    from omlx.patches.dflash_glm5 import _load_glm5_target_bundle
+    from omlx.utils import model_loading
+
+    (tmp_path / "config.json").write_text(
+        json.dumps({"model_type": "glm5_next"}), encoding="utf-8"
+    )
+    target = _fake_target()
+    processor = SimpleNamespace(tokenizer=object())
+    seen = {}
+
+    def vlm_loader(model_ref, **kwargs):
+        seen.update(model_ref=model_ref, **kwargs)
+        return target, processor
+
+    monkeypatch.setattr(
+        model_loading,
+        "maybe_load_custom_quantization",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(model_loading, "materialize_lazy_state", lambda _model: None)
+    monkeypatch.setattr(vlm_utils, "load", vlm_loader)
+    monkeypatch.setattr(
+        dflash_glm5.Glm5NextTargetOps,
+        "install_speculative_hooks",
+        lambda self, model: None,
+    )
+
+    bundle = _load_glm5_target_bundle(tmp_path, lazy=True)
+    assert bundle.model is target
+    assert seen == {
+        "model_ref": str(tmp_path),
+        "lazy": False,
+        "strict": True,
+    }
+
+
 def test_glm_target_loader_fails_before_hooks_if_materialization_fails(
     tmp_path, monkeypatch
 ):

--- a/tests/test_dflash_glm5.py
+++ b/tests/test_dflash_glm5.py
@@ -236,11 +236,15 @@ def test_backend_install_is_idempotent_and_registers_before_resolution():
     from omlx.patches.dflash_glm5 import (
         _BACKEND_PATH,
         install_dflash_glm5_backend,
+        restore_glm5_dflash_class_patches,
     )
 
-    install_dflash_glm5_backend()
-    install_dflash_glm5_backend()
-    assert target_ops.TARGET_BACKENDS.count(_BACKEND_PATH) == 1
+    try:
+        install_dflash_glm5_backend()
+        install_dflash_glm5_backend()
+        assert target_ops.TARGET_BACKENDS.count(_BACKEND_PATH) == 1
+    finally:
+        restore_glm5_dflash_class_patches()
 
 
 def test_verify_block_scopes_pooling_undo_gate_even_on_error(monkeypatch):
@@ -264,7 +268,12 @@ def test_verify_block_scopes_pooling_undo_gate_even_on_error(monkeypatch):
 
 
 def test_shared_lifecycle_restore_removes_glm_hook_without_qwen_backups():
-    from omlx.patches.dflash_glm5 import _install_glm5_recurrent_hook
+    from dflash_mlx.engine.spec_epoch import SpeculativeSession
+
+    from omlx.patches.dflash_glm5 import (
+        _install_glm5_prefill_chunking_bridge,
+        _install_glm5_recurrent_hook,
+    )
     from omlx.patches.dflash_lifecycle import restore_dflash_class_patches
 
     class Attention:
@@ -272,10 +281,230 @@ def test_shared_lifecycle_restore_removes_glm_hook_without_qwen_backups():
             return inputs
 
     original = Attention.__call__
+    original_prefill = SpeculativeSession._run_prefill_events
     _install_glm5_recurrent_hook(Attention())
+    _install_glm5_prefill_chunking_bridge()
     assert Attention.__call__ is not original
+    assert SpeculativeSession._run_prefill_events is not original_prefill
     restore_dflash_class_patches()
     assert Attention.__call__ is original
+    assert SpeculativeSession._run_prefill_events is original_prefill
+
+
+def _run_fake_prefill(*, backend_name: str, prompt_len: int = 11):
+    from dflash_mlx.engine.spec_epoch import (
+        SpeculativeSession,
+        _RequestState,
+        _SessionRequest,
+        _YieldPauseTracker,
+    )
+
+    calls = []
+
+    class TargetOps:
+        def __init__(self):
+            self.backend_name = backend_name
+
+        def forward_with_hidden_capture(
+            self,
+            target_model,
+            *,
+            input_ids,
+            cache,
+            capture_layer_ids,
+            logits_last_only,
+        ):
+            del target_model, cache, capture_layer_ids, logits_last_only
+            width = int(input_ids.shape[1])
+            calls.append(width)
+            return (
+                mx.zeros((1, 1, 16), dtype=mx.float32),
+                {1: mx.zeros((1, width, 2), dtype=mx.float32)},
+            )
+
+        def extract_context_feature(self, captured, target_layer_ids):
+            del target_layer_ids
+            return captured[1]
+
+    class Draft:
+        @staticmethod
+        def project_target_hidden(features):
+            return features
+
+    class SnapshotTrap:
+        active = True
+
+        def should_publish_frontier(self, *_args, **_kwargs):
+            raise AssertionError("GLM prefill must not consult snapshot publication")
+
+        def publish(self, *_args, **_kwargs):
+            raise AssertionError("GLM prefill must not publish a snapshot")
+
+    session = SpeculativeSession(
+        target_model=object(),
+        draft_model=Draft(),
+        target_ops=TargetOps(),
+        target_cache=[],
+        draft_cache=[],
+        draft_backend=object(),
+        runtime_config=SimpleNamespace(prefill_step_size=4),
+        quantize_kv_cache=False,
+        snap_prefix_len=0,
+        supports_prefix_snapshot=False,
+        allow_full_context_draft_layers=False,
+        draft_sink_size=0,
+        draft_window_size=0,
+        target_layer_id_list=[0],
+        capture_layer_ids={1},
+        profile_cycles=False,
+        memory_waterfall=False,
+        clear_cache_boundaries=False,
+        target_fa_window=0,
+        copyspec_index=object(),
+        copyspec_mode="off",
+    )
+    request = _SessionRequest.from_tokens(
+        prompt_tokens=list(range(prompt_len)),
+        max_new_tokens=0,
+        block_tokens=1,
+        stop_token_ids=None,
+        suppress_token_ids=None,
+        prefix_snapshot=object(),
+        snapshot_service=SnapshotTrap(),
+        stable_prefix_len=5,
+        prefix_cache_active=True,
+        publish_generation_snapshot=True,
+    )
+    generator = session._run_prefill_events(
+        request=request,
+        state=_RequestState(),
+        yield_pause=_YieldPauseTracker(enabled=False),
+    )
+    while True:
+        try:
+            next(generator)
+        except StopIteration as stopped:
+            return calls, stopped.value, session
+
+
+def test_glm_prefill_chunks_without_enabling_snapshots():
+    from omlx.patches.dflash_glm5 import (
+        _install_glm5_prefill_chunking_bridge,
+        restore_glm5_dflash_class_patches,
+    )
+
+    _install_glm5_prefill_chunking_bridge()
+    try:
+        calls, result, session = _run_fake_prefill(backend_name="glm5_next")
+        assert calls == [4, 4, 2, 1]
+        assert result.supports_prefix_snapshot is False
+        assert session.supports_prefix_snapshot is False
+    finally:
+        restore_glm5_dflash_class_patches()
+
+
+def test_glm_prefill_bridge_never_enables_snapshot_hydration(monkeypatch):
+    from dflash_mlx.engine import spec_epoch
+    from dflash_mlx.engine.spec_epoch import SpeculativeSession
+    from dflash_mlx.runtime.context import build_offline_runtime_context
+
+    from omlx.patches.dflash_glm5 import (
+        _install_glm5_prefill_chunking_bridge,
+        restore_glm5_dflash_class_patches,
+    )
+
+    class TargetOps:
+        @staticmethod
+        def make_cache(*_args, **_kwargs):
+            return []
+
+    class DraftBackend:
+        @staticmethod
+        def make_cache(**_kwargs):
+            return []
+
+    draft = SimpleNamespace(
+        args=SimpleNamespace(sliding_window=0, layer_types=()),
+        target_layer_ids=[0],
+    )
+    snapshot = SimpleNamespace(prefix_len=1, token_ids=(7,))
+    monkeypatch.setattr(
+        spec_epoch,
+        "hydrate_target_cache",
+        lambda *_args, **_kwargs: pytest.fail("GLM snapshots must never hydrate"),
+    )
+
+    _install_glm5_prefill_chunking_bridge()
+    try:
+        session = SpeculativeSession.open(
+            target_model=object(),
+            draft_model=draft,
+            draft_backend=DraftBackend(),
+            target_ops=TargetOps(),
+            supports_prefix_snapshot=False,
+            allow_full_context_draft_layers=False,
+            prompt_tokens=[7, 8],
+            max_new_tokens=1,
+            prefix_snapshot=snapshot,
+            quantize_kv_cache=False,
+            target_fa_window=0,
+            runtime_context=build_offline_runtime_context(),
+        )
+        assert session.snap_prefix_len == 0
+        assert session.supports_prefix_snapshot is False
+    finally:
+        restore_glm5_dflash_class_patches()
+
+
+def test_glm_prefill_bridge_leaves_non_glm_behavior_unchanged():
+    from omlx.patches.dflash_glm5 import (
+        _install_glm5_prefill_chunking_bridge,
+        restore_glm5_dflash_class_patches,
+    )
+
+    _install_glm5_prefill_chunking_bridge()
+    try:
+        calls, result, session = _run_fake_prefill(backend_name="qwen_gdn")
+        assert calls == [11]
+        assert result.supports_prefix_snapshot is False
+        assert session.supports_prefix_snapshot is False
+    finally:
+        restore_glm5_dflash_class_patches()
+
+
+def test_fully_accepted_cycle_clears_pooling_undo_without_changing_state():
+    from mlx_lm.models.cache import CacheList, KVCache
+
+    from omlx.patches.deepseek_v4 import apply_pooling_cache_support
+    from omlx.patches.dflash_glm5 import Glm5NextTargetOps
+    from omlx.patches.mlx_lm_mtp import cache_rollback
+
+    apply_pooling_cache_support()
+    from mlx_lm.models.cache import PoolingCache
+
+    cache = CacheList(KVCache(), PoolingCache(4))
+    keys = mx.ones((1, 1, 1, 3), dtype=mx.float32)
+    values = mx.zeros((1, 1, 1, 0), dtype=mx.float32)
+    cache[0].update_and_fetch(keys, values)
+    cache_rollback.set_undo_armed(True)
+    try:
+        kv = mx.ones((1, 1, 3), dtype=mx.float32)
+        gate = mx.ones((1, 1, 1), dtype=mx.float32)
+        cache[1].accumulate_windows(kv, gate, 0)
+    finally:
+        cache_rollback.set_undo_armed(False)
+    state_before = cache.state
+    assert cache[1]._undo is not None
+    assert cache[1]._undo_chain is True
+
+    Glm5NextTargetOps().restore_after_acceptance(
+        [cache], target_len=1, acceptance_length=0, drafted_tokens=0
+    )
+    assert cache[1]._undo is None
+    assert cache[1]._undo_chain is False
+    assert cache[0].offset == 1
+    for before, after in zip(state_before[0], cache[0].state, strict=True):
+        assert mx.array_equal(before, after).item()
 
 
 def test_glm_target_loader_prefers_omlx_custom_vlm_loader(tmp_path, monkeypatch):

--- a/tests/test_dflash_glm5.py
+++ b/tests/test_dflash_glm5.py
@@ -510,6 +510,7 @@ def test_fully_accepted_cycle_clears_pooling_undo_without_changing_state():
 def test_glm_target_loader_prefers_omlx_custom_vlm_loader(tmp_path, monkeypatch):
     import mlx_vlm.utils as vlm_utils
 
+    from omlx.patches import dflash_glm5
     from omlx.patches.dflash_glm5 import (
         _load_glm5_target_bundle,
         install_dflash_glm5_backend,
@@ -524,10 +525,20 @@ def test_glm_target_loader_prefers_omlx_custom_vlm_loader(tmp_path, monkeypatch)
     seen = []
 
     def custom_loader(model_ref, *, is_vlm):
-        seen.append((model_ref, is_vlm))
+        seen.append(("load", model_ref, is_vlm))
         return target, processor
 
     monkeypatch.setattr(model_loading, "maybe_load_custom_quantization", custom_loader)
+    monkeypatch.setattr(
+        model_loading,
+        "materialize_lazy_state",
+        lambda model: seen.append(("materialize", model)),
+    )
+    monkeypatch.setattr(
+        dflash_glm5.Glm5NextTargetOps,
+        "install_speculative_hooks",
+        lambda self, model: seen.append(("hooks", model)),
+    )
     monkeypatch.setattr(
         vlm_utils,
         "load",
@@ -537,7 +548,53 @@ def test_glm_target_loader_prefers_omlx_custom_vlm_loader(tmp_path, monkeypatch)
     bundle = _load_glm5_target_bundle(tmp_path)
     assert bundle.model is target
     assert bundle.tokenizer is processor.tokenizer
-    assert seen == [(str(tmp_path), True)]
+    assert seen == [
+        ("load", str(tmp_path), True),
+        ("materialize", target),
+        ("hooks", target),
+    ]
+
+
+def test_glm_target_loader_fails_before_hooks_if_materialization_fails(
+    tmp_path, monkeypatch
+):
+    from omlx.patches import dflash_glm5
+    from omlx.patches.dflash_glm5 import (
+        _load_glm5_target_bundle,
+        install_dflash_glm5_backend,
+    )
+    from omlx.utils import model_loading
+
+    (tmp_path / "config.json").write_text(
+        json.dumps({"model_type": "glm5_next"}), encoding="utf-8"
+    )
+    target = _fake_target()
+    processor = SimpleNamespace(tokenizer=object())
+    hooks = []
+
+    def fail_materialize(_model):
+        raise RuntimeError("materialize failed")
+
+    monkeypatch.setattr(
+        model_loading,
+        "maybe_load_custom_quantization",
+        lambda *_args, **_kwargs: (target, processor),
+    )
+    monkeypatch.setattr(
+        model_loading,
+        "materialize_lazy_state",
+        fail_materialize,
+    )
+    monkeypatch.setattr(
+        dflash_glm5.Glm5NextTargetOps,
+        "install_speculative_hooks",
+        lambda self, model: hooks.append(model),
+    )
+
+    install_dflash_glm5_backend()
+    with pytest.raises(RuntimeError, match="materialize failed"):
+        _load_glm5_target_bundle(tmp_path)
+    assert hooks == []
 
 
 def test_recurrent_verify_hook_matches_target_and_replays_accepted_prefix():

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -1916,12 +1916,12 @@ class TestAdmissionSoftTargetEviction:
         assert pool.loaded_model_count == 2
 
 
-class TestGuardOffBestEffortAdmission:
+class TestGuardOffSafeAdmission:
     """#2290: model-swap eviction must survive disabling the memory guard.
 
     With the guard off `_get_final_ceiling` reads 0; the pool falls back
     to `_get_admission_ceiling` (enforcer static ceiling) for LRU
-    eviction, but never refuses a load under it.
+    eviction and still refuses a load that would exceed physical residency.
     """
 
     @pytest.fixture
@@ -1963,10 +1963,8 @@ class TestGuardOffBestEffortAdmission:
         assert pool._entries["model-b"].engine is not None
 
     @pytest.mark.asyncio
-    async def test_nothing_evictable_admits_over_ceiling(
-        self, guard_off_pool, caplog
-    ):
-        """Guard off + nothing to evict: warn and load anyway, never raise."""
+    async def test_nothing_evictable_refuses_over_ceiling(self, guard_off_pool):
+        """Guard off never permits model residency to crash the host."""
         pool = guard_off_pool
         pool._entries["model-a"].is_pinned = True
 
@@ -1976,12 +1974,11 @@ class TestGuardOffBestEffortAdmission:
 
         with patch("omlx.engine_pool.BatchedEngine", return_value=mock_engine):
             await pool.get_engine("model-a")
-            with caplog.at_level(logging.WARNING, logger="omlx.engine_pool"):
+            with pytest.raises(InsufficientMemoryError):
                 await pool.get_engine("model-b")
 
         assert pool._entries["model-a"].engine is not None
-        assert pool._entries["model-b"].engine is not None
-        assert any("memory guard disabled" in r.message for r in caplog.records)
+        assert pool._entries["model-b"].engine is None
 
     @pytest.mark.asyncio
     async def test_no_admission_callback_admits_unconditionally(

--- a/tests/test_glm5_gated_delta_row_block.py
+++ b/tests/test_glm5_gated_delta_row_block.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exactness tests for GLM-5's vector-gated recurrent row blocking."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import mlx.core as mx
+import pytest
+
+
+_MODULE_PATH = (
+    Path(__file__).parents[1]
+    / "omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/"
+    "glm5_next/gated_delta.py"
+)
+
+
+def _load_gated_delta_module():
+    spec = importlib.util.spec_from_file_location(
+        "_omlx_test_glm5_gated_delta", _MODULE_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def gated_delta():
+    if not mx.metal.is_available():
+        pytest.skip("GLM-5 recurrent row blocking requires Metal")
+    return _load_gated_delta_module()
+
+
+def _glm_inputs(tokens: int, *, seed: int = 11):
+    """Return the production GLM-5 GDN geometry (64 heads, width 128)."""
+    mx.random.seed(seed)
+    batch, heads, width = 1, 64, 128
+    recurrent = (batch, tokens, heads, width)
+
+    def bf16(low: float, high: float, shape):
+        return mx.random.uniform(low, high, shape, dtype=mx.float32).astype(
+            mx.bfloat16
+        )
+
+    return {
+        "q": bf16(-0.1, 0.1, recurrent),
+        "k": bf16(-0.1, 0.1, recurrent),
+        "v": bf16(-0.1, 0.1, recurrent),
+        "a": bf16(-1.0, 1.0, recurrent),
+        "b": bf16(-1.0, 1.0, (batch, tokens, heads)),
+        "A_log": mx.random.uniform(
+            -2.0, 0.0, (heads, width), dtype=mx.float32
+        ),
+        "dt_bias": bf16(-1.0, 1.0, (heads, width)),
+        "state": mx.random.uniform(
+            -0.1,
+            0.1,
+            (batch, heads, width, width),
+            dtype=mx.float32,
+        ),
+    }
+
+
+def _assert_bitwise_equal(left, right):
+    mx.eval(left, right)
+    assert left.dtype == right.dtype
+    assert left.shape == right.shape
+    assert bool(mx.all(left == right).item())
+
+
+@pytest.mark.parametrize("tokens", [1, 5, 17])
+def test_vector_gate_r4_is_bitwise_equal_to_legacy_r1(gated_delta, tokens):
+    args = _glm_inputs(tokens, seed=100 + tokens)
+    gate = gated_delta.compute_g_safe(
+        args["A_log"], args["a"], args["dt_bias"], -5.0
+    )
+    beta = mx.sigmoid(args["b"])
+
+    legacy_y, legacy_state = gated_delta._gated_delta_kernel_rows(
+        args["q"],
+        args["k"],
+        args["v"],
+        gate,
+        beta,
+        args["state"],
+        rows_per_thread=1,
+        threadgroup_y=4,
+    )
+    blocked_y, blocked_state = gated_delta._gated_delta_kernel_rows(
+        args["q"],
+        args["k"],
+        args["v"],
+        gate,
+        beta,
+        args["state"],
+        rows_per_thread=4,
+        threadgroup_y=2,
+    )
+
+    _assert_bitwise_equal(blocked_y, legacy_y)
+    _assert_bitwise_equal(blocked_state, legacy_state)
+
+
+def test_r4_preserves_masked_output_and_cache_semantics(gated_delta):
+    args = _glm_inputs(5, seed=211)
+    gate = gated_delta.compute_g_safe(
+        args["A_log"], args["a"], args["dt_bias"], -5.0
+    )
+    beta = mx.sigmoid(args["b"])
+    mask = mx.array([[True, False, True, False, True]])
+
+    legacy_y, legacy_state = gated_delta._gated_delta_kernel_rows(
+        args["q"],
+        args["k"],
+        args["v"],
+        gate,
+        beta,
+        args["state"],
+        mask,
+        rows_per_thread=1,
+        threadgroup_y=4,
+    )
+    blocked_y, blocked_state = gated_delta._gated_delta_kernel_rows(
+        args["q"],
+        args["k"],
+        args["v"],
+        gate,
+        beta,
+        args["state"],
+        mask,
+        rows_per_thread=4,
+        threadgroup_y=2,
+    )
+
+    _assert_bitwise_equal(blocked_y, legacy_y)
+    _assert_bitwise_equal(blocked_state, legacy_state)
+    assert bool(mx.all(blocked_y[:, 1::2] == 0).item())
+
+    all_masked = mx.zeros((1, 5), dtype=mx.bool_)
+    masked_y, masked_state = gated_delta.gated_delta_kernel(
+        args["q"], args["k"], args["v"], gate, beta, args["state"], all_masked
+    )
+    _assert_bitwise_equal(masked_y, mx.zeros_like(masked_y))
+    _assert_bitwise_equal(masked_state, args["state"])
+
+
+def test_update_keeps_glm_safe_lower_bound_gate(gated_delta):
+    args = _glm_inputs(4, seed=307)
+    gate = gated_delta.compute_g_safe(
+        args["A_log"], args["a"], args["dt_bias"], -5.0
+    )
+    beta = mx.sigmoid(args["b"])
+    expected_y, expected_state = gated_delta._gated_delta_kernel_rows(
+        args["q"],
+        args["k"],
+        args["v"],
+        gate,
+        beta,
+        args["state"],
+        rows_per_thread=4,
+        threadgroup_y=2,
+    )
+    actual_y, actual_state = gated_delta.gated_delta_update(
+        args["q"],
+        args["k"],
+        args["v"],
+        args["a"],
+        args["b"],
+        args["A_log"],
+        args["dt_bias"],
+        state=args["state"],
+        lower_bound=-5.0,
+    )
+
+    _assert_bitwise_equal(actual_y, expected_y)
+    _assert_bitwise_equal(actual_state, expected_state)

--- a/tests/test_glm5_gated_delta_row_block.py
+++ b/tests/test_glm5_gated_delta_row_block.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import mlx.core as mx
 import pytest
 
-
 _MODULE_PATH = (
     Path(__file__).parents[1]
     / "omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/"

--- a/tests/test_glm_moe_dsa_patch.py
+++ b/tests/test_glm_moe_dsa_patch.py
@@ -232,6 +232,51 @@ def test_glm_adaptive_prefill_config_defaults_and_gates(monkeypatch):
     assert _glm_dsa_adaptive_prefill_config(model, 2048) is None
 
 
+def test_glm5_adaptive_prefill_requires_complete_native_sparse_route(monkeypatch):
+    from omlx.patches.glm_moe_dsa import generate_patch
+
+    model = SimpleNamespace(model_type="glm5_next")
+    monkeypatch.setattr(
+        generate_patch, "_glm5_native_sparse_available", lambda _model: False
+    )
+    monkeypatch.setenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP", "1")
+    assert generate_patch._glm_dsa_adaptive_prefill_config(model, 2048) is None
+
+    monkeypatch.setattr(
+        generate_patch, "_glm5_native_sparse_available", lambda _model: True
+    )
+    cfg = generate_patch._glm_dsa_adaptive_prefill_config(model, 2048)
+    assert cfg is not None
+    assert cfg.step_size == 8192
+
+    monkeypatch.delenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP")
+    assert generate_patch._glm_dsa_adaptive_prefill_config(model, 2048) is None
+
+
+def test_glm5_wide_prefill_requires_published_native_geometry():
+    from omlx.patches.glm_moe_dsa.generate_patch import (
+        _glm5_native_prefill_geometry,
+    )
+
+    text_config = SimpleNamespace(
+        num_attention_heads=64,
+        kv_lora_rank=512,
+        index_topk=2048,
+        index_n_heads=32,
+        index_head_dim=128,
+        index_kpool=4,
+        linear_num_heads=64,
+        linear_head_dim=128,
+        mla_use_nope=True,
+        qk_rope_head_dim=0,
+    )
+    model = SimpleNamespace(config=SimpleNamespace(text_config=text_config))
+    assert _glm5_native_prefill_geometry(model)
+
+    text_config.num_attention_heads = 32
+    assert not _glm5_native_prefill_geometry(model)
+
+
 def test_glm_adaptive_prefill_config_env_overrides(monkeypatch):
     from omlx.patches.glm_moe_dsa.generate_patch import (
         _glm_dsa_adaptive_prefill_config,

--- a/tests/test_glm_moe_dsa_patch.py
+++ b/tests/test_glm_moe_dsa_patch.py
@@ -379,6 +379,84 @@ def test_glm_direct_sparse_mla_uses_fork_default_threshold(monkeypatch):
     assert glm_moe_dsa_model._native_sparse_mla_default_min_k() == "11264"
 
 
+def test_glm5_nope_sparse_mla_fails_closed_without_dedicated_abi(monkeypatch):
+    mx = pytest.importorskip("mlx.core")
+    from omlx.patches.glm_moe_dsa import sparse_mla
+
+    monkeypatch.setattr(
+        sparse_mla,
+        "glm_fast",
+        SimpleNamespace(has=lambda _name: False),
+    )
+    q = mx.zeros((1, 64, 2, 512), dtype=mx.bfloat16)
+    kv = mx.zeros((1, 1, 16, 512), dtype=mx.bfloat16)
+    topk = mx.zeros((1, 1, 2, 16), dtype=mx.uint32)
+
+    assert sparse_mla.sparse_mla_attention_nope(q, kv, topk, 512**-0.5) is None
+
+
+def test_glm5_nope_sparse_mla_dispatches_zero_width_pe(monkeypatch):
+    mx = pytest.importorskip("mlx.core")
+    from omlx.patches.glm_moe_dsa import sparse_mla
+
+    sentinel = object()
+    captured = {}
+
+    class FakeFast:
+        @staticmethod
+        def has(name):
+            return name == "glm_dsa_nope_sparse_mla_attention"
+
+        @staticmethod
+        def glm_dsa_nope_sparse_mla_attention(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return sentinel
+
+    monkeypatch.setattr(sparse_mla, "glm_fast", FakeFast())
+    q = mx.zeros((1, 64, 2, 512), dtype=mx.bfloat16)
+    kv = mx.zeros((1, 1, 16, 512), dtype=mx.bfloat16)
+    topk = mx.zeros((1, 1, 2, 16), dtype=mx.uint32)
+
+    assert sparse_mla.sparse_mla_attention_nope(q, kv, topk, 512**-0.5) is sentinel
+    assert captured["args"][1].shape == (1, 64, 2, 0)
+    assert captured["args"][3].shape == (1, 1, 16, 0)
+    assert captured["args"][1].dtype == q.dtype
+    assert captured["args"][3].dtype == q.dtype
+
+
+def test_glm5_nope_sparse_mla_is_bitwise_equal_to_zero_pe_native():
+    mx = pytest.importorskip("mlx.core")
+    from omlx.custom_kernels.glm_moe_dsa import fast
+    from omlx.patches.glm_moe_dsa.sparse_mla import sparse_mla_attention_nope
+
+    if not fast.has_symbol("glm_dsa_nope_sparse_mla_attention"):
+        pytest.skip("GLM-5.3 NoPE sparse-MLA kernel is unavailable")
+
+    mx.random.seed(29)
+    q = mx.random.normal((1, 64, 32, 512), dtype=mx.bfloat16)
+    kv = mx.random.normal((1, 1, 64, 512), dtype=mx.bfloat16)
+    topk = mx.broadcast_to(
+        mx.arange(16, dtype=mx.uint32).reshape(1, 1, 1, 16),
+        (1, 1, 32, 16),
+    )
+    q_pe = mx.zeros((1, 64, 32, 64), dtype=mx.bfloat16)
+    k_pe = mx.zeros((1, 1, 64, 64), dtype=mx.bfloat16)
+    scale = 512**-0.5
+
+    reference = fast.glm_dsa_sparse_mla_attention(
+        q, q_pe, kv, k_pe, topk, scale
+    )
+    with pytest.raises(ValueError, match="zero-width q_pe and k_pe"):
+        fast.glm_dsa_nope_sparse_mla_attention(
+            q, q_pe, kv, k_pe, topk, scale
+        )
+    nope = sparse_mla_attention_nope(q, kv, topk, scale)
+    assert nope is not None
+    mx.eval(reference, nope)
+    assert bool(mx.array_equal(reference, nope).item())
+
+
 def test_glm_native_fused_kernels_match_reference(monkeypatch):
     mx = pytest.importorskip("mlx.core")
 

--- a/tests/test_mlx_vlm_glm5_next_compat.py
+++ b/tests/test_mlx_vlm_glm5_next_compat.py
@@ -7,6 +7,7 @@ import base64
 import importlib
 import io
 import json
+from types import SimpleNamespace
 
 import mlx.core as mx
 import pytest
@@ -120,6 +121,145 @@ def _feed_pool(cache, token_count: int) -> None:
     ready, _, _ = cache.accumulate_windows(values, gates, 0)
     pooled = ready.reshape(1, -1, cache.ratio, width).mean(axis=2)
     cache.update_and_fetch(pooled)
+
+
+def test_glm5_decode_indexer_uses_single_row_exact_mma_contract(
+    monkeypatch,
+):
+    """The L=1 route must not pad one decode query into 64 prefill rows."""
+    from mlx_vlm.models.glm5_next.language import Glm5NextIndexer
+
+    from omlx.custom_kernels.glm_moe_dsa import fast
+
+    mx.random.seed(5301)
+    indexer = SimpleNamespace(n_heads=32, head_dim=128)
+    q = mx.random.normal((1, 1, 32, 128), dtype=mx.bfloat16)
+    pool_keys = mx.random.normal((1, 4096, 128), dtype=mx.bfloat16)
+    weights = mx.random.normal((1, 1, 32), dtype=mx.bfloat16)
+    calls = []
+
+    def fake_indexer(qt, keys, w, **kwargs):
+        calls.append(qt.shape[2])
+        assert qt.shape == (1, 32, 1, 128)
+        assert keys.shape == (1, 1, 4096, 128)
+        assert w.shape == (1, 1, 32)
+        assert kwargs == {"causal": False}
+        scores = qt @ keys.swapaxes(-1, -2)
+        scores = mx.maximum(scores, mx.array(0, scores.dtype))
+        return (
+            (scores * w.transpose(0, 2, 1)[..., None])
+            .sum(axis=1, keepdims=True)
+            .astype(q.dtype)
+        )
+
+    monkeypatch.setattr(
+        fast,
+        "has_symbol",
+        lambda name: name == "dsa_indexer_scores",
+    )
+    monkeypatch.setattr(fast, "dsa_indexer_scores", fake_indexer)
+    direct = Glm5NextIndexer._native_scores(indexer, q, pool_keys, weights)
+    mx.eval(direct)
+
+    assert calls == [1]
+    assert direct.shape == (1, 1, 4096)
+
+
+def test_glm5_decode_indexer_m1_error_falls_back_to_padded_abi(monkeypatch):
+    """A stale M=1 implementation must retain the exact padded route."""
+    from mlx_vlm.models.glm5_next.language import Glm5NextIndexer
+
+    from omlx.custom_kernels.glm_moe_dsa import fast
+
+    indexer = SimpleNamespace(n_heads=32, head_dim=128)
+    q = mx.zeros((1, 1, 32, 128), dtype=mx.bfloat16)
+    pool_keys = mx.zeros((1, 4096, 128), dtype=mx.bfloat16)
+    weights = mx.zeros((1, 1, 32), dtype=mx.bfloat16)
+    calls = []
+
+    monkeypatch.setattr(fast, "has_symbol", lambda _name: True)
+
+    def m1_then_padded(qt, keys, w, **_kwargs):
+        calls.append(qt.shape[2])
+        if qt.shape[2] == 1:
+            raise RuntimeError("stale M=1 implementation")
+        assert qt.shape[2] == 64
+        return mx.zeros((1, 1, 64, keys.shape[2]), dtype=w.dtype)
+
+    monkeypatch.setattr(fast, "dsa_indexer_scores", m1_then_padded)
+    scores = Glm5NextIndexer._native_scores(indexer, q, pool_keys, weights)
+    mx.eval(scores)
+
+    assert calls == [1, 64]
+    assert scores.shape == (1, 1, 4096)
+
+
+def test_glm5_multirow_indexer_keeps_existing_padded_route(monkeypatch):
+    from mlx_vlm.models.glm5_next.language import Glm5NextIndexer
+
+    from omlx.custom_kernels.glm_moe_dsa import fast
+
+    indexer = SimpleNamespace(n_heads=32, head_dim=128)
+    query_rows = 2
+    pool_length = 4096
+    q = mx.zeros((1, query_rows, 32, 128), dtype=mx.bfloat16)
+    pool_keys = mx.zeros((1, pool_length, 128), dtype=mx.bfloat16)
+    weights = mx.zeros((1, query_rows, 32), dtype=mx.bfloat16)
+    calls = []
+
+    monkeypatch.setattr(fast, "has_symbol", lambda _name: True)
+
+    def fake_prefill(qt, keys, w, **_kwargs):
+        calls.append(qt.shape[2])
+        return mx.zeros((1, 1, qt.shape[2], keys.shape[2]), dtype=w.dtype)
+
+    monkeypatch.setattr(fast, "dsa_indexer_scores", fake_prefill)
+    scores = Glm5NextIndexer._native_scores(indexer, q, pool_keys, weights)
+    mx.eval(scores)
+
+    assert calls == [64]
+    assert scores.shape == (1, query_rows, pool_length)
+
+
+@pytest.mark.parametrize("pool_length", [513, 1024, 4095, 4096, 8191])
+def test_glm5_native_m1_mma_is_bit_exact_to_legacy_padded_row(pool_length):
+    """The BM8 decode specialization must preserve the deployed score sheet."""
+    from mlx_vlm.models.glm5_next.language import Glm5NextIndexer
+
+    from omlx.custom_kernels.glm_moe_dsa import fast
+
+    required = ("dsa_indexer_scores", "dsa_topk_indices")
+    if not fast.is_native_available() or any(
+        not fast.has_symbol(name) for name in required
+    ):
+        pytest.skip("packaged GLM native decode/indexer kernels are unavailable")
+
+    mx.random.seed(530_000 + pool_length)
+    indexer = SimpleNamespace(n_heads=32, head_dim=128)
+    q = mx.random.normal((1, 1, 32, 128), dtype=mx.bfloat16)
+    pool_keys = mx.random.normal((1, pool_length, 128), dtype=mx.bfloat16)
+    weights = mx.random.normal((1, 1, 32), dtype=mx.bfloat16)
+
+    direct = Glm5NextIndexer._native_scores(indexer, q, pool_keys, weights)
+    qt = q.transpose(0, 2, 1, 3)
+    keys = pool_keys[:, None]
+    q_pad = mx.pad(qt, [(0, 0), (0, 0), (0, 63), (0, 0)])
+    w_pad = mx.pad(weights, [(0, 0), (0, 63), (0, 0)])
+    k_pad = (-pool_length) % 64
+    if k_pad:
+        keys = mx.pad(keys, [(0, 0), (0, 0), (0, k_pad), (0, 0)])
+    legacy = fast.dsa_indexer_scores(
+        q_pad,
+        keys,
+        w_pad,
+        causal=False,
+    )[:, 0, :1, :pool_length]
+    direct_topk = fast.dsa_topk_indices(direct[:, None], 512)[:, 0]
+    legacy_topk = fast.dsa_topk_indices(legacy[:, None], 512)[:, 0]
+    mx.eval(direct, legacy, direct_topk, legacy_topk)
+
+    assert mx.array_equal(direct, legacy).item()
+    assert mx.array_equal(direct_topk, legacy_topk).item()
 
 
 def test_glm5_next_registers_pinned_upstream_model():

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3281,6 +3281,53 @@ class TestSchedulerArraysCacheBlockAlignment:
         finally:
             scheduler.shutdown()
 
+    def test_glm5_native_sparse_prefill_aligns_cache_boundary_to_8192(
+        self, mock_tokenizer, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP", "1")
+        with patch(
+            "omlx.patches.glm_moe_dsa.generate_patch._glm5_native_sparse_available",
+            return_value=True,
+        ):
+            scheduler = Scheduler(
+                model=self._hybrid_model(model_type="glm5_next"),
+                tokenizer=mock_tokenizer,
+                config=SchedulerConfig(
+                    paged_ssd_cache_dir=str(tmp_path),
+                    paged_cache_block_size=256,
+                ),
+            )
+
+        try:
+            assert scheduler._glm_dsa_adaptive_prefill is not None
+            assert scheduler._prefill_step_size_for_progress(0, 20_000) == 8192
+            assert scheduler.config.paged_cache_block_size == 8192
+        finally:
+            scheduler.shutdown()
+
+    def test_glm5_default_preserves_2048_cache_granularity(
+        self, mock_tokenizer, tmp_path, monkeypatch
+    ):
+        monkeypatch.delenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP", raising=False)
+        with patch(
+            "omlx.patches.glm_moe_dsa.generate_patch._glm5_native_sparse_available",
+            return_value=True,
+        ):
+            scheduler = Scheduler(
+                model=self._hybrid_model(model_type="glm5_next"),
+                tokenizer=mock_tokenizer,
+                config=SchedulerConfig(
+                    paged_ssd_cache_dir=str(tmp_path),
+                    paged_cache_block_size=256,
+                ),
+            )
+
+        try:
+            assert scheduler._glm_dsa_adaptive_prefill is None
+            assert scheduler.config.paged_cache_block_size == 2048
+        finally:
+            scheduler.shutdown()
+
     def test_custom_prefill_step_raises_arrays_block(self, mock_tokenizer, tmp_path):
         scheduler = Scheduler(
             model=self._hybrid_model(model_type="other_hybrid"),


### PR DESCRIPTION
## Depends on

- #3251 — exact GLM-5.3 single-row index-score preservation and prefill/decode baseline

## Summary

Add a fail-closed GLM-5.3 target adapter for the DFlash2 runtime already pinned by oMLX. This enables `incoai/GLM-5.3-Flash-DFlash2` to accelerate matched `glm5_next` targets, including custom oQ checkpoints, without changing native autoregressive output.

The integration:

- contracts GLM-5.3 MHC streams at the five checkpoint-declared capture layers;
- validates target/drafter architecture, hidden size, vocabulary, layer count, capture order, and MHC geometry before serving;
- rolls rejected verification tokens back across recurrent KDA state and composite DSA `CacheList(KVCache, PoolingCache)` state;
- replays recurrent state through GLM's exact native vector-gate recurrence instead of the generic innovation tape, which can drift at tail ULPs after repeated rejection cycles;
- chunks long cold prefill independently of prefix-snapshot support;
- loads mlx-vlm and custom oQ targets through their native loaders, eagerly materializes them, and restores process-global hooks on unload;
- stops generation at reasoning/tool parser boundaries before any sentinel can leak into streamed content;
- merges scalar tokenizer EOS metadata with model `generation_config.json` stop-token declarations at the oMLX boundary;
- owns and restores the temporary wired-memory limit used while materializing the target and drafter.

The adapter intentionally fails closed for unproven modes. DDTree/tree verification, target KV quantization, specialized verification linears, and DFlash L1/L2 prefix snapshots remain disabled for GLM-5.3. Image and video requests retain the existing unload-and-VLM-fallback path.

The drafter is not bundled or downloaded automatically. Its checkpoint is published under CC BY-NC-ND 4.0.

## Physical benchmark

Apple M3 Ultra, 256 GB unified memory; `GLM-5.3-Flash-oQ4e`; official `incoai/GLM-5.3-Flash-DFlash2` BF16 drafter; block size 8; single stream; MTP off; DFlash prefix caches off. Every primary matrix case generated all 500 requested tokens and matched the native autoregressive output hash exactly.

| Prompt | Native prefill | DFlash2 prefill | Native decode | DFlash2 decode | Decode gain | Correctness |
|---:|---:|---:|---:|---:|---:|:---|
| 2K | 415.2 tok/s | 407.6 tok/s | 25.8 tok/s | 80.0 tok/s | 3.10x | exact output hash |
| 10K | 378.0 tok/s | 372.0 tok/s | 25.8 tok/s | 79.1 tok/s | 3.07x | exact output hash |
| 20K | 379.4 tok/s | 368.2 tok/s | 25.7 tok/s | 77.6 tok/s | 3.02x | exact output hash |

A separate 1,500-token generation on the production precursor, containing the same production fixes, measured 80.0 tok/s DFlash2 versus 25.3 tok/s native AR and matched the native output exactly.

The exact-output block-size sweep measured 47.1, 56.5, 63.0, 65.9, and 80.0 tok/s at block sizes 3, 4, 5, 6, and 8 respectively. Block size 8 is therefore the tested default.

DFlash2 is a decode optimization, so the expected result is the large decode gain above rather than a prefill gain.

## Tool-call correctness gate

- [x] **Passed on the physical M3 Ultra target/drafter pair.** A forced `get_weather` call stopped at the GLM turn boundary after 32 completion tokens with `finish_reason=tool_calls`, `content=null`, and valid arguments `{"city":"San Francisco"}`. No parser sentinel or trailing text leaked.
- [x] The tool-result continuation completed normally in 2.24 seconds, returned a clean 61-token visible answer, emitted no second tool call, and finished with `stop`.

Unit coverage already exercises reasoning boundaries, tool-call boundaries split across streamed token chunks, generation-config stop tokens, and scalar EOS metadata.

## Tests

- `778 passed` across every DFlash suite plus server, reasoning, parser, and tool-call coverage
- `219 passed` across engine-pool, model-loading, and VLM-adapter coverage
- `git diff --check`
- `py_compile` for all changed Python modules/tests
- Ruff clean for the changed delta when excluding the pre-existing upstream `SIM105` in `dflash_lifecycle.py`

New GLM-specific coverage includes MHC capture, architecture/geometry fail-closed checks, recurrent rejection replay, composite DSA rollback, long-prefill chunking, mlx-vlm/oQ loader selection, eager materialization, parser-boundary stopping, generation-config/scalar EOS handling, wired-memory ownership/restoration, and unload lifecycle cleanup.
