### PR TITLE
fix: match safetensors shards lexically so symlinked checkpoints sanitize

### DIFF
--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -53,6 +53,7 @@ from ..utils.image import (
     compute_per_image_hashes,
     extract_images_from_messages,
 )
+from ..utils.safetensors_paths import model_shard_matcher
 from .base import (
     BaseEngine,
     GenerationOutput,
@@ -933,7 +934,7 @@ def _force_minimax_m3_moe_sanitize_on_load(model_dir: Path):
 
     original_safe_open = safetensors.safe_open
     original_sanitize_moe_weights = _minimax_m3_vl._sanitize_moe_weights
-    target_dir = model_dir.resolve()
+    is_target_shard = model_shard_matcher(model_dir)
 
     class _SafeOpenMetadataWrapper:
         def __init__(self, inner):
@@ -958,11 +959,7 @@ def _force_minimax_m3_moe_sanitize_on_load(model_dir: Path):
 
     def _patched_safe_open(filename, *args, **kwargs):
         handle = original_safe_open(filename, *args, **kwargs)
-        try:
-            path = Path(filename).resolve()
-        except TypeError:
-            return handle
-        if path.parent == target_dir and path.suffix == ".safetensors":
+        if is_target_shard(filename):
             return _SafeOpenMetadataWrapper(handle)
         return handle
 
@@ -1054,7 +1051,7 @@ def _force_qwen4_exp_sanitize_on_load(model_dir: Path):
     import safetensors
 
     original_safe_open = safetensors.safe_open
-    target_dir = model_dir.resolve()
+    is_target_shard = model_shard_matcher(model_dir)
 
     class _SafeOpenMetadataWrapper:
         def __init__(self, inner):
@@ -1079,11 +1076,7 @@ def _force_qwen4_exp_sanitize_on_load(model_dir: Path):
 
     def _patched_safe_open(filename, *args, **kwargs):
         handle = original_safe_open(filename, *args, **kwargs)
-        try:
-            path = Path(filename).resolve()
-        except TypeError:
-            return handle
-        if path.parent == target_dir and path.suffix == ".safetensors":
+        if is_target_shard(filename):
             return _SafeOpenMetadataWrapper(handle)
         return handle
 

--- a/omlx/utils/safetensors_paths.py
+++ b/omlx/utils/safetensors_paths.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Path identity for safetensors shards inside symlinked checkpoints.
+
+Several loaders decide whether a checkpoint is ``format=mlx`` from the
+safetensors header metadata, and oMLX sometimes hides that marker for a single
+load so a model's ``Model.sanitize()`` runs. That override is scoped to the
+shards belonging to the model being loaded, so it has to compare the filename
+handed to ``safe_open`` against the model directory.
+
+``Path.resolve()`` is the wrong tool for that comparison. Checkpoint layouts
+that keep shards as symlinks to a content-addressed store -- HF Hub cache
+snapshots, download mirrors, hand-made links -- resolve the shard name out of
+the model directory entirely, the comparison silently returns False, and the
+marker stays visible. The sanitize that would have dropped the model's
+self-managed tensors then never runs, and the load fails later on orphan keys
+reported by ``load_weights``.
+
+Match lexically first (symlinks preserved) and fall back to the fully resolved
+form, so both a symlinked shard and a symlinked model directory match.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from pathlib import Path
+
+__all__ = ["model_shard_matcher"]
+
+
+def _as_filename_str(filename: object) -> str | None:
+    """Return *filename* as a filesystem string, or ``None`` if not a path."""
+    try:
+        return os.fsdecode(os.fspath(filename))
+    except TypeError:
+        return None
+
+
+def _candidate_parents(name: str) -> set[Path]:
+    """Every spelling of the directory a shard name could belong to."""
+    parents = {Path(name).parent, Path(os.path.abspath(name)).parent}
+    try:
+        parents.add(Path(name).resolve().parent)
+    except (OSError, RuntimeError):
+        pass
+    return parents
+
+
+def model_shard_matcher(
+    model_dir: str | os.PathLike[str],
+) -> Callable[[object], bool]:
+    """Return a predicate matching ``safe_open`` filenames in *model_dir*.
+
+    A shard matches when any spelling of its directory -- as written, made
+    absolute, or followed through symlinks -- equals any spelling of
+    *model_dir*. Only direct children match, mirroring the
+    ``glob(model_path / "*.safetensors")`` scan the loaders perform.
+
+    The argument is deliberately ``object``: filenames reach ``safe_open`` from
+    callers that oMLX does not control, and anything that is not a
+    safetensors path must simply not match rather than abort the load.
+    """
+    raw_dir = os.fsdecode(os.fspath(model_dir))
+    targets = {Path(raw_dir), Path(os.path.abspath(raw_dir))}
+    try:
+        targets.add(Path(raw_dir).resolve())
+    except (OSError, RuntimeError):
+        pass
+
+    def matches(filename: object) -> bool:
+        name = _as_filename_str(filename)
+        if name is None or not name.endswith(".safetensors"):
+            return False
+        return bool(_candidate_parents(name) & targets)
+
+    return matches

--- a/tests/test_safetensors_paths.py
+++ b/tests/test_safetensors_paths.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for safetensors shard identity across symlinked checkpoint layouts."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from omlx.utils.safetensors_paths import model_shard_matcher
+
+
+@pytest.fixture
+def snapshot(tmp_path):
+    """A model directory whose shards are symlinks into a blob store."""
+    store = tmp_path / "blobs"
+    model_dir = tmp_path / "snapshots" / "rev"
+    store.mkdir()
+    model_dir.mkdir(parents=True)
+    for name in (
+        "model-00001-of-00002.safetensors",
+        "model-00002-of-00002.safetensors",
+    ):
+        (store / f"blob-{name}").write_bytes(b"")
+        os.symlink(store / f"blob-{name}", model_dir / name)
+    return model_dir
+
+
+def test_matches_plain_shards(tmp_path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    shard = model_dir / "model-00001-of-00001.safetensors"
+    shard.write_bytes(b"")
+
+    matches = model_shard_matcher(model_dir)
+    assert matches(shard)
+    assert matches(str(shard))
+    assert not matches(model_dir / "config.json")
+    assert not matches(tmp_path / "other.safetensors")
+
+
+def test_matches_symlinked_shards(snapshot):
+    store = snapshot.parent.parent / "blobs"
+    matches = model_shard_matcher(snapshot)
+
+    for shard in sorted(snapshot.glob("*.safetensors")):
+        assert matches(shard), shard
+    # The blob store holds the same bytes but is not the model directory.
+    assert not matches(store / "blob-model-00001-of-00002.safetensors")
+
+
+def test_matches_shards_through_a_symlinked_model_dir(tmp_path):
+    real = tmp_path / "real"
+    real.mkdir()
+    shard = real / "model-00001-of-00001.safetensors"
+    shard.write_bytes(b"")
+    link = tmp_path / "link"
+    os.symlink(real, link)
+
+    via_link = model_shard_matcher(link)
+    assert via_link(link / shard.name)
+    assert via_link(shard)
+    assert model_shard_matcher(real)(link / shard.name)
+
+
+def test_matches_relative_shard_names(tmp_path, monkeypatch):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    shard = model_dir / "model.safetensors"
+    shard.write_bytes(b"")
+
+    monkeypatch.chdir(model_dir)
+    assert model_shard_matcher(model_dir)("model.safetensors")
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        None,
+        1234,
+        "",
+        ".",
+        b"/tmp/model/x.safetensors",
+        "/tmp/model/nested/model.safetensors",
+        "/tmp/model/other.JSON",
+    ],
+)
+def test_non_matching_input_never_matches_and_never_raises(tmp_path, filename):
+    """Callers hand ``safe_open`` filenames oMLX does not control."""
+    assert not model_shard_matcher(tmp_path / "model")(filename)

--- a/tests/test_vlm_qwen4_exp_loader.py
+++ b/tests/test_vlm_qwen4_exp_loader.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 from types import SimpleNamespace
 
 import pytest
@@ -57,6 +58,50 @@ def test_qwen4_exp_mlx_metadata_is_hidden_during_load(tmp_path, monkeypatch):
             assert handle.metadata() == {"source": "test"}
 
     assert safetensors.safe_open is original
+
+
+def test_qwen4_exp_mlx_metadata_is_hidden_for_symlinked_shards(
+    tmp_path, monkeypatch
+):
+    """Symlinked shards must still get the sanitize override.
+
+    Checkpoint layouts that keep shards as symlinks into a content-addressed
+    store resolve outside the model directory, so a ``Path.resolve()``
+    comparison leaves ``format=mlx`` visible, skips ``Model.sanitize``, and
+    the load dies on the self-managed tensors sanitize was removing.
+    """
+    store = tmp_path / "blobs"
+    snapshot = tmp_path / "snapshots" / "rev"
+    store.mkdir()
+    snapshot.mkdir(parents=True)
+    (snapshot / "config.json").write_text(
+        json.dumps({"model_type": "qwen4_exp"}), encoding="utf-8"
+    )
+    blob = store / "blob-1"
+    blob.write_bytes(b"\x00")
+    shard = snapshot / "model-00001-of-00021.safetensors"
+    os.symlink(blob, shard)
+
+    class FakeHandle:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def metadata(self):
+            return {"format": "mlx", "source": "test"}
+
+    import safetensors
+
+    monkeypatch.setattr(safetensors, "safe_open", lambda *_a, **_k: FakeHandle())
+
+    with vlm_module._force_qwen4_exp_sanitize_on_load(snapshot):
+        with safetensors.safe_open(shard) as handle:
+            assert handle.metadata() == {"source": "test"}
+        # Files outside the model keep their marker untouched.
+        with safetensors.safe_open(blob) as handle:
+            assert handle.metadata() == {"format": "mlx", "source": "test"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## The failure

`Jundot/Qwen3.8-Flash-Next-oQ4e-mtp` fails to load when it is pulled from the Hugging Face Hub cache:

```
Received 384 parameters not in model
```

The same checkpoint, same settings, copied into `~/.omlx/models` starts fine.

This is specific to *where* the checkpoint is stored; anyone who loads a model from their HF cache instead of the models directory hits it. Turning on the new Qwen4-only **SSD N-gram Offload** setting is what makes the skipped sanitize visible instead of harmless.

384 = the `ngram_embedding.shards.N.{weight,scales,biases}` tensors that `DiskBackedShardedEmbedding` deliberately does **not** own when PLE runs in mmap mode. They are supposed to be dropped by `Model.sanitize()` before `load_weights` ever sees them.

## Root cause

`_force_qwen4_exp_sanitize_on_load()` in `omlx/engine/vlm.py` forces mlx-vlm's sanitize path by hiding the safetensors `format=mlx` marker for the duration of one load, scoped to the checkpoint's own shards:

```python
target_dir = model_dir.resolve()
...
path = Path(filename).resolve()
if path.parent == target_dir and path.suffix == ".safetensors":   # ← here
    return _SafeOpenMetadataWrapper(handle)
```

mlx-vlm builds those filenames itself:

```python
weight_files = [wf for wf in glob.glob(str(model_path / "*.safetensors")) ...]
with safetensors.safe_open(weight_files[0], framework="np") as f:
    is_mlx_format = f.metadata().get("format") == "mlx"
```

so the prefix keeps the caller's spelling — but `Path(filename).resolve()` **follows the symlink out of the snapshot directory**. An HF Hub cache snapshot keeps every shard as `model-*.safetensors -> ../../blobs/<sha>`, so the comparison silently returns `False`, the marker stays visible, `load_model` skips `Model.sanitize`, and those 384 self-managed tensors reach strict `load_weights`.

Verified against both copies of this checkpoint on a real install — old predicate, all 21 shards in each layout:

| layout | shards matched (pre-fix) | matched (post-fix) |
| --- | --- | --- |
| `~/.omlx/models/…` (real files) | 21 / 21 | 21 / 21 |
| `~/.cache/huggingface/hub/models--Jundot--Qwen3.8-Flash-Next-oQ4e-mtp/snapshots/<rev>/` (symlinks) | **0 / 21** | 21 / 21 |

That is the entire difference between the working directory and the broken one. The same defect covers any symlinked checkpoint layout, not just HF Hub: download mirrors, relocated blob stores, hand-made links.

## Fix

New `omlx/utils/safetensors_paths.py` with `model_shard_matcher(model_dir)`, which matches a shard when **any** spelling of its directory — as written, made absolute, or followed through symlinks — equals **any** spelling of the model directory. Matching lexically first is what keeps symlinked shards attached to the directory they were opened from; the resolved fallback still covers a symlinked *model directory*.

```python
def matches(filename: object) -> bool:
    name = _as_filename_str(filename)
    if name is None or not name.endswith(".safetensors"):
        return False
    return bool(_candidate_parents(name) & targets)
```

Properties, all pinned by tests:
- Only **direct children** match, mirroring the upstream `glob(model_path / "*.safetensors")` scan — the blob store holding the identical bytes does not match.
- Relative shard names resolve against the caller's cwd, so callers that glob relatively are covered too.
- Filenames reach `safe_open` from code paths oMLX does not control, so anything that is not a safetensors path (`None`, an `int`, `bytes`, a nested path) returns `False` instead of aborting the load.
- `model_dir` is resolved once when the matcher is built, not per filename.

Applied to the two overrides in `omlx/engine/vlm.py` that carried this comparison: `_force_qwen4_exp_sanitize_on_load()` and `_force_minimax_m3_moe_sanitize_on_load()`.

## Validation

- `tests/test_safetensors_paths.py` — new, 11 tests: plain shards, symlinked shards, symlinked model dir, relative names, and the non-path inputs above.
- `tests/test_vlm_qwen4_exp_loader.py` — new `test_qwen4_exp_mlx_metadata_is_hidden_for_symlinked_shards` alongside the existing plain-file case. Both assert the marker is hidden for the model's own shards and left **intact** for a file outside the model directory.
- Both new tests fail against the pre-fix code (`format: mlx` stays visible) and pass with the fix, so they are regression guards rather than tautologies.
- `tests/test_safetensors_paths.py tests/test_vlm_qwen4_exp_loader.py`: 18 passed.
- `tests/test_mlx_vlm_minimax_m3_compat.py tests/test_mlx_vlm_qwen4_exp_compat.py`: 71 passed, 1 failed — `test_qwen4_lightning_mtp_fusion_and_runtime_attachment`, an unrelated pre-existing numerics `allclose` at `atol 2e-5`. Reproduced with this PR's `vlm.py` reverted, so it does not come from this change.
- Confirmed live: `Jundot/Qwen3.8-Flash-Next-oQ4e-mtp` with SSD N-gram Offload enabled now loads from the HF Hub cache path.

## Scope

Deliberately narrow: the shared helper plus the two call sites in `vlm.py`. One is the reported Qwen4-Exp path; the other is the identical comparison a few functions away, which seemed worse to leave behind than to include.

`mlx_vlm_inkling_compat` has the same latent defect — its `_FORCE_SANITIZE_DIR` context var holds a `Path` and performs the same `resolve()` comparison, so Inkling checkpoints from the HF cache skip sanitize just as silently (its `_has_raw_inkling_weights()` gate reads *keys*, not the format marker, so the patch engages and then does nothing). That one needs the context var retyped to a predicate plus its own regression test, so it belongs in a follow-up PR that reuses this helper rather than widening this one.
