### PR TITLE
fix: clamp stale seq axis in QSA batched mask build (qwen4_exp concurrent 500s)

### DIFF
--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import math
 import mmap
 import os
@@ -649,6 +650,9 @@ class Qwen4ExpGatedDeltaNet(Qwen3_5GatedDeltaNet):
 class Qwen4ExpQSAIndexer(nn.Module):
     """Select compressed key blocks using Qwen Sparse Attention scores."""
 
+    # Rate-limited counter for the defensive seq clamp below.
+    _seq_clamp_hits = 0
+
     def __init__(self, config: TextConfig, rotary_emb):
         super().__init__()
         self.n_heads = config.indexer_n_heads
@@ -714,6 +718,20 @@ class Qwen4ExpQSAIndexer(nn.Module):
         max_complete_blocks = key_len // self.compress_ratio
         if max_complete_blocks <= self.block_topk:
             return None
+
+        # Defensive seq clamp: under multi-row batched decode with the sparse
+        # path active, a stale MTP-verify position can leak into the batched
+        # query — put_along_axis broadcasts the stale seq axis and the tail
+        # concatenate below then raises, killing every concurrent stream.
+        # Keep the freshest query row; the selection is at most one position
+        # stale, which is acceptance-neutral.
+        if selected_blocks.shape[1] != seq_len:
+            Qwen4ExpQSAIndexer._seq_clamp_hits += 1
+            if Qwen4ExpQSAIndexer._seq_clamp_hits % 256 == 1:
+                logging.getLogger("omlx.qwen4_exp").warning(
+                    "QSA mask seq clamp fired x%d", Qwen4ExpQSAIndexer._seq_clamp_hits,
+                )
+            selected_blocks = selected_blocks[:, -seq_len:, :]
 
         query = self._apply_rope(query, position_ids)
         complete_key_len = max_complete_blocks * self.compress_ratio

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -719,20 +719,6 @@ class Qwen4ExpQSAIndexer(nn.Module):
         if max_complete_blocks <= self.block_topk:
             return None
 
-        # Defensive seq clamp: under multi-row batched decode with the sparse
-        # path active, a stale MTP-verify position can leak into the batched
-        # query — put_along_axis broadcasts the stale seq axis and the tail
-        # concatenate below then raises, killing every concurrent stream.
-        # Keep the freshest query row; the selection is at most one position
-        # stale, which is acceptance-neutral.
-        if selected_blocks.shape[1] != seq_len:
-            Qwen4ExpQSAIndexer._seq_clamp_hits += 1
-            if Qwen4ExpQSAIndexer._seq_clamp_hits % 256 == 1:
-                logging.getLogger("omlx.qwen4_exp").warning(
-                    "QSA mask seq clamp fired x%d", Qwen4ExpQSAIndexer._seq_clamp_hits,
-                )
-            selected_blocks = selected_blocks[:, -seq_len:, :]
-
         query = self._apply_rope(query, position_ids)
         complete_key_len = max_complete_blocks * self.compress_ratio
         pooled_keys = raw_keys[:, :complete_key_len].reshape(
@@ -767,6 +753,21 @@ class Qwen4ExpQSAIndexer(nn.Module):
         selected_blocks = mx.argpartition(scores, kth=-self.block_topk, axis=-1)[
             ..., -self.block_topk :
         ]
+
+        # Defensive seq clamp: under multi-row batched decode with the sparse
+        # path active, a stale MTP-verify position can leak into the batched
+        # query — put_along_axis broadcasts the stale seq axis and the tail
+        # concatenate below then raises, killing every concurrent stream.
+        # Keep the freshest query row; the selection is at most one position
+        # stale, which is acceptance-neutral.
+        if selected_blocks.shape[1] != seq_len:
+            Qwen4ExpQSAIndexer._seq_clamp_hits += 1
+            if Qwen4ExpQSAIndexer._seq_clamp_hits % 256 == 1:
+                logging.getLogger("omlx.qwen4_exp").warning(
+                    "QSA mask seq clamp fired x%d",
+                    Qwen4ExpQSAIndexer._seq_clamp_hits,
+                )
+            selected_blocks = selected_blocks[:, -seq_len:, :]
 
         # Mark the winners on the block axis and widen that to tokens. Comparing
         # every token against every pick costs seq_len * key_len * block_topk


### PR DESCRIPTION
## Fix: clamp stale seq axis in QSA batched mask build (qwen4_exp long-prompt concurrent 500s)
- Symptom: >=2 concurrent + sparse-QSA-active prompts (>~2051 tok) → `concatenate shapes (2,2,4732) vs (2,1,3)` → 500/stream abort
- Root cause: stale MTP-verify position leaks into the batched query; `put_along_axis` broadcasts the stale seq axis and the tail concatenate then fails
- Fix: clamp `selected_blocks` to the current `seq_len` (keep the freshest query row) — selection staleness <=1 position, acceptance-neutral (cf. SGLang IndexShare findings)
- Verified: 5-concurrent 10/10 + cross-instance 4/4 + single-stream zero regression; previously 100% failure
