### PR TITLE
fix(glm5_next): stop routing projections through the qwen35 native qmm tile

### DIFF
--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/linear.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/linear.py
@@ -37,25 +37,14 @@ def _native_qmm(linear: nn.QuantizedLinear, x: mx.array):
 
 
 def linear_forward(linear: nn.Module, x: mx.array) -> mx.array:
-    """Use oMLX's affine prefill tile when it is supported and profitable."""
-    if isinstance(linear, nn.QuantizedLinear):
-        if (
-            "bias" in linear
-            and getattr(linear, "mode", None) == "affine"
-            and getattr(linear, "biases", None) is not None
-        ):
-            out = fused_quantized_matmul(
-                x,
-                linear.weight,
-                linear.scales,
-                linear.biases,
-                bits=int(linear.bits),
-                group_size=int(linear.group_size),
-            )
-            return out + linear.bias
-        out = _native_qmm(linear, x)
-        if out is not None:
-            return out
+    """Route GLM-5.3 projections through standard mlx quantized matmul.
+
+    The oMLX native qwen35 affine-qmm tile (``qwen35_q{bits}_affine_qmm_t``)
+    returns incorrect results for glm5_next 8-bit affine projections once the
+    token count reaches its 1024-token threshold, corrupting long-context
+    attention and breaking head/middle retrieval (jundot/omlx#3248). Standard
+    mlx quantized matmul is correct at every length, so use it unconditionally.
+    """
     return linear(x)
 
 


### PR DESCRIPTION
## Summary

Fixes long-context head/middle retrieval for GLM-5.3-Flash (`glm5_next`). A
brief instruction at the head of a prompt was not followed once the prompt
exceeded ~1k tokens, while the identical prompt worked below the threshold.

Tracked in #3248.

## Root cause

`omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/linear.py`
routes the glm5_next projections (`q_a_proj`, `q_b_proj`,
`kv_a_proj_with_mqa`, `o_proj`, MLP/MoE) through `linear_forward()`, which —
once the token count reaches `min_tokens = 1024` for 8-bit weights — dispatches
to the **Qwen3.5 native affine-qmm tile** `qwen35_q8_affine_qmm_t` (from
`omlx.custom_kernels.qwen35_prefill`).

That tile returns **incorrect results** for glm5_next's 8-bit affine weights
(the `_is_supported_affine_linear` gate does not catch it). The corrupted q/kv
projections break long-context attention. **The 1024 threshold is the smoking
gun** — it exactly matches the observed SEEN→LOST boundary (SEEN at ~710 prompt
tokens, LOST from ~1046 on).

## Fix

`glm5_next/linear.py` is glm5_next-specific, so `linear_forward()` now routes
through standard `mx.quantized_matmul` unconditionally (correct at every
length). This matches the known-good `feat/glm5-next` implementation, which
never used the native tile. Scoped to glm5_next only — other models are
unaffected.

## Verification

GLM-5.3-Flash-oQ8-mtp, one-line task word at the HEAD of the prompt, ask the
model to restate it:

| prompt_tokens | 43 | 710 | 1377 | 2710 | 6710 |
|---|---|---|---|---|---|
| before (main) | SEEN | SEEN | LOST | LOST | LOST |
| after (fix) | SEEN | SEEN | SEEN | SEEN | SEEN |

Note: the fix also requires clearing the tiered SSD cold cache once, because the
buggy tile had written corrupted KV values to it (they persist across restarts
and keep failing even after the tile is bypassed).
