### PR TITLE
fix(glm5_next): don't route 8-bit projections to the q8 prefill tile

### DIFF
--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/linear.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/linear.py
@@ -13,7 +13,13 @@ def _native_qmm(linear: nn.QuantizedLinear, x: mx.array):
         return None
     if getattr(linear, "mode", None) != "affine" or "bias" in linear:
         return None
-    min_tokens = 1024 if bits == 8 else 128
+    # The q8 tile miscomputes these projections and corrupts the hidden
+    # states, so any prompt that reaches the 1024-row prefill threshold
+    # comes out as unrelated text. Keep 8-bit on mx.quantized_matmul
+    # until the kernel is fixed; 4-bit is unaffected.
+    if bits == 8:
+        return None
+    min_tokens = 128
     if x.ndim < 2 or x.shape[-2] < min_tokens:
         return None
 


### PR DESCRIPTION
## Symptom

On oMLX 0.6.3, `GLM-5.3-Flash` loses the prompt entirely once it reaches ~1024 tokens. The model answers with fluent but completely unrelated text, or says the input "came through as corrupted" / "empty". Below the threshold it is perfect.

Greedy decoding (`temperature=0`), needle-in-a-haystack prompt, needle at 50%:

| prompt tokens | result |
|---|---|
| 862 | correct |
| 968 | correct |
| **1026** | *"it appears to contain a long string of characters..."* |
| 1090 | *"your message came through as unreadable or corrupted text"* |

The cliff is exact, not gradual — that points at a code path, not numerical degradation. It reproduces identically on a plain `oQ4` and an `oQ4e` conversion, so it is not a quantization artifact.

## Cause

`_native_qmm` in `glm5_next/linear.py` sends 8-bit affine projections to `qwen35_q8_affine_qmm_t` once a prefill batch reaches 1024 rows:

```python
min_tokens = 1024 if bits == 8 else 128
```

That tile miscomputes these projections and corrupts the hidden states, so from 1024 tokens on the model is effectively no longer conditioned on the prompt. Falling back to `mx.quantized_matmul` for 8-bit fixes it at every length.

## Scope of the change

Deliberately minimal:

- **Only `_native_qmm`.** I retested with `fused_quantized_matmul` left at `1024` and the model is correct, so that call site is untouched.
- **4-bit is untouched** (`min_tokens = 128`) — verified working well below and above the threshold.

## Verification

After the change, same greedy needle test, needle at 50%:

| prompt tokens | 862 | 1022 | 1086 | 2834 | 5828 |
|---|---|---|---|---|---|
| result | pass | pass | pass | pass | pass |

Also correct on a realistic task: a 2,679-token service table, asked to count `down` services and find the highest p99 — returned 37 and `SVC-049 / 861 ms`, both exact. Vision input and tool calling (`glm47` parser, including parallel calls) were re-tested and are unaffected.

Control: `Ornith-1.0-35B-mlx-bf16` passes the identical prompt at 1012 and 2802 tokens both before and after, so the engine, chat template, and prefix cache were never implicated.

## Cost

Prompt processing is slower, since 8-bit prefill drops back to `mx.quantized_matmul`. Same 12,393-token prompt, cache cold, M3 Ultra:

| | prefill |
|---|---|
| before (tile active) | 31.6 s (~438 tok/s) |
| after (this PR) | 45.1 s (~296 tok/s) |

Generation speed is unchanged. The before-number lines up with the 443–482 tok/s in the 0.6.3 release notes, which is a decent sanity check on the measurement.

This is a correctness-over-speed mitigation, not a real fix — the tile itself is what is wrong. I could not narrow it further from outside: `qwen35_q{4,5,6,8}_affine_qmm_t` are all bit-exact against `mx.quantized_matmul` when I test them standalone at this model's real layer shapes (4096→1536, 1536→16384, 16384→4096, 4096→12288, …, group_size 64, bf16), so the fault only shows in situ. If you can spot the shape or dtype that breaks it, a kernel-side fix would obviously be better than disabling the path.

Happy to run any further test you want on this hardware (M3 Ultra, 512 GB).
