### PR TITLE
fix(api): preserve empty no-thinking markers across turns

### DIFF
--- a/omlx/api/utils.py
+++ b/omlx/api/utils.py
@@ -45,6 +45,24 @@ def uses_native_reasoning_content(
     return "minimax" in lowered and "m3" in lowered
 
 
+def reasoning_content_for_history(
+    content: str,
+    *,
+    native_reasoning: bool,
+    chat_template_kwargs: dict[str, Any],
+) -> str | None:
+    """Retain Qwen's empty no-thinking marker when history preservation is enabled."""
+    if content:
+        return content
+    if (
+        native_reasoning
+        and chat_template_kwargs.get("enable_thinking") is False
+        and chat_template_kwargs.get("preserve_thinking") is True
+    ):
+        return "\n\n"
+    return None
+
+
 def merge_reasoning_effort_chat_template_kwargs(
     chat_template_kwargs: dict[str, Any] | None,
     reasoning_effort: Any | None,

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -173,6 +173,7 @@ from .api.utils import (
     has_nonleading_system_message,
     merge_reasoning_effort_chat_template_kwargs,
     prepare_system_messages_for_template,
+    reasoning_content_for_history,
     uses_native_reasoning_content,
 )
 from .engine import BaseEngine, VLMBatchedEngine
@@ -4026,8 +4027,10 @@ async def create_chat_completion(
                     ChatCompletionChoice(
                         message=AssistantMessage(
                             content=cleaned_text.strip() if cleaned_text else None,
-                            reasoning_content=(
-                                cleaned_thinking if cleaned_thinking else None
+                            reasoning_content=reasoning_content_for_history(
+                                cleaned_thinking,
+                                native_reasoning=native_reasoning,
+                                chat_template_kwargs=merged_ct_kwargs,
                             ),
                             tool_calls=tool_calls,
                         ),

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -54,6 +54,7 @@ from omlx.api.utils import (
     extract_text_content,
     merge_reasoning_effort_chat_template_kwargs,
     prepare_system_messages_for_template,
+    reasoning_content_for_history,
     uses_native_reasoning_content,
 )
 from omlx.exceptions import InvalidRequestError
@@ -633,6 +634,35 @@ class TestExtractTextContentNativeReasoningContent:
         assert len(result) == 1
         assert result[0]["content"] == "A"
         assert result[0]["reasoning_content"] == "R"
+
+
+class TestReasoningContentForHistory:
+    def test_preserves_no_thinking_marker_when_enabled(self):
+        assert reasoning_content_for_history(
+            "",
+            native_reasoning=True,
+            chat_template_kwargs={
+                "enable_thinking": False,
+                "preserve_thinking": True,
+            },
+        ) == "\n\n"
+
+    def test_drops_marker_when_preservation_is_disabled(self):
+        assert reasoning_content_for_history(
+            "",
+            native_reasoning=True,
+            chat_template_kwargs={
+                "enable_thinking": False,
+                "preserve_thinking": False,
+            },
+        ) is None
+
+    def test_keeps_nonempty_reasoning(self):
+        assert reasoning_content_for_history(
+            "reasoning",
+            native_reasoning=True,
+            chat_template_kwargs={},
+        ) == "reasoning"
 
 
 class TestUsesNativeReasoningContent:


### PR DESCRIPTION
## Summary

Qwen's native no-thinking template emits an empty reasoning marker in the assistant generation prefix:

```text
<think>\n\n</think>\n\n
```

The OpenAI response path currently collapses the empty extracted reasoning to `None`. A stateless client therefore cannot echo the marker on the next request, and the same logical conversation re-renders to a different token sequence. This prevents exact prefix-cache reuse past the first assistant turn.

When native reasoning is active and the existing settings explicitly request both:

```json
{
  "enable_thinking": false,
  "preserve_thinking": true
}
```

this PR returns the marker interior as `reasoning_content: "\n\n"`. The existing native reasoning path then reconstructs the same prompt tokens on the next turn. Other configurations are unchanged.

## Evidence

Using Qwen3.8 Flash Next through oMLX with a clean cache:

- before: first divergence at token 917 (`<think>\n\n</think>` vs direct `<tool_call>`), final `cached_tokens=0`;
- after: the next turn renders the same prefix and restores `cached_tokens=2048`;
- a 15-case file-localization run restored 2048 final-pass cached tokens on all 15 cases.

## Test plan

- `pytest -q tests/test_api_utils.py` — 240 passed
- Live multi-turn Qwen3.8 Flash Next test with a clean prefix cache — 2048-token hit restored

## AI assistance

This PR is AI-assisted. AI tools were used during investigation, implementation, and test preparation; the token-level diagnosis, diff, and live oMLX results were manually reviewed and verified on local Apple Silicon hardware.
