### PR TITLE
fix(oq): calibrate Qwen4 through RAM-safe proxies

### DIFF
--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -14,6 +14,7 @@ import json
 import logging
 import re
 import shutil
+import struct as _struct
 import tempfile
 import time as _time
 from dataclasses import dataclass
@@ -54,6 +55,37 @@ _QWEN4_EXP_NGRAM_SHARD_RE = re.compile(
     r"\.ple\.ple_embedding\.ngram_embedding\."
     r"(?:shard_\d+|shards\.\d+)$"
 )
+
+
+def _is_qwen4_exp_config(config: dict) -> bool:
+    """Return whether *config* selects the Qwen4-Exp/Flash-Next family."""
+    text_config = config.get("text_config")
+    if not isinstance(text_config, dict):
+        text_config = {}
+    return any(
+        str(model_type or "").lower().startswith("qwen4_exp")
+        for model_type in (config.get("model_type"), text_config.get("model_type"))
+    )
+
+
+def _configure_qwen4_exp_quantization_runtime(
+    model_path: str | Path,
+    config: dict,
+    *,
+    preserve_mtp: bool,
+) -> bool:
+    """Register Qwen4 and bind its mmap PLE/MTP state for quantization."""
+    if not _is_qwen4_exp_config(config):
+        return False
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import configure_qwen4_exp_runtime
+
+    configure_qwen4_exp_runtime(
+        model_path,
+        mode="mmap",
+        mtp_enabled=bool(preserve_mtp),
+    )
+    return True
+
 
 _MAX_MODEL_RAM_FRACTION = 0.75
 
@@ -150,6 +182,28 @@ def _is_vlm_load(config: dict) -> bool:
     return model_type in VLM_NATIVE_TEXT_MODEL_TYPES or (
         _has_vision_subconfig(config)
         and model_type not in MLX_LM_TEXT_ONLY_MODEL_TYPES
+    )
+
+
+def _calibration_model_settings(
+    config: dict,
+    *,
+    has_mtp_heads: bool,
+    has_mtp_weights: bool,
+):
+    """Build the temporary serving settings used by calibration loads."""
+    mtp_enabled = bool(has_mtp_heads and has_mtp_weights)
+    if not mtp_enabled and not _is_qwen4_exp_config(config):
+        return None
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        mtp_enabled=mtp_enabled,
+        mtp_num_draft_tokens=1,
+        # Calibration executes Qwen4 PLE, but only as sparse row gathers.
+        # Force the existing SSD mmap path even when a compact proxy falls
+        # below serving's automatic offload threshold.
+        qwen4_ple_ssd_offload=_is_qwen4_exp_config(config),
     )
 
 
@@ -340,14 +394,7 @@ def _is_qwen4_exp_ngram_embedding_tensor(path: str, config: dict) -> bool:
     forms so proxy construction and final streaming quantization use the same
     policy.
     """
-    text_config = config.get("text_config")
-    if not isinstance(text_config, dict):
-        text_config = {}
-    model_types = (
-        str(config.get("model_type") or "").lower(),
-        str(text_config.get("model_type") or "").lower(),
-    )
-    if not any(model_type.startswith("qwen4_exp") for model_type in model_types):
+    if not _is_qwen4_exp_config(config):
         return False
     return _QWEN4_EXP_NGRAM_SHARD_RE.search(_normalize_quant_path(path)) is not None
 
@@ -3226,7 +3273,11 @@ def estimate_bpw_and_size(
     # the raw header names when discovery is unavailable.
     plan_view = None
     try:
-        _sanitize_fn = _build_model_sanitizer(config)
+        _sanitize_fn = _build_model_sanitizer(
+            config,
+            model_path=source,
+            preserve_mtp=preserve_mtp,
+        )
         if _sanitize_fn is not None:
             _plan = _discover_sanitize_plan(_sanitize_fn, idx)
             if _plan:
@@ -3467,6 +3518,40 @@ def _metal_available_memory_bytes() -> int:
     return max(0, max_working_set - active)
 
 
+def _calibration_capability_capacity_bytes(
+    fallback_system_bytes: int = 0,
+) -> int:
+    """Return stable hardware/configuration capacity for calibration."""
+    tier = "balanced"
+    custom_ceiling_bytes = 0
+    try:
+        from omlx.settings import get_settings
+
+        memory = get_settings().memory
+        tier = str(memory.memory_guard_tier)
+        custom_ceiling_bytes = int(
+            float(memory.memory_guard_custom_ceiling_gb) * 1024**3
+        )
+    except Exception:
+        # Direct library callers may not have initialized GlobalSettings.
+        pass
+
+    try:
+        from omlx.process_memory_enforcer import (
+            get_memory_capability_ceiling_bytes,
+        )
+
+        capacity = get_memory_capability_ceiling_bytes(
+            tier,
+            custom_ceiling_bytes,
+        )
+        if capacity > 0:
+            return int(capacity)
+    except Exception as exc:
+        logger.debug("Calibration capability ceiling unavailable: %s", exc)
+    return max(0, int(fallback_system_bytes))
+
+
 def _checkpoint_storage_bytes(weight_files) -> int:
     """Return the complete on-disk size of checkpoint weight shards.
 
@@ -3484,28 +3569,109 @@ def _checkpoint_storage_bytes(weight_files) -> int:
     return total
 
 
+def _qwen4_exp_checkpoint_roots(model_path: str | Path, config: dict) -> set[Path]:
+    """Return the compute and optional bounded external PLE artifact roots."""
+    compute_path = Path(model_path).expanduser().resolve()
+    roots = {compute_path}
+    artifact = config.get("qwen4_exp_artifact") or {}
+    relative_ple = artifact.get("ple_artifact")
+    if relative_ple is None:
+        return roots
+    relative_ple = Path(relative_ple)
+    if relative_ple.is_absolute():
+        return roots
+    candidate = (compute_path / relative_ple).resolve()
+    artifact_root = compute_path.parent.resolve()
+    if candidate == artifact_root or artifact_root in candidate.parents:
+        roots.add(candidate)
+    return roots
+
+
+def _calibration_resident_checkpoint_bytes(
+    model_path: str | Path,
+    config: dict,
+) -> int:
+    """Estimate checkpoint bytes touched by calibration model forwards.
+
+    Ordinary architectures retain the historical complete-file accounting.
+    Qwen4-Exp calibration reads PLE rows through SSD mmap and its manual text
+    layer walk invokes neither the vision tower nor the ordinary ``lm_head``.
+    Safetensors headers and every other tensor remain charged to the model.
+    """
+    roots = (
+        _qwen4_exp_checkpoint_roots(model_path, config)
+        if _is_qwen4_exp_config(config)
+        else {Path(model_path)}
+    )
+    weight_files = sorted(
+        {path.resolve() for root in roots for path in root.glob("*.safetensors")}
+    )
+    checkpoint_bytes = _checkpoint_storage_bytes(weight_files)
+    if not _is_qwen4_exp_config(config):
+        return checkpoint_bytes
+
+    deferred_bytes = 0
+    for path in weight_files:
+        try:
+            with path.open("rb") as file:
+                raw_size = file.read(8)
+                if len(raw_size) != 8:
+                    continue
+                header_size = _struct.unpack("<Q", raw_size)[0]
+                header = json.loads(file.read(header_size))
+        except (OSError, ValueError, _struct.error):
+            # Failure to classify a file stays conservative: charge it all.
+            continue
+        for tensor_name, metadata in header.items():
+            if tensor_name == "__metadata__":
+                continue
+            if not (
+                _is_qwen4_exp_ngram_embedding_tensor(tensor_name, config)
+                or _is_vision_tensor(tensor_name)
+                or tensor_name.endswith("lm_head.weight")
+            ):
+                continue
+            try:
+                start, end = metadata["data_offsets"]
+                deferred_bytes += max(0, int(end) - int(start))
+            except (KeyError, TypeError, ValueError):
+                continue
+    return max(0, checkpoint_bytes - deferred_bytes)
+
+
 def _calibration_memory_budget(
     checkpoint_bytes: int = 0,
     *,
     fallback_system_bytes: int = 0,
 ) -> dict[str, int | bool]:
-    """Return the live memory budget for full-model calibration forwards.
+    """Return the stable capability budget for calibration forwards.
 
-    Apple Silicon uses unified memory, but Metal exposes a recommended working
-    set that can be smaller than physical RAM.  The safe capacity is therefore
-    the smaller positive value of live system memory and remaining Metal
-    working-set memory.  A proportional 25% reserve scales down to 16/32 GiB
-    machines without imposing a fixed reserve that would reject every model.
+    Hard admission uses total RAM minus the configured tier's OS reserve,
+    capped by Metal (and by a configured custom ceiling). Live availability is
+    retained as diagnostics and for downstream micro-batch sizing, but other
+    applications and transient file cache do not redefine machine capability.
+    A proportional 25% reserve remains between the resident checkpoint and
+    the stable capability ceiling.
     """
     system_available = _system_available_memory_bytes()
     metal_available = _metal_available_memory_bytes()
-    candidates = [value for value in (system_available, metal_available) if value > 0]
-    capacity = min(candidates) if candidates else max(0, int(fallback_system_bytes))
+    live_candidates = [
+        value for value in (system_available, metal_available) if value > 0
+    ]
+    live_capacity = min(live_candidates) if live_candidates else 0
+    capability_capacity = _calibration_capability_capacity_bytes(
+        fallback_system_bytes=fallback_system_bytes,
+    )
+    capacity = capability_capacity or live_capacity or max(
+        0, int(fallback_system_bytes)
+    )
     model_limit = int(capacity * _MAX_MODEL_RAM_FRACTION)
     checkpoint_bytes = max(0, int(checkpoint_bytes))
     return {
         "system_available_bytes": int(system_available),
         "metal_available_bytes": int(metal_available),
+        "live_capacity_bytes": int(live_capacity),
+        "capability_capacity_bytes": int(capability_capacity),
         "capacity_bytes": int(capacity),
         "model_limit_bytes": int(model_limit),
         "reserve_bytes": max(0, int(capacity) - int(model_limit)),
@@ -3791,7 +3957,13 @@ def _cast_passthrough_tensor(tensor_name: str, w_mx, target_dtype):
     return w_mx
 
 
-def _build_model_sanitizer(config: dict, text_only: bool = False):
+def _build_model_sanitizer(
+    config: dict,
+    text_only: bool = False,
+    *,
+    model_path: str | Path | None = None,
+    preserve_mtp: bool = False,
+):
     """Build a sanitize function from the model class.
 
     For VLM models, uses mlx-vlm's model class (preserves vision weights).
@@ -3819,6 +3991,27 @@ def _build_model_sanitizer(config: dict, text_only: bool = False):
         or _has_vision_subconfig(config)
         or model_type in VLM_NATIVE_TEXT_MODEL_TYPES
     ) and not (text_only or mlx_lm_text_only)
+
+    # Serving normally registers oMLX's vendored Qwen4 implementation before
+    # mlx-vlm class lookup. Quantization does not pass through that loader.
+    # Without this setup the lookup fails, sanitize is skipped, and the raw
+    # packed MoE tensors (which lack a ``.weight`` suffix) remain BF16.
+    if _is_qwen4_exp_config(config):
+        try:
+            if model_path is not None:
+                _configure_qwen4_exp_quantization_runtime(
+                    model_path,
+                    config,
+                    preserve_mtp=preserve_mtp,
+                )
+            else:
+                from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+                    apply_mlx_vlm_qwen4_exp_compat_patch,
+                )
+
+                apply_mlx_vlm_qwen4_exp_compat_patch()
+        except Exception as patch_err:
+            logger.debug("Qwen4-Exp quantization patch not applied: %s", patch_err)
 
     if is_vlm:
         try:
@@ -4349,8 +4542,6 @@ def _gs_for_mode(bits: int, default_gs: int) -> int:
 
 
 # --- chunked-quantize helpers (added for Qwen3.5-397B) ---------------------
-import struct as _struct
-
 import numpy as _np
 
 
@@ -5736,12 +5927,13 @@ def quantize_oq_streaming(
     if _model_requires_proxy and static_sensitivity_map is None:
         logger.info(
             f"oQ{oq_level:g}: calibration footprint ({_format_size(_calibration_bytes)}) "
-            f"exceeds {int(_MAX_MODEL_RAM_FRACTION * 100)}% of calibration "
-            f"capacity ({_format_size(int(_calibration_budget['capacity_bytes']))}; "
+            f"exceeds {int(_MAX_MODEL_RAM_FRACTION * 100)}% of stable calibration "
+            "capability "
+            f"({_format_size(int(_calibration_budget['capacity_bytes']))}; "
             f"limit={_format_size(int(_calibration_budget['model_limit_bytes']))}, "
-            "system available="
+            "live system available="
             f"{_format_size(int(_calibration_budget['system_available_bytes']))}, "
-            "Metal available="
+            "live Metal available="
             f"{_format_size(int(_calibration_budget['metal_available_bytes']))}). "
             "Full-model calibration will use a proxy."
         )
@@ -5778,8 +5970,12 @@ def quantize_oq_streaming(
                 preserve_mtp=preserve_mtp,
             )
             proxy_bytes = _checkpoint_storage_bytes(candidate.glob("*.safetensors"))
+            proxy_resident_bytes = _calibration_resident_checkpoint_bytes(
+                candidate,
+                config,
+            )
             proxy_budget = _calibration_memory_budget(
-                proxy_bytes,
+                proxy_resident_bytes,
                 fallback_system_bytes=_system_ram,
             )
             if int(proxy_budget["capacity_bytes"]) > 0 and bool(
@@ -5787,16 +5983,21 @@ def quantize_oq_streaming(
             ):
                 shutil.rmtree(candidate, ignore_errors=True)
                 raise RuntimeError(
-                    "calibration proxy is still too large for the live memory "
+                    "calibration proxy is still too large for the stable capability "
                     f"budget (proxy={_format_size(proxy_bytes)}, "
+                    f"resident={_format_size(proxy_resident_bytes)}, "
                     f"limit={_format_size(int(proxy_budget['model_limit_bytes']))}, "
-                    f"capacity={_format_size(int(proxy_budget['capacity_bytes']))})"
+                    f"capability={_format_size(int(proxy_budget['capacity_bytes']))}, "
+                    f"live={_format_size(int(proxy_budget['live_capacity_bytes']))})"
                 )
             _ram_safe_proxy_dir = candidate
             logger.info(
                 f"oQ{oq_level:g}: calibration proxy size "
-                f"{_format_size(proxy_bytes)} within "
-                f"{_format_size(int(proxy_budget['model_limit_bytes']))} limit"
+                f"{_format_size(proxy_bytes)} on disk, resident calibration "
+                f"footprint {_format_size(proxy_resident_bytes)} within "
+                f"{_format_size(int(proxy_budget['model_limit_bytes']))} stable "
+                "capability limit (live capacity "
+                f"{_format_size(int(proxy_budget['live_capacity_bytes']))})"
             )
         return _ram_safe_proxy_dir
 
@@ -5996,7 +6197,12 @@ def quantize_oq_streaming(
     )
 
     # --- Sanitize-plan discovery ------------------------------------------
-    sanitize_fn = _build_model_sanitizer(config, text_only=text_only)
+    sanitize_fn = _build_model_sanitizer(
+        config,
+        text_only=text_only,
+        model_path=source,
+        preserve_mtp=preserve_mtp,
+    )
     cast_predicate = getattr(sanitize_fn, "_omlx_cast_predicate", None)
     # When preserve_mtp is True, the patched sanitize functions
     # (mlx_lm_mtp/qwen35_model.py and mlx_vlm_mtp/qwen35_vlm_model.py)
@@ -7638,11 +7844,33 @@ def _collect_imatrix_from_model(
         seq_length=seq_length,
     )
     if calib_data is None:
-        return {}, {"dataset": calib_dataset, "processed_samples": 0}
+        return {}, {
+            "dataset": calib_dataset,
+            "processed_samples": 0,
+            "failure_stage": "dataset",
+            "failure_reason": "calibration dataset produced no usable samples",
+        }
 
     embed_fn, layers = _find_model_layers(model)
     if embed_fn is None or layers is None:
-        return {}, {"dataset": calib_dataset, "processed_samples": 0}
+        return {}, {
+            "dataset": calib_dataset,
+            "processed_samples": 0,
+            "model_class": f"{type(model).__module__}.{type(model).__name__}",
+            "failure_stage": "layer_discovery",
+            "failure_reason": "no embedding function or decoder layers found",
+        }
+
+    layer_model = _find_layer_model(model, layers)
+    layer_args = getattr(layer_model, "args", None)
+    layer_config = getattr(layer_model, "config", None)
+    layer_model_type = str(
+        getattr(layer_args, "model_type", "")
+        or getattr(layer_config, "model_type", "")
+        or getattr(model, "model_type", "")
+        or ""
+    )
+    layer_count = len(layers)
 
     collector = OQImatrixCollector()
     installed = collector.install(model)
@@ -7651,6 +7879,16 @@ def _collect_imatrix_from_model(
             "dataset": calib_dataset,
             "installed_modules": 0,
             "processed_samples": 0,
+            "model_class": f"{type(model).__module__}.{type(model).__name__}",
+            "layer_model_class": (
+                f"{type(layer_model).__module__}.{type(layer_model).__name__}"
+                if layer_model is not None
+                else None
+            ),
+            "layer_model_type": layer_model_type,
+            "layer_count": layer_count,
+            "failure_stage": "collector_install",
+            "failure_reason": "no supported capture modules found",
         }
 
     available_samples = int(calib_data.shape[0])
@@ -7673,6 +7911,10 @@ def _collect_imatrix_from_model(
     micro_batch_size = int(batch_plan["micro_batch_size"])
     processed_samples = 0
     micro_batches = 0
+    layer_state_kind = None
+    successful_layer_forwards = 0
+    skipped_layer_forwards = 0
+    mtp_head_forwards = 0
     rounds: list[dict[str, Any]] = []
     require_expert_counts = _imatrix_requires_expert_counts(
         config, collector.switch_capture_modules
@@ -7702,6 +7944,10 @@ def _collect_imatrix_from_model(
                 inputs, layer_masks, position_ids = _prepare_layer_inputs(
                     model, layers, batch, inputs
                 )
+                if isinstance(position_ids, dict):
+                    layer_state_kind = position_ids.get("kind")
+                elif layer_state_kind is None:
+                    layer_state_kind = "generic"
 
                 inner = getattr(model, "language_model", None) or model
                 args = getattr(inner, "args", None)
@@ -7728,7 +7974,9 @@ def _collect_imatrix_from_model(
                         layer_idx=layer_idx,
                     )
                     if out is None:
+                        skipped_layer_forwards += 1
                         continue
+                    successful_layer_forwards += 1
                     mx.eval(out)
                     inputs = out
                     # DSpark config uses one-based completed layer depths,
@@ -7754,6 +8002,7 @@ def _collect_imatrix_from_model(
                     inputs,
                     dspark_hiddens=dspark_hiddens,
                 ):
+                    mtp_head_forwards += 1
                     mx.synchronize()
                     mx.clear_cache()
 
@@ -7853,6 +8102,18 @@ def _collect_imatrix_from_model(
         "micro_batches": micro_batches,
         "batch_plan": batch_plan,
         "processed_samples": processed_samples,
+        "model_class": f"{type(model).__module__}.{type(model).__name__}",
+        "layer_model_class": (
+            f"{type(layer_model).__module__}.{type(layer_model).__name__}"
+            if layer_model is not None
+            else None
+        ),
+        "layer_model_type": layer_model_type,
+        "layer_count": layer_count,
+        "layer_state_kind": layer_state_kind,
+        "successful_layer_forwards": successful_layer_forwards,
+        "skipped_layer_forwards": skipped_layer_forwards,
+        "mtp_head_forwards": mtp_head_forwards,
         "installed_modules": installed,
         "capture_module_classes": dict(
             sorted(collector.capture_module_classes.items())
@@ -7864,6 +8125,19 @@ def _collect_imatrix_from_model(
         "coverage": coverage,
         "rounds": rounds,
     }
+    if not collector.entries:
+        metadata["failure_stage"] = "layer_forward"
+        if successful_layer_forwards == 0:
+            metadata["failure_reason"] = (
+                "no decoder layer forward completed successfully"
+            )
+        else:
+            metadata["failure_stage"] = "capture"
+            metadata["failure_reason"] = (
+                f"{installed} hooks were installed and "
+                f"{successful_layer_forwards} layer forwards completed, "
+                "but no hook captured a compatible activation"
+            )
     return collector.entries, metadata
 
 
@@ -7888,14 +8162,11 @@ def _collect_imatrix(
     is_vlm = _is_vlm_load(config)
     has_mtp_weights = _checkpoint_has_mtp_weights(model_path)
     has_mtp_heads = _has_mtp_heads(config)
-    calibration_settings = None
-    if has_mtp_heads and has_mtp_weights:
-        from types import SimpleNamespace
-
-        calibration_settings = SimpleNamespace(
-            mtp_enabled=True,
-            mtp_num_draft_tokens=1,
-        )
+    calibration_settings = _calibration_model_settings(
+        config,
+        has_mtp_heads=has_mtp_heads,
+        has_mtp_weights=has_mtp_weights,
+    )
     patch_kwargs: dict[str, Any] = {"for_vlm": is_vlm}
     if calibration_settings is not None:
         patch_kwargs["model_settings"] = calibration_settings
@@ -7929,24 +8200,19 @@ def _collect_imatrix(
 
     try:
         if is_vlm:
-            import mlx.nn as _nn
             from mlx_vlm.utils import load_model as vlm_load_model
 
-            _orig_lw = _nn.Module.load_weights
-
-            def _lenient_load_weights(self, file_or_weights, *args, **kwargs):
-                kwargs.pop("strict", None)
-                return _orig_lw(self, file_or_weights, *args, strict=False, **kwargs)
-
-            _nn.Module.load_weights = _lenient_load_weights
-            try:
-                model = vlm_load_model(
-                    Path(model_path),
-                    lazy=True,
-                    trust_remote_code=trust_remote_code,
-                )
-            finally:
-                _nn.Module.load_weights = _orig_lw
+            # Calibration proxies deliberately retain SSD-mapped tensors that
+            # are consumed by model-specific mmap modules rather than owned as
+            # normal MLX parameters (Qwen4 PLE shards are the primary case).
+            # mlx-vlm exposes ``strict`` specifically for this final weight
+            # load; pass it directly instead of monkeypatching Module globally.
+            model = vlm_load_model(
+                Path(model_path),
+                lazy=True,
+                trust_remote_code=trust_remote_code,
+                strict=False,
+            )
             from mlx_lm.tokenizer_utils import load as load_tokenizer
 
             tokenizer = load_tokenizer(Path(model_path))
@@ -7961,13 +8227,13 @@ def _collect_imatrix(
             )
     except Exception as e:
         logger.error("oQe imatrix: model load failed (%s)", e)
-        return {}, {"dataset": calib_dataset, "processed_samples": 0}
+        raise RuntimeError(f"oQe imatrix model load failed: {e}") from e
     finally:
         if restore_mtp_active is not None:
             restore_mtp_active()
 
     try:
-        model_bytes = _checkpoint_storage_bytes(Path(model_path).glob("*.safetensors"))
+        model_bytes = _calibration_resident_checkpoint_bytes(model_path, config)
         return _collect_imatrix_from_model(
             model,
             tokenizer,
@@ -8086,7 +8352,16 @@ def _load_or_collect_imatrix(
         progress_end=progress_end,
     )
     if not entries:
-        raise RuntimeError("oQe imatrix collection produced no entries")
+        stage = str(collection_metadata.get("failure_stage", "unknown"))
+        reason = str(
+            collection_metadata.get(
+                "failure_reason", "collector returned no captured activations"
+            )
+        )
+        raise RuntimeError(
+            "oQe imatrix collection produced no entries "
+            f"(stage={stage}: {reason})"
+        )
     metadata = {
         **expected,
         "entry_count": len(entries),
@@ -8228,14 +8503,11 @@ def _measure_sensitivity(
     # Reuse the centralised pre-load dispatch so every current and future
     # patch (MTP sanitize, DeepSeek V4, nested-visual, load_config, …) is
     # applied exactly as in the production load path.
-    calibration_settings = None
-    if has_mtp_heads and has_mtp_weights:
-        from types import SimpleNamespace
-
-        calibration_settings = SimpleNamespace(
-            mtp_enabled=True,
-            mtp_num_draft_tokens=1,
-        )
+    calibration_settings = _calibration_model_settings(
+        config,
+        has_mtp_heads=has_mtp_heads,
+        has_mtp_weights=has_mtp_weights,
+    )
     patch_kwargs: dict[str, Any] = {"for_vlm": is_vlm}
     if calibration_settings is not None:
         patch_kwargs["model_settings"] = calibration_settings
@@ -8265,31 +8537,17 @@ def _measure_sensitivity(
 
     try:
         if is_vlm:
-            import mlx.nn as _nn
             from mlx_vlm.utils import load_model as vlm_load_model
 
-            # mlx_vlm.load_model calls model.load_weights(weights) without strict=False.
-            # Shared-KV models (e.g. Gemma 4 2B/4B) omit k/v weights for shared layers,
-            # so strict=True raises ValueError. Relax temporarily — sensitivity only needs
-            # approximate weights; shared layers receive pre-computed KV at inference time.
-            _orig_lw = _nn.Module.load_weights
-
-            def _lenient_load_weights(self, file_or_weights, *args, **kwargs):
-                kwargs.pop("strict", None)
-                return _orig_lw(self, file_or_weights, *args, strict=False, **kwargs)
-
-            _nn.Module.load_weights = _lenient_load_weights
-            try:
-                # No QAT config override needed here: mlx_vlm.utils.load_model
-                # uses quantization_config.get("quant_method") rather than direct
-                # key access, so a missing quant_method falls through silently.
-                model = vlm_load_model(
-                    Path(model_path),
-                    lazy=True,
-                    trust_remote_code=trust_remote_code,
-                )
-            finally:
-                _nn.Module.load_weights = _orig_lw
+            # Sensitivity uses the same proxy representation as imatrix
+            # calibration. Allow intentionally unowned mmap/shared-KV tensors
+            # through mlx-vlm's supported load option.
+            model = vlm_load_model(
+                Path(model_path),
+                lazy=True,
+                trust_remote_code=trust_remote_code,
+                strict=False,
+            )
             from mlx_lm.tokenizer_utils import load as load_tokenizer
 
             tokenizer = load_tokenizer(Path(model_path))
@@ -8430,7 +8688,12 @@ def _build_streaming_proxy_for_sensitivity(
         raise ValueError(f"No .safetensors files found in {model_path}")
 
     all_weights = _LazyTensorIndex(weight_files, config=config)
-    sanitize_fn = _build_model_sanitizer(config, text_only=False)
+    sanitize_fn = _build_model_sanitizer(
+        config,
+        text_only=False,
+        model_path=source,
+        preserve_mtp=preserve_mtp,
+    )
     cast_predicate = getattr(sanitize_fn, "_omlx_cast_predicate", None)
     if sanitize_fn is not None:
         try:
@@ -8649,14 +8912,11 @@ def _measure_sensitivity_from_quantized_model(
     is_vlm = _is_vlm_load(config)
     has_mtp_weights = _checkpoint_has_mtp_weights(model_path)
     has_mtp_heads = _has_mtp_heads(config)
-    calibration_settings = None
-    if has_mtp_heads and has_mtp_weights:
-        from types import SimpleNamespace
-
-        calibration_settings = SimpleNamespace(
-            mtp_enabled=True,
-            mtp_num_draft_tokens=1,
-        )
+    calibration_settings = _calibration_model_settings(
+        config,
+        has_mtp_heads=has_mtp_heads,
+        has_mtp_weights=has_mtp_weights,
+    )
     patch_kwargs: dict[str, Any] = {"for_vlm": is_vlm}
     if calibration_settings is not None:
         patch_kwargs["model_settings"] = calibration_settings
@@ -8693,6 +8953,11 @@ def _measure_sensitivity_from_quantized_model(
                 Path(model_path),
                 lazy=True,
                 trust_remote_code=trust_remote_code,
+                # Quantized calibration proxies may retain model-specific
+                # tensors consumed directly by mmap modules rather than
+                # represented as ordinary MLX parameters (Qwen4 PLE shards).
+                # Match the imatrix and non-proxy sensitivity load paths.
+                strict=False,
             )
             tokenizer = load_tokenizer(Path(model_path))
         else:

--- a/omlx/process_memory_enforcer.py
+++ b/omlx/process_memory_enforcer.py
@@ -75,6 +75,22 @@ _ACTIVE_RECLAIM_RATIO: dict[str, float] = {
     "aggressive": 0.8,
 }
 
+
+def _static_memory_ceiling_bytes(system_bytes: int, tier: str) -> int:
+    """Return total RAM minus the tier-scaled OS reserve."""
+    system_bytes = max(0, int(system_bytes))
+    tier = (tier or "").strip().lower()
+    if tier not in _STATIC_RESERVE_LARGE:
+        tier = "balanced"
+    if tier == "custom":
+        reserve = _STATIC_RESERVE_LARGE["custom"]
+    elif system_bytes < _SMALL_SYSTEM_THRESHOLD:
+        reserve = _SMALL_SYSTEM_RESERVE
+    else:
+        reserve = _STATIC_RESERVE_LARGE[tier]
+    return max(0, system_bytes - reserve)
+
+
 # Default soft watermark per tier. A saved 0.85 from older configs is treated
 # as the legacy default so balanced / aggressive can move to their tier defaults.
 _LEGACY_SOFT_THRESHOLD = 0.85
@@ -182,6 +198,37 @@ def get_effective_metal_cap_bytes() -> int:
     if sysctl_cap > 0:
         return sysctl_cap
     return _get_max_metal_working_set_bytes()
+
+
+def get_memory_capability_ceiling_bytes(
+    memory_guard_tier: str = "balanced",
+    memory_guard_custom_ceiling_bytes: int = 0,
+) -> int:
+    """Return the stable machine/configuration memory ceiling.
+
+    Unlike the enforcer's dynamic ceiling, this deliberately excludes live
+    free/active/inactive page counts.  It answers whether the machine is
+    fundamentally capable of a workload: total RAM minus the tier's static OS
+    reserve, capped by Metal and by an explicit custom ceiling when configured.
+    """
+    tier = (memory_guard_tier or "").strip().lower()
+    if tier not in _STATIC_RESERVE_LARGE:
+        tier = "balanced"
+    try:
+        total = max(0, int(_settings.get_system_memory()))
+    except Exception:  # noqa: BLE001
+        total = 0
+
+    static_ceiling = _static_memory_ceiling_bytes(total, tier)
+
+    candidates = [static_ceiling] if static_ceiling > 0 else []
+    metal_cap = get_effective_metal_cap_bytes()
+    if metal_cap > 0:
+        candidates.append(int(metal_cap))
+    custom_ceiling = max(0, int(memory_guard_custom_ceiling_bytes))
+    if tier == "custom" and custom_ceiling > 0:
+        candidates.append(custom_ceiling)
+    return min(candidates) if candidates else 0
 
 
 def _wired_limit_suggestion_bytes(desired_bytes: int) -> int:
@@ -563,16 +610,12 @@ class ProcessMemoryEnforcer:
 
     def _get_static_ceiling(self) -> int:
         """Total RAM minus tier-scaled static reserve."""
-        from .settings import get_system_memory
-
-        system_bytes = get_system_memory()
-        if self._memory_guard_tier == "custom":
-            return max(0, system_bytes - _STATIC_RESERVE_LARGE["custom"])
-        if system_bytes < _SMALL_SYSTEM_THRESHOLD:
-            reserve = _SMALL_SYSTEM_RESERVE
-        else:
-            reserve = _STATIC_RESERVE_LARGE[self._memory_guard_tier]
-        return max(0, system_bytes - reserve)
+        tier = self._memory_guard_tier
+        try:
+            system_bytes = max(0, int(_settings.get_system_memory()))
+        except Exception:  # noqa: BLE001
+            system_bytes = 0
+        return _static_memory_ceiling_bytes(system_bytes, tier)
 
     def _get_dynamic_ceiling(self) -> int:
         """Tier-aware reclaimable-memory ceiling.

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -3025,6 +3025,68 @@ class TestModelExceedsRamGuard:
         assert index.nbytes() == weight.nbytes
         assert _checkpoint_storage_bytes([path]) >= weight.nbytes + scales.nbytes
 
+    def test_qwen4_calibration_charges_only_touched_resident_storage(self, tmp_path):
+        from safetensors.numpy import save_file as np_save
+
+        from omlx.oq import _calibration_resident_checkpoint_bytes
+
+        resident = np.zeros((32, 64), dtype=np.float16)
+        ple_weight = np.zeros((256, 20), dtype=np.uint32)
+        ple_scales = np.zeros((256, 5), dtype=np.float16)
+        ple_biases = np.zeros((256, 5), dtype=np.float16)
+        vision = np.zeros((16, 64), dtype=np.float16)
+        lm_head = np.zeros((32, 64), dtype=np.float16)
+        ple = (
+            "language_model.model.layers.1.ple.ple_embedding."
+            "ngram_embedding.shards.0"
+        )
+        tensors = {
+            "language_model.model.layers.0.self_attn.q_proj.weight": resident,
+            f"{ple}.weight": ple_weight,
+            f"{ple}.scales": ple_scales,
+            f"{ple}.biases": ple_biases,
+            "vision_tower.blocks.0.attn.q_proj.weight": vision,
+            "language_model.lm_head.weight": lm_head,
+        }
+        path = tmp_path / "model.safetensors"
+        np_save(tensors, str(path))
+        config = {
+            "model_type": "qwen4_exp",
+            "text_config": {"model_type": "qwen4_exp_text"},
+        }
+
+        deferred = sum(
+            tensor.nbytes
+            for name, tensor in tensors.items()
+            if name.startswith(ple)
+            or name.startswith("vision_tower.")
+            or name.endswith("lm_head.weight")
+        )
+        assert _calibration_resident_checkpoint_bytes(tmp_path, config) == (
+            path.stat().st_size - deferred
+        )
+
+    def test_non_qwen4_resident_accounting_remains_complete_storage(self, tmp_path):
+        from safetensors.numpy import save_file as np_save
+
+        from omlx.oq import _calibration_resident_checkpoint_bytes
+
+        path = tmp_path / "model.safetensors"
+        np_save(
+            {
+                "model.layers.0.weight": np.zeros((32, 64), dtype=np.float16),
+                # A similarly named tensor has no mmap contract on other models.
+                "model.ngram_embedding.shards.0.weight": np.zeros(
+                    (128, 64), dtype=np.float16
+                ),
+            },
+            str(path),
+        )
+
+        assert _calibration_resident_checkpoint_bytes(
+            tmp_path, {"model_type": "llama"}
+        ) == path.stat().st_size
+
     @pytest.mark.parametrize("capacity_gib", [16, 32, 64])
     def test_budget_reserves_25_percent_on_smaller_systems(
         self, monkeypatch, capacity_gib
@@ -3034,10 +3096,7 @@ class TestModelExceedsRamGuard:
         gib = 1024**3
         capacity = capacity_gib * gib
         monkeypatch.setattr(
-            oq_module, "_system_available_memory_bytes", lambda: capacity
-        )
-        monkeypatch.setattr(
-            oq_module, "_metal_available_memory_bytes", lambda: capacity
+            oq_module, "_calibration_capability_capacity_bytes", lambda **_k: capacity
         )
 
         budget = _calibration_memory_budget()
@@ -3046,15 +3105,14 @@ class TestModelExceedsRamGuard:
         assert budget["model_limit_bytes"] == int(capacity * 0.75)
         assert budget["reserve_bytes"] == capacity - int(capacity * 0.75)
 
-    def test_budget_uses_smaller_metal_working_set(self, monkeypatch):
+    def test_budget_uses_stable_capability_ceiling(self, monkeypatch):
         from omlx import oq as oq_module
 
         gib = 1024**3
         monkeypatch.setattr(
-            oq_module, "_system_available_memory_bytes", lambda: 512 * gib
-        )
-        monkeypatch.setattr(
-            oq_module, "_metal_available_memory_bytes", lambda: 464 * gib
+            oq_module,
+            "_calibration_capability_capacity_bytes",
+            lambda **_k: 464 * gib,
         )
 
         budget = _calibration_memory_budget(413 * gib)
@@ -3068,18 +3126,87 @@ class TestModelExceedsRamGuard:
 
         capacity = 4000
         monkeypatch.setattr(
-            oq_module, "_system_available_memory_bytes", lambda: capacity
-        )
-        monkeypatch.setattr(
-            oq_module, "_metal_available_memory_bytes", lambda: capacity
+            oq_module, "_calibration_capability_capacity_bytes", lambda **_k: capacity
         )
 
         at_limit = int(capacity * _MAX_MODEL_RAM_FRACTION)
         assert _calibration_memory_budget(at_limit)["requires_proxy"] is False
         assert _calibration_memory_budget(at_limit + 1)["requires_proxy"] is True
 
+    def test_capability_admission_ignores_live_memory_pressure(self, monkeypatch):
+        from omlx import oq as oq_module
+
+        gib = 1024**3
+        capability = int(107.5 * gib)
+        monkeypatch.setattr(
+            oq_module,
+            "_calibration_capability_capacity_bytes",
+            lambda **_k: capability,
+        )
+        monkeypatch.setattr(
+            oq_module, "_system_available_memory_bytes", lambda: int(72.9 * gib)
+        )
+        monkeypatch.setattr(
+            oq_module, "_metal_available_memory_bytes", lambda: int(107.5 * gib)
+        )
+
+        budget = _calibration_memory_budget(int(67.0 * gib))
+
+        assert budget["live_capacity_bytes"] == int(72.9 * gib)
+        assert budget["capacity_bytes"] == capability
+        assert budget["model_limit_bytes"] == int(capability * 0.75)
+        assert budget["requires_proxy"] is False
+
+    def test_capability_admission_still_rejects_unsafe_resident_model(
+        self, monkeypatch
+    ):
+        from omlx import oq as oq_module
+
+        gib = 1024**3
+        capability = int(107.5 * gib)
+        monkeypatch.setattr(
+            oq_module,
+            "_calibration_capability_capacity_bytes",
+            lambda **_k: capability,
+        )
+        monkeypatch.setattr(
+            oq_module, "_system_available_memory_bytes", lambda: int(72.9 * gib)
+        )
+        monkeypatch.setattr(
+            oq_module, "_metal_available_memory_bytes", lambda: int(107.5 * gib)
+        )
+
+        budget = _calibration_memory_budget(int(81.0 * gib))
+
+        assert budget["model_limit_bytes"] == int(capability * 0.75)
+        assert budget["requires_proxy"] is True
+
 
 class TestOqeCalibrationBatchPlan:
+    def test_qwen4_calibration_forces_ssd_ple_and_keeps_mtp(self):
+        from omlx.oq import _calibration_model_settings
+
+        settings = _calibration_model_settings(
+            {"model_type": "qwen4_exp"},
+            has_mtp_heads=True,
+            has_mtp_weights=True,
+        )
+
+        assert settings.qwen4_ple_ssd_offload is True
+        assert settings.mtp_enabled is True
+
+    def test_ordinary_non_mtp_calibration_has_no_serving_override(self):
+        from omlx.oq import _calibration_model_settings
+
+        assert (
+            _calibration_model_settings(
+                {"model_type": "llama"},
+                has_mtp_heads=False,
+                has_mtp_weights=False,
+            )
+            is None
+        )
+
     def test_subtracts_lazy_model_footprint(self, monkeypatch):
         from omlx import oq as oq_module
 
@@ -3418,6 +3545,80 @@ class TestBuildProxyForSensitivity:
         assert f"{prefix}.key_proj" not in quantization
         assert f"{prefix}.value_proj" not in quantization
 
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    def test_qwen4_proxy_quantizes_packed_experts_and_preserves_mtp_vision(
+        self, tmp_path, monkeypatch
+    ):
+        """Exercise the source layout that produced the 263.1 GiB proxy."""
+        from safetensors import safe_open
+        from safetensors.numpy import save_file as np_save
+
+        src = tmp_path / "src"
+        out = tmp_path / "proxy"
+        src.mkdir()
+        config = {
+            "model_type": "qwen4_exp",
+            "architectures": ["Qwen4ExpForConditionalGeneration"],
+            "text_config": {"model_type": "qwen4_exp_text"},
+            "vision_config": {"hidden_size": 16},
+        }
+        (src / "config.json").write_text(json.dumps(config), encoding="utf-8")
+        raw = "model.language_model.layers.0.mlp.experts"
+        ngram = (
+            "model.language_model.layers.0.ple.ple_embedding."
+            "ngram_embedding.shard_0"
+        )
+        vision = "model.visual.blocks.0.attn.q_proj.weight"
+        np_save(
+            {
+                f"{raw}.gate_up_proj": np.ones((2, 128, 64), dtype=np.float16),
+                f"{raw}.down_proj": np.ones((2, 64, 64), dtype=np.float16),
+                f"{ngram}.weight": np.ones((4, 160), dtype=np.float16),
+                "mtp.fc_hidden.weight": np.ones((64, 64), dtype=np.float16),
+                vision: np.ones((16, 64), dtype=np.float16),
+            },
+            str(src / "model.safetensors"),
+        )
+
+        def qwen4_sanitize(weights):
+            gate_up = weights.pop(f"{raw}.gate_up_proj")
+            gate, up = mx.split(gate_up, 2, axis=-2)
+            prefix = "language_model.model.layers.0.mlp.switch_mlp"
+            weights[f"{prefix}.gate_proj.weight"] = gate
+            weights[f"{prefix}.up_proj.weight"] = up
+            weights[f"{prefix}.down_proj.weight"] = weights.pop(
+                f"{raw}.down_proj"
+            )
+            return weights
+
+        monkeypatch.setattr(
+            "omlx.oq._build_model_sanitizer",
+            lambda *_args, **_kwargs: qwen4_sanitize,
+        )
+        monkeypatch.setattr("omlx.oq._build_non_quantizable_set", lambda _c: set())
+        _build_streaming_proxy_for_sensitivity(
+            str(src),
+            out,
+            dtype="bfloat16",
+            preserve_mtp=True,
+        )
+
+        keys = set()
+        for path in out.glob("*.safetensors"):
+            with safe_open(str(path), framework="numpy") as file:
+                keys.update(file.keys())
+        prefix = "language_model.model.layers.0.mlp.switch_mlp"
+        for projection in ("gate_proj", "up_proj", "down_proj"):
+            assert f"{prefix}.{projection}.scales" in keys
+        assert not any("mlp.experts.gate_up_proj" in key for key in keys)
+        assert f"{ngram}.scales" in keys
+        assert "mtp.fc_hidden.scales" in keys
+        assert vision in keys
+        assert vision.removesuffix(".weight") + ".scales" not in keys
+
+        quantization = json.loads((out / "config.json").read_text())["quantization"]
+        assert quantization[ngram]["group_size"] == 32
+
 
 class TestSensitivityRequiredEnforcement:
     """Regression tests: quantize_oq_streaming must abort when sensitivity
@@ -3443,6 +3644,9 @@ class TestSensitivityRequiredEnforcement:
         from omlx import settings as _settings
 
         monkeypatch.setattr(_settings, "get_system_memory", lambda: 0)
+        monkeypatch.setattr(
+            _oq, "_calibration_capability_capacity_bytes", lambda **_k: 0
+        )
         monkeypatch.setattr(_oq, "_system_available_memory_bytes", lambda: 0)
         monkeypatch.setattr(_oq, "_metal_available_memory_bytes", lambda: 0)
 
@@ -3484,6 +3688,9 @@ class TestSensitivityRequiredEnforcement:
 
         from omlx import oq as _oq
 
+        monkeypatch.setattr(
+            _oq, "_calibration_capability_capacity_bytes", lambda **_k: 0
+        )
         monkeypatch.setattr(_oq, "_system_available_memory_bytes", lambda: 0)
         monkeypatch.setattr(_oq, "_metal_available_memory_bytes", lambda: 0)
 
@@ -3532,6 +3739,9 @@ class TestSensitivityRequiredEnforcement:
         monkeypatch.setattr(_settings, "get_system_memory", lambda: 0)
         from omlx import oq as _oq
 
+        monkeypatch.setattr(
+            _oq, "_calibration_capability_capacity_bytes", lambda **_k: 0
+        )
         monkeypatch.setattr(_oq, "_system_available_memory_bytes", lambda: 0)
         monkeypatch.setattr(_oq, "_metal_available_memory_bytes", lambda: 0)
 
@@ -3564,6 +3774,9 @@ class TestSensitivityRequiredEnforcement:
 
         from omlx import oq as oq_module
 
+        monkeypatch.setattr(
+            oq_module, "_calibration_capability_capacity_bytes", lambda **_k: 1000
+        )
         monkeypatch.setattr(oq_module, "_system_available_memory_bytes", lambda: 1000)
         monkeypatch.setattr(oq_module, "_metal_available_memory_bytes", lambda: 1000)
         proxy = tmp_path / "proxy"
@@ -3585,7 +3798,9 @@ class TestSensitivityRequiredEnforcement:
 
         assert not proxy.exists()
 
-    def test_oqe_uses_proxy_when_source_exceeds_live_limit(self, tmp_path, monkeypatch):
+    def test_oqe_uses_proxy_when_source_exceeds_capability_limit(
+        self, tmp_path, monkeypatch
+    ):
         if not HAS_MLX:
             pytest.skip("mlx not available")
         from safetensors.numpy import save_file as np_save
@@ -3600,6 +3815,9 @@ class TestSensitivityRequiredEnforcement:
 
         from omlx import oq as oq_module
 
+        monkeypatch.setattr(
+            oq_module, "_calibration_capability_capacity_bytes", lambda **_k: 1000
+        )
         monkeypatch.setattr(oq_module, "_system_available_memory_bytes", lambda: 1000)
         monkeypatch.setattr(oq_module, "_metal_available_memory_bytes", lambda: 1000)
         proxy = tmp_path / "proxy"
@@ -4974,6 +5192,110 @@ class TestBuildModelSanitizerMiniMaxCompat:
         assert sanitize({"weight": 1}) == {"weight": 1}
 
 
+class TestBuildModelSanitizerQwen4Compat:
+    def test_qwen4_applies_compat_before_model_lookup(self, monkeypatch):
+        pytest.importorskip("mlx_vlm.utils")
+        from types import SimpleNamespace
+
+        import mlx_vlm.utils as vlm_utils
+
+        from omlx.oq import _build_model_sanitizer
+
+        class _Cfg:
+            def __init__(self, **fields):
+                self.__dict__.update(fields)
+
+            @classmethod
+            def from_dict(cls, fields):
+                return cls(**fields)
+
+        class _FakeModel:
+            @staticmethod
+            def sanitize(_proxy, weights):
+                return weights
+
+        fake_module = SimpleNamespace(
+            Model=_FakeModel,
+            ModelConfig=_Cfg,
+            VisionConfig=_Cfg,
+            TextConfig=_Cfg,
+            VisionModel=object,
+            LanguageModel=object,
+        )
+        applied = []
+
+        def unsupported_get_model_and_args(_config):
+            raise ValueError("Model type qwen4_exp not supported")
+
+        def apply_compat_patch():
+            applied.append(True)
+            vlm_utils.get_model_and_args = lambda _config: (fake_module, "qwen4_exp")
+            return True
+
+        monkeypatch.setattr(
+            vlm_utils,
+            "get_model_and_args",
+            unsupported_get_model_and_args,
+        )
+        monkeypatch.setattr(
+            "omlx.patches.mlx_vlm_qwen4_exp_compat."
+            "apply_mlx_vlm_qwen4_exp_compat_patch",
+            apply_compat_patch,
+        )
+        monkeypatch.setattr(
+            "mlx_vlm.utils.sanitize_weights",
+            lambda _model, weights, _config: weights,
+        )
+        config = {
+            "architectures": ["Qwen4ExpForConditionalGeneration"],
+            "model_type": "qwen4_exp",
+            "text_config": {
+                "model_type": "qwen4_exp_text",
+                "num_hidden_layers": 1,
+                "hidden_size": 16,
+            },
+            "vision_config": {"hidden_size": 8},
+        }
+
+        sanitize = _build_model_sanitizer(config, text_only=False)
+
+        assert applied == [True]
+        assert sanitize is not None
+
+    def test_qwen4_model_path_binds_mmap_and_preserve_mtp(
+        self, tmp_path, monkeypatch
+    ):
+        from omlx import oq
+
+        configured = MagicMock(return_value=True)
+        monkeypatch.setattr(
+            oq,
+            "_configure_qwen4_exp_quantization_runtime",
+            configured,
+        )
+        # The registration behavior itself is covered above; this assertion
+        # isolates the path/MTP state passed by quantization call sites.
+        monkeypatch.setattr(
+            "omlx.patches.mlx_vlm_qwen4_exp_compat."
+            "apply_mlx_vlm_qwen4_exp_compat_patch",
+            lambda: True,
+        )
+        oq._build_model_sanitizer(
+            {
+                "model_type": "qwen4_exp",
+                "architectures": [],
+                "text_config": {"model_type": "qwen4_exp_text"},
+            },
+            model_path=tmp_path,
+            preserve_mtp=True,
+        )
+
+        configured.assert_called_once()
+        assert configured.call_args.args[0] == tmp_path
+        assert configured.call_args.args[1]["model_type"] == "qwen4_exp"
+        assert configured.call_args.kwargs == {"preserve_mtp": True}
+
+
 # =============================================================================
 # Test _vlm_sanitize proxy exposes the gemma-4 audio-guard attributes
 # =============================================================================
@@ -5321,6 +5643,78 @@ class TestCollectImatrixTextLoad:
 
         assert "trust_remote_code" not in mock_load.call_args.kwargs
 
+    def test_vlm_proxy_passes_lenient_load_directly(self, monkeypatch):
+        """SSD-mapped proxy tensors are not normal model parameters.
+
+        The supported mlx-vlm ``strict`` option must reach load_model itself;
+        patching Module.load_weights globally did not reliably affect the real
+        Qwen4 proxy load and rejected every retained PLE shard.
+        """
+        import omlx.utils.model_loading as model_loading
+
+        from omlx import oq as oq_mod
+
+        vlm_load = MagicMock(return_value=MagicMock())
+        tokenizer_load = MagicMock(return_value=MagicMock())
+        monkeypatch.setitem(
+            sys.modules, "mlx_vlm.utils", MagicMock(load_model=vlm_load)
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "mlx_lm.tokenizer_utils",
+            MagicMock(load=tokenizer_load),
+        )
+        monkeypatch.setattr(
+            model_loading, "_checkpoint_has_mtp_weights", lambda _path: False
+        )
+        monkeypatch.setattr(model_loading, "_has_mtp_heads", lambda _config: False)
+        monkeypatch.setattr(model_loading, "maybe_apply_pre_load_patches", MagicMock())
+        monkeypatch.setattr(
+            oq_mod, "_collect_imatrix_from_model", MagicMock(return_value=({}, {}))
+        )
+
+        oq_mod._collect_imatrix(
+            "/fake/qwen4-proxy",
+            {
+                "model_type": "qwen4_exp",
+                "vision_config": {"hidden_size": 8},
+                "text_config": {"model_type": "qwen4_exp_text"},
+            },
+            trust_remote_code=True,
+        )
+
+        assert vlm_load.call_args.kwargs["strict"] is False
+        assert vlm_load.call_args.kwargs["trust_remote_code"] is True
+
+    def test_empty_collection_reports_the_failed_stage(self, monkeypatch, tmp_path):
+        from omlx import oq as oq_mod
+
+        monkeypatch.setattr(
+            oq_mod,
+            "_collect_imatrix",
+            MagicMock(
+                return_value=(
+                    {},
+                    {
+                        "failure_stage": "collector_install",
+                        "failure_reason": "no supported capture modules found",
+                    },
+                )
+            ),
+        )
+
+        with pytest.raises(RuntimeError, match="stage=collector_install"):
+            oq_mod._load_or_collect_imatrix(
+                str(tmp_path),
+                {},
+                cache_path=str(tmp_path / "imatrix.npz"),
+                reuse_cache=False,
+                num_samples=1,
+                seq_length=8,
+                strict=False,
+                trust_remote_code=False,
+            )
+
 
 class TestMeasureSensitivityQuantizedVlm:
     def test_quantized_vlm_proxy_uses_vlm_loader(self, monkeypatch):
@@ -5375,6 +5769,7 @@ class TestMeasureSensitivityQuantizedVlm:
         assert vlm_load.call_args.args[0] == Path("/fake/minimax-proxy")
         assert vlm_load.call_args.kwargs["lazy"] is True
         assert vlm_load.call_args.kwargs["trust_remote_code"] is True
+        assert vlm_load.call_args.kwargs["strict"] is False
         tokenizer_load.assert_called_once_with(Path("/fake/minimax-proxy"))
         lm_load.assert_not_called()
 
@@ -6269,6 +6664,9 @@ class TestCalibrationFootprint:
         import omlx.oq as oq
 
         # Fixed capacity 400 -> model_limit = int(0.75 * 400) = 300.
+        monkeypatch.setattr(
+            oq, "_calibration_capability_capacity_bytes", lambda **_k: 400
+        )
         monkeypatch.setattr(oq, "_system_available_memory_bytes", lambda: 400)
         monkeypatch.setattr(oq, "_metal_available_memory_bytes", lambda: 400)
 

--- a/tests/test_process_memory_enforcer.py
+++ b/tests/test_process_memory_enforcer.py
@@ -951,6 +951,34 @@ class TestStaticCeiling:
             result = enforcer._get_static_ceiling()
         assert result == 10 * 1024**3
 
+    def test_capability_ceiling_uses_static_ram_and_metal_cap(self):
+        gib = 1024**3
+        with (
+            patch("omlx.settings.get_system_memory", return_value=128 * gib),
+            patch(
+                "omlx.process_memory_enforcer.get_effective_metal_cap_bytes",
+                return_value=int(107.5 * gib),
+            ),
+        ):
+            result = pme.get_memory_capability_ceiling_bytes("balanced")
+
+        assert result == int(107.5 * gib)
+
+    def test_capability_ceiling_respects_explicit_custom_limit(self):
+        gib = 1024**3
+        with (
+            patch("omlx.settings.get_system_memory", return_value=128 * gib),
+            patch(
+                "omlx.process_memory_enforcer.get_effective_metal_cap_bytes",
+                return_value=int(107.5 * gib),
+            ),
+        ):
+            result = pme.get_memory_capability_ceiling_bytes(
+                "custom", 70 * gib
+            )
+
+        assert result == 70 * gib
+
 
 class TestDynamicCeilingActiveRatio:
     """Dynamic ceiling sums free + inactive + active * tier ratio


### PR DESCRIPTION
## Summary

Fresh oQe quantization of Qwen3.8-Flash-Next failed on a 128 GB M5 Max in the RAM-safe calibration-proxy path.

Follow-up to #3174. Fresh oQe calibration for Qwen3.8 Flash Next can require the RAM-safe uniform-4-bit proxy path, but that path did not initialize the Qwen4 runtime before sanitizer/model lookup and did not load SSD-mapped PLE tensors with the intended lenient VLM loader contract.

This left fresh calibration unable to reach the existing Qwen4 layer walk on machines that cannot load the full BF16 checkpoint.

## Problem

The failure occurred in three stages:

1. Quantization bypassed serving's Qwen4 compatibility registration, so sanitizer discovery could fail and leave packed MoE expert tensors in BF16, producing an oversized proxy.
2. Proxy admission charged the complete on-disk checkpoint and recomputed capability from transient live memory, including pressure created by the proxy itself. Qwen4 PLE rows are SSD-mapped and the manual calibration walk does not invoke the vision tower or ordinary LM head.
3. Once the proxy layout was corrected, `mlx_vlm.load_model()` rejected 384 retained PLE weight/scale/bias tensors that are intentionally consumed by mmap modules instead of owned as normal MLX parameters. The load exception was converted into the generic `oQe imatrix collection produced no entries` error.

## Fix

- Detect Qwen4-Exp through both top-level and text configuration.
- Register and bind the Qwen4 runtime before sanitize-plan discovery, forcing PLE mmap during calibration while preserving MTP when present.
- Quantize the sanitized packed expert representation when building the proxy.
- Account for the Qwen4 tensors actually resident during the manual calibration walk, while retaining complete checkpoint accounting for other model families.
- Base hard calibration admission on the stable configured machine/Metal capability; retain live availability for diagnostics and micro-batch decisions.
- Pass `strict=False` through the supported mlx-vlm loader API for calibration proxies instead of temporarily monkeypatching `Module.load_weights`.
- Preserve the first load/layer/capture failure stage when an iMatrix collection is empty.

## Validation

- Four representative regression tests fail against unchanged upstream and pass with this change.
- 43 focused Qwen proxy, iMatrix, MTP, and memory-admission tests passed.
- All 591 tests in `tests/test_oq.py` and `tests/test_process_memory_enforcer.py` passed.
- `pytest -m "not slow"`: 10,476 passed, 109 skipped, and four unrelated failures. All four reproduce against unchanged upstream (three existing numerical-tolerance failures and one bundled subprocess that cannot import MLX).
- Changed-file Python syntax compilation passed.
- Critical Ruff checks (`E9,F63,F7,F82`) passed; the full-file Ruff findings are pre-existing in the upstream files.
- `git diff --check` passed.

Real-checkpoint validation used the canonical Qwen3.8-Flash-Next BF16 checkpoint (131 safetensors shards):

- The corrected proxy was approximately 98 GB on disk and 67 GB resident.
- Fresh Qwen4 trunk and MTP calibration produced 937 iMatrix entries.
- The iMatrix cache was written and subsequently reused.
- The oQ4e conversion completed, the output loaded with PLE mmap enabled, and inference completed successfully on a 128 GB Apple Silicon Mac.
