### PR TITLE
glm5_next: disable q8 affine qmm (wrong output for GLM shapes) and suppress <|assistant|> in output logits

### DIFF
--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/language.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/language.py
@@ -925,6 +925,17 @@ class LanguageModel(nn.Module):
             out = self.model.embed_tokens.as_linear(out)
         else:
             out = linear_forward(self.lm_head, out)
+        # <|assistant|> (154828) is a prompt-structure token the template never
+        # expects in output; quantized checkpoints occasionally sample it at
+        # action boundaries (instead of <tool_call> or a stop), derailing into
+        # self-dialogue or truncating tool calls. Suppress it outright.
+        if out.shape[-1] > 154828:
+            neg = mx.full((1,), -mx.inf, dtype=out.dtype)
+            out = mx.concatenate(
+                [out[..., :154828], mx.broadcast_to(neg, out.shape[:-1] + (1,)),
+                 out[..., 154829:]],
+                axis=-1,
+            )
         return LanguageModelOutput(logits=out)
 
     def sanitize(self, weights):

--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/linear.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/linear.py
@@ -13,7 +13,10 @@ def _native_qmm(linear: nn.QuantizedLinear, x: mx.array):
         return None
     if getattr(linear, "mode", None) != "affine" or "bias" in linear:
         return None
-    min_tokens = 1024 if bits == 8 else 128
+    # The q8 affine qmm tile produces incorrect output for glm5_next
+    # projection shapes; route 8-bit through stock quantized_matmul until
+    # the kernel supports them. 4/5/6-bit tiles verified correct on GLM.
+    min_tokens = 10**9 if bits == 8 else 128
     if x.ndim < 2 or x.shape[-2] < min_tokens:
         return None
 
@@ -69,7 +72,10 @@ def fused_quantized_matmul(
     group_size: int,
 ) -> mx.array:
     """Route a concatenated projection through the same native affine tile."""
-    min_tokens = 1024 if bits == 8 else 128
+    # The q8 affine qmm tile produces incorrect output for glm5_next
+    # projection shapes; route 8-bit through stock quantized_matmul until
+    # the kernel supports them. 4/5/6-bit tiles verified correct on GLM.
+    min_tokens = 10**9 if bits == 8 else 128
     if (
         x.ndim >= 2
         and x.shape[-2] >= min_tokens


### PR DESCRIPTION
Two independent GLM-5.3-Flash (glm5_next) correctness fixes, one commit each.

## 1. Disable the q8 affine qmm fast path (Fixes #3270)

`qwen35_q8_affine_qmm_t` is tuned for Qwen3.5 projection shapes and produces incorrect output for GLM projections once a prompt reaches the 1024-token routing threshold (`min_tokens = 1024 if bits == 8 else 128` in the vendored `glm5_next/linear.py`). oQ conversions boost the most sensitive layers to 8-bit, so past ~1K prompt tokens every such layer emits garbage and the model is completely blind to its context while still generating fluently — throughput benchmarks pass right over it.

The fix routes 8-bit through stock `mx.quantized_matmul` (both call sites) until the kernel supports GLM shapes. The 4/5/6-bit tiles (`min_tokens` 128) are exercised by every passing sub-1K prompt and appear correct for GLM shapes, so they stay enabled.

## 2. Suppress `<|assistant|>` in output logits (Fixes #3271)

Quantized checkpoints occasionally sample `<|assistant|>` (154828) at action boundaries, where the model should begin a `<tool_call>` or stop. It is not in `eos_token_id`, so generation runs away into fabricated Human/Assistant self-dialogue. Adding it to eos is the wrong fix: the chat template renders tool calls in-segment, so an eos there truncates the response exactly when the model intends a tool call. Per the template the token is prompt structure that never legitimately appears in output, so the `LanguageModel` now masks it to `-inf` in the output logits, eliminating both failure modes.

## Verification

M3 Ultra 512GB, GLM-5.3-Flash-oQ4e:

- Needle-in-haystack retrieval clean at 1.4K / 7K / 14K prompt tokens (previously MISS at everything ≥1043; the cliff sat exactly at the 1024 q8 routing threshold)
- Clean `tool_use` blocks with `stop_reason=tool_use`; 12/12 clean tool calls across temperatures 0.3 / 0.6 / 1.0 with an 8-tool schema set; no runaway self-dialogue
- Full agentic session in an Anthropic-API harness completing skill + bash exploration end to end

Note for anyone applying this: the SSD prefix cache preserves KV computed by the broken kernel, so cached prefixes replay poisoned state until the cache is cleared (see #3270 for the versioning suggestion).

Independent of #3243 / #3246.

Fixes #3270
Fixes #3271
