### PR TITLE
Preserve Claude Code per-agent model selection

### DIFF
--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -432,6 +432,7 @@ def launch_command(args, extra_args: list[str] | None = None):
     cli_opus_model = _optional_str(getattr(args, "opus_model", None))
     cli_sonnet_model = _optional_str(getattr(args, "sonnet_model", None))
     cli_haiku_model = _optional_str(getattr(args, "haiku_model", None))
+    cli_subagent_model = _optional_str(getattr(args, "subagent_model", None))
     settings_opus_model = _optional_str(getattr(claude_settings, "opus_model", None))
     settings_sonnet_model = _optional_str(
         getattr(claude_settings, "sonnet_model", None)
@@ -519,6 +520,7 @@ def launch_command(args, extra_args: list[str] | None = None):
             ("Opus tier ", opus_model),
             ("Sonnet tier ", sonnet_model),
             ("Haiku tier ", haiku_model),
+            ("Subagent ", cli_subagent_model),
         ]
         validated_models: set[str] = set()
         for role, model_id in models_to_validate:
@@ -550,6 +552,7 @@ def launch_command(args, extra_args: list[str] | None = None):
         opus_model=opus_model if tool_name == "claude" else None,
         sonnet_model=sonnet_model if tool_name == "claude" else None,
         haiku_model=haiku_model if tool_name == "claude" else None,
+        subagent_model=cli_subagent_model if tool_name == "claude" else None,
         context_window=model_info.get("max_context_window"),
         max_tokens=model_info.get("max_tokens"),
         model_type=model_info.get("model_type"),
@@ -1289,6 +1292,15 @@ Example directory structure:
         type=str,
         default=None,
         help="Claude Code Haiku tier model (Claude integration only)",
+    )
+    launch_parser.add_argument(
+        "--subagent-model",
+        type=str,
+        default=None,
+        help=(
+            "Force every Claude Code subagent to one model; omitted preserves "
+            "each subagent's own model selection (Claude integration only)"
+        ),
     )
     launch_parser.add_argument(
         "--cross-session",

--- a/omlx/integrations/base.py
+++ b/omlx/integrations/base.py
@@ -22,6 +22,7 @@ class IntegrationContext:
     opus_model: str | None = None
     sonnet_model: str | None = None
     haiku_model: str | None = None
+    subagent_model: str | None = None
     context_window: int | None = None
     max_tokens: int | None = None
     model_type: str | None = None

--- a/omlx/integrations/claude.py
+++ b/omlx/integrations/claude.py
@@ -139,9 +139,12 @@ class ClaudeCodeIntegration(Integration):
         if haiku_model:
             env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = haiku_model
 
-        subagent_model = haiku_model or sonnet_model or opus_model
-        if subagent_model:
-            env["CLAUDE_CODE_SUBAGENT_MODEL"] = subagent_model
+        # This variable is a global override: Claude Code applies it to every
+        # subagent, including agents that explicitly select opus or sonnet.
+        # Leave it unset unless the operator asks for that override so the
+        # configured tier aliases and per-agent model choices remain useful.
+        if ctx.subagent_model:
+            env["CLAUDE_CODE_SUBAGENT_MODEL"] = ctx.subagent_model
 
         if ctx.context_window:
             env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = str(ctx.context_window)

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1405,7 +1405,7 @@ class TestClaudeCodeIntegration:
         assert env["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "qwen3.5"
         assert env["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "qwen3.5"
         assert env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "qwen3.5"
-        assert env["CLAUDE_CODE_SUBAGENT_MODEL"] == "qwen3.5"
+        assert "CLAUDE_CODE_SUBAGENT_MODEL" not in env
         assert env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "131072"
         assert env["CLAUDE_CODE_MAX_CONTEXT_TOKENS"] == "131072"
         # Bundled-python vars must be stripped so claude code subprocess hooks
@@ -1413,6 +1413,31 @@ class TestClaudeCodeIntegration:
         assert "PYTHONHOME" not in env
         assert "PYTHONPATH" not in env
         assert "PYTHONDONTWRITEBYTECODE" not in env
+
+    def test_launch_sets_explicit_subagent_model_override(self):
+        cc = ClaudeCodeIntegration()
+        captured = {}
+
+        def fake_execvpe(binary, argv, env):
+            captured["env"] = env
+
+        with (
+            patch("omlx.integrations.claude.os.execvpe", side_effect=fake_execvpe),
+            patch.object(
+                ClaudeCodeIntegration, "_find_claude_binary", return_value="claude"
+            ),
+        ):
+            cc.launch(
+                ctx(
+                    port=8000,
+                    model="qwen3.5",
+                    haiku_model="small-reader",
+                    subagent_model="small-reader",
+                    context_window=131072,
+                )
+            )
+
+        assert captured["env"]["CLAUDE_CODE_SUBAGENT_MODEL"] == "small-reader"
 
     def test_model_disabled_reason_below_48k(self):
         cc = ClaudeCodeIntegration()
@@ -1749,7 +1774,7 @@ class TestClaudeCodeIntegration:
         assert env["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "opus-local"
         assert env["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "sonnet-local"
         assert env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "haiku-local"
-        assert env["CLAUDE_CODE_SUBAGENT_MODEL"] == "haiku-local"
+        assert "CLAUDE_CODE_SUBAGENT_MODEL" not in env
 
     def test_launch_open_server_uses_omlx_token(self):
         cc = ClaudeCodeIntegration()


### PR DESCRIPTION
## Problem

`omlx launch claude` always sets `CLAUDE_CODE_SUBAGENT_MODEL` to the configured Haiku tier. Claude Code treats that variable as a global override, so agents that explicitly select Opus, Sonnet, or `inherit` are silently forced onto Haiku. That defeats the existing three-tier model mapping.

## Change

- leave `CLAUDE_CODE_SUBAGENT_MODEL` unset by default
- add `--subagent-model` for operators who intentionally want one global override
- validate the explicit override against Claude Code's existing 48K minimum
- retain the existing Opus/Sonnet/Haiku environment mappings

## Verification

`195 passed` across `tests/test_integrations.py` and `tests/test_cli.py` using the bundled oMLX 0.6.3 runtime.
