### PR TITLE
fix(glm5_next): copy strided inputs before the affine prefill tile

### DIFF
--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/linear.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/linear.py
@@ -24,6 +24,9 @@ def _native_qmm(linear: nn.QuantizedLinear, x: mx.array):
         name = f"qwen35_q{bits}_affine_qmm_t"
         if not fast.has_symbol(name) or not _is_supported_affine_linear(linear, x):
             return None
+        # The tile indexes x as row-major packed and ignores its strides, so a
+        # last-axis view reads the wrong lanes.
+        x = mx.contiguous(x)
         return getattr(fast, name)(
             x,
             linear.weight,
@@ -87,6 +90,8 @@ def fused_quantized_matmul(
 
             name = f"qwen35_q{bits}_affine_qmm_t"
             if fast.has_symbol(name) and fast.qmm_supports_group_size(group_size):
+                # The tile ignores the input's strides. See _native_qmm.
+                x = mx.contiguous(x)
                 return getattr(fast, name)(
                     x,
                     weight,

--- a/tests/test_mlx_vlm_glm5_next_compat.py
+++ b/tests/test_mlx_vlm_glm5_next_compat.py
@@ -650,3 +650,66 @@ def test_glm5_next_q8_indexer_prefill_uses_shared_qmm_kernel(monkeypatch):
 
     assert calls == 1
     assert mx.allclose(actual, reference, atol=2e-3, rtol=2e-3).item()
+
+
+@pytest.mark.parametrize(("bits", "tokens"), [(5, 128), (8, 1024)])
+def test_glm5_next_prefill_qmm_handles_strided_input(bits, tokens):
+    import mlx.nn as nn
+    from mlx_vlm.models.glm5_next.linear import linear_forward
+
+    from omlx.custom_kernels.qwen35_prefill import fast
+
+    name = f"qwen35_q{bits}_affine_qmm_t"
+    if not fast.has_symbol(name):
+        pytest.skip(f"{name} native kernel is not built")
+
+    mx.random.seed(11)
+    dims = 128
+    base = nn.Linear(dims, dims, bias=False)
+    base.set_dtype(mx.float16)
+    linear = base.to_quantized(group_size=64, bits=bits, mode="affine")
+
+    wide = mx.random.normal((1, tokens, 2 * dims), dtype=mx.float16)
+    mx.eval(wide)
+    strided = mx.split(wide, [dims], axis=-1)[1]
+
+    reference = linear(strided)
+    actual = linear_forward(linear, strided)
+    mx.eval(actual, reference)
+
+    assert mx.allclose(actual, reference, atol=2e-3, rtol=2e-3).item()
+
+
+@pytest.mark.parametrize(("bits", "tokens"), [(5, 128), (8, 1024)])
+def test_glm5_next_fused_qmm_handles_strided_input(bits, tokens):
+    import mlx.nn as nn
+    from mlx_vlm.models.glm5_next.linear import fused_quantized_matmul
+
+    from omlx.custom_kernels.qwen35_prefill import fast
+
+    name = f"qwen35_q{bits}_affine_qmm_t"
+    if not fast.has_symbol(name):
+        pytest.skip(f"{name} native kernel is not built")
+
+    mx.random.seed(11)
+    dims = 128
+    base = nn.Linear(dims, dims, bias=False)
+    base.set_dtype(mx.float16)
+    linear = base.to_quantized(group_size=64, bits=bits, mode="affine")
+
+    wide = mx.random.normal((1, tokens, 2 * dims), dtype=mx.float16)
+    mx.eval(wide)
+    strided = mx.split(wide, [dims], axis=-1)[1]
+
+    reference = linear(strided)
+    actual = fused_quantized_matmul(
+        strided,
+        linear.weight,
+        linear.scales,
+        linear.biases,
+        bits=bits,
+        group_size=64,
+    )
+    mx.eval(actual, reference)
+
+    assert mx.allclose(actual, reference, atol=2e-3, rtol=2e-3).item()


### PR DESCRIPTION
`linear_forward` and `fused_quantized_matmul` dispatch a quantized projection to `qwen35_q{bits}_affine_qmm_t` once the token count reaches `min_tokens`, which is 1024 for 8-bit weights and 128 otherwise. The tile indexes `x` as row-major packed and ignores its strides, so an input that is a view returns wrong values and raises nothing.

`Glm5NextLinearAttention._fused_in_proj` computes q, k, v, f_a, g_a and b in one matmul and splits the result on the last axis. The f_a and g_a splits are views whose row stride is the full fused width, and they are the inputs to `f_b_proj` and `g_b_proj`. On GLM-5.3-Flash both are 128 to 8192, so the forget gate and the output gate of every linear-attention layer are computed from the wrong lanes.

The visible effect is that the model stops seeing its prompt and answers a question nobody asked. On `GLM-5.3-Flash-oQ4e`, 27 of the 34 linear-attention layers hold 8-bit projections and 7 hold 5-bit, so 7 layers are wrong from 128 tokens onward and the remaining 27 join at 1024.

Both call sites now copy `x` with `mx.contiguous` before the dispatch.

Measured on `GLM-5.3-Flash-oQ4e`, M3 Ultra 256 GB, greedy, a fresh prompt per request so nothing hits the prefix cache. Before: correct up to 1018 prompt tokens, wrong at 1025, 1465, 1730, 2374, 4693, 9574 and 19365. After: correct at every one of those lengths.

Tests cover `linear_forward` and `fused_quantized_matmul` at 5 bits with 128 tokens and at 8 bits with 1024 tokens, each on a last-axis `mx.split` view. All four fail without the copy.
