### PR TITLE
perf(loading): use float16 activations on M1/M2, where bfloat16 is emulated

### DIFF
--- a/omlx/admin/i18n/en.json
+++ b/omlx/admin/i18n/en.json
@@ -625,6 +625,7 @@
   "modal.model_settings.limit_tool_placeholder": "e.g. 2000",
   "modal.model_settings.activation_fp16": "Convert activations to float16 on load (recommended on M1/M2)",
   "modal.model_settings.activation_fp16_hint": "Recasts the checkpoint's bfloat16 leaves to float16 after loading, so the forward runs on the GPU's native float16 path instead of the emulated one. Quantized weights are untouched. Takes effect on the next model load.",
+  "modal.model_settings.activation_fp16_unsupported": "This checkpoint is already stored in float16 — there is nothing to recast.",
   "modal.model_settings.turboquant_kv": "TurboQuant KV Cache",
   "modal.model_settings.turboquant_kv_hint": "Compress KV cache using vector quantization. Lower bits = more compression, higher bits = better quality. Supports 2 to 8 bits.",
   "modal.model_settings.turboquant_kv_bits_label": "Bits per channel",

--- a/omlx/admin/i18n/en.json
+++ b/omlx/admin/i18n/en.json
@@ -623,6 +623,8 @@
   "modal.model_settings.limit_tool_result": "Limit Tool Result Tokens",
   "modal.model_settings.limit_tool_result_hint": "Truncate large tool results (e.g. file reads) to a token limit",
   "modal.model_settings.limit_tool_placeholder": "e.g. 2000",
+  "modal.model_settings.activation_fp16": "Convert activations to float16 on load (recommended on M1/M2)",
+  "modal.model_settings.activation_fp16_hint": "Recasts the checkpoint's bfloat16 leaves to float16 after loading, so the forward runs on the GPU's native float16 path instead of the emulated one. Quantized weights are untouched. Takes effect on the next model load.",
   "modal.model_settings.turboquant_kv": "TurboQuant KV Cache",
   "modal.model_settings.turboquant_kv_hint": "Compress KV cache using vector quantization. Lower bits = more compression, higher bits = better quality. Supports 2 to 8 bits.",
   "modal.model_settings.turboquant_kv_bits_label": "Bits per channel",

--- a/omlx/admin/i18n/es.json
+++ b/omlx/admin/i18n/es.json
@@ -625,6 +625,7 @@
   "modal.model_settings.limit_tool_placeholder": "ej. 2000",
   "modal.model_settings.activation_fp16": "Convertir activaciones a float16 al cargar (recomendado en M1/M2)",
   "modal.model_settings.activation_fp16_hint": "Reconvierte los tensores bfloat16 del checkpoint a float16 después de la carga, para que la pasada se ejecute en la ruta float16 nativa de la GPU en lugar de la emulada. Los pesos cuantizados no se tocan. Se aplica en la próxima carga del modelo.",
+  "modal.model_settings.activation_fp16_unsupported": "Este checkpoint ya está almacenado en float16: no hay nada que reconvertir.",
   "modal.model_settings.turboquant_kv": "Caché KV TurboQuant",
   "modal.model_settings.turboquant_kv_hint": "Comprimir caché KV usando cuantización vectorial. Bits más bajos = más compresión, bits más altos = mejor calidad. Soporta de 2 a 8 bits.",
   "modal.model_settings.turboquant_kv_bits_label": "Bits por canal",

--- a/omlx/admin/i18n/es.json
+++ b/omlx/admin/i18n/es.json
@@ -623,6 +623,8 @@
   "modal.model_settings.limit_tool_result": "Limitar Tokens de Resultado de Herramienta",
   "modal.model_settings.limit_tool_result_hint": "Recortar resultados grandes de herramientas (ej. lecturas de archivos) a un límite de tokens",
   "modal.model_settings.limit_tool_placeholder": "ej. 2000",
+  "modal.model_settings.activation_fp16": "Convertir activaciones a float16 al cargar (recomendado en M1/M2)",
+  "modal.model_settings.activation_fp16_hint": "Reconvierte los tensores bfloat16 del checkpoint a float16 después de la carga, para que la pasada se ejecute en la ruta float16 nativa de la GPU en lugar de la emulada. Los pesos cuantizados no se tocan. Se aplica en la próxima carga del modelo.",
   "modal.model_settings.turboquant_kv": "Caché KV TurboQuant",
   "modal.model_settings.turboquant_kv_hint": "Comprimir caché KV usando cuantización vectorial. Bits más bajos = más compresión, bits más altos = mejor calidad. Soporta de 2 a 8 bits.",
   "modal.model_settings.turboquant_kv_bits_label": "Bits por canal",

--- a/omlx/admin/i18n/fr.json
+++ b/omlx/admin/i18n/fr.json
@@ -625,6 +625,7 @@
   "modal.model_settings.limit_tool_placeholder": "par ex. 2000",
   "modal.model_settings.activation_fp16": "Convertir les activations en float16 au chargement (recommandé sur M1/M2)",
   "modal.model_settings.activation_fp16_hint": "Reconvertit les tenseurs bfloat16 du checkpoint en float16 après le chargement, afin que la passe s'exécute sur le chemin float16 natif du GPU plutôt que sur celui émulé. Les poids quantifiés ne sont pas modifiés. Prend effet au prochain chargement du modèle.",
+  "modal.model_settings.activation_fp16_unsupported": "Ce checkpoint est déjà stocké en float16 — il n'y a rien à reconvertir.",
   "modal.model_settings.turboquant_kv": "Cache KV TurboQuant",
   "modal.model_settings.turboquant_kv_hint": "Compressez le cache KV en utilisant la quantification vectorielle. Bits inférieurs = plus de compression, bits supérieurs = meilleure qualité. Supporte 2 à 8 bits.",
   "modal.model_settings.turboquant_kv_bits_label": "Bits par canal",

--- a/omlx/admin/i18n/fr.json
+++ b/omlx/admin/i18n/fr.json
@@ -623,6 +623,8 @@
   "modal.model_settings.limit_tool_result": "Limiter les tokens de résultat d'outil",
   "modal.model_settings.limit_tool_result_hint": "Tronquez les résultats d'outil volumineux (par ex. lectures de fichiers) à une limite de tokens",
   "modal.model_settings.limit_tool_placeholder": "par ex. 2000",
+  "modal.model_settings.activation_fp16": "Convertir les activations en float16 au chargement (recommandé sur M1/M2)",
+  "modal.model_settings.activation_fp16_hint": "Reconvertit les tenseurs bfloat16 du checkpoint en float16 après le chargement, afin que la passe s'exécute sur le chemin float16 natif du GPU plutôt que sur celui émulé. Les poids quantifiés ne sont pas modifiés. Prend effet au prochain chargement du modèle.",
   "modal.model_settings.turboquant_kv": "Cache KV TurboQuant",
   "modal.model_settings.turboquant_kv_hint": "Compressez le cache KV en utilisant la quantification vectorielle. Bits inférieurs = plus de compression, bits supérieurs = meilleure qualité. Supporte 2 à 8 bits.",
   "modal.model_settings.turboquant_kv_bits_label": "Bits par canal",

--- a/omlx/admin/i18n/ja.json
+++ b/omlx/admin/i18n/ja.json
@@ -625,6 +625,7 @@
   "modal.model_settings.limit_tool_placeholder": "例: 2000",
   "modal.model_settings.activation_fp16": "読み込み時に活性値を float16 に変換（M1/M2 で推奨）",
   "modal.model_settings.activation_fp16_hint": "読み込み後にチェックポイントの bfloat16 テンソルを float16 に変換し、エミュレーションではなく GPU ネイティブの float16 経路で順伝播を実行します。量子化された重みは変更されません。次回のモデル読み込みから有効になります。",
+  "modal.model_settings.activation_fp16_unsupported": "このチェックポイントはすでに float16 で保存されているため、変換するものがありません。",
   "modal.model_settings.turboquant_kv": "TurboQuant KV Cache",
   "modal.model_settings.turboquant_kv_hint": "Compress KV cache using vector quantization. Reduces memory ~60-75% with near-lossless quality for long context.",
   "modal.model_settings.turboquant_kv_bits_label": "Bits per channel",

--- a/omlx/admin/i18n/ja.json
+++ b/omlx/admin/i18n/ja.json
@@ -623,6 +623,8 @@
   "modal.model_settings.limit_tool_result": "ツール結果トークン制限",
   "modal.model_settings.limit_tool_result_hint": "大きなツール結果（ファイル読み込みなど）をトークン制限に合わせて切り詰めます",
   "modal.model_settings.limit_tool_placeholder": "例: 2000",
+  "modal.model_settings.activation_fp16": "読み込み時に活性値を float16 に変換（M1/M2 で推奨）",
+  "modal.model_settings.activation_fp16_hint": "読み込み後にチェックポイントの bfloat16 テンソルを float16 に変換し、エミュレーションではなく GPU ネイティブの float16 経路で順伝播を実行します。量子化された重みは変更されません。次回のモデル読み込みから有効になります。",
   "modal.model_settings.turboquant_kv": "TurboQuant KV Cache",
   "modal.model_settings.turboquant_kv_hint": "Compress KV cache using vector quantization. Reduces memory ~60-75% with near-lossless quality for long context.",
   "modal.model_settings.turboquant_kv_bits_label": "Bits per channel",

--- a/omlx/admin/i18n/ko.json
+++ b/omlx/admin/i18n/ko.json
@@ -623,6 +623,8 @@
   "modal.model_settings.limit_tool_result": "Tool calling 토큰 제한",
   "modal.model_settings.limit_tool_result_hint": "Tool calling(예: 파일 읽기) 결과를 정해진 크기로 자릅니다",
   "modal.model_settings.limit_tool_placeholder": "예: 2000",
+  "modal.model_settings.activation_fp16": "로드 시 활성값을 float16으로 변환 (M1/M2 권장)",
+  "modal.model_settings.activation_fp16_hint": "로드 후 체크포인트의 bfloat16 텐서를 float16으로 변환하여, 에뮬레이션 대신 GPU의 네이티브 float16 경로에서 순전파가 실행되도록 합니다. 양자화된 가중치는 변경되지 않습니다. 다음 모델 로드부터 적용됩니다.",
   "modal.model_settings.turboquant_kv": "TurboQuant KV Cache",
   "modal.model_settings.turboquant_kv_hint": "Compress KV cache using vector quantization. Reduces memory ~60-75% with near-lossless quality for long context.",
   "modal.model_settings.turboquant_kv_bits_label": "Bits per channel",

--- a/omlx/admin/i18n/ko.json
+++ b/omlx/admin/i18n/ko.json
@@ -625,6 +625,7 @@
   "modal.model_settings.limit_tool_placeholder": "예: 2000",
   "modal.model_settings.activation_fp16": "로드 시 활성값을 float16으로 변환 (M1/M2 권장)",
   "modal.model_settings.activation_fp16_hint": "로드 후 체크포인트의 bfloat16 텐서를 float16으로 변환하여, 에뮬레이션 대신 GPU의 네이티브 float16 경로에서 순전파가 실행되도록 합니다. 양자화된 가중치는 변경되지 않습니다. 다음 모델 로드부터 적용됩니다.",
+  "modal.model_settings.activation_fp16_unsupported": "이 체크포인트는 이미 float16으로 저장되어 있어 변환할 것이 없습니다.",
   "modal.model_settings.turboquant_kv": "TurboQuant KV Cache",
   "modal.model_settings.turboquant_kv_hint": "Compress KV cache using vector quantization. Reduces memory ~60-75% with near-lossless quality for long context.",
   "modal.model_settings.turboquant_kv_bits_label": "Bits per channel",

--- a/omlx/admin/i18n/pt-BR.json
+++ b/omlx/admin/i18n/pt-BR.json
@@ -623,6 +623,8 @@
   "modal.model_settings.limit_tool_result": "Limitar Tokens de Resultado de Ferramenta",
   "modal.model_settings.limit_tool_result_hint": "Truncar resultados grandes de ferramentas (ex: leituras de arquivo) para um limite de tokens",
   "modal.model_settings.limit_tool_placeholder": "ex: 2000",
+  "modal.model_settings.activation_fp16": "Converter ativações para float16 na carga (recomendado em M1/M2)",
+  "modal.model_settings.activation_fp16_hint": "Reconverte os tensores bfloat16 do checkpoint para float16 depois da carga, para que a passada rode no caminho float16 nativo da GPU em vez do emulado. Os pesos quantizados não são tocados. Vale a partir da próxima carga do modelo.",
   "modal.model_settings.turboquant_kv": "Cache KV TurboQuant",
   "modal.model_settings.turboquant_kv_hint": "Comprimir o cache KV usando quantização vetorial. Menos bits = mais compressão, mais bits = melhor qualidade. Suporta de 2 a 8 bits.",
   "modal.model_settings.turboquant_kv_bits_label": "Bits por canal",

--- a/omlx/admin/i18n/pt-BR.json
+++ b/omlx/admin/i18n/pt-BR.json
@@ -625,6 +625,7 @@
   "modal.model_settings.limit_tool_placeholder": "ex: 2000",
   "modal.model_settings.activation_fp16": "Converter ativações para float16 na carga (recomendado em M1/M2)",
   "modal.model_settings.activation_fp16_hint": "Reconverte os tensores bfloat16 do checkpoint para float16 depois da carga, para que a passada rode no caminho float16 nativo da GPU em vez do emulado. Os pesos quantizados não são tocados. Vale a partir da próxima carga do modelo.",
+  "modal.model_settings.activation_fp16_unsupported": "Este checkpoint já está armazenado em float16 — não há o que converter.",
   "modal.model_settings.turboquant_kv": "Cache KV TurboQuant",
   "modal.model_settings.turboquant_kv_hint": "Comprimir o cache KV usando quantização vetorial. Menos bits = mais compressão, mais bits = melhor qualidade. Suporta de 2 a 8 bits.",
   "modal.model_settings.turboquant_kv_bits_label": "Bits por canal",

--- a/omlx/admin/i18n/ru.json
+++ b/omlx/admin/i18n/ru.json
@@ -625,6 +625,7 @@
   "modal.model_settings.limit_tool_placeholder": "например, 2000",
   "modal.model_settings.activation_fp16": "Преобразовывать активации в float16 при загрузке (рекомендуется на M1/M2)",
   "modal.model_settings.activation_fp16_hint": "Преобразует тензоры bfloat16 из чекпоинта в float16 после загрузки, чтобы прямой проход выполнялся по нативному пути float16 на GPU, а не по эмулируемому. Квантованные веса не затрагиваются. Вступает в силу при следующей загрузке модели.",
+  "modal.model_settings.activation_fp16_unsupported": "Этот чекпоинт уже хранится в float16 — преобразовывать нечего.",
   "modal.model_settings.turboquant_kv": "TurboQuant KV-кэш",
   "modal.model_settings.turboquant_kv_hint": "Сжимайте KV-кэш с помощью векторного квантования. Меньшее число бит = сильнее сжатие, большее = лучше качество. Поддерживает от 2 до 8 бит.",
   "modal.model_settings.turboquant_kv_bits_label": "Битов на канал",

--- a/omlx/admin/i18n/ru.json
+++ b/omlx/admin/i18n/ru.json
@@ -623,6 +623,8 @@
   "modal.model_settings.limit_tool_result": "Ограничить токены результата инструмента",
   "modal.model_settings.limit_tool_result_hint": "Обрезать большие результаты инструментов, например чтение файлов, до лимита токенов",
   "modal.model_settings.limit_tool_placeholder": "например, 2000",
+  "modal.model_settings.activation_fp16": "Преобразовывать активации в float16 при загрузке (рекомендуется на M1/M2)",
+  "modal.model_settings.activation_fp16_hint": "Преобразует тензоры bfloat16 из чекпоинта в float16 после загрузки, чтобы прямой проход выполнялся по нативному пути float16 на GPU, а не по эмулируемому. Квантованные веса не затрагиваются. Вступает в силу при следующей загрузке модели.",
   "modal.model_settings.turboquant_kv": "TurboQuant KV-кэш",
   "modal.model_settings.turboquant_kv_hint": "Сжимайте KV-кэш с помощью векторного квантования. Меньшее число бит = сильнее сжатие, большее = лучше качество. Поддерживает от 2 до 8 бит.",
   "modal.model_settings.turboquant_kv_bits_label": "Битов на канал",

--- a/omlx/admin/i18n/zh-TW.json
+++ b/omlx/admin/i18n/zh-TW.json
@@ -623,6 +623,8 @@
   "modal.model_settings.limit_tool_result": "限制工具回傳 Token 數",
   "modal.model_settings.limit_tool_result_hint": "將過長的回傳結果（如檔案讀取）截斷至指定 Token 數量上限",
   "modal.model_settings.limit_tool_placeholder": "例如 2000",
+  "modal.model_settings.activation_fp16": "載入時將激活值轉換為 float16（建議在 M1/M2 上啟用）",
+  "modal.model_settings.activation_fp16_hint": "載入後將檢查點中的 bfloat16 張量轉換為 float16，使前向計算走 GPU 原生的 float16 路徑而非模擬路徑。量化權重不受影響。下次載入模型時生效。",
   "modal.model_settings.turboquant_kv": "TurboQuant KV Cache",
   "modal.model_settings.turboquant_kv_hint": "使用向量量化壓縮 KV 快取。較低位元 = 更多壓縮，較高位元 = 更佳品質。支援 2 到 8 位元。",
   "modal.model_settings.turboquant_kv_bits_label": "每通道位元數",

--- a/omlx/admin/i18n/zh-TW.json
+++ b/omlx/admin/i18n/zh-TW.json
@@ -625,6 +625,7 @@
   "modal.model_settings.limit_tool_placeholder": "例如 2000",
   "modal.model_settings.activation_fp16": "載入時將激活值轉換為 float16（建議在 M1/M2 上啟用）",
   "modal.model_settings.activation_fp16_hint": "載入後將檢查點中的 bfloat16 張量轉換為 float16，使前向計算走 GPU 原生的 float16 路徑而非模擬路徑。量化權重不受影響。下次載入模型時生效。",
+  "modal.model_settings.activation_fp16_unsupported": "此檢查點已以 float16 儲存，沒有需要轉換的內容。",
   "modal.model_settings.turboquant_kv": "TurboQuant KV Cache",
   "modal.model_settings.turboquant_kv_hint": "使用向量量化壓縮 KV 快取。較低位元 = 更多壓縮，較高位元 = 更佳品質。支援 2 到 8 位元。",
   "modal.model_settings.turboquant_kv_bits_label": "每通道位元數",

--- a/omlx/admin/i18n/zh.json
+++ b/omlx/admin/i18n/zh.json
@@ -623,6 +623,8 @@
   "modal.model_settings.limit_tool_result": "限制工具结果 Token",
   "modal.model_settings.limit_tool_result_hint": "截断过长的工具结果（如文件读取）到 Token 限制",
   "modal.model_settings.limit_tool_placeholder": "例如 2000",
+  "modal.model_settings.activation_fp16": "加载时将激活值转换为 float16（建议在 M1/M2 上启用）",
+  "modal.model_settings.activation_fp16_hint": "加载后将检查点中的 bfloat16 张量转换为 float16，使前向计算走 GPU 原生的 float16 路径而非模拟路径。量化权重不受影响。下次加载模型时生效。",
   "modal.model_settings.turboquant_kv": "TurboQuant KV 缓存",
   "modal.model_settings.turboquant_kv_hint": "使用向量量化压缩 KV Cache。位数越低压缩越多，位数越高质量越好。支持 2 到 8 位。",
   "modal.model_settings.turboquant_kv_bits_label": "每通道位数",

--- a/omlx/admin/i18n/zh.json
+++ b/omlx/admin/i18n/zh.json
@@ -625,6 +625,7 @@
   "modal.model_settings.limit_tool_placeholder": "例如 2000",
   "modal.model_settings.activation_fp16": "加载时将激活值转换为 float16（建议在 M1/M2 上启用）",
   "modal.model_settings.activation_fp16_hint": "加载后将检查点中的 bfloat16 张量转换为 float16，使前向计算走 GPU 原生的 float16 路径而非模拟路径。量化权重不受影响。下次加载模型时生效。",
+  "modal.model_settings.activation_fp16_unsupported": "该检查点已以 float16 存储，没有需要转换的内容。",
   "modal.model_settings.turboquant_kv": "TurboQuant KV 缓存",
   "modal.model_settings.turboquant_kv_hint": "使用向量量化压缩 KV Cache。位数越低压缩越多，位数越高质量越好。支持 2 到 8 位。",
   "modal.model_settings.turboquant_kv_bits_label": "每通道位数",

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -1949,6 +1949,14 @@ async def list_models(is_admin: bool = Depends(require_admin)):
         is_paroquant, paroquant_reason = _paroquant_compat_for_model(model_info)
         compat_ok, compat_reason = _dflash_compat_for_model(model_info)
         mtp_compat_ok, mtp_compat_reason = _mtp_compat_for_model(model_info)
+        try:
+            from ..utils.model_loading import checkpoint_has_bf16_leaves
+
+            activation_fp16_supported = checkpoint_has_bf16_leaves(
+                model_info.get("model_path", "") or ""
+            )
+        except (OSError, TypeError, ValueError):
+            activation_fp16_supported = False
         qwen4_ple_ssd_offload_supported = False
         qwen4_ple_ssd_offload_forced = False
         qwen4_resident_bytes = 0
@@ -2032,6 +2040,7 @@ async def list_models(is_admin: bool = Depends(require_admin)):
             "qwen4_ple_mmap_bytes": qwen4_mmap_bytes,
             "is_paroquant": is_paroquant,
             "paroquant_reason": paroquant_reason,
+            "activation_fp16_supported": activation_fp16_supported,
         }
 
         # Add settings if available

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -142,6 +142,8 @@ class ModelSettingsRequest(BaseModel):
     thinking_budget_tokens: int | None = None
     # MTP draft tokens per cycle for legacy MTP (None = adaptive default).
     mtp_num_draft_tokens: int | None = None
+    # Recast the checkpoint's bfloat16 leaves to float16 after load
+    activation_fp16_enabled: bool | None = None
     # TurboQuant KV cache (mlx-vlm backend)
     turboquant_kv_enabled: bool | None = None
     turboquant_kv_bits: float | None = None
@@ -2394,6 +2396,11 @@ async def update_model_settings(
             request.index_cache_freq
             if request.index_cache_freq and request.index_cache_freq >= 2
             else None
+        )
+    # Load-time activation dtype recast
+    if "activation_fp16_enabled" in sent:
+        current_settings.activation_fp16_enabled = (
+            request.activation_fp16_enabled or False
         )
     # TurboQuant KV cache settings
     if "turboquant_kv_enabled" in sent:

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -7388,6 +7388,7 @@
                     ttl_seconds: s.ttl_seconds ?? null,
                     enableIndexCache: !!(s.index_cache_freq),
                     index_cache_freq: s.index_cache_freq || null,
+                    activation_fp16_enabled: s.activation_fp16_enabled || false,
                     turboquant_kv_enabled: s.turboquant_kv_enabled || false,
                     turboquant_kv_bits: s.turboquant_kv_bits || 4,
                     qwen35_ane_prefill_enabled: s.qwen35_ane_prefill_enabled || false,
@@ -8315,6 +8316,7 @@
                                     ? chatTemplateKwargs : null,
                                 forced_ct_kwargs: forcedCtKwargs.length > 0
                                     ? forcedCtKwargs : null,
+                                activation_fp16_enabled: !!this.modelSettings.activation_fp16_enabled,
                                 turboquant_kv_enabled: this.modelSettings.turboquant_kv_enabled,
                                 turboquant_kv_bits: this.modelSettings.turboquant_kv_enabled
                                     ? (parseFloat(this.modelSettings.turboquant_kv_bits) || 4)

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -7389,6 +7389,8 @@
                     enableIndexCache: !!(s.index_cache_freq),
                     index_cache_freq: s.index_cache_freq || null,
                     activation_fp16_enabled: s.activation_fp16_enabled || false,
+                    // Checkpoint already stored in float16 → the recast is a no-op.
+                    activation_fp16_supported: model?.activation_fp16_supported !== false,
                     turboquant_kv_enabled: s.turboquant_kv_enabled || false,
                     turboquant_kv_bits: s.turboquant_kv_bits || 4,
                     qwen35_ane_prefill_enabled: s.qwen35_ane_prefill_enabled || false,

--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -1020,6 +1020,23 @@
                                     </div>
                                 </template>
 
+                                <!-- float16 activations -->
+                                <div class="p-4 bg-neutral-50 rounded-xl space-y-3 mb-3">
+                                    <div class="flex items-start justify-between gap-3">
+                                        <div class="min-w-0">
+                                            <span class="text-sm font-medium text-neutral-700">{{ t('modal.model_settings.activation_fp16') }}</span>
+                                            <p class="text-xs text-neutral-500 mt-0.5">{{ t('modal.model_settings.activation_fp16_hint') }}</p>
+                                        </div>
+                                        <button type="button"
+                                                @click="modelSettings.activation_fp16_enabled = !modelSettings.activation_fp16_enabled"
+                                                :class="modelSettings.activation_fp16_enabled ? 'bg-black' : 'bg-neutral-200'"
+                                                class="relative flex-shrink-0 w-11 h-6 mt-0.5 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
+                                            <span :class="modelSettings.activation_fp16_enabled ? 'translate-x-5' : 'translate-x-0'"
+                                                  class="block w-5 h-5 bg-white rounded-full shadow-sm transform transition-transform duration-300 absolute top-0.5 left-0.5"></span>
+                                        </button>
+                                    </div>
+                                </div>
+
                                 <!-- TurboQuant KV Cache -->
                                 <div class="p-4 bg-neutral-50 rounded-xl space-y-3 mb-3">
                                     <div class="flex items-start justify-between gap-3">

--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -1030,7 +1030,7 @@
                                         <button type="button"
                                                 @click="if (modelSettings.activation_fp16_supported) modelSettings.activation_fp16_enabled = !modelSettings.activation_fp16_enabled"
                                                 :disabled="!modelSettings.activation_fp16_supported"
-                                                :title="modelSettings.activation_fp16_supported ? '' : '{{ t('modal.model_settings.activation_fp16_unsupported') }}'"
+                                                :title="modelSettings.activation_fp16_supported ? '' : '{{ t('modal.model_settings.activation_fp16_unsupported')|replace('\\', '\\\\')|replace("'", "\\'") }}'"
                                                 :class="[
                                                     modelSettings.activation_fp16_enabled ? 'bg-black' : 'bg-neutral-200',
                                                     !modelSettings.activation_fp16_supported ? 'opacity-40 cursor-not-allowed' : ''

--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -1028,8 +1028,13 @@
                                             <p class="text-xs text-neutral-500 mt-0.5">{{ t('modal.model_settings.activation_fp16_hint') }}</p>
                                         </div>
                                         <button type="button"
-                                                @click="modelSettings.activation_fp16_enabled = !modelSettings.activation_fp16_enabled"
-                                                :class="modelSettings.activation_fp16_enabled ? 'bg-black' : 'bg-neutral-200'"
+                                                @click="if (modelSettings.activation_fp16_supported) modelSettings.activation_fp16_enabled = !modelSettings.activation_fp16_enabled"
+                                                :disabled="!modelSettings.activation_fp16_supported"
+                                                :title="modelSettings.activation_fp16_supported ? '' : '{{ t('modal.model_settings.activation_fp16_unsupported') }}'"
+                                                :class="[
+                                                    modelSettings.activation_fp16_enabled ? 'bg-black' : 'bg-neutral-200',
+                                                    !modelSettings.activation_fp16_supported ? 'opacity-40 cursor-not-allowed' : ''
+                                                ]"
                                                 class="relative flex-shrink-0 w-11 h-6 mt-0.5 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
                                             <span :class="modelSettings.activation_fp16_enabled ? 'translate-x-5' : 'translate-x-0'"
                                                   class="block w-5 h-5 bg-white rounded-full shadow-sm transform transition-transform duration-300 absolute top-0.5 left-0.5"></span>

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -30,6 +30,7 @@ import importlib
 import inspect
 import json
 import logging
+import os
 import threading
 from collections.abc import AsyncIterator
 from pathlib import Path
@@ -1751,6 +1752,26 @@ class VLMBatchedEngine(BaseEngine):
         await loop.run_in_executor(
             get_mlx_executor(), materialize_lazy_state, self._vlm_model
         )
+
+        # Native-fp16 activations. Off by default; OMLX_ACT_FP16=1 forces it on
+        # for a one-off A/B without touching persisted settings.
+        if os.environ.get("OMLX_ACT_FP16") == "1" or getattr(
+            self._model_settings, "activation_fp16_enabled", False
+        ):
+            try:
+                from ..utils.model_loading import cast_bf16_params_to_fp16
+
+                recast = await loop.run_in_executor(
+                    get_mlx_executor(), cast_bf16_params_to_fp16, self._vlm_model
+                )
+                logger.info(
+                    "activation dtype: bfloat16 -> float16 (%d tensors)", recast
+                )
+            except Exception:
+                logger.warning(
+                    "fp16 activation recast failed; staying on bfloat16",
+                    exc_info=True,
+                )
 
         # t5 ternary: free unused bias tensors to recover ~420 MB RAM.
         # The repacked safetensors carries 2-bit biases for format compat;

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1764,9 +1764,14 @@ class VLMBatchedEngine(BaseEngine):
                 recast = await loop.run_in_executor(
                     get_mlx_executor(), cast_bf16_params_to_fp16, self._vlm_model
                 )
-                logger.info(
-                    "activation dtype: bfloat16 -> float16 (%d tensors)", recast
-                )
+                if recast:
+                    logger.info(
+                        "activation dtype: bfloat16 -> float16 (%d tensors)", recast
+                    )
+                else:
+                    logger.info(
+                        "activation dtype: already float16 or better; nothing to recast"
+                    )
             except Exception:
                 logger.warning(
                     "fp16 activation recast failed; staying on bfloat16",

--- a/omlx/model_profiles.py
+++ b/omlx/model_profiles.py
@@ -104,6 +104,9 @@ EXCLUDED_FROM_PROFILES = frozenset(
         "ttl_seconds",
         # Hardware-specific residency choice; never propagate across models.
         "qwen4_ple_ssd_offload",
+        # Only meaningful for checkpoints that carry bfloat16 leaves; the
+        # dashboard gates it per model, so a profile must not carry it over.
+        "activation_fp16_enabled",
         # Security flag must be explicit per model — never propagated via profiles.
         "trust_remote_code",
     }

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -220,6 +220,11 @@ class ModelSettings:
     # through mmap. The runtime may force this on when resident loading cannot
     # fit under the configured model-memory ceiling but mmap loading can.
     qwen4_ple_ssd_offload: bool = False
+    # Recast the checkpoint's bfloat16 leaves (scales, norms, embeddings) to
+    # float16 after load, so the forward runs on the GPU's native float16 path
+    # instead of the emulated bfloat16 one. Quantized payloads are untouched.
+    # Measured on Qwen3.8-Flash-Next / M1 Ultra: -9% ms per decode cycle.
+    activation_fp16_enabled: bool = False
     preserve_thinking: Optional[bool] = (
         None  # Keep <think> blocks in historical turns (None = auto, True when template supports it)
     )

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -1199,6 +1199,33 @@ def materialize_lazy_state(model: Any) -> None:
             mx.eval(arrays[start : start + _MATERIALIZE_EVAL_CHUNK])
 
 
+def checkpoint_has_bf16_leaves(model_path: str) -> bool:
+    """Whether the checkpoint on disk still carries bfloat16 tensors.
+
+    The fp16 activation recast only has work to do when it does: a checkpoint
+    already stored in float16 makes the toggle a no-op, so the admin UI uses
+    this to gate it out. Reads only the safetensors headers (a few KB each) and
+    stops at the first bfloat16 tensor.
+    """
+    if not model_path:
+        return False
+    try:
+        shards = sorted(Path(model_path).glob("*.safetensors"))
+    except OSError:
+        return False
+    for shard in shards:
+        try:
+            with open(shard, "rb") as handle:
+                header_len = int.from_bytes(handle.read(8), "little")
+                header = json.loads(handle.read(header_len))
+        except (OSError, ValueError):
+            continue
+        for name, spec in header.items():
+            if name != "__metadata__" and isinstance(spec, dict) and spec.get("dtype") == "BF16":
+                return True
+    return False
+
+
 def cast_bf16_params_to_fp16(model: Any) -> int:
     """Recast every bfloat16 parameter of a loaded model to float16.
 
@@ -1249,7 +1276,12 @@ def apply_post_load_transforms(model: Any, model_settings: Any = None) -> Any:
     ):
         try:
             recast = cast_bf16_params_to_fp16(model)
-            logger.info("activation dtype: bfloat16 -> float16 (%d tensors)", recast)
+            if recast:
+                logger.info("activation dtype: bfloat16 -> float16 (%d tensors)", recast)
+            else:
+                logger.info(
+                    "activation dtype: already float16 or better; nothing to recast"
+                )
         except Exception:
             logger.warning("fp16 activation recast failed; staying on bfloat16", exc_info=True)
 

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Any
 
@@ -1198,6 +1199,34 @@ def materialize_lazy_state(model: Any) -> None:
             mx.eval(arrays[start : start + _MATERIALIZE_EVAL_CHUNK])
 
 
+def cast_bf16_params_to_fp16(model: Any) -> int:
+    """Recast every bfloat16 parameter of a loaded model to float16.
+
+    The M1/M2 GPU has no native bfloat16 ALU path — Metal emulates it — while
+    float16 is native. Activation dtype follows the dtype of the non-quantized
+    leaves (scales, biases, norms, embeddings), so recasting them moves the
+    whole forward onto the native path. Quantized U32 payloads are untouched.
+
+    Conversion runs in the same bounded chunks materialize_lazy_state uses, and
+    updates the tree per chunk so the bfloat16 originals are released as we go
+    instead of doubling peak memory.
+
+    Returns the number of tensors recast.
+    """
+    from mlx.utils import tree_unflatten
+
+    pending = [
+        (key, value)
+        for key, value in tree_flatten(model.parameters())
+        if isinstance(value, mx.array) and value.dtype == mx.bfloat16
+    ]
+    for start in range(0, len(pending), _MATERIALIZE_EVAL_CHUNK):
+        chunk = [(key, value.astype(mx.float16)) for key, value in pending[start : start + _MATERIALIZE_EVAL_CHUNK]]
+        mx.eval([value for _, value in chunk])
+        model.update(tree_unflatten(chunk))
+    return len(pending)
+
+
 def apply_post_load_transforms(model: Any, model_settings: Any = None) -> Any:
     """Apply optional post-load model transforms based on settings.
 
@@ -1213,6 +1242,17 @@ def apply_post_load_transforms(model: Any, model_settings: Any = None) -> Any:
     Returns:
         The (possibly patched) model.
     """
+    # Native-fp16 activations. Off by default; OMLX_ACT_FP16=1 forces it on for
+    # a one-off A/B without touching persisted settings.
+    if os.environ.get("OMLX_ACT_FP16") == "1" or getattr(
+        model_settings, "activation_fp16_enabled", False
+    ):
+        try:
+            recast = cast_bf16_params_to_fp16(model)
+            logger.info("activation dtype: bfloat16 -> float16 (%d tensors)", recast)
+        except Exception:
+            logger.warning("fp16 activation recast failed; staying on bfloat16", exc_info=True)
+
     # t5 bias recovery for text-engine loads (~420 MB on Bonsai-27B).
     # VLMBatchedEngine calls free_t5_biases explicitly; this covers the
     # BatchedEngine / LLM path, and is a no-op for non-t5 models.

--- a/tests/test_activation_fp16_recast.py
+++ b/tests/test_activation_fp16_recast.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cover the fp16 activation recast used by the OMLX_ACT_FP16 experiment."""
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.utils import tree_flatten
+
+from omlx.utils.model_loading import cast_bf16_params_to_fp16
+
+
+def _toy_quantized_model() -> nn.Module:
+    model = nn.Sequential(
+        nn.Linear(64, 128),
+        nn.RMSNorm(128),
+        nn.Linear(128, 32),
+    )
+    model.set_dtype(mx.bfloat16)
+    nn.quantize(model, group_size=64, bits=4)
+    mx.eval(model.parameters())
+    return model
+
+
+def test_recast_moves_bf16_leaves_to_fp16_and_keeps_u32_payloads():
+    model = _toy_quantized_model()
+    x = mx.random.normal((4, 64)).astype(mx.bfloat16)
+    before = model(x)
+    mx.eval(before)
+
+    quant_before = {
+        key: value
+        for key, value in tree_flatten(model.parameters())
+        if value.dtype == mx.uint32
+    }
+    assert quant_before, "toy model should carry quantized weights"
+
+    recast = cast_bf16_params_to_fp16(model)
+    assert recast > 0
+
+    dtypes = {value.dtype for _, value in tree_flatten(model.parameters())}
+    assert mx.bfloat16 not in dtypes
+    assert mx.float16 in dtypes
+
+    for key, value in tree_flatten(model.parameters()):
+        if key in quant_before:
+            assert value.dtype == mx.uint32
+            assert mx.array_equal(value, quant_before[key])
+
+    after = model(x.astype(mx.float16))
+    mx.eval(after)
+    assert after.dtype == mx.float16
+    # Same math, different rounding: bf16 has 8 mantissa bits, fp16 has 11.
+    assert mx.allclose(after.astype(mx.float32), before.astype(mx.float32), atol=5e-2)
+
+
+def test_recast_is_a_noop_when_nothing_is_bf16():
+    model = nn.Linear(8, 8)
+    model.set_dtype(mx.float16)
+    mx.eval(model.parameters())
+    assert cast_bf16_params_to_fp16(model) == 0
+
+
+if __name__ == "__main__":
+    test_recast_moves_bf16_leaves_to_fp16_and_keeps_u32_payloads()
+    test_recast_is_a_noop_when_nothing_is_bf16()
+    print("OK")

--- a/tests/test_activation_fp16_recast.py
+++ b/tests/test_activation_fp16_recast.py
@@ -63,3 +63,28 @@ if __name__ == "__main__":
     test_recast_moves_bf16_leaves_to_fp16_and_keeps_u32_payloads()
     test_recast_is_a_noop_when_nothing_is_bf16()
     print("OK")
+
+
+def test_checkpoint_has_bf16_leaves_reads_safetensors_headers(tmp_path):
+    import json as _json
+    import struct
+
+    from omlx.utils.model_loading import checkpoint_has_bf16_leaves
+
+    def _write(path, dtype):
+        header = _json.dumps({"w": {"dtype": dtype, "shape": [2], "data_offsets": [0, 4]}}).encode()
+        path.write_bytes(struct.pack("<Q", len(header)) + header + b"\x00" * 4)
+
+    bf16_dir = tmp_path / "bf16"
+    bf16_dir.mkdir()
+    _write(bf16_dir / "model-00001.safetensors", "F16")
+    _write(bf16_dir / "model-00002.safetensors", "BF16")
+    assert checkpoint_has_bf16_leaves(str(bf16_dir)) is True
+
+    fp16_dir = tmp_path / "fp16"
+    fp16_dir.mkdir()
+    _write(fp16_dir / "model-00001.safetensors", "F16")
+    assert checkpoint_has_bf16_leaves(str(fp16_dir)) is False
+
+    assert checkpoint_has_bf16_leaves("") is False
+    assert checkpoint_has_bf16_leaves(str(tmp_path / "nao-existe")) is False

--- a/tests/test_admin_api_key.py
+++ b/tests/test_admin_api_key.py
@@ -133,6 +133,61 @@ class TestListModelsSettings:
         assert model["qwen4_ple_resident_bytes"] == 1000
         assert model["qwen4_ple_mmap_bytes"] == 400
 
+    def test_list_models_reports_activation_fp16_support(self, tmp_path):
+        import json as _json
+        import struct
+
+        def _checkpoint(name, dtype):
+            path = tmp_path / name
+            path.mkdir()
+            header = _json.dumps(
+                {"w": {"dtype": dtype, "shape": [2], "data_offsets": [0, 4]}}
+            ).encode()
+            (path / "model-00001.safetensors").write_bytes(
+                struct.pack("<Q", len(header)) + header + b"\x00" * 4
+            )
+            return path
+
+        def _supported(model_path):
+            pool = MagicMock()
+            pool.get_status.return_value = {
+                "models": [
+                    {
+                        "id": model_path.name,
+                        "model_path": str(model_path),
+                        "estimated_size": 1000,
+                    }
+                ]
+            }
+            manager = MagicMock()
+            manager.get_all_settings.return_value = {}
+            state = MagicMock(default_model=None)
+
+            with (
+                patch.object(admin_routes, "_get_engine_pool", return_value=pool),
+                patch.object(
+                    admin_routes, "_get_settings_manager", return_value=manager
+                ),
+                patch.object(admin_routes, "_get_server_state", return_value=state),
+                patch.object(admin_routes, "_get_global_settings", return_value=None),
+                patch.object(
+                    admin_routes, "_dflash_compat_for_model", return_value=(False, "")
+                ),
+                patch.object(
+                    admin_routes, "_mtp_compat_for_model", return_value=(False, "")
+                ),
+                patch.object(
+                    admin_routes,
+                    "_paroquant_compat_for_model",
+                    return_value=(False, ""),
+                ),
+            ):
+                result = asyncio.run(admin_routes.list_models(is_admin=True))
+            return result["models"][0]["activation_fp16_supported"]
+
+        assert _supported(_checkpoint("bf16", "BF16")) is True
+        assert _supported(_checkpoint("fp16", "F16")) is False
+
     def test_list_models_adds_display_name_without_changing_id(self, tmp_path):
         """Ensure nested model paths only affect UI display names."""
         model_root = tmp_path / "models"


### PR DESCRIPTION
## The problem

M1 and M2 have no bfloat16 circuit — Metal emulates it in software. float16 they run
natively.

Which one the forward uses is decided by the checkpoint's non-quantized tensors: the
scales, biases, norms and embeddings. On a published quant those are bf16, so every
forward pays the emulation, on hardware that has the fast path sitting idle.

## What this does

After the model is loaded, walk the parameter tree and recast **only the bf16 tensors** to
fp16. On Qwen3.8-Flash-Next that is 2725 tensors (15.41 GB). The 1020 quantized U32 tensors
(90.88 GB) are packed integers — they have no float dtype and are never touched.

Both dtypes are 16 bits, so nothing grows. The walk goes in chunks of 8, updating the tree
as it goes, so the old tensors are freed along the way instead of all at the end — otherwise
peak memory would spike by 15 GB. Cost: 0.6 s on a 42 s load, measured over 63 loads.

Off by default. `model_settings.activation_fp16_enabled` per model, or `OMLX_ACT_FP16=1`
for a one-off A/B.

## Results

Apple M1 Ultra 128 GB, `Qwen3.8-Flash-Next-oQ4e-mtp`, model-card sampling.

**Decode** — spec-ab neutral preset, 24 runs per side per scenario, two loads per arm:

```
scenario           bf16          fp16    gain     floor
rewrite    28.29+-0.67   32.26+-0.94  +14.0%      6.9%
novel      22.89+-0.36   24.07+-0.29   +5.2%      2.8%
```

**Prefill** — arms interleaved bf16/fp16/bf16/fp16, unique prompt each run, no cache hits:

```
mode    n     mean    se
bf16    6    313.2   3.2   tokens/s
fp16    6    500.2   6.6   tokens/s     +59.7%  [+55.0 .. +64.4]
```

Prefill gains four times what decode does: it processes thousands of positions at once, so
arithmetic dominates. Decode processes 1-16 and is latency-bound.

Per-cycle cost drops ~9% in both decode scenarios while draft acceptance stays flat
(0.588→0.601, 0.470→0.442). That is a cheaper forward, not better drafting.

## Correctness

All 12 prefill runs (~19k unique tokens each) returned the same answer, and it is correct.
Not bit-identical to bf16 — 8 mantissa bits vs 11, so rounding differs and greedy can take a
different path. No saturation at 17.4k prompt tokens.

`tests/test_activation_fp16_recast.py` pins that the recast converts bf16 leaves, leaves U32
payloads bit-identical, and is a no-op when nothing is bf16.

## Relation to #3255

That PR picks the dtype when **generating** a checkpoint. This one fixes a checkpoint that
already exists on disk — for anyone who downloaded a published bf16-scaled quant and cannot
regenerate 100 GB+. They compose; neither replaces the other.

## Not claimed

Untested on M3+, where bf16 is native and this should stay off. Numbers come from one model.
