### PR TITLE
fix(glm5_next): register the model in mlx-vlm's prompt MODEL_CONFIG

### DIFF
--- a/omlx/patches/mlx_vlm_glm5_next_compat/__init__.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/__init__.py
@@ -41,6 +41,18 @@ def apply_mlx_vlm_glm5_next_compat_patch() -> bool:
         _append_package_path(mlx_vlm, _VENDOR_MLX_VLM)
         _append_package_path(mlx_vlm.models, _VENDOR_MLX_VLM / "models")
         importlib.import_module("mlx_vlm.models.glm5_next")
+
+        # mlx-vlm has no glm5_next entry in MODEL_CONFIG, so get_message_json()
+        # raises "Unsupported model: glm5_next" on every turn that carries no
+        # image.  That aborts _format_messages_for_vlm_template() as a whole,
+        # so the engine falls back to mlx-vlm's generic formatter, which emits
+        # no image placeholders -- while oMLX still extracts the images.  Any
+        # conversation mixing an image with a plain turn then fails with
+        # "More images were provided than image tokens."  GLM-5.3 takes the
+        # same list-with-image-first shape as glm4v.
+        from mlx_vlm.prompt_utils import MODEL_CONFIG, MessageFormat
+
+        MODEL_CONFIG.setdefault("glm5_next", MessageFormat.LIST_WITH_IMAGE_FIRST)
     except Exception as exc:  # noqa: BLE001
         logger.debug("GLM-5.3 mlx-vlm registration failed: %s", exc)
         return False


### PR DESCRIPTION
## Symptom

Any GLM-5.3-Flash conversation that carries an image **alongside a plain turn** fails:

```
Failed to process inputs with error: More images were provided than image tokens.
```

In practice that is every agentic session that looks at a screenshot — ZCode after a browser capture, Codex `view_image`. The stream dies mid-turn and the client shows `Reconnecting... 1/5 … 5/5`.

The confusing part, and why this took a while to pin down: **a lone image in a user message works fine.** It only breaks once the conversation also contains a text-only turn.

| shape | before |
|---|---|
| user message with an image | works |
| image inside a `tool_result` / `function_call_output` | fails |

## Cause

`mlx_vlm.prompt_utils.MODEL_CONFIG` has no `glm5_next` entry, so `get_message_json()` raises for turns without an image:

```
>>> get_message_json("glm5_next", "merhaba", "user", num_images=0, ...)
ValueError: Unsupported model: glm5_next
```

`_format_messages_for_vlm_template()` calls it in the `else` branch for exactly those turns, so the exception propagates out of the whole function. `vlm.chat()` catches it and falls back to mlx-vlm's generic formatter — which emits no image placeholders — while oMLX has already extracted the images. `images=1` against `image_tokens=0` then trips the processor.

The knock-on effect is that the `elif model_type == "glm5_next" and msg_num_images > 0:` branch already present in `_format_messages_for_vlm_template()` (the one that inserts `{"type": "image"}` markers) never gets a chance to run. Its own comment notes mlx-vlm doesn't register the model — this PR closes that gap so the branch can work.

## Fix

Register `glm5_next` in `MODEL_CONFIG` from the compat patch that already vendors the model. With the entry present:

```
>>> get_message_json("glm5_next", "kac kare", "user", num_images=1, skip_image_token=False, ...)
{'role': 'user', 'content': [{'type': 'image'}, {'type': 'text', 'text': 'kac kare', ...}]}
```

and the checkpoint's own chat template expands each marker to the GLM image-token triplet (`<|begin_of_image|><|image|><|end_of_image|>`). `setdefault` so a future upstream mlx-vlm entry wins.

`LIST_WITH_IMAGE_FIRST` mirrors `glm4v` / `glm4v_moe` / `glm_ocr`, and matches what the GLM-5.3 template's `visible_text` macro expects.

## Verification

All against `GLM-5.3-Flash` (a local oQ4e conversion), oMLX 0.6.3, M3 Ultra 512 GB:

| case | endpoint | before | after |
|---|---|---|---|
| image in an Anthropic `tool_result` | `/v1/messages` | 500 | correct answer |
| image in a `function_call_output` | `/v1/responses` | 500 | correct answer |
| plain image in a user message | `/v1/messages` | ok | ok |
| plain image in a user message | `/v1/chat/completions` | ok | ok |
| tool calling, no images | `/v1/messages` | ok | ok (`stop_reason: tool_use`) |
| long-context text | `/v1/chat/completions` | ok | ok |

The image used is a generated PNG with 3 blue squares, 1 red circle and 2 green triangles; the model counts all of them correctly and OCRs the embedded caption, through every path above.

Offline check of the two halves in isolation, which is what made the mechanism legible:

```
messages built by convert_anthropic_to_internal(preserve_images=True):  1 image
tokenizer.apply_chat_template(...) on those messages:                   1 <|image|>
```

so the message pipeline was never at fault — only the formatter that the engine actually uses.

Happy to run anything else on this hardware.
