### PR TITLE
fix(scheduler): materialize restored mRoPE seed

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1382,6 +1382,8 @@ def _seed_text_only_mrope_delta_for_cached_prefill(model: Any, request: Any) -> 
     if lm is None or not hasattr(lm, "_rope_deltas"):
         return
     lm._rope_deltas = mx.zeros((1, 1), dtype=mx.int64)
+    # Keep the restore-only seed concrete before the engine-stream graph uses it.
+    mx.eval(lm._rope_deltas)
 
 
 def _vlm_extra_seq_slice(val: mx.array, s: slice) -> mx.array:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -5751,17 +5751,101 @@ class TestVLMPositionStateClearing:
         request.num_prompt_tokens = 4
         request.cached_tokens = 2048
 
-        scheduler._do_external_prefill(
-            request,
-            tokens=[1, 2, 3, 4],
-            existing_cache=[],
-            vlm_embeds=None,
-        )
+        with patch.object(
+            scheduler_module,
+            "_seed_text_only_mrope_delta_for_cached_prefill",
+            wraps=scheduler_module._seed_text_only_mrope_delta_for_cached_prefill,
+        ) as seed_mrope:
+            scheduler._do_external_prefill(
+                request,
+                tokens=[1, 2, 3, 4],
+                existing_cache=[],
+                vlm_embeds=None,
+            )
 
         model.clear_vlm_position_state.assert_called_once()
+        seed_mrope.assert_called_once_with(model, request)
         seeded = model._language_model._rope_deltas
         assert seeded.shape == (1, 1)
+        assert seeded.dtype == mx.int64
         assert seeded.item() == 0
+
+    def test_cached_text_only_mrope_seed_is_materialized(self):
+        """The exact restore-only seed must be concrete before prefill starts."""
+        language_model = SimpleNamespace(_rope_deltas=mx.array([[123]]))
+        model = SimpleNamespace(_language_model=language_model)
+        request = SimpleNamespace(cached_tokens=2048)
+
+        with patch.object(scheduler_module.mx, "eval") as eval_mock:
+            scheduler_module._seed_text_only_mrope_delta_for_cached_prefill(
+                model, request
+            )
+
+        seeded = language_model._rope_deltas
+        assert seeded.shape == (1, 1)
+        assert seeded.dtype == mx.int64
+        assert eval_mock.call_count == 1
+        assert eval_mock.call_args.args[0] is seeded
+
+    def test_fresh_text_only_prefill_does_not_seed_or_evaluate_mrope(self):
+        previous = mx.array([[123]])
+        language_model = SimpleNamespace(_rope_deltas=previous)
+        model = SimpleNamespace(_language_model=language_model)
+        request = SimpleNamespace(cached_tokens=0)
+
+        with patch.object(scheduler_module.mx, "eval") as eval_mock:
+            scheduler_module._seed_text_only_mrope_delta_for_cached_prefill(
+                model, request
+            )
+
+        assert language_model._rope_deltas is previous
+        eval_mock.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            SimpleNamespace(),
+            SimpleNamespace(_language_model=SimpleNamespace()),
+        ],
+    )
+    def test_text_only_mrope_seed_ignores_models_without_state(self, model):
+        before = vars(model).copy()
+        request = SimpleNamespace(cached_tokens=2048)
+
+        with patch.object(scheduler_module.mx, "eval") as eval_mock:
+            scheduler_module._seed_text_only_mrope_delta_for_cached_prefill(
+                model, request
+            )
+
+        assert vars(model) == before
+        eval_mock.assert_not_called()
+
+    def test_chunked_prefill_initialization_seeds_cached_text_mrope(
+        self, mock_tokenizer
+    ):
+        model = self._make_vlm_model()
+        model._language_model = SimpleNamespace(_rope_deltas=mx.array([[123]]))
+        scheduler = Scheduler(model=model, tokenizer=mock_tokenizer)
+        request = Request(
+            request_id="text-cached-chunked-001",
+            prompt="hello world",
+            sampling_params=SamplingParams(max_tokens=50),
+        )
+        request.cached_tokens = 2048
+
+        with patch.object(
+            scheduler_module,
+            "_seed_text_only_mrope_delta_for_cached_prefill",
+            wraps=scheduler_module._seed_text_only_mrope_delta_for_cached_prefill,
+        ) as seed_mrope:
+            scheduler._begin_prefill(
+                request,
+                tokens=[1, 2, 3, 4],
+                existing_cache=[],
+            )
+
+        model.clear_vlm_position_state.assert_called_once()
+        seed_mrope.assert_called_once_with(model, request)
 
 
 class TestBuildStateMachineStopStrings:


### PR DESCRIPTION
## Summary

Fixes #3233.

Materialize the text-only mRoPE seed created when continuing from a restored prefix cache before the engine-stream prefill graph consumes it.

For restored text-only requests, the scheduler assigns a lazy zero-valued array to `lm._rope_deltas`. Qwen3.8 uses this seed while constructing positions for the uncached suffix. Because the seed was created outside the engine stream, it introduced a lazy cross-stream dependency into the prefill graph.

This could corrupt Qwen3.8 ANE/NAX prefills or cause a Metal command-buffer timeout. Observed symptoms included continuation of earlier tool content, immediate EOS, and run-to-run variance with combined MLP and GDN offload.

## Fix

Evaluate the restore-only seed immediately after creating it:

```python
lm._rope_deltas = mx.zeros((1, 1), dtype=mx.int64)
mx.eval(lm._rope_deltas)
```

This makes the seed concrete before the engine-stream graph consumes it. The evaluation occurs once per restored text-only request and does not affect fresh requests or models without the relevant mRoPE state.

## Validation

Added focused tests covering:

- creation of a `(1, 1)` `int64` seed;
- evaluation of that exact seed object;
- no seeding or evaluation for fresh requests;
- no changes to models without the relevant language-model state;
- both external and chunked-prefill initialization paths.

Test results:

- `tests/test_scheduler.py::TestVLMPositionStateClearing`: 8 passed
- `tests/test_scheduler.py`: 226 passed
- Related chunked-prefill, VLM adapter, and Qwen ANE tests: 234 passed
- Non-slow suite: 10,472 passed, 106 skipped, 77 deselected

The same correction was also validated on:

- M3 Max: deterministic minimized server reproduction and direct scheduler reproduction;
- M5 Pro/NAX: restored padded-tail case 5/5 and combined MLP+GDN comparison 5/5;
- M3 Ultra with Lightning MTP, dual ANE, and concurrent requests: 20/20 agentic turns.

The lazy cross-stream dependency is the confirmed causal trigger. The precise native failure mode—command-buffer deadlock versus consumption of incompletely produced buffers—remains inferred.
