### PR TITLE
fix(admin): persist mtp_num_draft_tokens via settings PUT

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -2395,7 +2395,12 @@ async def update_model_settings(
     if "turboquant_kv_bits" in sent:
         current_settings.turboquant_kv_bits = request.turboquant_kv_bits or 4
     if "turboquant_skip_last" in sent:
-        current_settings.turboquant_skip_last = bool(request.turboquant_skip_last)
+        # null = clear to the model default (True); bool(None) would flip it
+        # to False and silently disable the skip-last corruption guard.
+        current_settings.turboquant_skip_last = (
+            True if request.turboquant_skip_last is None
+            else bool(request.turboquant_skip_last)
+        )
     # Private Qwen3.5/3.6/3.8 ANE/GPU fixed-shape prefill. These are all load-time
     # controls; the runtime signature below causes a loaded model to be
     # re-created when the user applies a changed profile.
@@ -2930,8 +2935,6 @@ async def update_model_settings(
         or "dflash_in_memory_cache_max_bytes" in sent
         or "dflash_ssd_cache" in sent
         or "dflash_ssd_cache_max_bytes" in sent
-        # MTP draft token count is an engine-construction control.
-        or "mtp_num_draft_tokens" in sent
         # trust_remote_code is plumbed at model load time; toggling it on
         # an already-loaded engine has no effect until reload.
         or "trust_remote_code" in sent

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -28,7 +28,7 @@ import requests
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from ..api.markitdown import MARKITDOWN_MODEL_ID, markitdown_model_visible
 from ..api.openai_models import _coerce_tool_call_arguments
@@ -112,6 +112,8 @@ class CacheProbeRequest(BaseModel):
 class ModelSettingsRequest(BaseModel):
     """Request model for updating per-model settings."""
 
+    model_config = ConfigDict(extra="forbid")
+
     model_alias: str | None = None
     model_type_override: str | None = None
     max_context_window: int | None = None
@@ -129,12 +131,18 @@ class ModelSettingsRequest(BaseModel):
     ttl_seconds: int | None = None
     index_cache_freq: int | None = None
     enable_thinking: bool | None = None
+    # Keep  thinking blocks in historical turns (None = auto, True when the
+    # template supports it). Mirrors ModelSettings.preserve_thinking.
+    preserve_thinking: bool | None = None
     qwen4_ple_ssd_offload: bool | None = None
     thinking_budget_enabled: bool | None = None
     thinking_budget_tokens: int | None = None
+    # MTP draft tokens per cycle for legacy MTP (None = adaptive default).
+    mtp_num_draft_tokens: int | None = None
     # TurboQuant KV cache (mlx-vlm backend)
     turboquant_kv_enabled: bool | None = None
     turboquant_kv_bits: float | None = None
+    turboquant_skip_last: bool | None = None
     # Private Qwen3.5/3.6/3.8 ANE/GPU fixed-shape prefill
     qwen35_ane_prefill_enabled: bool | None = None
     qwen35_ane_prefill_sequence_length: int | None = None
@@ -2358,6 +2366,16 @@ async def update_model_settings(
             if request.thinking_budget_tokens and request.thinking_budget_tokens > 0
             else None
         )
+    if "mtp_num_draft_tokens" in sent:
+        value = request.mtp_num_draft_tokens
+        if value is not None and value < 1:
+            raise HTTPException(
+                status_code=400,
+                detail="mtp_num_draft_tokens must be a positive integer (or null).",
+            )
+        current_settings.mtp_num_draft_tokens = value
+    if "preserve_thinking" in sent:
+        current_settings.preserve_thinking = request.preserve_thinking
     if "chat_template_kwargs" in sent:
         current_settings.chat_template_kwargs = request.chat_template_kwargs
     if "forced_ct_kwargs" in sent:
@@ -2376,6 +2394,8 @@ async def update_model_settings(
         current_settings.turboquant_kv_enabled = request.turboquant_kv_enabled or False
     if "turboquant_kv_bits" in sent:
         current_settings.turboquant_kv_bits = request.turboquant_kv_bits or 4
+    if "turboquant_skip_last" in sent:
+        current_settings.turboquant_skip_last = bool(request.turboquant_skip_last)
     # Private Qwen3.5/3.6/3.8 ANE/GPU fixed-shape prefill. These are all load-time
     # controls; the runtime signature below causes a loaded model to be
     # re-created when the user applies a changed profile.
@@ -2910,6 +2930,8 @@ async def update_model_settings(
         or "dflash_in_memory_cache_max_bytes" in sent
         or "dflash_ssd_cache" in sent
         or "dflash_ssd_cache_max_bytes" in sent
+        # MTP draft token count is an engine-construction control.
+        or "mtp_num_draft_tokens" in sent
         # trust_remote_code is plumbed at model load time; toggling it on
         # an already-loaded engine has no effect until reload.
         or "trust_remote_code" in sent

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -586,6 +586,11 @@ class EnginePool:
         # force a reload when the corresponding feature is disabled.
         mtp_active = bool(data.get("mtp_enabled", False))
         add("mtp_enabled", mtp_active)
+        # Draft depth is read once at engine construction; it must be in the
+        # signature while Lightning MTP is active so a change reloads the
+        # engine, but a stale value must not force one when MTP is off.
+        if mtp_active:
+            add("mtp_num_draft_tokens", data.get("mtp_num_draft_tokens"))
         if entry is not None:
             qwen4_offload, _, _ = self._qwen4_ple_offload_status(entry, settings)
             add("qwen4_ple_ssd_offload", qwen4_offload)

--- a/tests/test_admin_model_settings.py
+++ b/tests/test_admin_model_settings.py
@@ -397,3 +397,48 @@ def test_unknown_settings_fields_are_rejected_loudly():
     with pytest.raises(pydantic.ValidationError, match="bogus_field"):
         # Simulate a client sending a field that has no admin-PUT support.
         admin_routes.ModelSettingsRequest(mtp_num_draft_tokens=8, bogus_field=1)
+
+
+@pytest.mark.asyncio
+async def test_turboquant_skip_last_null_preserves_default_true():
+    """null = clear to the model default; it must not flip the default to
+    False via bool(None) (review feedback on the silent-drop fix)."""
+    pool, _ = _failed_pool()
+    settings = ModelSettings()  # default turboquant_skip_last=True
+
+    result = await _update_settings(
+        pool,
+        settings,
+        admin_routes.ModelSettingsRequest(turboquant_skip_last=None),
+    )
+
+    assert settings.turboquant_skip_last is True
+    assert result["settings"]["turboquant_skip_last"] is True
+
+
+def test_runtime_signature_gates_mtp_depth_on_lightning_mtp():
+    """mtp_num_draft_tokens must be part of the engine runtime signature only
+    while Lightning MTP (mtp_enabled) is active (review feedback), so a depth
+    change reloads a loaded engine, but a stale value never forces one."""
+    from omlx.engine_pool import EnginePool
+
+    pool = EnginePool()
+
+    depth_3_on = ModelSettings(mtp_enabled=True, mtp_num_draft_tokens=3)
+    depth_8_on = ModelSettings(mtp_enabled=True, mtp_num_draft_tokens=8)
+    depth_3_off = ModelSettings(mtp_enabled=False, mtp_num_draft_tokens=3)
+    depth_8_off = ModelSettings(mtp_enabled=False, mtp_num_draft_tokens=8)
+
+    on_keys = {k for k, _ in pool._engine_runtime_signature("m", depth_3_on)}
+    assert "mtp_num_draft_tokens" in on_keys
+    off_keys = {k for k, _ in pool._engine_runtime_signature("m", depth_3_off)}
+    assert "mtp_num_draft_tokens" not in off_keys
+
+    # Active MTP: different depths produce different signatures (reload).
+    assert pool._engine_runtime_signature("m", depth_3_on) != pool._engine_runtime_signature(
+        "m", depth_8_on
+    )
+    # Inactive MTP: the value is invisible to the signature (no reload).
+    assert pool._engine_runtime_signature("m", depth_3_off) == pool._engine_runtime_signature(
+        "m", depth_8_off
+    )

--- a/tests/test_admin_model_settings.py
+++ b/tests/test_admin_model_settings.py
@@ -334,3 +334,66 @@ async def test_qwen_ane_prefill_rejects_other_model_families():
             ModelSettings(),
             admin_routes.ModelSettingsRequest(qwen35_ane_prefill_enabled=True),
         )
+
+
+@pytest.mark.asyncio
+async def test_mtp_draft_tokens_is_persisted_not_dropped():
+    """#2823: mtp_num_draft_tokens used to be silently discarded by PUT."""
+    pool, _ = _failed_pool()
+    settings = ModelSettings(mtp_num_draft_tokens=None)
+
+    result = await _update_settings(
+        pool,
+        settings,
+        admin_routes.ModelSettingsRequest(mtp_num_draft_tokens=8),
+    )
+
+    assert settings.mtp_num_draft_tokens == 8
+    assert result["settings"]["mtp_num_draft_tokens"] == 8
+
+
+@pytest.mark.asyncio
+async def test_preserve_thinking_and_turboquant_skip_last_are_persisted():
+    """Same silent-drop class as #2823 for the other two engine settings."""
+    pool, _ = _failed_pool()
+    settings = ModelSettings(
+        preserve_thinking=False,
+        turboquant_skip_last=True,
+    )
+
+    result = await _update_settings(
+        pool,
+        settings,
+        admin_routes.ModelSettingsRequest(
+            preserve_thinking=True,
+            turboquant_skip_last=False,
+        ),
+    )
+
+    assert settings.preserve_thinking is True
+    assert settings.turboquant_skip_last is False
+    assert result["settings"]["preserve_thinking"] is True
+    assert result["settings"]["turboquant_skip_last"] is False
+
+
+@pytest.mark.asyncio
+async def test_mtp_draft_tokens_rejects_non_positive_values():
+    pool, _ = _failed_pool()
+
+    with pytest.raises(
+        admin_routes.HTTPException, match="must be a positive integer"
+    ):
+        await _update_settings(
+            pool,
+            ModelSettings(),
+            admin_routes.ModelSettingsRequest(mtp_num_draft_tokens=0),
+        )
+
+
+def test_unknown_settings_fields_are_rejected_loudly():
+    """Unknown keys must 422 instead of silently returning success:true."""
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError, match="bogus_field"):
+        # Simulate a client sending a field that has no admin-PUT support.
+        admin_routes.ModelSettingsRequest(mtp_num_draft_tokens=8, bogus_field=1)


### PR DESCRIPTION
## Summary

`PUT /admin/api/models/{id}/settings` silently dropped `mtp_num_draft_tokens`
(returning `success: true` while the value never reached
`model_settings.json`). The same silent-drop class also affected
`preserve_thinking` and `turboquant_skip_last` — all three are valid
`ModelSettings` fields but were never registered on the admin PUT path, so
Pydantic's default `extra="ignore"` swallowed them at parse time and the
handler never applied them.

Changes:

- Register `mtp_num_draft_tokens`, `preserve_thinking` and
  `turboquant_skip_last` on `ModelSettingsRequest` and apply them in the
  PUT handler. `mtp_num_draft_tokens` is validated as a positive integer
  or null, and — being an engine-construction control — a change also
  triggers the existing auto-reload path.
- Switch `ModelSettingsRequest` to `extra="forbid"`: unknown fields now
  fail with a 422 instead of silently returning `success: true`. The admin
  frontend sends exactly the declared fields (verified: all 65 payload
  keys are within the schema), so this cannot break the UI — it turns
  future "added to the engine but never registered on the API" mistakes
  into loud errors.

Verification:

- New unit tests: persistence for all three fields, positive-int
  validation, loud rejection of unknown keys. `tests/test_admin_model_settings.py`
  passes 19/19.
- Adjacent admin suites: 92 passed.
- Full suite with the CI filter (`pytest tests/ -m "not slow and not
  integration"`): 10439 passed. The 6 failures reproduce unchanged on
  clean `main` (cluster SSH supervisor, cluster seams, VLM MTP e2e —
  environment-bound) or are flaky (2 GDN sidecar tests pass on rerun);
  none touch this change.
- Live smoke against a server run from this branch: PUT
  `mtp_num_draft_tokens=8` → returned in the response **and** persisted in
  `model_settings.json`; unknown key → 422; `mtp=0` → 400; omitted fields
  are left untouched.

Closes #2823