### PR TITLE
fix(chat): promote "Regenerate with <model>" to the active model

### DIFF
--- a/omlx/admin/templates/chat.html
+++ b/omlx/admin/templates/chat.html
@@ -6691,6 +6691,21 @@
             generationOverride = { temperature: temp };
         }
 
+        // "Regenerate with <model>" promotes the override to this chat's active
+        // model (fixes #2729): the header/picker must follow the model that
+        // actually generates the reply, and the per-model settings for that
+        // model must feed the call instead of the stale settings of the model
+        // that previously failed to load.
+        if (opts.model) {
+            const gatewayId = this.resolveGatewayModelId(opts.model);
+            this.currentModel = gatewayId;
+            session.model = gatewayId;
+            if (!this.loadModelSettingsForModel(session, gatewayId)) {
+                await this.ensureSessionModelSettings(session, gatewayId);
+                this.saveModelSettingsForModel(session, gatewayId);
+            }
+        }
+
         await this.streamResponse({
             chatId: this.currentChatId,
             model: this.currentModel,

--- a/tests/test_chat_ui_overhaul.py
+++ b/tests/test_chat_ui_overhaul.py
@@ -208,3 +208,20 @@ def test_empty_thinking_content_is_not_rendered_or_replayed():
     assert "reasoning_content: this.hasVisibleThinking(stream.streamingThinking)" in stream
     assert 'x-if="hasVisibleThinking(msg._thinking)"' in html
     assert 'x-show="hasVisibleThinking(currentStream()?.streamingThinking)"' in html
+
+
+def test_regenerate_with_model_promotes_override_to_active_model():
+    """#2729: "Regenerate with <model>" must update the header/picker and load
+    the override model's settings instead of leaving the stale failed model
+    active."""
+    method = _section(
+        _template(),
+        '// "Regenerate with <model>" promotes the override to this chat\'s active',
+        "await this.streamResponse({",
+    )
+
+    assert "this.currentModel = gatewayId;" in method
+    assert "session.model = gatewayId;" in method
+    assert "this.loadModelSettingsForModel(session, gatewayId)" in method
+    assert "this.ensureSessionModelSettings(session, gatewayId)" in method
+    assert "this.saveModelSettingsForModel(session, gatewayId)" in method


### PR DESCRIPTION
## Summary

When a model failed to load and the user regenerated with a different
model via the "Regenerate with" dropdown, the floating header/picker
kept showing the failed model. The one-off `_modelOverride` streamed
with the right model (so the reply's model label was correct), but it
never updated `currentModel` or `session.model`, and the call reused the
failed model's stale generation settings.

Changes (in `regenerateMessage`):

- An explicit `opts.model` is now promoted to the chat's active model:
  `currentModel` and `session.model` are both updated, so the header
  follows the model that actually responds, and later sends / reopening
  the chat stay on it (the per-model settings map is keyed by session
  model, so settings for the regenerated-with model are loaded before
  streaming instead of reusing the previous model's).
- The "one-off override never mutates saved settings" invariant is
  preserved: only the active-model pointer and its settings view change,
  never the stored per-model settings.

Verified:

- New regression test in `tests/test_chat_ui_overhaul.py` asserts the
  promotion and settings-load logic in `regenerateMessage`.
- Chat-related suites: 53 passed; chat.html inline JS passes `node
  --check` (Jinja stripped).
- Full suite with the CI filter: 10440 passed; the 6 failures reproduce
  unchanged on clean `main` (cluster SSH supervisor, cluster seams, VLM
  MTP e2e — environment-bound) or are flaky (2 GDN sidecar tests pass on
  rerun); none relate to this change.

Closes #2729