### PR TITLE
fix(qwen4-exp): resolve prefill memory blowup for QSA long-context

### DIFF
--- a/omlx/cache/boundary_snapshot_store.py
+++ b/omlx/cache/boundary_snapshot_store.py
@@ -97,8 +97,37 @@ def _gdn_rht_sign_values(dim: int, seed: int) -> tuple[float, ...]:
     )
 
 
+def _session_owner_pid_is_live(pid: int) -> bool:
+    """Is the process that owns a boundary-snapshot session still running?
+
+    Mirrors ``cluster/liveness.py``'s ``_pid_is_live``, kept as a local
+    copy rather than an import so this module carries no dependency on
+    the optional cluster package — the same reasoning that module states
+    for keeping its own copy local. An unreadable pid is treated as live:
+    refusing to reap is the safe answer when we cannot tell.
+    """
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except (PermissionError, OverflowError, TypeError, ValueError):
+        return True
+    return True
+
+
 def reset_boundary_snapshot_root(base_dir: Path) -> None:
-    """Remove all boundary snapshot sessions for a server lifecycle boundary."""
+    """Remove dead-owner boundary snapshot sessions for a lifecycle boundary.
+
+    Per-session-aware (design doc §B2): a blanket rmtree strips every
+    session under this root, including one belonging to a *second* oMLX
+    process on this Mac (a server on another port, or a start racing a
+    slow shutdown) whose request is still in flight — the reset ignored
+    that sessions are per-process (``<pid>-<uuid>``) precisely so multiple
+    processes can coexist. Delete only sessions whose owning pid is dead;
+    in the common single-process case every existing session's owner is
+    necessarily dead (a fresh start has no other live line), so this
+    reduces to exactly the prior blanket-rmtree behavior.
+    """
     snapshot_root = base_dir / "_boundary_snapshots"
     if snapshot_root.is_symlink():
         logger.warning(
@@ -106,11 +135,29 @@ def reset_boundary_snapshot_root(base_dir: Path) -> None:
             snapshot_root,
         )
         return
-    if snapshot_root.exists():
-        try:
-            shutil.rmtree(snapshot_root)
-        except Exception as e:
-            logger.warning("Failed to reset boundary snapshots: %s", e)
+    if snapshot_root.is_dir():
+        for session_dir in list(snapshot_root.iterdir()):
+            if session_dir.is_symlink() or not session_dir.is_dir():
+                continue
+            pid_str, _, _rest = session_dir.name.partition("-")
+            try:
+                pid = int(pid_str)
+            except ValueError:
+                # This module only ever names a session "<pid>-<uuid>hex>";
+                # anything else was never a live session under this
+                # convention and is foreign debris, same treatment as a
+                # malformed name anywhere else in the cache tree (§A1).
+                pid = None
+            if pid is not None and _session_owner_pid_is_live(pid):
+                continue
+            try:
+                shutil.rmtree(session_dir)
+            except Exception as e:
+                logger.warning(
+                    "Failed to reap dead boundary snapshot session %s: %s",
+                    session_dir,
+                    e,
+                )
     snapshot_root.mkdir(parents=True, exist_ok=True)
 
 
@@ -187,6 +234,13 @@ class BoundarySnapshotSSDStore:
         self._pending_peak_bytes = 0
         self._backpressure_ms = 0.0
 
+        # Set by the external disk-pressure guard tick (design doc §R2).
+        # A boundary snapshot is only ever needed for a mid-chain restart;
+        # the request itself already has an existing degraded-save path
+        # (the placeholder marker below), so refusing under hard pressure
+        # reuses that path rather than inventing a new failure mode.
+        self._disk_pressure_hard = False
+
         # Cancelled requests with remaining queue item counts. Writer
         # thread decrements on each skip; entry is deleted when count
         # reaches zero, preventing unbounded growth. All access is
@@ -215,6 +269,14 @@ class BoundarySnapshotSSDStore:
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
+
+    def set_disk_pressure_hard(self, active: bool) -> None:
+        """Toggle the hard-floor degrade switch (design doc §R2).
+
+        Set by the external disk-pressure guard tick. Admission (serving
+        the request) is untouched; only new snapshot staging degrades.
+        """
+        self._disk_pressure_hard = bool(active)
 
     def save(
         self,
@@ -258,6 +320,13 @@ class BoundarySnapshotSSDStore:
             with self._pending_lock:
                 if pw_key in self._pending_writes:
                     return True
+
+            if self._disk_pressure_hard:
+                # Degrade to the existing failed-save placeholder path
+                # (design doc §R2/B1) instead of staging a new checkpoint —
+                # a boundary snapshot is only ever needed for a mid-chain
+                # restart, never for the request currently in flight.
+                return False
 
             # 1. Extract dict-format states on inference thread.
             extracted, model_cache_config = extract_cache_states_fn(snapshot_cache)

--- a/omlx/cache/boundary_snapshot_store.py
+++ b/omlx/cache/boundary_snapshot_store.py
@@ -50,6 +50,10 @@ logger = logging.getLogger(__name__)
 _MAX_PENDING_WRITES = 128
 _DEFAULT_PENDING_MAX_BYTES = 512 * 1024 * 1024
 _PENDING_RESERVATION_TIMEOUT_S = 2.0
+# A single boundary snapshot above this is almost certainly carrying a
+# sliceable layer's full KV prefix (recurrent-only state is ~100-200MB) —
+# see the oversized-snapshot warning in save().
+_OVERSIZED_SNAPSHOT_WARN_BYTES = 256 * 1024 * 1024
 _GDN_SIDECAR_FORMAT_VERSION = "2"
 _GDN_STATE_DTYPES = frozenset(
     {"fp32", "bf16", "int8", "rht_int8", "rht_int16"}
@@ -233,6 +237,8 @@ class BoundarySnapshotSSDStore:
         self._pending_bytes = 0
         self._pending_peak_bytes = 0
         self._backpressure_ms = 0.0
+        # Requests already warned about oversized snapshots (once per request).
+        self._oversized_warned_requests: set[str] = set()
 
         # Set by the external disk-pressure guard tick (design doc §R2).
         # A boundary snapshot is only ever needed for a mid-chain restart;
@@ -349,6 +355,29 @@ class BoundarySnapshotSSDStore:
             del extracted
 
             raw_size = sum(len(raw) for raw, _dtype, _shape in tensors_raw.values())
+
+            # Regression guard for the next unregistered sliceable cache
+            # class: recurrent boundary state (GDN etc.) is ~100-200MB per
+            # snapshot; a snapshot far above that almost certainly carries a
+            # sliceable layer's full KV prefix that the capture site failed
+            # to blank (Qwen4-Exp QSAKVCache shipped exactly this — ~1.1GB
+            # snapshots at 40k tokens, quadratic across a request, #2551
+            # class of bug). Warn once per request so the log names the
+            # problem before the memory guard does.
+            if raw_size > _OVERSIZED_SNAPSHOT_WARN_BYTES:
+                if request_id not in self._oversized_warned_requests:
+                    self._oversized_warned_requests.add(request_id)
+                    logger.warning(
+                        "Boundary snapshot for %s at %d tokens is unexpectedly "
+                        "large (%.0fMB > %.0fMB): a sliceable cache class may "
+                        "be missing from the boundary-snapshot skip set "
+                        "(scheduler._KNOWN_SLICEABLE_CACHE_TYPES), making "
+                        "snapshot cost quadratic in context length.",
+                        request_id,
+                        token_count,
+                        raw_size / 1024**2,
+                        _OVERSIZED_SNAPSHOT_WARN_BYTES / 1024**2,
+                    )
 
             # 3. Reserve a byte-bounded pending slot.  A single checkpoint is
             # allowed to exceed the configured cap when the queue is empty;
@@ -735,6 +764,7 @@ class BoundarySnapshotSSDStore:
         # Remove from registry.
         with self._registry_lock:
             self._file_registry.pop(request_id, None)
+        self._oversized_warned_requests.discard(request_id)
 
         # Wait briefly for the writer to finish any item it had already
         # pulled. If it's genuinely stuck (slow disk, dead thread) fall

--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -161,6 +161,19 @@ _MAX_PENDING_WRITES = _compute_max_pending_writes()
 # cost of taking multiple saves to fully reconverge.
 _MAX_INLINE_UNLINKS_PER_SAVE = 32
 
+# Throttle for persisting a main-block LRU touch to disk mtime on an SSD-tier
+# hit (design doc §A2). GDN sidecars always os.utime on hit; main blocks are
+# hit far more often, so this only fires once the previously recorded access
+# is itself more than this long stale — one extra syscall per cold hit that
+# actually needed it, none on a chain being hit repeatedly within the window.
+_MAIN_BLOCK_UTIME_THROTTLE_SECONDS = 3600
+
+# Minimum age (mtime) before a `*_tmp.safetensors` staging leftover is
+# treated as a crash remnant rather than a concurrent manager's in-flight
+# rename target. A live writer renames within seconds of creating the temp
+# file (`_write_block_file`), so this has wide margin.
+_TMP_STAGING_MIN_AGE_SECONDS = 600
+
 
 # Cache format version. Bump when on-disk layout or RotatingKVCache meta_state
 # semantics change in a way that older blocks become unsafe to load.
@@ -259,6 +272,7 @@ def _cache_compat_signature(
     cachelist_subtypes: dict[str, list[str]] | None = None,
     payload_layout: str | None = None,
     gdn_sidecar_state_dtype: str | None = None,
+    ane_prefill: bool | None = None,
 ) -> str:
     """Return a stable compatibility signature for a persisted cache block."""
     payload = {
@@ -267,6 +281,15 @@ def _cache_compat_signature(
         "block_size": int(block_size or 0),
         "layer_cache_types": list(layer_cache_types or []),
     }
+    # ANE prefill computes KV through a different numeric path (fp16
+    # fixed-shape ANE programs vs the GPU kernels), so blocks written under
+    # it are not interchangeable with GPU-computed blocks — and if the ANE
+    # path ever corrupts (seen live on an unsupported MoE model), an
+    # unstamped cache converts that transient corruption into persistent
+    # poisoning that survives disabling the setting. Only stamped when
+    # active so pre-existing signatures stay byte-identical.
+    if ane_prefill:
+        payload["ane_prefill"] = True
     # TurboQuant packed state width depends on the bit depth
     # (packed_width = ceil(head_dim * bits / 32)), so blocks written at
     # different bit depths are shape-incompatible (#2045). Only stamped
@@ -315,6 +338,19 @@ def cache_signature_for(
         cachelist_subtypes=cachelist_subtypes,
         gdn_sidecar_state_dtype=gdn_sidecar_state_dtype,
     )
+
+
+def _signature_ane_prefill(cache_signature: str) -> bool:
+    """True when a stored signature was stamped as ANE-prefill-computed."""
+    if not cache_signature:
+        return False
+    try:
+        payload = json.loads(cache_signature)
+    except (TypeError, ValueError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    return bool(payload.get("ane_prefill"))
 
 
 def _signature_turboquant_bits(cache_signature: str) -> float | None:
@@ -1693,6 +1729,11 @@ class PagedSSDCacheManager(CacheManager):
         # the layer signature. None disables the check (legacy managers /
         # models without mixed CacheList layers).
         self._expected_cachelist_subtypes: dict[str, list[str]] | None = None
+        # Whether Qwen ANE prefill is active for the live engine; learned
+        # together with the layer signature. ANE-computed KV is a different
+        # numeric path than GPU-computed KV, so blocks written under one
+        # must not be replayed under the other.
+        self._expected_ane_prefill: bool = False
         # Set once we have swept stale-signature blocks for the current
         # ``_expected_layer_cache_types`` / ``_expected_turboquant_kv_bits``.
         # Re-assigning the signature (e.g., via
@@ -1707,10 +1748,17 @@ class PagedSSDCacheManager(CacheManager):
         self._last_disk_pressure_warn: float = 0.0
         self._last_promotion_failure_warn: float = 0.0
 
+        # Set by the external disk-pressure guard tick (design doc §R2) once
+        # free disk falls below the configured hard floor. A cache write is
+        # always optional — refusing one here is strictly safe, unlike
+        # refusing a request; admission is deliberately untouched by this.
+        self._disk_pressure_hard = False
+
         # Statistics
         self._stats = {
             "saves": 0,
             "saves_persisted": 0,
+            "saves_refused_disk_pressure": 0,
             "loads": 0,
             "hits": 0,
             "misses": 0,
@@ -1726,6 +1774,12 @@ class PagedSSDCacheManager(CacheManager):
             "preload_time_ms": 0.0,
             "ssd_write_drops": 0,
             "ssd_inline_write_fallbacks": 0,
+            # Tier hit-rates (design doc §0.4/§A3): ``hits`` already lumps
+            # every tier together (hot cache + main-block SSD reads); these
+            # two isolate the SSD-tier main-block vs. sidecar-restore split
+            # that A3's budget-share decision needs.
+            "main_block_ssd_hits": 0,
+            "gdn_sidecar_restore_hits": 0,
         }
 
         # --- Hot cache (in-memory raw-bytes tier) ---
@@ -1908,6 +1962,12 @@ class PagedSSDCacheManager(CacheManager):
             return False
         if not entry.get("dirty", True):
             return True
+        if self._disk_pressure_hard:
+            # Same refusal as save_block's direct path (design doc §R2) —
+            # this is the single choke point hot-cache LRU spill also goes
+            # through, independent of any in-flight save_block call.
+            self._stats["saves_refused_disk_pressure"] += 1
+            return False
 
         blk_meta = entry.get("block_metadata")
         if blk_meta is None:
@@ -2214,6 +2274,31 @@ class PagedSSDCacheManager(CacheManager):
             if root_fd is not None:
                 os.close(root_fd)
 
+    def _persist_main_block_lru_touch(
+        self, file_path: Path, previous_last_access: float
+    ) -> None:
+        """Throttled disk-mtime touch on a main-block SSD-tier hit (§A2).
+
+        Only the in-memory ``PagedSSDBlockMetadata.last_access`` was ever
+        updated on a hit; ``_read_file_metadata`` reseeds ``last_access``
+        from ``st_mtime`` at every restart, so a heavily-reused old prefix
+        looked exactly as stale as a written-yesterday-never-hit block —
+        and the shared three-index eviction walk compared main-block
+        *write* time against sidecar *access* time, systematically
+        evicting the main blocks whose loss forces a full re-prefill.
+        Callers pass the access time recorded *before* this hit so the
+        throttle measures how stale the persisted signal already was.
+        """
+        if (
+            time.time() - previous_last_access
+            < _MAIN_BLOCK_UTIME_THROTTLE_SECONDS
+        ):
+            return
+        try:
+            os.utime(file_path, None)
+        except OSError as e:
+            logger.debug("Failed to persist main-block LRU touch: %s", e)
+
     def _tracked_ssd_size(self) -> int:
         """Return all tracked main-KV and GDN-sidecar bytes.
 
@@ -2235,6 +2320,135 @@ class PagedSSDCacheManager(CacheManager):
             + self._gdn_sidecar_index.count
         )
 
+    def _reap_stale_tmp_staging_files(self) -> tuple[int, int]:
+        """Delete age-gated ``*_tmp.safetensors`` staging leftovers.
+
+        A live writer renames its temp file within seconds of creating it
+        (``_write_block_file``); anything older than
+        ``_TMP_STAGING_MIN_AGE_SECONDS`` is a crash remnant, not an
+        in-flight write from a concurrent manager on the same directory
+        (design doc §7 rule 2). Runs inside the single-writer scan window,
+        before these names would otherwise be skipped by the indexing glob.
+        """
+        if self._cache_dir is None:
+            return 0, 0
+        now = time.time()
+        candidates: list[Path] = []
+        for subdir in self.SUBDIR_CHARS:
+            subdir_path = self._cache_dir / subdir
+            if subdir_path.is_symlink() or not subdir_path.is_dir():
+                continue
+            candidates.extend(subdir_path.glob("*_tmp.safetensors"))
+        sidecar_root = self._cache_dir / self._GDN_SIDECAR_DIRNAME
+        if sidecar_root.is_dir() and not sidecar_root.is_symlink():
+            for signature_dir in sidecar_root.iterdir():
+                if signature_dir.is_symlink() or not signature_dir.is_dir():
+                    continue
+                candidates.extend(signature_dir.glob("*_tmp.safetensors"))
+
+        count = 0
+        total_bytes = 0
+        for tmp_path in candidates:
+            if tmp_path.is_symlink():
+                continue
+            try:
+                st = tmp_path.stat()
+            except OSError:
+                continue
+            if now - st.st_mtime < _TMP_STAGING_MIN_AGE_SECONDS:
+                continue
+            try:
+                tmp_path.unlink()
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                logger.warning(
+                    "Failed to reap stale staging file %s: %s", tmp_path, exc
+                )
+                continue
+            count += 1
+            total_bytes += st.st_size
+        if count:
+            logger.info(
+                "Reaped %d stale staging file(s) (%s)",
+                count,
+                format_bytes(total_bytes),
+            )
+        return count, total_bytes
+
+    def _reap_corrupt_final_file(self, file_path: Path) -> int:
+        """Delete a final-name cache file whose metadata failed to parse.
+
+        Only called for names that survived the ``*_tmp.safetensors``
+        filter, so ``file_path`` was created by a completed, fsync'd atomic
+        rename (``_write_block_file``) — an unparseable file at that name is
+        corrupt, not in-flight, and safe to remove outright (design doc §7
+        rule 2 only age-gates the staging-name class; this is the
+        already-final class).
+        """
+        if file_path.is_symlink():
+            return 0
+        try:
+            size = file_path.stat().st_size
+            file_path.unlink()
+        except FileNotFoundError:
+            return 0
+        except OSError as exc:
+            logger.warning("Failed to reap corrupt cache file %s: %s", file_path, exc)
+            return 0
+        logger.info("Reaped corrupt cache file %s (%s)", file_path, format_bytes(size))
+        return size
+
+    def _reap_gdn_sidecar_digest_dirs(self) -> int:
+        """Remove malformed-name sidecar digest dirs and now-empty ones.
+
+        A digest dir is only ever created with a valid hex digest name
+        (``commit_gdn_checkpoint_file`` / ``_gdn_signature_digest``);
+        anything else at that level was never indexed by
+        ``_scan_existing_gdn_sidecars`` and is safe to remove outright. A
+        validly-named dir left empty (its sidecars were all evicted or
+        reaped) is inert clutter.
+        """
+        if self._cache_dir is None:
+            return 0
+        root = self._cache_dir / self._GDN_SIDECAR_DIRNAME
+        if root.is_symlink() or not root.is_dir():
+            return 0
+
+        removed = 0
+        for signature_dir in list(root.iterdir()):
+            if signature_dir.is_symlink() or not signature_dir.is_dir():
+                continue
+            digest = signature_dir.name
+            valid_name = len(digest) == self._GDN_SIGNATURE_DIGEST_LENGTH
+            if valid_name:
+                try:
+                    bytes.fromhex(digest)
+                except ValueError:
+                    valid_name = False
+            try:
+                is_empty = not any(signature_dir.iterdir())
+            except OSError:
+                continue
+            if valid_name and not is_empty:
+                continue
+            try:
+                if valid_name:
+                    signature_dir.rmdir()
+                else:
+                    shutil.rmtree(signature_dir)
+            except OSError as exc:
+                logger.warning(
+                    "Failed to reap GDN sidecar digest dir %s: %s",
+                    signature_dir,
+                    exc,
+                )
+                continue
+            removed += 1
+        if removed:
+            logger.info("Reaped %d GDN sidecar digest dir(s)", removed)
+        return removed
+
     def _scan_existing_files(self) -> None:
         """Scan cache directory for existing files and build the compatible index.
 
@@ -2242,14 +2456,24 @@ class PagedSSDCacheManager(CacheManager):
         indexed. Incompatible blocks are left on disk so a shared SSD cache
         directory can safely serve multiple loaded models without one model's
         startup scan deleting another model's cache.
+
+        Runs inside the single-writer window (before the writer thread
+        starts), so this is also where the age-gated staging-file and
+        provably-corrupt/orphaned reconciliation sweep runs (design doc §7
+        R1) — sweeping here means multi-manager double-runs on a shared
+        directory are idempotent rather than racing a live writer.
         """
         logger.info(f"Scanning SSD cache directory: {self._cache_dir}")
+
+        self._reap_stale_tmp_staging_files()
 
         scanned = 0
         indexed = 0
         skipped_incompatible = 0
         skipped_incompatible_bytes = 0
         errors = 0
+        reaped_corrupt = 0
+        reaped_corrupt_bytes = 0
 
         for subdir in self.SUBDIR_CHARS:
             subdir_path = self._cache_dir / subdir
@@ -2257,10 +2481,19 @@ class PagedSSDCacheManager(CacheManager):
                 continue
 
             for file_path in subdir_path.glob("*.safetensors"):
+                if file_path.name.endswith("_tmp.safetensors"):
+                    # Staging leftovers are handled (age-gated) above, not
+                    # indexed here regardless of age.
+                    continue
                 scanned += 1
                 try:
                     metadata = self._read_file_metadata(file_path)
                     if metadata is None:
+                        if HAS_MLX:
+                            reaped = self._reap_corrupt_final_file(file_path)
+                            if reaped:
+                                reaped_corrupt += 1
+                                reaped_corrupt_bytes += reaped
                         continue
                     if not self._is_compatible_block(metadata):
                         skipped_incompatible += 1
@@ -2276,6 +2509,7 @@ class PagedSSDCacheManager(CacheManager):
         sidecars_indexed, sidecars_skipped, sidecars_bytes = (
             self._scan_existing_gdn_sidecars()
         )
+        reaped_digest_dirs = self._reap_gdn_sidecar_digest_dirs()
 
         self._index.sort_lru_by_last_access()
         self._incompatible_index.sort_lru_by_last_access()
@@ -2295,6 +2529,13 @@ class PagedSSDCacheManager(CacheManager):
             log_msg += f", skipped_gdn_sidecars={sidecars_skipped}"
         if sidecars_bytes > 0:
             log_msg += f", gdn_size={format_bytes(sidecars_bytes)}"
+        if reaped_corrupt > 0:
+            log_msg += (
+                f", reaped_corrupt={reaped_corrupt} files "
+                f"({format_bytes(reaped_corrupt_bytes)})"
+            )
+        if reaped_digest_dirs > 0:
+            log_msg += f", reaped_gdn_digest_dirs={reaped_digest_dirs}"
         logger.info(log_msg)
 
         # Startup can find a cache directory that already exceeds the shared
@@ -2310,6 +2551,13 @@ class PagedSSDCacheManager(CacheManager):
         rewrite it merely to rebuild the LRU index, so the signature digest and
         source hash are recovered from the namespace path and timestamps/sizes
         are recovered from ``stat``.
+
+        A file whose name doesn't parse as a hex source hash is corrupt or
+        foreign at a final path (sidecars have no in-directory `_tmp`
+        staging convention of their own — they're promoted directly via
+        ``os.replace`` from external staging), so it's reaped outright,
+        symlinks excepted (design doc §7 R1 step 2, "same treatment in the
+        sidecar... scans").
         """
         if self._cache_dir is None:
             return 0, 0, 0
@@ -2333,13 +2581,23 @@ class PagedSSDCacheManager(CacheManager):
                 skipped += 1
                 continue
             for file_path in signature_dir.glob("*.safetensors"):
+                if file_path.name.endswith("_tmp.safetensors"):
+                    continue
                 try:
                     source_hash = bytes.fromhex(file_path.stem)
-                    if (
-                        not source_hash
-                        or file_path.is_symlink()
-                        or not file_path.is_file()
-                    ):
+                    if not source_hash:
+                        raise ValueError("empty sidecar source hash")
+                except ValueError as e:
+                    skipped += 1
+                    logger.debug(
+                        "Skipping malformed GDN sidecar name %s: %s", file_path, e
+                    )
+                    if not file_path.is_symlink():
+                        with contextlib.suppress(OSError):
+                            file_path.unlink()
+                    continue
+                try:
+                    if file_path.is_symlink() or not file_path.is_file():
                         raise ValueError("invalid sidecar source hash or file")
                     stat_result = file_path.stat()
                     metadata = GDNCheckpointMetadata(
@@ -2374,6 +2632,13 @@ class PagedSSDCacheManager(CacheManager):
         """Atomically promote a request-local recurrent snapshot to SSD."""
         if self._hot_cache_only or self._cache_dir is None:
             return None
+        if self._disk_pressure_hard:
+            # Same refusal as save_block (design doc §R2): a sidecar
+            # commit is an optional cache write, never required for
+            # correctness — the caller's boundary-snapshot store keeps its
+            # own degrade-to-placeholder path for exactly this case.
+            self._stats["saves_refused_disk_pressure"] += 1
+            return None
         if not isinstance(source_block_hash, bytes) or not source_block_hash:
             return None
         staged_path = Path(staged_path)
@@ -2386,46 +2651,70 @@ class PagedSSDCacheManager(CacheManager):
 
         signature_digest = self._gdn_signature_digest(cache_signature)
         final_path = self._get_gdn_sidecar_path(source_block_hash, cache_signature)
-        with self._lock:
-            try:
-                sidecar_root = self._cache_dir / self._GDN_SIDECAR_DIRNAME
-                sidecar_root.mkdir(parents=True, exist_ok=True)
-                if (
-                    sidecar_root.is_symlink()
-                    or sidecar_root.resolve(strict=True).parent
-                    != self._cache_dir.resolve(strict=True)
-                ):
-                    logger.warning("Rejecting unsafe GDN sidecar root")
-                    return None
-                final_path.parent.mkdir(parents=True, exist_ok=True)
-                if (
-                    final_path.parent.is_symlink()
-                    or final_path.parent.resolve(strict=True).parent
-                    != sidecar_root.resolve(strict=True)
-                ):
-                    logger.warning("Rejecting unsafe GDN sidecar destination")
-                    return None
-                if staged_stat.st_dev != final_path.parent.stat().st_dev:
-                    logger.warning("Rejecting cross-filesystem GDN sidecar promotion")
-                    return None
+        try:
+            # Directory-safety checks and mkdir are pure filesystem
+            # introspection with no dependency on shared index/LRU state, so
+            # they run unlocked; mkdir(exist_ok=True) is safe under
+            # concurrent callers by construction.
+            sidecar_root = self._cache_dir / self._GDN_SIDECAR_DIRNAME
+            sidecar_root.mkdir(parents=True, exist_ok=True)
+            if (
+                sidecar_root.is_symlink()
+                or sidecar_root.resolve(strict=True).parent
+                != self._cache_dir.resolve(strict=True)
+            ):
+                logger.warning("Rejecting unsafe GDN sidecar root")
+                return None
+            final_path.parent.mkdir(parents=True, exist_ok=True)
+            if (
+                final_path.parent.is_symlink()
+                or final_path.parent.resolve(strict=True).parent
+                != sidecar_root.resolve(strict=True)
+            ):
+                logger.warning("Rejecting unsafe GDN sidecar destination")
+                return None
+            if staged_stat.st_dev != final_path.parent.stat().st_dev:
+                logger.warning("Rejecting cross-filesystem GDN sidecar promotion")
+                return None
+
+            # From here, the index-removal window IS the concurrency guard:
+            # only the single store-cache worker thread ever calls this
+            # method (ThreadPoolExecutor max_workers=1, scheduler.py — "we
+            # never have two stores racing on the same paged_ssd index"), so
+            # commit-vs-commit races on the same key cannot happen. Holding
+            # self._lock only for the two index mutations below — not across
+            # os.replace/fsync/the inline eviction unlinks inside
+            # enforce_size_limit — matches enforce_size_limit's own stated
+            # policy (decide evictions under the lock, unlink outside it) and
+            # keeps the lock available to the inference thread's
+            # latency-sensitive GDN restore/lookup path
+            # (get_gdn_checkpoint_file_with_diagnostic, forget_gdn_checkpoint)
+            # during the slow disk I/O below. Removing `old` from the index
+            # here, before releasing the lock, is what makes the unlocked
+            # window safe: forget_gdn_checkpoint's own remove()+unlink()
+            # (also under self._lock) will see the key already absent and
+            # skip its unlink, so it can never race os.replace for the same
+            # path.
+            with self._lock:
                 old = self._gdn_sidecar_index.remove(
                     source_block_hash, signature_digest
                 )
-                try:
-                    # Temporarily remove the destination from LRU accounting so
-                    # size enforcement cannot evict/unlink the checkpoint being
-                    # replaced. Account for the full incoming file while the old
-                    # entry is protected; on promotion failure the old metadata
-                    # is restored below and its file remains intact.
-                    self._enforce_size_limit_for_new_block(staged_stat.st_size)
-                    os.replace(staged_path, final_path)
-                    _fsync_parent_dir(final_path)
-                    committed_at = time.time()
-                    # os.replace preserves the staging file's timestamps. Stamp
-                    # the actual commit/access time so a restart reconstructs LRU
-                    # order from a meaningful mtime rather than stale staging age.
-                    with contextlib.suppress(OSError):
-                        os.utime(final_path, (committed_at, committed_at))
+            try:
+                # Temporarily removed from LRU accounting above so size
+                # enforcement cannot evict/unlink the checkpoint being
+                # replaced. Account for the full incoming file while the old
+                # entry is protected; on promotion failure the old metadata
+                # is restored below and its file remains intact.
+                self._enforce_size_limit_for_new_block(staged_stat.st_size)
+                os.replace(staged_path, final_path)
+                _fsync_parent_dir(final_path)
+                committed_at = time.time()
+                # os.replace preserves the staging file's timestamps. Stamp
+                # the actual commit/access time so a restart reconstructs LRU
+                # order from a meaningful mtime rather than stale staging age.
+                with contextlib.suppress(OSError):
+                    os.utime(final_path, (committed_at, committed_at))
+                with self._lock:
                     self._gdn_sidecar_index.add(
                         GDNCheckpointMetadata(
                             source_block_hash=source_block_hash,
@@ -2439,16 +2728,17 @@ class PagedSSDCacheManager(CacheManager):
                             last_access=committed_at,
                         )
                     )
-                    return final_path
-                except OSError:
-                    if old is not None and self._is_safe_gdn_sidecar_file(
-                        old.file_path
-                    ):
+                return final_path
+            except OSError:
+                if old is not None and self._is_safe_gdn_sidecar_file(
+                    old.file_path
+                ):
+                    with self._lock:
                         self._gdn_sidecar_index.add(old)
-                    raise
-            except OSError as exc:
-                logger.warning("Failed to commit GDN sidecar: %s", exc)
-                return None
+                raise
+        except OSError as exc:
+            logger.warning("Failed to commit GDN sidecar: %s", exc)
+            return None
 
     def get_gdn_checkpoint_file(
         self, source_block_hash: bytes, cache_signature: str
@@ -2511,6 +2801,7 @@ class PagedSSDCacheManager(CacheManager):
             if used_legacy_fp32_fallback:
                 self._gdn_legacy_fp32_fallbacks += 1
 
+            self._stats["gdn_sidecar_restore_hits"] += 1
             self._gdn_sidecar_index.touch(source_block_hash, signature_digest)
             try:
                 # Persist the LRU touch across manager restarts without
@@ -2687,7 +2978,23 @@ class PagedSSDCacheManager(CacheManager):
         if not self._signature_bits_match(metadata.cache_signature):
             return False
 
+        if not self._signature_ane_match(metadata.cache_signature):
+            return False
+
         return True
+
+    def _signature_ane_match(self, cache_signature: str) -> bool:
+        """True when a block's ANE-prefill provenance matches expectations.
+
+        Strict both ways: an ANE-off session must never replay
+        ANE-computed blocks (the poisoning vector this check exists for),
+        and an ANE-on session must not adopt GPU-computed blocks as its
+        own numeric lineage. Legacy blocks carry no stamp and count as
+        GPU-computed.
+        """
+        return _signature_ane_prefill(cache_signature) == bool(
+            self._expected_ane_prefill
+        )
 
     def _signature_bits_match(self, cache_signature: str) -> bool:
         """True when a block's recorded TurboQuant depth satisfies expectations.
@@ -2735,6 +3042,13 @@ class PagedSSDCacheManager(CacheManager):
             return (
                 "TurboQuant depth: expected "
                 f"{self._expected_turboquant_kv_bits}, got {actual}"
+            )
+        if not self._signature_ane_match(cache_signature):
+            return (
+                "ANE prefill provenance: expected "
+                f"{'ANE' if self._expected_ane_prefill else 'GPU'}-computed, "
+                f"got {'ANE' if _signature_ane_prefill(cache_signature) else 'GPU'}"
+                "-computed"
             )
 
         expected_subtypes = self._expected_cachelist_subtypes
@@ -2802,6 +3116,7 @@ class PagedSSDCacheManager(CacheManager):
             turboquant_kv_bits=turboquant_kv_bits,
             cachelist_subtypes=cachelist_subtypes,
             payload_layout=self._payload_layout,
+            ane_prefill=self._expected_ane_prefill or None,
         )
 
     def gdn_cache_signature_for(
@@ -3228,6 +3543,14 @@ class PagedSSDCacheManager(CacheManager):
                 return True
             return False
 
+        if self._disk_pressure_hard:
+            # A cache write is always optional (design doc §R2) — refuse
+            # rather than risk pushing an already-critical disk over the
+            # edge. The block is simply recomputed/re-saved once pressure
+            # eases; admission (serving the request) is untouched.
+            self._stats["saves_refused_disk_pressure"] += 1
+            return False
+
         file_path = self._get_file_path(block_hash)
 
         try:
@@ -3416,6 +3739,14 @@ class PagedSSDCacheManager(CacheManager):
             # derived arrays before memoryview() so the buffer protocol never
             # becomes the first MLX eval site on the store-cache worker thread.
             # Race history: #978/#1040/#1106/#1437/#1558.
+            #
+            # Batch-eval all arrays in one command-buffer submission (mirrors
+            # boundary_snapshot_store's pattern) instead of letting each
+            # _extract_tensor_bytes call trigger its own separate eval —
+            # measured 19ms/48-layer state one-by-one; per-array mx.eval calls
+            # below become no-op re-checks once the arrays are materialized.
+            if arrays:
+                mx.eval(*arrays.values())
             tensors_raw = {}
             for name, arr in arrays.items():
                 tensors_raw[name] = _extract_tensor_bytes(arr)
@@ -3868,9 +4199,12 @@ class PagedSSDCacheManager(CacheManager):
                 return None
 
             # Update access time
+            previous_last_access = metadata.last_access
             self._index.touch(block_hash)
+            self._persist_main_block_lru_touch(file_path, previous_last_access)
             self._stats["loads"] += 1
             self._stats["hits"] += 1
+            self._stats["main_block_ssd_hits"] += 1
 
             # Promote to hot cache for faster access next time
             if self._hot_cache_enabled:
@@ -4069,9 +4403,12 @@ class PagedSSDCacheManager(CacheManager):
                         pass
 
             # Update access time
+            previous_last_access = block_metadata.last_access
             self._index.touch(block_hash)
+            self._persist_main_block_lru_touch(file_path, previous_last_access)
             self._stats["loads"] += 1
             self._stats["hits"] += 1
+            self._stats["main_block_ssd_hits"] += 1
 
             # Promote to hot cache for faster access next time
             if self._hot_cache_enabled and promote_to_hot_cache:
@@ -4275,6 +4612,7 @@ class PagedSSDCacheManager(CacheManager):
         *,
         turboquant_kv_bits: float | None = None,
         cachelist_subtypes: dict[str, list[str]] | None = None,
+        ane_prefill: bool = False,
     ) -> bool:
         """Set the live layer-cache signature, replacing stale expectations.
 
@@ -4299,6 +4637,8 @@ class PagedSSDCacheManager(CacheManager):
             float(turboquant_kv_bits) if turboquant_kv_bits is not None else None
         )
 
+        new_ane = bool(ane_prefill)
+
         with self._lock:
             old_signature = self._expected_layer_cache_types
             old_canonical = _canonicalize_layer_cache_types(old_signature)
@@ -4306,10 +4646,12 @@ class PagedSSDCacheManager(CacheManager):
             subtypes_changed = (
                 cachelist_subtypes != self._expected_cachelist_subtypes
             )
+            ane_changed = new_ane != self._expected_ane_prefill
             if (
                 old_canonical == new_canonical
                 and not bits_changed
                 and not subtypes_changed
+                and not ane_changed
             ):
                 if old_signature != new_signature:
                     self._expected_layer_cache_types = new_signature
@@ -4318,16 +4660,18 @@ class PagedSSDCacheManager(CacheManager):
             self._expected_layer_cache_types = new_signature
             self._expected_turboquant_kv_bits = new_bits
             self._expected_cachelist_subtypes = cachelist_subtypes
+            self._expected_ane_prefill = new_ane
             self._signature_sweep_completed = False
 
         logger.info(
             "PagedSSDCacheManager updated layer cache signature "
             "(%d layers, %d unique types, turboquant_kv_bits=%s, "
-            "cachelist_subtypes=%s)",
+            "cachelist_subtypes=%s, ane_prefill=%s)",
             len(new_signature),
             len(set(new_canonical or ())),
             new_bits,
             "yes" if cachelist_subtypes else "no",
+            "yes" if new_ane else "no",
         )
         return True
 
@@ -4389,6 +4733,9 @@ class PagedSSDCacheManager(CacheManager):
                     stale.append(h)
                     continue
                 if not self._signature_bits_match(meta.cache_signature):
+                    stale.append(h)
+                    continue
+                if not self._signature_ane_match(meta.cache_signature):
                     stale.append(h)
                     continue
                 if self._expected_cachelist_subtypes is not None and (
@@ -4625,9 +4972,83 @@ class PagedSSDCacheManager(CacheManager):
                     f"above target for subsequent saves to drain"
                 )
 
-    def enforce_size_limit(self) -> int:
+    _RECONCILE_BATCH_SIZE = 32
+
+    def reconcile_tracked_sizes(self, batch_size: int = _RECONCILE_BATCH_SIZE) -> int:
+        """Stat-validate a bounded batch of LRU-tail entries, pruning dead ones.
+
+        Design doc §A5: several ``PagedSSDCacheManager`` instances can own
+        one shared cache directory (one per loaded model, plus a
+        draft-model manager under SpecPrefill/DFlash). When manager A
+        evicts and unlinks a file manager B still has indexed, B's
+        ``total_size`` keeps counting it and ``has_block`` still reports
+        True until B happens to touch the entry — this is the periodic
+        decay the disk-pressure guard tick drives so drift doesn't
+        accumulate indefinitely between natural touches. Read-only stat
+        plus in-memory index mutation only; never unlinks a file (there is
+        nothing to unlink — a dead entry is dead precisely because the
+        file is already gone).
+        """
+        if self._cache_dir is None:
+            return 0
+
+        pruned = 0
+        with self._lock:
+            candidates: list[tuple[Any, Any]] = []
+            for source_index in (
+                self._index,
+                self._incompatible_index,
+                self._gdn_sidecar_index,
+            ):
+                for metadata in source_index.get_lru_entries(batch_size):
+                    candidates.append((source_index, metadata))
+
+            for source_index, metadata in candidates:
+                try:
+                    alive = metadata.file_path.is_file()
+                except OSError:
+                    alive = False
+                if alive:
+                    continue
+                if source_index is self._gdn_sidecar_index:
+                    source_index.remove_key(metadata.key)
+                else:
+                    source_index.remove(metadata.block_hash)
+                pruned += 1
+
+        if pruned:
+            logger.info(
+                "Disk pressure guard reconcile: pruned %d dead index entr%s",
+                pruned,
+                "y" if pruned == 1 else "ies",
+            )
+        return pruned
+
+    def set_disk_pressure_hard(self, active: bool) -> None:
+        """Toggle the hard-floor write-refusal switch (design doc §R2).
+
+        Set by the external disk-pressure guard tick, not by this manager —
+        the guard is the cross-consumer, idle-time actor; this class only
+        owns the mechanism. Admission (serving requests) is deliberately
+        untouched; only optional cache writes are refused.
+        """
+        self._disk_pressure_hard = bool(active)
+
+    def enforce_size_limit(
+        self, *, trigger_fraction: float = 1.0, target_fraction: float = 0.9
+    ) -> int:
         """
         Enforce SSD cache size limit by evicting LRU files.
+
+        Args:
+            trigger_fraction: Fraction of the effective max size at which
+                eviction triggers. 1.0 (default) preserves the historical
+                behavior of only reacting once the full cap is exceeded.
+                The disk-pressure guard tick passes a smaller value under
+                soft pressure so the cache sheds gradually before the save-
+                time clamp would otherwise force a cliff eviction burst.
+            target_fraction: Fraction of the effective max size to shave
+                down to once triggered.
 
         Returns:
             Number of bytes freed.
@@ -4641,11 +5062,12 @@ class PagedSSDCacheManager(CacheManager):
         with self._lock:
             initial_size = self._tracked_ssd_size()
             effective_max = self._get_effective_max_size()
+            trigger_size = int(effective_max * trigger_fraction)
 
-            if initial_size <= effective_max:
+            if initial_size <= trigger_size:
                 return 0
 
-            target_size = int(effective_max * 0.9)  # 90% of effective max
+            target_size = int(effective_max * target_fraction)
             evicted = self._evict_tracked_until_size(target_size)
 
         # Do NOT remove from hot cache — see _enforce_size_limit_for_new_block
@@ -4979,6 +5401,13 @@ class PagedSSDCacheManager(CacheManager):
                 ),
                 "gdn_sidecar_count": self._gdn_sidecar_index.count,
                 "gdn_sidecar_size_bytes": self._gdn_sidecar_index.total_size,
+                # Per-tier breakdown (design doc §0.1): turns the doc's
+                # one-off du/stat table into a trackable series.
+                "compatible_block_count": self._index.count,
+                "compatible_block_size_bytes": self._index.total_size,
+                "incompatible_block_count": self._incompatible_index.count,
+                "incompatible_block_size_bytes": self._incompatible_index.total_size,
+                "disk_pressure_hard": self._disk_pressure_hard,
                 **self._stats,
             }
 

--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -222,6 +222,19 @@ class MemoryMonitor:
         # full-attention formula. Empty for non-hybrid models.
         self._rotating_layer_specs: tuple[tuple[int, int], ...] = ()
         self._prefill_memory_profile: PrefillMemoryProfile | None = None
+        # Per-instance tiled-prefill override for kernels whose tiled route
+        # is gated on THIS scheduler's own config (e.g. TurboQuant's
+        # quantized_attention, gated on turboquant_kv_bits), not on head_dim
+        # alone. Unlike _SDPA_TILED_PREFILL_HEAD_DIMS below (a module-level
+        # global, correct only for kernels that are unconditionally active
+        # process-wide for a head_dim, e.g. the sdpa256 monkeypatch), this
+        # must stay scoped to this MemoryMonitor/Scheduler instance:
+        # engine_pool.py keeps two models resident during a swap, and a
+        # global registration would leak one model's turboquant config into
+        # another concurrently-resident model sharing the same head_dim,
+        # under-charging that other model's admission guard.
+        # (query_block, kv_tile, min_kv_len); see register_tiled_prefill_tile.
+        self._tiled_prefill_override: tuple[int, int, int] | None = None
         # Fixed-shape ANE prefill I/O surfaces (issue #2841); set via
         # set_model_info, 0 unless the Qwen ANE prefill backend is attached.
         self._ane_prefill_transient_bytes: int = 0
@@ -684,6 +697,33 @@ class MemoryMonitor:
 
         return total + self._fixed_state_bytes
 
+    def register_tiled_prefill_tile(
+        self, *, query_block: int, kv_tile: int, min_kv_len: int
+    ) -> None:
+        """Register a bounded-transient tiled prefill route for THIS
+        scheduler's model, scoped to this MemoryMonitor instance (unlike
+        ``register_tiled_prefill_head_dim``'s module-global registry — see
+        that function's docstring, and the ``_tiled_prefill_override``
+        field comment, for why this must stay instance-scoped for
+        TurboQuant: its tiled route is gated on this model's own config,
+        not on head_dim alone, and engine_pool.py can keep two models
+        resident concurrently during a swap).
+
+        query_block bounds the query axis the kernel actually tiles at
+        (e.g. TurboQuant's ``quantized_attention`` blocks queries at 256
+        regardless of the chunk's true query_tokens); kv_tile bounds the KV
+        axis. min_kv_len must match the kernel's own route-gate threshold —
+        registering a lower value would charge the cheap tile estimate for
+        calls that actually take the expensive unfused fallback."""
+        self._tiled_prefill_override = (
+            int(query_block),
+            int(kv_tile),
+            int(min_kv_len),
+        )
+
+    def clear_tiled_prefill_tile(self) -> None:
+        self._tiled_prefill_override = None
+
     def _uses_fused_sdpa(self, query_tokens: int, kv_len: int) -> bool:
         hd = self._head_dim or 0
         n_q = self._num_attention_heads or 0
@@ -722,6 +762,26 @@ class MemoryMonitor:
         output = n_q * query_tokens * hd * 4
         if self._uses_fused_sdpa(query_tokens, kv_len):
             return output + bias
+
+        # Per-instance tiled route (e.g. TurboQuant's quantized_attention),
+        # scoped to this model/scheduler -- see register_tiled_prefill_tile.
+        # Checked before the module-global head_dim registry below since it
+        # reflects this specific model's own config, not a process-wide
+        # kernel install. query_tokens is capped at query_block because the
+        # kernel itself tiles the query axis (e.g. TurboQuant blocks queries
+        # at 256 regardless of how large this chunk's query_tokens is) --
+        # using the raw query_tokens here would re-introduce an O(L^2)-ish
+        # over-charge on large chunks, defeating the point of registering it.
+        if self._tiled_prefill_override is not None:
+            query_block, kv_tile, min_kv_len = self._tiled_prefill_override
+            if query_tokens > 1 and kv_len >= min_kv_len:
+                tile_scores = (
+                    n_q
+                    * min(query_tokens, query_block)
+                    * min(kv_tile, kv_len)
+                    * self._score_dtype_size
+                )
+                return output + tile_scores + bias
 
         # O(L) tiled-prefill kernel active for this head_dim (e.g. the head_dim
         # 256 sdpa256 patch): the score matrix is never materialized. The peak

--- a/omlx/patches/sdpa256_attention.py
+++ b/omlx/patches/sdpa256_attention.py
@@ -7,22 +7,39 @@ materializes the full ``[n_q, query_len, kv_len]`` score matrix -> O(L^2) memory
 OOMing / tripping the prefill guard far below the context window. Decode
 (query_len == 1) is unaffected (MLX has a fused vector kernel for 256).
 
-This routes head_dim=256 causal prefill to a flash-style online-softmax pass in
-pure MLX array ops (tiled over KV; running max/sum/accumulator) that never
-materializes the score matrix -> peak memory O(L). It rides MLX's GEMM, so speed
-is on par with the fallback; the win is memory. ``register_tiled_prefill_head_dim``
-flips the prefill-guard estimator to O(L) in lockstep (else it keeps rejecting).
+This routes head_dim=256 causal prefill through three possible paths, picked
+per-call by ``_route_decision``:
 
-The route is memory-aware (issue #2204): the unfused fallback is faster
-everywhere its score matrix fits (on NAX GPUs its big GEMMs run on the tensor
-units; even pre-NAX it is ~2x faster than the tiled pass at long context, issue
-#2155), so when the Scheduler has registered a headroom provider the tiled pass
-engages only if the unfused transient would NOT fit under the prefill-guard
-ceiling. Without a provider (no Scheduler, ceiling not propagated yet) the
+- **unfused** (stock MLX fallback): the fast path wherever its
+  ``[n_q, query_len, kv_len]`` score matrix fits under live guard headroom.
+- **q-split** (``_unfused_qsplit_sdpa``): when the full unfused call doesn't
+  fit, split the query axis into sub-tiles (keys/values narrowed to each
+  sub-tile's causal end) and run the SAME fast stock kernel per sub-tile —
+  smaller transient, still the fast kernel, no accuracy cost.
+- **tiled** (``_flash_sdpa256``): a flash-style online-softmax pass in pure
+  MLX array ops (tiled over KV; running max/sum/accumulator) that never
+  materializes the score matrix -> true O(L) peak, at the cost of one
+  ``mx.eval`` per KV tile (real measured overhead, not "on par with the
+  fallback" — thousands of small CPU<->GPU syncs at long context). This is
+  now the last resort once even a minimum-size q-split slice wouldn't fit,
+  or when headroom info is unavailable (memory-safe #2025 default).
+  ``register_tiled_prefill_head_dim`` flips the prefill-guard estimator to
+  O(L) in lockstep so it prices this route instead of the O(L^2) unfused
+  formula (else the guard keeps rejecting requests the tiled route could
+  actually serve).
+
+The route is memory-aware (issue #2204, extended for q-split): unfused is
+faster everywhere its score matrix fits (on NAX GPUs its big GEMMs run on
+the tensor units), so when the Scheduler has registered a headroom provider
+the route only narrows to q-split, then finally tiled, as live headroom
+shrinks. Without a provider (no Scheduler, ceiling not propagated yet) the
 route keeps the memory-safe default: always tiled past the kv_len threshold.
-``OMLX_SDPA256_TILED=1`` forces the tiled pass whenever the shape gates match
-(pre-#2204 behavior); ``OMLX_SDPA256_TILED=0`` never engages it (restores the
-O(L^2) memory wall — benchmarking only).
+``OMLX_SDPA256_TILED=1`` forces the tiled pass whenever the shape gates
+match (pre-#2204 behavior, also skips q-split); ``OMLX_SDPA256_TILED=0``
+never engages tiled OR q-split (restores the O(L^2) memory wall —
+benchmarking only). ``OMLX_SDPA256_QSPLIT=0`` disables q-split specifically,
+falling straight to tiled once unfused doesn't fit (pre-q-split behavior,
+for rollback without touching the tiled/unfused override).
 
 Install mechanics mirror turboquant_attention.py (patch the module attr + rebind
 already-imported model modules). The route is strictly gated (see _should_route);
@@ -69,30 +86,91 @@ _HEADROOM_PROVIDER: "weakref.WeakMethod | None" = None
 # OMLX_SDPA256_TILED override, parsed at apply time: True = always tiled,
 # False = never tiled, None = memory-aware auto.
 _FORCE_TILED: bool | None = None
-# Tiled-route reasons already logged. The tiled pass trades substantial
-# prefill throughput at long kv_len for O(L) memory, and nothing surfaced the
-# route decision before (issue #2283 took an A/B repro to diagnose), so the
-# first engagement per reason logs at INFO; repeats stay silent to keep the
-# hot path quiet.
-_TILED_ROUTE_LOGGED: "set[str]" = set()
+# OMLX_SDPA256_QSPLIT override, parsed at apply time: False disables the
+# q-split route (falls straight to tiled once unfused doesn't fit, restoring
+# pre-q-split behavior for rollback); True/None (default) leaves it enabled.
+_QSPLIT_ENABLED: bool = True
+# Minimum query rows per q-split sub-call. Below this the per-call overhead
+# stops paying for itself and genuinely tight headroom is better served by
+# the tiled path's true O(L) floor.
+_QSPLIT_MIN_Q = 128
+# Route decisions round-trip through here so callers branch on one value.
+_ROUTE_UNFUSED = "unfused"
+_ROUTE_QSPLIT = "qsplit"
+_ROUTE_TILED = "tiled"
+# Last route decision, so we log every *transition* (not just the
+# first-ever engagement) at INFO — cheap, and lets a live server log show a
+# request flapping between routes as guard headroom rises and falls
+# mid-prefill (see the docstring on
+# omlx.scheduler.Scheduler._sdpa256_unfused_headroom for why that happens).
+# The tiled/qsplit pass trades substantial prefill throughput at long
+# kv_len for safer memory, and nothing surfaced the route decision before
+# (issue #2283 took an A/B repro to diagnose), so this stays at INFO rather
+# than DEBUG.
+_LAST_ROUTE_DECISION_NO_CACHE: str | None = None
 
 
-def _note_tiled_route(reason: str, detail: str) -> None:
-    if reason in _TILED_ROUTE_LOGGED:
-        return
-    _TILED_ROUTE_LOGGED.add(reason)
+def _note_route(cache, decision: str, detail) -> None:
+    """``detail`` may be a plain string or a zero-arg callable. This runs on
+    every head-dim-256 prefill SDPA call (thousands per long-context
+    request), and the vast majority hit the decision == last-decision
+    no-op below -- callers with a formatted (f-string) detail should pass a
+    lambda so the string is only built on an actual transition.
+
+    The last-logged decision is stashed on ``cache`` (mirroring the
+    ``_sdpa256_q_sub_ceiling`` hysteresis floor in ``_should_route``) rather
+    than a single module-global: the model passes one cache per layer, so a
+    module-global was shared across all 16 full-attention layers (and every
+    concurrent request) at once, and interleaved calls from different
+    layers/requests made the transition log flap on every call instead of
+    only on real transitions. Falls back to a module-global only when
+    ``cache`` is None -- a real, persistent case (a guard-off server with no
+    headroom provider wired up routes every call this way, issue #2283),
+    where per-call spam is exactly what the dedup exists to prevent and
+    there is no per-request identity available to key on instead.
+    See docs/qwen35-hardening-and-optimization.md E5."""
+    global _LAST_ROUTE_DECISION_NO_CACHE
+    if cache is not None:
+        try:
+            if decision == getattr(cache, "_sdpa256_last_route", None):
+                return
+            cache._sdpa256_last_route = decision
+        except Exception:
+            pass
+    else:
+        if decision == _LAST_ROUTE_DECISION_NO_CACHE:
+            return
+        _LAST_ROUTE_DECISION_NO_CACHE = decision
+    if callable(detail):
+        detail = detail()
     logger.info(
-        "sdpa256: head-dim-256 prefill taking the tiled (memory-safe, slower) "
-        "path: %s. The unfused fast path resumes when guard headroom allows; "
-        "OMLX_SDPA256_TILED=1/0 forces the route.",
+        "sdpa256: route -> %s (%s). OMLX_SDPA256_TILED=1/0 forces "
+        "unfused/tiled; OMLX_SDPA256_QSPLIT=0 disables the q-split route.",
+        decision,
         detail,
     )
 
 
+def _max_q_sub_for_headroom(
+    n_q_heads: int, kv_len: int, head_dim: int, score_dtype_size: float, headroom: int
+) -> int:
+    """Largest query-row count whose unfused transient fits ``headroom``,
+    inverting ``estimate_unfused_sdpa_call_bytes`` exactly (same formula the
+    route gate and the admission guard already share) so q-split sizing
+    never drifts from what actually gets charged."""
+    per_row = n_q_heads * (kv_len * score_dtype_size + head_dim * 4)
+    if per_row <= 0 or headroom <= 0:
+        return 0
+    return int(headroom // per_row)
+
+
 def set_unfused_headroom_provider(method) -> None:
-    """Register a bound method returning the prefill guard's live headroom in
-    bytes (negative when no ceiling is active). Lets ``_should_route`` prefer
-    the faster unfused fallback whenever its O(L^2) transient fits."""
+    """Register a bound method(kv_len) -> live headroom in bytes (negative
+    when no ceiling is active). Lets ``_should_route`` prefer the faster
+    unfused fallback whenever its O(L^2) transient fits. ``kv_len`` lets the
+    provider tell a same-shape repeat call (safe to credit pooled memory
+    against) from the first call at a new, larger kv_len (not safe -- see
+    Scheduler._sdpa256_unfused_headroom)."""
     global _HEADROOM_PROVIDER
     _HEADROOM_PROVIDER = weakref.WeakMethod(method)
 
@@ -106,55 +184,114 @@ def _parse_force_tiled_env() -> bool | None:
     return None
 
 
-def _tiled_route_required(queries, keys) -> bool:
-    """Decide tiled vs stock for a shape-matched prefill call (True = tiled).
+def _parse_qsplit_env() -> bool:
+    return os.environ.get("OMLX_SDPA256_QSPLIT", "").strip() != "0"
 
-    The stock unfused fallback is faster wherever its score matrix fits
-    (issues #2155 / #2204), so take the tiled pass only when the unfused
-    transient would not fit under the guard ceiling — or when no headroom
-    info is available, keeping the memory-safe #2025 behavior."""
+
+def _route_decision(
+    queries, keys, cache=None, q_sub_ceiling: int | None = None
+) -> tuple[str, int]:
+    """Decide unfused / q-split / tiled for a shape-matched prefill call.
+
+    Returns ``(route, q_sub)`` — ``q_sub`` is only meaningful for
+    ``_ROUTE_QSPLIT`` (query rows per sub-call), 0 otherwise.
+
+    The stock unfused fallback is faster wherever its transient fits
+    (issues #2155 / #2204): take it whole when the full call fits, split
+    the query axis into sub-calls that individually fit when the full call
+    doesn't (still the fast kernel, just narrower), and fall back to the
+    true O(L) tiled pass only once even a minimum-size q-split slice
+    wouldn't fit, or when headroom info is unavailable (memory-safe
+    #2025 default).
+
+    ``q_sub_ceiling`` is this request's hysteresis floor (set by
+    ``_should_route`` once a call has ever needed a smaller transient than
+    the full call): caps how large a transient this call may use, not just
+    which route label it gets. kv_len only grows within a request, so a
+    transient shed earlier reflects real, non-relaxing pressure -- and
+    capping only the *route* (skip the "fits" fast path but still let
+    q_sub float back up to q_len when headroom looks momentarily generous)
+    was verified live to reproduce byte-for-byte the same full-size
+    transient as plain unfused, just labeled qsplit, moments before the
+    reactive guard aborted a request. ``q_sub_ceiling == 0`` means a
+    previous call already needed tiled -- never try qsplit or unfused
+    again this request."""
     if _FORCE_TILED is not None:
         if _FORCE_TILED:
-            _note_tiled_route("forced", "forced by OMLX_SDPA256_TILED=1")
-        return _FORCE_TILED
+            _note_route(cache, _ROUTE_TILED, "forced by OMLX_SDPA256_TILED=1")
+            return _ROUTE_TILED, 0
+        _note_route(cache, _ROUTE_UNFUSED, "forced by OMLX_SDPA256_TILED=0")
+        return _ROUTE_UNFUSED, 0
     try:
+        if q_sub_ceiling == 0:
+            _note_route(
+                cache,
+                _ROUTE_TILED,
+                "held at tiled by this request's hysteresis floor",
+            )
+            return _ROUTE_TILED, 0
         provider = _HEADROOM_PROVIDER() if _HEADROOM_PROVIDER is not None else None
         if provider is None:
-            _note_tiled_route(
-                "no-provider",
+            _note_route(
+                cache,
+                _ROUTE_TILED,
                 "no guard headroom provider registered "
                 "(engine without a scheduler, or scheduler gone)",
             )
-            return True
-        headroom = provider()
+            return _ROUTE_TILED, 0
+        batch, n_q, q_len, _ = queries.shape
+        kv_len = keys.shape[-2]
+        n_q_heads = batch * n_q
+        dtype_size = queries.dtype.size
+        headroom = provider(kv_len)
         if headroom is None or headroom < 0:
-            _note_tiled_route(
-                "no-ceiling",
+            _note_route(
+                cache,
+                _ROUTE_TILED,
                 "memory ceiling not available (enforcer state not yet "
                 "propagated)",
             )
-            return True
-        batch, n_q, q_len, _ = queries.shape
+            return _ROUTE_TILED, 0
         transient = estimate_unfused_sdpa_call_bytes(
-            batch * n_q,
-            q_len,
-            keys.shape[-2],
-            HEAD_DIM,
-            score_dtype_size=queries.dtype.size,
+            n_q_heads, q_len, kv_len, HEAD_DIM, score_dtype_size=dtype_size
         )
-        if transient > headroom:
-            _note_tiled_route(
-                "insufficient-headroom",
-                f"unfused transient ~{transient / 2**20:.0f}MiB exceeds live "
-                f"guard headroom ~{headroom / 2**20:.0f}MiB at "
-                f"kv_len={keys.shape[-2]}",
+        if transient <= headroom and q_sub_ceiling is None:
+            _note_route(
+                cache,
+                _ROUTE_UNFUSED,
+                lambda: f"full call ~{transient / 2**20:.0f}MiB fits "
+                f"~{headroom / 2**20:.0f}MiB headroom at kv_len={kv_len}",
             )
-            return True
-        return False
+            return _ROUTE_UNFUSED, 0
+        if _QSPLIT_ENABLED:
+            q_sub = _max_q_sub_for_headroom(
+                n_q_heads, kv_len, HEAD_DIM, dtype_size, headroom
+            )
+            q_sub = (q_sub // 128) * 128
+            if q_sub_ceiling is not None:
+                q_sub = min(q_sub, q_sub_ceiling)
+            if q_sub >= _QSPLIT_MIN_Q:
+                q_sub = min(q_sub, q_len)
+                _note_route(
+                    cache,
+                    _ROUTE_QSPLIT,
+                    lambda: f"q_sub={q_sub} of q_len={q_len} fits "
+                    f"~{headroom / 2**20:.0f}MiB headroom at kv_len={kv_len} "
+                    f"(full-call transient ~{transient / 2**20:.0f}MiB)",
+                )
+                return _ROUTE_QSPLIT, q_sub
+        _note_route(
+            cache,
+            _ROUTE_TILED,
+            lambda: f"unfused transient ~{transient / 2**20:.0f}MiB exceeds "
+            f"~{headroom / 2**20:.0f}MiB headroom at kv_len={kv_len} even "
+            f"at the q-split floor ({_QSPLIT_MIN_Q} rows)",
+        )
+        return _ROUTE_TILED, 0
     except Exception:
-        _note_tiled_route("probe-error", "guard headroom probe failed")
         logger.debug("sdpa256 headroom probe failed", exc_info=True)
-        return True  # headroom info unavailable -> memory-safe default
+        _note_route(cache, _ROUTE_TILED, "guard headroom probe failed")
+        return _ROUTE_TILED, 0  # headroom info unavailable -> memory-safe default
 
 
 def _flash_sdpa256(queries, keys, values, scale, mask):
@@ -228,7 +365,56 @@ def _flash_sdpa256(queries, keys, values, scale, mask):
     return out.reshape(batch, n_q, q_len, head_dim)
 
 
-def _should_route(queries, keys, cache, mask, sinks) -> bool:
+def _unfused_qsplit_sdpa(
+    queries, keys, values, cache, scale, mask, sinks, original_sdpa, q_sub
+):
+    """Run the fast stock (unfused) SDPA kernel over query sub-tiles instead
+    of the whole chunk, each with keys/values narrowed to that sub-tile's
+    causal end -- same kernel as the full-call fast path, just a smaller
+    per-call transient so it fits under tighter headroom than a single call
+    would.
+
+    Correctness: MLX's ``mask="causal"`` right-aligns queries to the tail of
+    the key axis (see ``_flash_sdpa256``'s comment on the same convention).
+    For sub-tile [qi0:qi1) with global offset ``kv_off = k_len - q_len``,
+    narrowing keys/values to [0:kv_off+qi1) makes MLX infer the offset
+    ``(kv_off+qi1) - (qi1-qi0) = kv_off+qi0`` for this call -- exactly the
+    sub-tile's true global offset -- so no manual position masking is
+    needed. This also does less wasted compute than a single full call:
+    each sub-tile's GEMM only covers the KV prefix its own causal window
+    can see, not the full kv_len every time.
+
+    Memory: each sub-tile's keys/values window grows with ``qi1`` (a later
+    sub-tile sees a wider causal prefix than an earlier one), so without
+    forcing evaluation between sub-tiles MLX's laziness lets every sub-call's
+    graph -- including its own score-matrix transient -- stay unmaterialized
+    and pile up simultaneously, rather than bounding the live set to one
+    sub-tile at a time the way ``q_sub``'s sizing assumes. ``mx.eval`` here
+    mirrors ``_flash_sdpa256``'s own per-tile eval for the same reason: it
+    converts "smaller instantaneous peak" from an aspiration into something
+    actually true of the live Metal graph (confirmed necessary, not just
+    defensive, by a live run where q-split engaged but didn't prevent the
+    memory trip it was sized to avoid).
+    """
+    q_len = queries.shape[-2]
+    causal = mask == "causal"
+    kv_off = keys.shape[-2] - q_len if causal else 0
+    out_tiles = []
+    for qi0 in range(0, q_len, q_sub):
+        qi1 = min(qi0 + q_sub, q_len)
+        q_slice = queries[..., qi0:qi1, :]
+        if causal:
+            k_slice = keys[..., : kv_off + qi1, :]
+            v_slice = values[..., : kv_off + qi1, :]
+        else:
+            k_slice, v_slice = keys, values
+        out_tile = original_sdpa(q_slice, k_slice, v_slice, cache, scale, mask, sinks)
+        mx.eval(out_tile)
+        out_tiles.append(out_tile)
+    return mx.concatenate(out_tiles, axis=-2)
+
+
+def _should_route(queries, keys, cache, mask, sinks) -> tuple[str, int]:
     # Never raise: any unexpected input must fall through to the original SDPA,
     # never break a request. Worst case we decline to engage.
     # Shape gates first: this wrapper is installed unconditionally and runs
@@ -236,37 +422,67 @@ def _should_route(queries, keys, cache, mask, sinks) -> bool:
     # verify) case must exit on the q_len check alone (issue #2132).
     try:
         if queries.shape[-2] < _SDPA256_MIN_Q_LEN:  # decode / MTP verify
-            return False
+            return _ROUTE_UNFUSED, 0
         if queries.shape[-1] != HEAD_DIM:
-            return False
+            return _ROUTE_UNFUSED, 0
         if keys.shape[-2] < _SDPA256_MIN_KV_LEN:
-            return False
+            return _ROUTE_UNFUSED, 0
         if sinks is not None:
-            return False
+            return _ROUTE_UNFUSED, 0
         # Quantized KV cache (TurboQuant etc.): keys/values are packed state,
         # not plain [.., kv, hd] arrays. MLX's own dispatcher detects this via
         # hasattr(cache, "bits"); let the quant-aware path handle it.
         if cache is not None and hasattr(cache, "bits"):
-            return False
+            return _ROUTE_UNFUSED, 0
         if not (mask is None or (isinstance(mask, str) and mask == "causal")):
-            return False
+            return _ROUTE_UNFUSED, 0
         n_q = queries.shape[-3]
         n_kv = keys.shape[-3]
         if n_kv <= 0 or n_q % n_kv != 0:
-            return False
-        return _tiled_route_required(queries, keys)
+            return _ROUTE_UNFUSED, 0
+        # Hysteresis floor: once this request's cache has needed a smaller
+        # transient than the full call, never let a later chunk's estimate
+        # push the transient back up -- kv_len is monotone within a
+        # request, so the pressure that forced the downgrade cannot have
+        # relaxed by the next chunk. Ratchets on transient SIZE (q_sub),
+        # not just the route label: capping only the label and letting
+        # q_sub float back up to q_len when headroom looks momentarily
+        # generous was verified live to reproduce the identical full-size
+        # transient labeled qsplit instead of unfused. Stashed on ``cache``,
+        # which is per-layer, not shared across the request's 16
+        # full-attention layers -- each layer's ratchet is independently
+        # self-consistent (kv_len is still monotone per-layer), just not a
+        # single request-wide floor (docs/qwen35-hardening-and-optimization.md
+        # E5). ``cache._sdpa256_q_sub_ceiling = 0`` (tiled) is a latch that's
+        # never cleared once set, which is intentional, not a leak: memory
+        # pressure that forced tiled doesn't spontaneously relax within a
+        # request, and the cache (hence the latch) dies with the request.
+        ceiling = getattr(cache, "_sdpa256_q_sub_ceiling", None)
+        route, q_sub = _route_decision(queries, keys, cache, q_sub_ceiling=ceiling)
+        if cache is not None:
+            try:
+                if route == _ROUTE_TILED:
+                    cache._sdpa256_q_sub_ceiling = 0
+                elif route == _ROUTE_QSPLIT:
+                    cache._sdpa256_q_sub_ceiling = (
+                        q_sub if ceiling is None else min(ceiling, q_sub)
+                    )
+            except Exception:
+                pass
+        return route, q_sub
     except Exception:
-        return False
+        return _ROUTE_UNFUSED, 0
 
 
 def apply_sdpa256_attention_patch(min_kv_len: int = _SDPA256_MIN_KV_LEN) -> bool:
     """Monkey-patch mlx-lm's scaled_dot_product_attention for head_dim=256
     long-context prefill, and register the O(L) cost with the memory monitor."""
-    global _PATCHED, _SDPA256_MIN_KV_LEN, _FORCE_TILED
+    global _PATCHED, _SDPA256_MIN_KV_LEN, _FORCE_TILED, _QSPLIT_ENABLED
     if _PATCHED:
         return False
     _SDPA256_MIN_KV_LEN = min_kv_len
     _FORCE_TILED = _parse_force_tiled_env()
+    _QSPLIT_ENABLED = _parse_qsplit_env()
 
     try:
         from mlx_lm.models import base as mlx_base
@@ -284,14 +500,20 @@ def apply_sdpa256_attention_patch(min_kv_len: int = _SDPA256_MIN_KV_LEN) -> bool
         mask: mx.array | None,
         sinks: mx.array | None = None,
     ) -> mx.array:
-        if _should_route(queries, keys, cache, mask, sinks):
-            try:
-                return _flash_sdpa256(queries, keys, values, scale, mask)
-            except Exception:
-                logger.warning(
-                    "sdpa256 prefill kernel failed; falling back to MLX SDPA",
-                    exc_info=True,
+        route, q_sub = _should_route(queries, keys, cache, mask, sinks)
+        try:
+            if route == _ROUTE_QSPLIT:
+                return _unfused_qsplit_sdpa(
+                    queries, keys, values, cache, scale, mask, sinks,
+                    original_sdpa, q_sub,
                 )
+            if route == _ROUTE_TILED:
+                return _flash_sdpa256(queries, keys, values, scale, mask)
+        except Exception:
+            logger.warning(
+                "sdpa256 prefill kernel failed; falling back to MLX SDPA",
+                exc_info=True,
+            )
         return original_sdpa(queries, keys, values, cache, scale, mask, sinks)
 
     mlx_base.scaled_dot_product_attention = patched_sdpa
@@ -335,15 +557,21 @@ def apply_sdpa256_attention_patch(min_kv_len: int = _SDPA256_MIN_KV_LEN) -> bool
                 mask=None,
                 sinks=None,
             ) -> mx.array:
-                if _should_route(queries, keys, cache, mask, sinks):
-                    try:
-                        return _flash_sdpa256(queries, keys, values, scale, mask)
-                    except Exception:
-                        logger.warning(
-                            "sdpa256 prefill kernel failed; falling back to "
-                            "MLX SDPA",
-                            exc_info=True,
+                route, q_sub = _should_route(queries, keys, cache, mask, sinks)
+                try:
+                    if route == _ROUTE_QSPLIT:
+                        return _unfused_qsplit_sdpa(
+                            queries, keys, values, cache, scale, mask, sinks,
+                            original_vlm_sdpa, q_sub,
                         )
+                    if route == _ROUTE_TILED:
+                        return _flash_sdpa256(queries, keys, values, scale, mask)
+                except Exception:
+                    logger.warning(
+                        "sdpa256 prefill kernel failed; falling back to "
+                        "MLX SDPA",
+                        exc_info=True,
+                    )
                 return original_vlm_sdpa(
                     queries, keys, values, cache, scale, mask, sinks
                 )
@@ -371,11 +599,12 @@ def apply_sdpa256_attention_patch(min_kv_len: int = _SDPA256_MIN_KV_LEN) -> bool
 
     _PATCHED = True
     if _FORCE_TILED is None:
-        routing = "tiled only when unfused exceeds guard headroom"
+        qsplit_note = "q-split then " if _QSPLIT_ENABLED else ""
+        routing = f"{qsplit_note}tiled only when unfused exceeds guard headroom"
     elif _FORCE_TILED:
         routing = "always tiled (OMLX_SDPA256_TILED=1)"
     else:
-        routing = "never tiled (OMLX_SDPA256_TILED=0)"
+        routing = "never tiled or q-split (OMLX_SDPA256_TILED=0)"
     logger.info(
         "sdpa256 attention patch applied (head_dim=256 prefill, kv_len>=%d, %s)",
         min_kv_len,

--- a/omlx/patches/sdpa256_attention.py
+++ b/omlx/patches/sdpa256_attention.py
@@ -189,7 +189,11 @@ def _parse_qsplit_env() -> bool:
 
 
 def _route_decision(
-    queries, keys, cache=None, q_sub_ceiling: int | None = None
+    queries,
+    keys,
+    cache=None,
+    q_sub_ceiling: int | None = None,
+    allow_qsplit: bool = True,
 ) -> tuple[str, int]:
     """Decide unfused / q-split / tiled for a shape-matched prefill call.
 
@@ -263,7 +267,7 @@ def _route_decision(
                 f"~{headroom / 2**20:.0f}MiB headroom at kv_len={kv_len}",
             )
             return _ROUTE_UNFUSED, 0
-        if _QSPLIT_ENABLED:
+        if _QSPLIT_ENABLED and allow_qsplit:
             q_sub = _max_q_sub_for_headroom(
                 n_q_heads, kv_len, HEAD_DIM, dtype_size, headroom
             )
@@ -294,17 +298,55 @@ def _route_decision(
         return _ROUTE_TILED, 0  # headroom info unavailable -> memory-safe default
 
 
+def _broadcast_mask_5d(mask, batch, n_kv, group_size, q_len, k_len):
+    """Reshape a boolean attention mask so it broadcasts against the tiled
+    kernel's 5-D ``[batch, n_kv, group, q, k]`` layout.
+
+    Accepts the shapes model code actually emits: ``[B, 1, L, T]`` (QSA's
+    per-layer sparse mask, and most create_causal_mask outputs), a full
+    per-head ``[B, n_q, L, T]``, ``[B, L, T]``, or a bare ``[L, T]``. The
+    trailing two axes must already match the CALL's (q_len, k_len) —
+    Qwen3_5Attention narrows the mask to kv_seq_len before SDPA.
+    """
+    if mask.ndim == 4:
+        if mask.shape[1] == 1:
+            return mask[:, :, None]  # [B, 1, 1, L, T]
+        # Per-head mask: fold heads into (n_kv, group).
+        return mask.reshape(batch, n_kv, group_size, q_len, k_len)
+    if mask.ndim == 3:
+        return mask[:, None, None]
+    if mask.ndim == 2:
+        return mask[None, None, None]
+    raise ValueError(f"unsupported attention mask ndim: {mask.ndim}")
+
+
 def _flash_sdpa256(queries, keys, values, scale, mask):
     """Flash-style online-softmax attention for head_dim=256 prefill.
 
     queries: [batch, n_q, q_len, head_dim]
     keys/values: [batch, n_kv, k_len, head_dim]   (n_q % n_kv == 0)
-    mask: "causal" or None. Returns [batch, n_q, q_len, head_dim] in
+    mask: "causal", None, or a BOOLEAN mx.array (e.g. Qwen4-Exp QSA's
+    block-sparse selection mask). Returns [batch, n_q, q_len, head_dim] in
     queries.dtype.
 
     Tiles over Q and KV, keeping a running (max m, sum denom, accumulator acc) per
     query row so the [q x full_kv] score matrix is never materialized. fp32
     accumulators; output cast back to the input dtype. GQA via reshape+broadcast.
+
+    Boolean masks are sliced per (q, kv) tile and applied with the same
+    finite ``_NEG_INF`` sentinel the causal branch uses. A query row whose
+    LEADING tiles are fully masked transiently accumulates uniform exp(0)
+    weight, but the first tile containing a real score raises the running
+    max from ``_NEG_INF`` so ``corr = exp(_NEG_INF - real) == 0.0`` wipes
+    the accumulators exactly — the online softmax self-corrects, and QSA
+    guarantees every row at least one visible key (its tail term always
+    includes the query's own position). A row masked EVERYWHERE degrades to
+    uniform weights over the row — the same degenerate output the stock
+    unfused fallback produces for such rows (softmax over equal finfo-min
+    scores), with no NaN in either path. For array masks the causal
+    early-exit on the KV loop is skipped: an arbitrary bool mask may permit
+    keys past the causal diagonal, and with a cached prefix the truncation
+    saves almost nothing anyway.
 
     MLX is lazy: without forcing materialization the whole tiled graph would stay
     live until eval (peak dominated by graph buildup, not the O(L) working set),
@@ -314,7 +356,12 @@ def _flash_sdpa256(queries, keys, values, scale, mask):
     batch, n_q, q_len, head_dim = queries.shape
     _, n_kv, k_len, _ = keys.shape
     group_size = n_q // n_kv
-    causal = mask == "causal"
+    causal = isinstance(mask, str) and mask == "causal"
+    bool_mask = None
+    if isinstance(mask, mx.array):
+        if mask.dtype != mx.bool_:
+            raise ValueError("_flash_sdpa256 only supports boolean array masks")
+        bool_mask = _broadcast_mask_5d(mask, batch, n_kv, group_size, q_len, k_len)
 
     qr = queries.reshape(batch, n_kv, group_size, q_len, head_dim)
     kr = keys.reshape(batch, n_kv, 1, k_len, head_dim)
@@ -347,6 +394,8 @@ def _flash_sdpa256(queries, keys, values, scale, mask):
             if causal:
                 k_pos = mx.arange(kj0, kj1).reshape(1, 1, 1, 1, kt)
                 s = mx.where(k_pos > q_pos, _NEG_INF, s)
+            elif bool_mask is not None:
+                s = mx.where(bool_mask[..., qi0:qi1, kj0:kj1], s, _NEG_INF)
 
             m_tile = mx.max(s, axis=-1, keepdims=True)
             m_new = mx.maximum(m, m_tile)
@@ -397,7 +446,8 @@ def _unfused_qsplit_sdpa(
     memory trip it was sized to avoid).
     """
     q_len = queries.shape[-2]
-    causal = mask == "causal"
+    causal = isinstance(mask, str) and mask == "causal"
+    is_array_mask = isinstance(mask, mx.array)
     kv_off = keys.shape[-2] - q_len if causal else 0
     out_tiles = []
     for qi0 in range(0, q_len, q_sub):
@@ -406,9 +456,20 @@ def _unfused_qsplit_sdpa(
         if causal:
             k_slice = keys[..., : kv_off + qi1, :]
             v_slice = values[..., : kv_off + qi1, :]
+            sub_mask = mask
         else:
+            # Array masks (e.g. QSA's boolean selection) carry their own
+            # per-position visibility, so the causal keys-narrowing trick
+            # (which relies on MLX's right-aligned "causal" semantics) does
+            # not apply: keep keys/values full-width and slice the mask's
+            # query rows to this sub-tile. Transient per sub-call is
+            # n_q x q_sub x kv_len — the same width _max_q_sub_for_headroom
+            # sized q_sub against.
             k_slice, v_slice = keys, values
-        out_tile = original_sdpa(q_slice, k_slice, v_slice, cache, scale, mask, sinks)
+            sub_mask = mask[..., qi0:qi1, :] if is_array_mask else mask
+        out_tile = original_sdpa(
+            q_slice, k_slice, v_slice, cache, scale, sub_mask, sinks
+        )
         mx.eval(out_tile)
         out_tiles.append(out_tile)
     return mx.concatenate(out_tiles, axis=-2)
@@ -434,7 +495,21 @@ def _should_route(queries, keys, cache, mask, sinks) -> tuple[str, int]:
         # hasattr(cache, "bits"); let the quant-aware path handle it.
         if cache is not None and hasattr(cache, "bits"):
             return _ROUTE_UNFUSED, 0
-        if not (mask is None or (isinstance(mask, str) and mask == "causal")):
+        # Boolean array masks are routable: Qwen4-Exp QSA replaces the
+        # "causal" string with a [B, 1, L, T] block-sparse bool mask on
+        # every long-context prefill, which previously forced the stock
+        # unfused O(L*T) fallback here — the head_dim-256 memory wall this
+        # patch exists to fix, resurfacing through the mask gate. The
+        # q-split route row-slices such masks; the tiled route applies them
+        # per (q, kv) tile. Additive float masks stay unroutable (nothing
+        # on the hd-256 prefill path emits them; keeping them out narrows
+        # the blast radius of this process-wide wrapper).
+        mask_is_bool = isinstance(mask, mx.array) and mask.dtype == mx.bool_
+        if not (
+            mask is None
+            or (isinstance(mask, str) and mask == "causal")
+            or mask_is_bool
+        ):
             return _ROUTE_UNFUSED, 0
         n_q = queries.shape[-3]
         n_kv = keys.shape[-3]
@@ -458,7 +533,23 @@ def _should_route(queries, keys, cache, mask, sinks) -> tuple[str, int]:
         # pressure that forced tiled doesn't spontaneously relax within a
         # request, and the cache (hence the latch) dies with the request.
         ceiling = getattr(cache, "_sdpa256_q_sub_ceiling", None)
-        route, q_sub = _route_decision(queries, keys, cache, q_sub_ceiling=ceiling)
+        # Bool-array masks (QSA) must never take q-split: unlike the causal
+        # route, array-mask sub-calls cannot narrow keys/values to a causal
+        # end, so each sub-call still materializes an n_q x q_sub x kv_len
+        # slab — and the hysteresis ratchet walks q_sub DOWN between calls,
+        # so every layer/call produces a DIFFERENT slab size the Metal pool
+        # cannot reuse. Measured live (Qwen3.8-Flash 40k probe): +7.3GB pool
+        # growth by kv_len=14336 and a pre-chunk guard rejection at 14k —
+        # worse than the unfused O(L*T) wall it replaced. Unfused (single
+        # reusable slab) when it fits, else straight to tiled (uniform
+        # O(tile) buffers), nothing in between.
+        route, q_sub = _route_decision(
+            queries,
+            keys,
+            cache,
+            q_sub_ceiling=ceiling,
+            allow_qsplit=not mask_is_bool,
+        )
         if cache is not None:
             try:
                 if route == _ROUTE_TILED:

--- a/omlx/patches/turboquant_attention.py
+++ b/omlx/patches/turboquant_attention.py
@@ -606,25 +606,29 @@ def apply_turboquant_attention_patch() -> bool:
                         "falling back to prefill paths",
                         exc_info=True,
                     )
-            # Prefill: try quantized fast path, fallback to dequantize+SDPA
-            result = real_cache.prefill_attention(
-                queries,
-                keys_state=keys,
-                values_state=values,
-                scale=scale,
-                mask=mask,
-            )
-            if result is not None:
-                return result
+            # Prefill routing. Above the long-prefill threshold the tiled
+            # online-softmax route (quantized_attention: query_block x
+            # key_chunk, T-bounded transient) must run FIRST:
+            # prefill_attention materializes the FULL (B*n_kv*n_rep, L, T)
+            # fp32 score + softmax slabs with no T-tiling, and — unlike the
+            # str-mask case, which bails out of it lazily — it ACCEPTS
+            # array masks, so trying it first turned every long array-mask
+            # prefill into an O(L*T) memory spike. That also silently
+            # contradicted the scheduler's estimator, which registers the
+            # tiled query_block/key_chunk cost for exactly this threshold
+            # (Scheduler._set_model_info_for_monitor's
+            # register_tiled_prefill_tile call). Short prefills keep the
+            # single-dispatch prefill_attention fast path unchanged.
             keys_state = getattr(keys, "_state", keys)
             try:
                 total_tokens = _state_length(keys_state)
             except Exception:
                 total_tokens = 0
-            if (
+            use_tiled_first = (
                 total_tokens > _LONG_PREFILL_QUANTIZED_THRESHOLD
                 and hasattr(real_cache, "quantized_attention")
-            ):
+            )
+            if use_tiled_first:
                 old_query_block_size = getattr(
                     real_cache, "prefill_query_block_size", None
                 )
@@ -646,7 +650,8 @@ def apply_turboquant_attention_patch() -> bool:
                 except Exception:
                     logger.debug(
                         "TurboQuant quantized prefill attention failed; "
-                        "falling back to dequantize+SDPA",
+                        "falling back to prefill_attention / "
+                        "dequantize+SDPA",
                         exc_info=True,
                     )
                 finally:
@@ -654,6 +659,16 @@ def apply_turboquant_attention_patch() -> bool:
                         real_cache.prefill_query_block_size = old_query_block_size
                     if old_key_chunk_size is not None:
                         real_cache.prefill_key_chunk_size = old_key_chunk_size
+            # Short prefills, and the fallback when the tiled route raised.
+            result = real_cache.prefill_attention(
+                queries,
+                keys_state=keys,
+                values_state=values,
+                scale=scale,
+                mask=mask,
+            )
+            if result is not None:
+                return result
             # Pass the request's own views, matching prefill_attention/
             # quantized_attention above -- dequantize() defaults to None,
             # which dequantizes the ENTIRE resident cache in one shot

--- a/omlx/patches/turboquant_attention.py
+++ b/omlx/patches/turboquant_attention.py
@@ -654,7 +654,15 @@ def apply_turboquant_attention_patch() -> bool:
                         real_cache.prefill_query_block_size = old_query_block_size
                     if old_key_chunk_size is not None:
                         real_cache.prefill_key_chunk_size = old_key_chunk_size
-            dequantized_keys, dequantized_values = real_cache.dequantize()
+            # Pass the request's own views, matching prefill_attention/
+            # quantized_attention above -- dequantize() defaults to None,
+            # which dequantizes the ENTIRE resident cache in one shot
+            # instead of just what this call needs (instant OOM at long
+            # context on this fallback path).
+            # See docs/qwen35-hardening-and-optimization.md F4.
+            dequantized_keys, dequantized_values = real_cache.dequantize(
+                keys_state=keys, values_state=values
+            )
             return mx.fast.scaled_dot_product_attention(
                 queries,
                 dequantized_keys.astype(queries.dtype),

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1224,6 +1224,22 @@ _KNOWN_SLICEABLE_CACHE_TYPES = frozenset(
         "BatchTurboQuantKVCache",
         "ChunkedKVCache",
         "MiniMaxM3KVCache",
+        # Qwen4-Exp QSA full-attention caches: their handlers declare
+        # supports_block_slicing=True with token axes for all four state
+        # members (keys/values/index_keys/index_position_ids), and
+        # _fill_boundary_placeholders_from_live_cache fills blanked
+        # layers from the live cache gated on that same registry flag.
+        # Omitting QSAKVCache here made EVERY boundary snapshot carry the
+        # full K/V+index prefix (~27.9KB/token x token_count, ~1.1GB per
+        # snapshot at 40k) — the #2551 quadratic-across-snapshots trap
+        # resurfacing for a new cache class, measured live as ~5GB of
+        # request-tied RAM at 47k tokens and a pre-chunk guard rejection,
+        # plus 532MB GDN sidecars that should be ~113MB. The lockstep
+        # test in tests/test_boundary_snapshot_qsa.py keeps this set in
+        # sync with the handler registry so the next sliceable cache
+        # class cannot regress the same way.
+        "QSAKVCache",
+        "QSAQuantizedKVCache",
     }
 )
 
@@ -1281,6 +1297,31 @@ def _first_leaf_cache_offset(cache_obj: Any) -> int | None:
         return int(offset)
     except Exception:
         return None
+
+
+def _snapshot_value_nbytes(value: Any) -> int:
+    """Best-effort byte size of an in-memory boundary snapshot value.
+
+    Walks lists/tuples/dicts summing ``nbytes`` of leaf arrays (mx or np).
+    Diagnostic only — returns what it can and never raises.
+    """
+    total = 0
+    try:
+        stack = [value]
+        seen = 0
+        while stack and seen < 100_000:
+            item = stack.pop()
+            seen += 1
+            nbytes = getattr(item, "nbytes", None)
+            if isinstance(nbytes, int):
+                total += nbytes
+            elif isinstance(item, dict):
+                stack.extend(item.values())
+            elif isinstance(item, (list, tuple)):
+                stack.extend(item)
+    except Exception:
+        pass
+    return total
 
 
 def _prompt_cache_needs_snapshots(prompt_cache: list[Any]) -> bool:
@@ -6327,13 +6368,23 @@ class Scheduler:
             if saved:
                 self._boundary_cache_snapshots[request_id][token_count] = None
             else:
-                self._boundary_cache_snapshots[request_id][token_count] = (
-                    _compact_boundary_snapshot_value(
-                        self._prefill_snapshot_value(snapshot_cache),
-                        token_count,
-                        block_size,
-                        self._stream,
-                    )
+                value = _compact_boundary_snapshot_value(
+                    self._prefill_snapshot_value(snapshot_cache),
+                    token_count,
+                    block_size,
+                    self._stream,
+                )
+                self._boundary_cache_snapshots[request_id][token_count] = value
+                # A silent RAM fallback is how snapshot residency creeps into
+                # the prefill memory budget unobserved (the Fix-4/qwen4_exp
+                # investigation needed live A/B to even see it). Surface it,
+                # with size, every time it happens.
+                logger.info(
+                    "Boundary snapshot SSD save failed for %s at %d tokens; "
+                    "keeping ~%.0fMB in RAM",
+                    request_id,
+                    token_count,
+                    _snapshot_value_nbytes(value) / 1024**2,
                 )
         else:
             self._boundary_cache_snapshots[request_id][token_count] = (

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1902,6 +1902,12 @@ class Scheduler:
         # One-shot marker for the guard-off fast-path INFO emitted by
         # _sdpa256_unfused_headroom.
         self._sdpa256_unguarded_logged: bool = False
+        # kv_len of the most recent _sdpa256_unfused_headroom call, so it can
+        # tell a same-shape repeat (layers 2..N of one chunk, safe to credit
+        # pool reuse) from the first head-dim-256 call at a new, larger
+        # kv_len (whose transient is strictly bigger than anything freed so
+        # far this request -- see _sdpa256_unfused_headroom's docstring).
+        self._sdpa256_last_kv_len: int | None = None
         # Set to True by ProcessMemoryEnforcer when phys_footprint crosses
         # soft_threshold. Schedulers stop admitting new prefills while this is
         # set; in-flight requests proceed.
@@ -3031,6 +3037,11 @@ class Scheduler:
             prefill_step_size=self.config.prefill_step_size,
             stream=self._stream,
         )
+        # MTP's draft-acceptance math (_accept_lp_for) reconstructs temp/
+        # top_p/min_p/top_k but has no XTC term, so the emitted distribution
+        # would diverge from the target under XTC. Gate MTP off at
+        # eligibility time rather than model XTC in the acceptance math.
+        bg._omlx_mtp_disabled_xtc = sampling_params.xtc_probability > 0
 
         return bg
 
@@ -3895,18 +3906,50 @@ class Scheduler:
         safety_cap = self._prefill_abort_cap()
         return base_cap, safety_cap, self._prefill_abort_margin
 
-    def _sdpa256_unfused_headroom(self) -> int:
-        """Live headroom (bytes) for one unfused SDPA transient, under the
-        same target the adaptive prefill throttle enforces (hard ceiling x
-        headroom safety, clamped by the abort cap). Negative when the
-        ceiling is unknown (enforcer not propagated yet), which tells the
-        sdpa256 route to keep its memory-safe tiled default. When the guard
-        is explicitly disabled there is no ceiling to respect: the user
-        opted out of memory management, so the route gets unbounded
-        headroom and keeps the unfused fast path instead of pinning
-        guard-off servers to the ~2x-slower tiled pass (#2283). Called from
-        the route gate on the MLX step thread mid-prefill, where refreshing
-        the active-memory sample is safe (issue #2204)."""
+    def _sdpa256_unfused_headroom(self, kv_len: int) -> int:
+        """Live headroom (bytes) for one unfused SDPA transient at ``kv_len``,
+        under the same target the adaptive prefill throttle enforces (hard
+        ceiling x headroom safety, clamped by ``_admission_limit_bytes`` --
+        the same hard-watermark line the reactive process-memory enforcer
+        actually kills requests at, not the separately-derived abort cap).
+        Negative when the ceiling is unknown (enforcer not propagated yet),
+        which tells the sdpa256 route to keep its memory-safe tiled default.
+        When the guard is explicitly disabled there is no ceiling to
+        respect: the user opted out of memory management, so the route gets
+        unbounded headroom and keeps the unfused fast path instead of
+        pinning guard-off servers to the ~2x-slower tiled pass (#2283).
+        Called from the route gate on the MLX step thread mid-prefill, where
+        refreshing the active-memory sample is safe (issue #2204).
+
+        Two corrections on top of the raw target-minus-usage number, both
+        found via the same live 258k-token run and confirmed by a second
+        run that the first correction alone didn't fix:
+
+        1. Credits the retained Metal buffer pool (``credit_cache_memory``)
+           only when ``kv_len`` matches the previous call's -- i.e. this is
+           a repeat of the same chunk's shape (layers 2..N of the same
+           forward pass), not the chunk's first head-dim-256 call. Within a
+           chunk every full-attention layer shares one (kv_len, q_len)
+           shape, so a same-kv_len call is guaranteed a same-size transient
+           just freed into the pool: genuine reuse, safe to credit. The
+           FIRST call at a new (larger) kv_len has no such guarantee.
+
+        2. Charges 2x the candidate transient, not 1x (see the ``// 2`` at
+           the end). kv_len only grows within a request, so by the time
+           this chunk's transient goes cold, the pool can't reuse it for
+           the next (bigger) chunk -- it rides along as unreclaimed
+           physical footprint until a reclaim finally runs, which can't
+           happen mid-chunk (the MLX executor thread is busy inside this
+           very call). So a call at kv_len L doesn't just cost T(L); it
+           also carries roughly one dead, same-size predecessor from the
+           chunk before it. This alone (without the 2x charge) was proven
+           insufficient live: the router still rode the fast path to the
+           same abort point as the original bug, just one chunk later.
+
+        The q-split route (patches.sdpa256_attention) degrades gracefully
+        on a misestimate here (a smaller q_sub, not a wrong answer), so
+        being conservative costs a smaller q_sub for one call, not
+        correctness."""
         hard_cap = self._memory_hard_limit_bytes
         if hard_cap <= 0:
             if self._memory_limits_propagated and not self._prefill_memory_guard:
@@ -3924,11 +3967,31 @@ class Scheduler:
         headroom_safety = getattr(
             self, "_prefill_headroom_safety", self._PREFILL_HEADROOM_SAFETY
         )
-        target = int(hard_cap * headroom_safety)
-        abort_cap = self._prefill_abort_cap()
-        if abort_cap > 0:
-            target = min(target, abort_cap)
-        return target - self._current_usage_bytes()
+        # Target the SAME line the reactive enforcer actually kills at (the
+        # hard watermark via _admission_limit_bytes), not the separately
+        # -derived abort cap -- the two can diverge, and a route decision
+        # computed against a looser number than what the killer polls is
+        # exactly how "fits on paper" and "dies anyway" coexisted before
+        # this fix (confirmed via a live 258k-token run).
+        base_cap = self._admission_limit_bytes() or hard_cap
+        target = int(base_cap * headroom_safety)
+        same_shape_as_last_call = kv_len == self._sdpa256_last_kv_len
+        self._sdpa256_last_kv_len = kv_len
+        headroom = target - self._current_usage_bytes(
+            credit_cache_memory=same_shape_as_last_call
+        )
+        # Charge k=2x the candidate transient against that headroom, not 1x.
+        # By the time this chunk's own transient goes cold, kv_len has
+        # already grown for the next chunk, so kv_len monotonicity means the
+        # pool can never actually reuse it -- it rides along as unreclaimed
+        # physical footprint until the process-wide reclaim finally runs
+        # (which can't happen mid-chunk, since the MLX executor thread is
+        # busy inside this very call). So a call landing at kv_len L doesn't
+        # just cost T(L); it also carries roughly one dead, same-size
+        # predecessor from the chunk before it. Halving the returned
+        # headroom (equivalently: requiring T(L) <= headroom / 2) prices
+        # that in without needing to track the predecessor's exact size.
+        return headroom // 2 if headroom > 0 else headroom
 
     # Two pauses, not one: a marginal pooled-buffer reclaim can satisfy the
     # first pass's target check while buying only a couple of minutes of KV
@@ -4365,13 +4428,27 @@ class Scheduler:
                 logger.debug("Failed to read local hot-cache byte counter")
                 return 0
 
-    def _current_usage_bytes(self, *, refresh_mlx_active: bool = True) -> int:
+    def _current_usage_bytes(
+        self, *, refresh_mlx_active: bool = True, credit_cache_memory: bool = False
+    ) -> int:
         """Current memory usage for scheduler-side guard checks.
 
         Scheduler steps run on the MLX executor thread, so they can refresh
         mx.get_active_memory() safely. Event-loop callers such as early
         preflight use the cached executor sample and phys_footprint instead.
-        """
+
+        ``credit_cache_memory``: subtract MLX's retained-but-reusable Metal
+        buffer pool (``mx.get_cache_memory()``) from the phys-footprint side
+        only, not from ``active`` (which never included pooled memory to
+        begin with). ``phys_footprint`` lags actual reclaim by a full chunk
+        boundary (see ``_reclaim_prefill_headroom``'s docstring — 42.8GB at
+        a mid-chunk check vs 24.6GB right after), so counting the whole pool
+        against a would-be allocation double-charges memory a new call could
+        largely satisfy by reusing pooled buffers instead of growing the
+        physical footprint. Default False: existing admission/throttle/OOM
+        checks keep their current (more conservative) accounting; opt in
+        per call site once a specific caller is verified to want the
+        looser, more accurate number."""
         active = self._last_mlx_active_memory_bytes
         if refresh_mlx_active:
             active = max(0, int(mx.get_active_memory()))
@@ -4382,6 +4459,8 @@ class Scheduler:
         else:
             hot_cache_bytes = Scheduler._hot_cache_cpu_bytes(self)
         phys = max(0, int(get_phys_footprint()) - hot_cache_bytes)
+        if credit_cache_memory:
+            phys = max(0, phys - max(0, int(mx.get_cache_memory())))
         return max(active, phys)
 
     def get_active_hot_cache_block_hashes(self) -> set[bytes]:
@@ -10605,6 +10684,25 @@ class Scheduler:
 
             if not is_finished:
                 self._maybe_capture_boundary_snapshot(request, response.uid)
+                # Throttled decode-phase progress (every 8 tokens, not every
+                # token) so the tracker's O(1) lock isn't hit on every decode
+                # step across many concurrent requests. Reuses the same
+                # tracker/entry prefill already populates (phase="prefill")
+                # so SSE/dashboard consumers key on one request_id regardless
+                # of phase.
+                if (
+                    request.num_output_tokens > completion_tokens_before
+                    and request.num_output_tokens % 8 == 0
+                ):
+                    max_tokens = getattr(request.sampling_params, "max_tokens", None)
+                    if max_tokens:
+                        get_prefill_tracker().update(
+                            request_id=request_id,
+                            processed=request.num_output_tokens,
+                            total=max_tokens,
+                            model_id=self.config.model_name,
+                            phase="decode",
+                        )
 
             # Handle finished requests
             if is_finished:
@@ -10616,6 +10714,11 @@ class Scheduler:
                 output.finished = True
                 output.finish_reason = response.finish_reason
                 finished_ids.add(request_id)
+                # Most requests finish via EOS/stop well before max_tokens,
+                # so update()'s own processed>=total auto-remove never fires
+                # for them — remove explicitly here instead of leaking an
+                # entry for the tracker's lifetime.
+                get_prefill_tracker().remove(request_id)
 
                 if parser_session is not None:
                     final_result = parser_session.finalize()
@@ -12239,7 +12342,7 @@ class Scheduler:
                 except Exception:
                     pass
 
-            if (
+            tq_active = (
                 self._turboquant_kv_bits is not None
                 and isinstance(head_dim, int)
                 and not isinstance(head_dim, bool)
@@ -12253,7 +12356,8 @@ class Scheduler:
                         self._model_uses_mla() or self._model_uses_attention_sinks()
                     )
                 )
-            ):
+            )
+            if tq_active:
                 tq_dtype_size = float(self._turboquant_kv_bits) / 8.0 + (2.0 / head_dim)
                 if (
                     self._turboquant_skip_last
@@ -12342,6 +12446,41 @@ class Scheduler:
                 except Exception:
                     logger.debug(
                         "attention-bias transient registration failed",
+                        exc_info=True,
+                    )
+
+                # TurboQuant's long-prefill route (quantized_attention, once
+                # KV length exceeds its own threshold) tiles at a bounded
+                # query_block x kv_tile, not the full O(L^2) unfused score
+                # matrix -- register it on THIS monitor instance (§B3/3.2).
+                # Deliberately per-instance, not the module-global
+                # register_tiled_prefill_head_dim registry sdpa256 uses:
+                # that registry is correct only for kernels active
+                # unconditionally process-wide for a head_dim (sdpa256's
+                # monkeypatch genuinely is); TurboQuant's tiled route is
+                # gated on THIS scheduler's own config, and engine_pool.py
+                # keeps two models resident during a swap, so a global
+                # registration would leak this model's turboquant config
+                # into a concurrently-resident non-turboquant model
+                # sharing the same head_dim, under-charging its guard.
+                try:
+                    from .patches.turboquant_attention import (
+                        _LONG_PREFILL_KEY_CHUNK_SIZE,
+                        _LONG_PREFILL_QUANTIZED_THRESHOLD,
+                        _LONG_PREFILL_QUERY_BLOCK_SIZE,
+                    )
+
+                    if tq_active:
+                        self.memory_monitor.register_tiled_prefill_tile(
+                            query_block=_LONG_PREFILL_QUERY_BLOCK_SIZE,
+                            kv_tile=_LONG_PREFILL_KEY_CHUNK_SIZE,
+                            min_kv_len=_LONG_PREFILL_QUANTIZED_THRESHOLD,
+                        )
+                    else:
+                        self.memory_monitor.clear_tiled_prefill_tile()
+                except Exception:
+                    logger.debug(
+                        "turboquant tiled-prefill registration failed",
                         exc_info=True,
                     )
                 logger.debug(
@@ -12467,6 +12606,12 @@ class Scheduler:
                     layer_cache_types,
                     turboquant_kv_bits=turboquant_kv_bits,
                     cachelist_subtypes=cachelist_subtypes,
+                    # ANE-computed KV is a different numeric lineage than
+                    # GPU-computed KV; the flag is set by the engine when
+                    # the ANE prefill patch actually activates.
+                    ane_prefill=bool(
+                        getattr(self, "_qwen35_ane_prefill_active", False)
+                    ),
                 )
             else:
                 manager.adopt_layer_signature_if_unset(layer_cache_types)

--- a/omlx/turboquant_kv.py
+++ b/omlx/turboquant_kv.py
@@ -210,6 +210,54 @@ def _pad_state_left(state, pad_length: int):
     return _concat_state(pad, state)
 
 
+def _roll_state(state, shifts, axis: int = 2):
+    """Roll a quantized state along its token axis by per-row ``shifts``.
+
+    Mirrors dynamic_roll's per-batch-row dynamic shift (same axis/shifts
+    convention as _slice_state/_concat_state above), applied directly to the
+    packed representation instead of dequantize -> roll -> requantize: roll
+    is pure reindexing along the token axis, so applying it independently to
+    every field that shares that axis (norms, packed indices, radii, ...)
+    preserves their per-token pairing exactly, with no fp16 materialization
+    and no re-rounding through the codec on the way back in.
+    """
+    if state is None:
+        return None
+    if isinstance(state, TurboQuantMSEState):
+        return TurboQuantMSEState(
+            dynamic_roll(state.norms, shifts, axis=axis),
+            dynamic_roll(state.indices, shifts, axis=axis),
+        )
+    if isinstance(state, TurboQuantProdState):
+        return TurboQuantProdState(
+            dynamic_roll(state.norms, shifts, axis=axis),
+            dynamic_roll(state.mse_indices, shifts, axis=axis),
+            dynamic_roll(state.residual_norms, shifts, axis=axis),
+            dynamic_roll(state.qjl_signs, shifts, axis=axis),
+        )
+    if isinstance(state, TurboQuantPolarState):
+        return TurboQuantPolarState(
+            dynamic_roll(state.radii, shifts, axis=axis),
+            tuple(
+                dynamic_roll(level, shifts, axis=axis)
+                for level in state.level_indices
+            ),
+        )
+    if isinstance(state, TurboQuantPolarProdState):
+        return TurboQuantPolarProdState(
+            dynamic_roll(state.norms, shifts, axis=axis),
+            _roll_state(state.polar_state, shifts, axis=axis),
+            dynamic_roll(state.residual_norms, shifts, axis=axis),
+            dynamic_roll(state.qjl_signs, shifts, axis=axis),
+        )
+    if isinstance(state, TurboQuantSplitState):
+        return TurboQuantSplitState(
+            _roll_state(state.low, shifts, axis=axis),
+            _roll_state(state.high, shifts, axis=axis),
+        )
+    raise TypeError(f"Unsupported TurboQuant state type: {type(state)!r}")
+
+
 def _empty_state_batch_like(state, batch_size: int):
     """Allocate an empty token state with the requested batch size."""
     if state is None:
@@ -364,11 +412,15 @@ class BatchTurboQuantKVCache(TurboQuantKVCache):
             return
         padding = self._right_padding
         if self.keys is not None:
-            k_fp16, v_fp16 = self.dequantize()
-            k_rolled = dynamic_roll(k_fp16, padding[:, None], axis=2)
-            v_rolled = dynamic_roll(v_fp16, padding[:, None], axis=2)
-            self.keys = self.key_codec.quantize(k_rolled)
-            self.values = self.value_codec.quantize(v_rolled)
+            # Roll the already-quantized state directly (_roll_state) rather
+            # than dequantize -> dynamic_roll -> requantize: roll only
+            # reindexes along the token axis, so it's exact on the packed
+            # representation and skips both the fp16 materialization and the
+            # requantization codec's re-rounding of an already-quantized
+            # value.
+            shifts = padding[:, None]
+            self.keys = _roll_state(self.keys, shifts, axis=2)
+            self.values = _roll_state(self.values, shifts, axis=2)
             mx.eval(self.keys, self.values)
         self.offset -= (
             padding if isinstance(self.offset, mx.array) else padding[0].item()

--- a/tests/test_boundary_snapshot_qsa.py
+++ b/tests/test_boundary_snapshot_qsa.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Boundary-snapshot capture must blank block-sliceable cache layers.
+
+Qwen4-Exp's QSAKVCache was missing from ``_KNOWN_SLICEABLE_CACHE_TYPES``,
+so every boundary snapshot carried the full K/V+index prefix
+(~27.9KB/token x token_count) — the #2551 quadratic-across-snapshots trap
+resurfacing for a new cache class. Measured live: ~5GB of request-tied RAM
+at 47k tokens and a pre-chunk guard rejection, plus 532MB GDN sidecars
+that should be ~113MB. These tests pin the fix and add a registry-lockstep
+guard so the NEXT sliceable cache class cannot silently regress the same
+way.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from omlx.scheduler import (
+    _KNOWN_SLICEABLE_CACHE_TYPES,
+    _snapshot_value_nbytes,
+    Scheduler,
+)
+
+
+def test_qsa_kvcache_is_snapshot_sliceable():
+    # Both handlers declare supports_block_slicing=True (verified against
+    # the live registry, not source grep — an earlier source scan
+    # misattributed the quantized handler's flag).
+    assert "QSAKVCache" in _KNOWN_SLICEABLE_CACHE_TYPES
+    assert "QSAQuantizedKVCache" in _KNOWN_SLICEABLE_CACHE_TYPES
+    # Batch wrapper never appears in per-request prefill capture, and its
+    # handler declares slicing=False.
+    assert "BatchQSAKVCache" not in _KNOWN_SLICEABLE_CACHE_TYPES
+
+
+def test_registry_sliceable_handlers_locked_to_snapshot_skip_set():
+    """Every registered handler that declares supports_block_slicing=True
+    must be in the boundary-snapshot skip set. A True handler missing from
+    the set means every boundary snapshot for that model carries the
+    layer's full KV prefix — quadratic snapshot cost in context length
+    (how the Qwen4-Exp QSAKVCache 5GB-at-47k regression shipped).
+
+    Exemptions, both deliberate:
+    - Batch-side classes: prefill capture sees per-request cache objects,
+      never batch wrappers.
+    - PoolingCache: captured ON PURPOSE but compacted to a single-block
+      delta (`_compact_boundary_snapshot_value` /
+      `_decode_boundary_snapshot_value`), so its snapshot cost is linear,
+      not quadratic — blanking it would break the pooling store path.
+      (Its "True" comes from the DefaultCacheHandler fallback, not a
+      dedicated handler.)
+    """
+    # Handlers self-register on module import (_initialize_default_handlers).
+    from omlx.cache.type_registry import CacheTypeRegistry
+
+    compacted_by_design = {"PoolingCache"}
+
+    for class_name in CacheTypeRegistry.list_known_class_names():
+        if class_name.startswith("Batch") or class_name in compacted_by_design:
+            continue
+        handler = CacheTypeRegistry.get_handler_by_class_name(class_name)
+        if handler.supports_block_slicing:
+            assert class_name in _KNOWN_SLICEABLE_CACHE_TYPES, (
+                f"{class_name} declares supports_block_slicing=True but is "
+                "missing from scheduler._KNOWN_SLICEABLE_CACHE_TYPES — its "
+                "full state will be captured into every boundary snapshot "
+                "(quadratic in context length)."
+            )
+
+
+class QSAKVCache:  # test double: classification is by class NAME
+    pass
+
+
+class ArraysCache:
+    pass
+
+
+class CacheList:
+    def __init__(self):
+        self.caches = ()
+
+
+class SomeUnknownFutureCache:
+    pass
+
+
+def test_emit_prefill_boundary_snapshot_blanks_sliceable_layers():
+    captured = {}
+
+    stub = SimpleNamespace(
+        _on_prefill_boundary_snapshot=(
+            lambda request_id, snapshot_cache, token_count: captured.update(
+                request_id=request_id,
+                snapshot_cache=snapshot_cache,
+                token_count=token_count,
+            )
+        )
+    )
+    request = SimpleNamespace(request_id="req-1")
+    qsa, arrays, clist, unknown = (
+        QSAKVCache(),
+        ArraysCache(),
+        CacheList(),
+        SomeUnknownFutureCache(),
+    )
+    prompt_cache = [qsa, arrays, clist, unknown]
+
+    Scheduler._emit_prefill_boundary_snapshot(stub, request, prompt_cache, 2048)
+
+    snap = captured["snapshot_cache"]
+    assert snap[0] is None, "sliceable QSAKVCache must be blanked"
+    assert snap[1] is arrays, "recurrent ArraysCache must be captured"
+    assert snap[2] is clist, "composite CacheList keeps capture behavior"
+    assert snap[3] is unknown, "unknown classes stay captured (safe default)"
+    assert captured["request_id"] == "req-1"
+    assert captured["token_count"] == 2048
+
+
+def test_snapshot_value_nbytes_walks_nested_structures():
+    class FakeArray:
+        def __init__(self, nbytes):
+            self.nbytes = nbytes
+
+    value = [
+        {"state": (FakeArray(100), [FakeArray(20)]), "meta_state": "x"},
+        None,
+        FakeArray(3),
+    ]
+    assert _snapshot_value_nbytes(value) == 123
+    assert _snapshot_value_nbytes(None) == 0
+    assert _snapshot_value_nbytes(object()) == 0
+
+
+def test_oversized_snapshot_warning_threshold_exists():
+    from omlx.cache import boundary_snapshot_store as bss
+
+    # ~100-200MB is legitimate recurrent state; the guard must not fire on
+    # it, and must exist to fire on full-KV-prefix snapshots (>1GB at 40k).
+    assert bss._OVERSIZED_SNAPSHOT_WARN_BYTES >= 200 * 1024 * 1024
+    assert bss._OVERSIZED_SNAPSHOT_WARN_BYTES <= 1024 * 1024 * 1024

--- a/tests/test_paged_ssd_cache.py
+++ b/tests/test_paged_ssd_cache.py
@@ -8,6 +8,7 @@ enabling larger effective cache sizes than GPU memory allows.
 
 import errno
 import gc
+import hashlib
 import json
 import logging
 import os
@@ -762,6 +763,78 @@ class TestPagedSSDCacheManagerWithMLX:
             assert keys.shape == (1, 8, 64, 64)
             assert values.shape == (1, 8, 64, 64)
 
+    def test_save_block_refused_under_hard_disk_pressure(
+        self, tmp_path: Path, mock_mlx
+    ):
+        """A cache write is always optional (design doc §R2/C1): under the
+        hard floor, save_block becomes a no-op that counts a stat instead
+        of writing — never an admission refusal."""
+        mx = mock_mlx
+        manager = PagedSSDCacheManager(
+            cache_dir=tmp_path / "ssd_cache",
+            max_size_bytes=1024**3,
+        )
+        manager.set_disk_pressure_hard(True)
+
+        block_hash = b"refused_hash"
+        cache_data = [(mx.zeros((1, 8, 64, 64)), mx.zeros((1, 8, 64, 64)))]
+
+        result = manager.save_block(
+            block_hash=block_hash,
+            cache_data=cache_data,
+            token_count=64,
+            model_name="test-model",
+            layer_cache_types=["KVCache"],
+        )
+
+        assert result is False
+        assert not manager.has_block(block_hash)
+        assert manager.get_stats_dict()["saves_refused_disk_pressure"] == 1
+
+    def test_save_block_resumes_once_pressure_clears(self, tmp_path: Path, mock_mlx):
+        mx = mock_mlx
+        manager = PagedSSDCacheManager(
+            cache_dir=tmp_path / "ssd_cache",
+            max_size_bytes=1024**3,
+        )
+        manager.set_disk_pressure_hard(True)
+        block_hash = b"resumes_hash"
+        cache_data = [(mx.zeros((1, 8, 64, 64)), mx.zeros((1, 8, 64, 64)))]
+        manager.save_block(
+            block_hash=block_hash,
+            cache_data=cache_data,
+            token_count=64,
+            model_name="test-model",
+            layer_cache_types=["KVCache"],
+        )
+        assert not manager.has_block(block_hash)
+
+        manager.set_disk_pressure_hard(False)
+        result = manager.save_block(
+            block_hash=block_hash,
+            cache_data=cache_data,
+            token_count=64,
+            model_name="test-model",
+            layer_cache_types=["KVCache"],
+        )
+
+        assert result is True
+        assert manager.has_block(block_hash)
+
+    def test_enforce_size_limit_default_trigger_unchanged(
+        self, tmp_path: Path, mock_mlx
+    ):
+        """Backward compatibility: the no-arg call must trigger at exactly
+        the same threshold as before trigger_fraction existed (only once
+        the full effective cap is exceeded)."""
+        mx = mock_mlx
+        manager = PagedSSDCacheManager(
+            cache_dir=tmp_path / "ssd_cache",
+            max_size_bytes=1024**3,
+        )
+        # Nothing stored: tracked size (0) is always <= any positive cap.
+        assert manager.enforce_size_limit() == 0
+
     def test_load_block_with_metadata(self, tmp_path: Path, mock_mlx):
         """Test loading block with metadata."""
         mx = mock_mlx
@@ -796,6 +869,163 @@ class TestPagedSSDCacheManagerWithMLX:
         assert loaded_meta["block_size"] == 64
         assert loaded_meta["cache_signature"]
         assert loaded_meta["layer_cache_types"] == ["KVCache", "RotatingKVCache"]
+
+    def test_reconcile_prunes_index_entry_whose_file_another_manager_deleted(
+        self, tmp_path: Path, mock_mlx
+    ):
+        """design doc §A5: a second manager sharing this cache directory can
+        evict+unlink a file this manager still has indexed. reconcile_tracked_sizes
+        is the periodic decay that catches it rather than waiting for a
+        touch that may never come."""
+        mx = mock_mlx
+        cache_dir = tmp_path / "ssd_cache"
+        manager = PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+
+        block_hash = b"reconcile_hash"
+        cache_data = [(mx.zeros((1, 8, 32, 32)), mx.zeros((1, 8, 32, 32)))]
+        manager.save_block(
+            block_hash=block_hash,
+            cache_data=cache_data,
+            token_count=32,
+            model_name="m",
+            layer_cache_types=["KVCache"],
+        )
+        manager.close()
+        # Reopen so the block is indexed from disk, not held live in the
+        # hot cache/pending buffer (reconcile only prunes disk-backed
+        # index entries; a hot-cache-only entry is never "dead" this way).
+        manager = PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+        assert manager.has_block(block_hash)
+
+        # Simulate a second manager over the same dir evicting+unlinking it.
+        metadata = manager._index.get(block_hash)
+        metadata.file_path.unlink()
+
+        pruned = manager.reconcile_tracked_sizes()
+
+        assert pruned == 1
+        assert not manager.has_block(block_hash)
+
+    def test_reconcile_leaves_live_entries_alone(self, tmp_path: Path, mock_mlx):
+        mx = mock_mlx
+        cache_dir = tmp_path / "ssd_cache"
+        manager = PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+        block_hash = b"live_hash"
+        cache_data = [(mx.zeros((1, 8, 32, 32)), mx.zeros((1, 8, 32, 32)))]
+        manager.save_block(
+            block_hash=block_hash,
+            cache_data=cache_data,
+            token_count=32,
+            model_name="m",
+            layer_cache_types=["KVCache"],
+        )
+        manager.close()
+        manager = PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+
+        pruned = manager.reconcile_tracked_sizes()
+
+        assert pruned == 0
+        assert manager.has_block(block_hash)
+
+    def test_stale_main_block_lru_touch_persisted_on_ssd_hit(
+        self, tmp_path: Path, mock_mlx
+    ):
+        """A main-block SSD-tier hit persists its LRU recency to disk mtime
+        once the previously recorded access is stale (design doc §A2):
+        restart previously reseeded `last_access` from write-time mtime, so
+        a heavily-reused old prefix looked exactly as stale as a
+        written-yesterday-never-hit block, biasing eviction against it."""
+        mx = mock_mlx
+        cache_dir = tmp_path / "ssd_cache"
+        block_hash = b"\x80" + b"\x00" * 31
+        file_path = self._write_versioned_fixture_block(
+            cache_dir, mx, block_hash, num_layers=1, model_name="m"
+        )
+        old_time = time.time() - 7200
+        os.utime(file_path, (old_time, old_time))
+
+        manager = PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+        assert manager.has_block(block_hash)
+
+        loaded = manager.load_block(block_hash)
+
+        assert loaded is not None
+        assert file_path.stat().st_mtime > old_time + 1000
+
+    def test_fresh_main_block_lru_touch_not_persisted_within_throttle(
+        self, tmp_path: Path, mock_mlx
+    ):
+        """No extra utime syscall on a chain being hit repeatedly within the
+        throttle window — only the sidecar-recency-bias fix matters, not
+        churning mtimes on a hot chain."""
+        mx = mock_mlx
+        cache_dir = tmp_path / "ssd_cache"
+        block_hash = b"\x82" + b"\x00" * 31
+        self._write_versioned_fixture_block(
+            cache_dir, mx, block_hash, num_layers=1, model_name="m"
+        )
+        # Just written: file mtime and the scan-seeded last_access are both
+        # "now", well within the throttle window.
+
+        manager = PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+
+        with patch("omlx.cache.paged_ssd_cache.os.utime") as utime_spy:
+            loaded = manager.load_block(block_hash)
+
+        assert loaded is not None
+        utime_spy.assert_not_called()
+
+    def test_stale_main_block_lru_touch_persisted_on_metadata_load(
+        self, tmp_path: Path, mock_mlx
+    ):
+        """Same throttled persistence via `load_block_with_metadata`."""
+        mx = mock_mlx
+        cache_dir = tmp_path / "ssd_cache"
+        block_hash = b"\x83" + b"\x00" * 31
+        file_path = self._write_versioned_fixture_block(
+            cache_dir, mx, block_hash, num_layers=1, model_name="m"
+        )
+        old_time = time.time() - 7200
+        os.utime(file_path, (old_time, old_time))
+
+        manager = PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+
+        loaded, meta = manager.load_block_with_metadata(block_hash)
+
+        assert loaded is not None
+        assert meta is not None
+        assert file_path.stat().st_mtime > old_time + 1000
+
+    def test_main_block_ssd_hit_counted_separately_from_hot_cache_hit(
+        self, tmp_path: Path, mock_mlx
+    ):
+        """design doc §0.4/§A3: `hits` lumps every tier together; the
+        disk-cleanup work's budget-share decision needs the SSD-tier
+        main-block/sidecar split isolated from hot-cache hits."""
+        mx = mock_mlx
+        cache_dir = tmp_path / "ssd_cache"
+        block_hash = b"\x84" + b"\x00" * 31
+        self._write_versioned_fixture_block(
+            cache_dir, mx, block_hash, num_layers=1, model_name="m"
+        )
+        manager = PagedSSDCacheManager(
+            cache_dir=cache_dir,
+            max_size_bytes=1024**3,
+            hot_cache_max_bytes=1024**3,  # enable promotion for the 2nd-load assertion
+        )
+
+        # First load: disk-backed index entry, not yet promoted — SSD-tier hit.
+        assert manager.load_block(block_hash) is not None
+        stats = manager.get_stats_dict()
+        assert stats["main_block_ssd_hits"] == 1
+        assert stats["hot_cache_hits"] == 0
+
+        # Second load: now hot-cache-resident — must not double-count as
+        # an SSD-tier hit.
+        assert manager.load_block(block_hash) is not None
+        stats = manager.get_stats_dict()
+        assert stats["main_block_ssd_hits"] == 1
+        assert stats["hot_cache_hits"] == 1
 
     def test_save_canonicalizes_buffered_rotating_metadata(
         self, tmp_path: Path, mock_mlx
@@ -1205,8 +1435,11 @@ class TestPagedSSDCacheManagerWithMLX:
 
         assert not manager.has_block(corrupt_hash)
         assert manager.has_block(healthy_hash)
-        # Scan-time skips stay non-destructive (shared cache directories).
-        assert corrupt_path.exists()
+        # A final-name file that fails to parse is corrupt, not in-flight
+        # (only ever created by a completed fsync'd rename): the startup
+        # reconciliation sweep reaps it outright rather than leaking it
+        # forever (design doc §7 R1 step 2 / A1).
+        assert not corrupt_path.exists()
 
     def test_scan_rejects_corrupt_layer_meta_states_json(
         self, tmp_path: Path, mock_mlx
@@ -1228,6 +1461,109 @@ class TestPagedSSDCacheManagerWithMLX:
         )
 
         assert not manager.has_block(corrupt_hash)
+
+    def test_stale_tmp_staging_file_reaped_on_scan(self, tmp_path: Path, mock_mlx):
+        """A `*_tmp.safetensors` crash remnant older than the age gate is
+        deleted by the startup reconciliation sweep (design doc §A1/R1)."""
+        cache_dir = tmp_path / "ssd_cache"
+        sub_dir = cache_dir / "a"
+        sub_dir.mkdir(parents=True)
+        tmp_path_file = sub_dir / "abc_tmp.safetensors"
+        tmp_path_file.write_bytes(b"partial")
+        old_time = time.time() - 3600
+        os.utime(tmp_path_file, (old_time, old_time))
+
+        PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+
+        assert not tmp_path_file.exists()
+
+    def test_fresh_tmp_staging_file_survives_scan(self, tmp_path: Path, mock_mlx):
+        """A `_tmp.safetensors` file younger than the age gate may be a
+        concurrent manager's in-flight rename target and must survive."""
+        cache_dir = tmp_path / "ssd_cache"
+        sub_dir = cache_dir / "a"
+        sub_dir.mkdir(parents=True)
+        tmp_path_file = sub_dir / "abc_tmp.safetensors"
+        tmp_path_file.write_bytes(b"partial")
+
+        manager = PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+
+        assert tmp_path_file.exists()
+        # Never indexed either way, regardless of age.
+        assert not manager.has_block(b"\xab\xc0" + b"\x00" * 30)
+
+    def test_symlinked_tmp_name_never_unlinked(self, tmp_path: Path, mock_mlx):
+        """Reaping never follows a symlink, even at a stale staging name."""
+        cache_dir = tmp_path / "ssd_cache"
+        sub_dir = cache_dir / "a"
+        sub_dir.mkdir(parents=True)
+        target = tmp_path / "outside_target.safetensors"
+        target.write_bytes(b"do not delete me")
+        link_path = sub_dir / "abc_tmp.safetensors"
+        link_path.symlink_to(target)
+        old_time = time.time() - 3600
+        os.utime(target, (old_time, old_time), follow_symlinks=False)
+
+        PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+
+        assert target.exists()
+
+    def test_empty_gdn_sidecar_digest_dir_removed(self, tmp_path: Path, mock_mlx):
+        """An empty (validly-named) sidecar digest dir is inert clutter and
+        is removed by the reconciliation sweep."""
+        cache_dir = tmp_path / "ssd_cache"
+        digest = hashlib.sha256(b"sig").hexdigest()
+        digest_dir = cache_dir / "_gdn_sidecars" / digest
+        digest_dir.mkdir(parents=True)
+
+        PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+
+        assert not digest_dir.exists()
+
+    def test_malformed_gdn_sidecar_digest_dir_removed(self, tmp_path: Path, mock_mlx):
+        """A digest dir whose name never came from `_gdn_signature_digest`
+        (bad length/not hex) was never indexed and is reaped outright."""
+        cache_dir = tmp_path / "ssd_cache"
+        bad_dir = cache_dir / "_gdn_sidecars" / "not-a-valid-digest"
+        bad_dir.mkdir(parents=True)
+        (bad_dir / "junk.safetensors").write_bytes(b"junk")
+
+        PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+
+        assert not bad_dir.exists()
+
+    def test_nonempty_valid_gdn_sidecar_digest_dir_survives(
+        self, tmp_path: Path, mock_mlx
+    ):
+        """A validly-named digest dir with real sidecar content is left
+        alone by the digest-dir reap pass (only malformed/empty dirs go)."""
+        cache_dir = tmp_path / "ssd_cache"
+        digest = hashlib.sha256(b"sig").hexdigest()
+        digest_dir = cache_dir / "_gdn_sidecars" / digest
+        digest_dir.mkdir(parents=True)
+        source_hash = b"\x11" * 32
+        sidecar_file = digest_dir / f"{source_hash.hex()}.safetensors"
+        sidecar_file.write_bytes(b"real sidecar content")
+
+        PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+
+        assert digest_dir.exists()
+        assert sidecar_file.exists()
+
+    def test_malformed_gdn_sidecar_filename_reaped(self, tmp_path: Path, mock_mlx):
+        """A file inside a valid digest dir whose name isn't a hex source
+        hash is corrupt/foreign at a final path (sidecars have no `_tmp`
+        staging convention of their own) and is reaped."""
+        cache_dir = tmp_path / "ssd_cache"
+        digest = hashlib.sha256(b"sig").hexdigest()
+        digest_dir = cache_dir / "_gdn_sidecars" / digest
+        digest_dir.mkdir(parents=True)
+        bad_file = digest_dir / "not-hex.safetensors"
+        bad_file.write_bytes(b"junk")
+
+        PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+
+        assert not bad_file.exists()
 
     def test_scan_logs_skipped_incompatible_count(
         self, tmp_path: Path, mock_mlx, caplog
@@ -4046,6 +4382,84 @@ class TestLayerSignatureSweep:
             "PrefillReadyRotatingKVCache",
         ]
         assert mgr._signature_sweep_completed is True
+
+    # ---- ANE-prefill provenance (see docs/ane-prefill-moe-support.md) ----
+
+    def test_ane_prefill_change_triggers_sweep(self, tmp_path: Path):
+        """Toggling ANE prefill alone must re-arm the stale-signature sweep:
+        blocks written under the other numeric lineage (including the
+        poisoned-cache incident's ANE-corrupted blocks) must not survive
+        into the new session."""
+        mgr = self._make_manager(
+            tmp_path, expected_layer_cache_types=["ArraysCache", "KVCache"]
+        )
+        mgr._signature_sweep_completed = True
+
+        changed = mgr.set_expected_layer_signature(
+            ["ArraysCache", "KVCache"], ane_prefill=True
+        )
+
+        assert changed is True
+        assert mgr._expected_ane_prefill is True
+        assert mgr._signature_sweep_completed is False
+
+    def test_signature_stamps_ane_prefill_only_when_active(self, tmp_path: Path):
+        mgr = self._make_manager(
+            tmp_path, expected_layer_cache_types=["ArraysCache", "KVCache"]
+        )
+        plain = mgr.cache_signature_for(
+            model_name="test-model",
+            num_layers=2,
+            block_size=2048,
+            layer_cache_types=["ArraysCache", "KVCache"],
+        )
+        assert '"ane_prefill"' not in plain
+
+        mgr.set_expected_layer_signature(
+            ["ArraysCache", "KVCache"], ane_prefill=True
+        )
+        stamped = mgr.cache_signature_for(
+            model_name="test-model",
+            num_layers=2,
+            block_size=2048,
+            layer_cache_types=["ArraysCache", "KVCache"],
+        )
+        assert '"ane_prefill":true' in stamped
+
+    def test_ane_provenance_mismatch_is_rejected_both_ways(self, tmp_path: Path):
+        mgr = self._make_manager(
+            tmp_path, expected_layer_cache_types=["ArraysCache", "KVCache"]
+        )
+        gpu_sig = mgr.cache_signature_for(
+            model_name="test-model",
+            num_layers=2,
+            block_size=2048,
+            layer_cache_types=["ArraysCache", "KVCache"],
+        )
+        # GPU-expected manager accepts GPU-computed blocks.
+        assert mgr.is_signature_compatible(gpu_sig)
+
+        mgr.set_expected_layer_signature(
+            ["ArraysCache", "KVCache"], ane_prefill=True
+        )
+        ane_sig = mgr.cache_signature_for(
+            model_name="test-model",
+            num_layers=2,
+            block_size=2048,
+            layer_cache_types=["ArraysCache", "KVCache"],
+        )
+        # ANE-expected manager: accepts ANE blocks, rejects GPU blocks.
+        assert mgr.is_signature_compatible(ane_sig)
+        assert not mgr.is_signature_compatible(gpu_sig)
+        assert "ANE prefill provenance" in mgr.signature_mismatch_reason(gpu_sig)
+
+        # Back to GPU-expected: the ANE block (the poisoning vector) is
+        # rejected.
+        mgr.set_expected_layer_signature(
+            ["ArraysCache", "KVCache"], ane_prefill=False
+        )
+        assert not mgr.is_signature_compatible(ane_sig)
+        assert mgr.is_signature_compatible(gpu_sig)
 
     def test_sweep_leaves_other_models_alone(self, tmp_path: Path):
         turbo = ["ArraysCache", "TurboQuantKVCache"]

--- a/tests/test_sdpa256_attention.py
+++ b/tests/test_sdpa256_attention.py
@@ -159,6 +159,231 @@ def test_qsplit_no_mask_matches_reference():
     assert _max_abs(out, ref) < 2e-2
 
 
+# --- boolean array masks (Qwen4-Exp QSA block-sparse selection) ----------
+#
+# QSA replaces the "causal" string with a [B, 1, L, T] bool mask on every
+# long-context prefill; the routes must apply it exactly (tiled: per
+# (q, kv) tile; qsplit: row-sliced with full-width keys). Reference is a
+# dense fp32 pass using the same finite _NEG_INF sentinel convention. FA256
+# precedent tolerances: <=5e-3 vs the dense fp32 reference, NaN assertion
+# on every output.
+
+
+def _dense_ref_bool(q, k, v, scale, mask):
+    """Dense fp32 masked attention reference (finite -1e30 sentinel)."""
+    from omlx.patches.sdpa256_attention import _NEG_INF
+
+    B, n_q, L, D = q.shape
+    n_kv, T = k.shape[1], k.shape[2]
+    g = n_q // n_kv
+    qf = q.astype(mx.float32).reshape(B, n_kv, g, L, D)
+    kf = k.astype(mx.float32).reshape(B, n_kv, 1, T, D)
+    vf = v.astype(mx.float32).reshape(B, n_kv, 1, T, D)
+    s = (qf @ mx.swapaxes(kf, -1, -2)) * scale
+    m5 = mask[:, :, None] if mask.ndim == 4 else mask
+    s = mx.where(m5, s, _NEG_INF)
+    w = mx.softmax(s, axis=-1)
+    out = w @ vf
+    return out.reshape(B, n_q, L, D).astype(q.dtype)
+
+
+def _qsa_like_mask(q_len, k_len, block=64, topk=8, seed=7):
+    """Causal-subset block-sparse mask shaped like QSA's output: for each
+    query row, a random top-k of complete causal blocks plus the causal
+    tail (which always includes the query's own position — QSA's >=1
+    visible key guarantee)."""
+    import numpy as np
+
+    rng = np.random.default_rng(seed)
+    offset = k_len - q_len
+    m = np.zeros((q_len, k_len), dtype=bool)
+    for i in range(q_len):
+        gpos = offset + i
+        n_complete = (gpos + 1) // block
+        if n_complete > 0:
+            winners = rng.choice(n_complete, size=min(topk, n_complete), replace=False)
+            for b in winners:
+                m[i, b * block : (b + 1) * block] = True
+        # causal tail: incomplete trailing block through self
+        m[i, n_complete * block : gpos + 1] = True
+    return mx.array(m)[None, None]  # [1, 1, L, T]
+
+
+def test_flash_sdpa256_bool_mask_matches_dense_reference():
+    from omlx.patches.sdpa256_attention import _flash_sdpa256
+
+    q_len, k_len = 256, 8448  # chunked prefill over a long cached prefix
+    q, _, _ = _qkv(q_len, q_len)
+    _, k, v = _qkv(k_len, k_len)
+    mask = _qsa_like_mask(q_len, k_len)
+    out = _flash_sdpa256(q, k, v, SCALE_256, mask)
+    ref = _dense_ref_bool(q, k, v, SCALE_256, mask)
+    mx.eval(out, ref)
+    assert not mx.any(mx.isnan(out)).item()
+    assert _max_abs(out, ref) < 5e-3
+
+
+def test_flash_sdpa256_bool_mask_matches_stock_sdpa():
+    """Also agree with MLX's own bool-mask handling (finfo-min convention) —
+    catches a sentinel-convention divergence the dense ref would share."""
+    from omlx.patches.sdpa256_attention import _flash_sdpa256
+
+    q_len, k_len = 256, 8448
+    q, _, _ = _qkv(q_len, q_len)
+    _, k, v = _qkv(k_len, k_len)
+    mask = _qsa_like_mask(q_len, k_len)
+    out = _flash_sdpa256(q, k, v, SCALE_256, mask)
+    ref = mx.fast.scaled_dot_product_attention(q, k, v, scale=SCALE_256, mask=mask)
+    mx.eval(out, ref)
+    assert not mx.any(mx.isnan(out)).item()
+    assert _max_abs(out, ref) < 2e-2
+
+
+def test_flash_sdpa256_bool_mask_fully_masked_leading_tiles():
+    """A row whose first KV tiles are ALL masked exercises the online-softmax
+    late-wipe path: uniform exp(0) garbage accumulates until the first tile
+    with a real score raises the running max from _NEG_INF, making
+    corr == exp(_NEG_INF - real) == 0.0 wipe the accumulators exactly."""
+    import numpy as np
+
+    from omlx.patches.sdpa256_attention import _KV_TILE, _flash_sdpa256
+
+    q_len, k_len = 64, 4 * _KV_TILE + 128
+    q, _, _ = _qkv(q_len, q_len)
+    _, k, v = _qkv(k_len, k_len)
+    m = np.zeros((q_len, k_len), dtype=bool)
+    # rows 0..31: nothing visible until midway through tile 2
+    m[:32, 2 * _KV_TILE + 512 :] = True
+    # rows 32..62: standard causal-ish tail
+    m[32:63, : k_len - 256] = True
+    # row 63: visible ONLY in the final partial tile
+    m[63, 4 * _KV_TILE :] = True
+    mask = mx.array(m)[None, None]
+
+    out = _flash_sdpa256(q, k, v, SCALE_256, mask)
+    ref = _dense_ref_bool(q, k, v, SCALE_256, mask)
+    mx.eval(out, ref)
+    assert not mx.any(mx.isnan(out)).item()
+    assert _max_abs(out, ref) < 5e-3
+
+
+def test_flash_sdpa256_bool_mask_all_false_row_no_nan():
+    """A row masked EVERYWHERE (impossible under QSA, possible for arbitrary
+    callers of this process-wide patch) must degrade to uniform weights —
+    the same degenerate output the stock unfused fallback produces — with
+    no NaN."""
+    import numpy as np
+
+    from omlx.patches.sdpa256_attention import _flash_sdpa256
+
+    q_len, k_len = 32, 2048
+    q, _, _ = _qkv(q_len, q_len)
+    _, k, v = _qkv(k_len, k_len)
+    m = np.ones((q_len, k_len), dtype=bool)
+    m[5, :] = False
+    mask = mx.array(m)[None, None]
+
+    out = _flash_sdpa256(q, k, v, SCALE_256, mask)
+    ref = _dense_ref_bool(q, k, v, SCALE_256, mask)
+    mx.eval(out, ref)
+    assert not mx.any(mx.isnan(out)).item()
+    assert not mx.any(mx.isnan(ref)).item()
+    assert _max_abs(out, ref) < 5e-3
+
+
+def test_qsplit_bool_mask_matches_dense_reference():
+    """qsplit with an array mask keeps keys/values FULL-WIDTH (the causal
+    keys-narrowing trick does not apply) and row-slices the mask."""
+    from omlx.patches.sdpa256_attention import _unfused_qsplit_sdpa
+
+    q_len, k_len = 256, 8448
+    q, _, _ = _qkv(q_len, q_len)
+    _, k, v = _qkv(k_len, k_len)
+    mask = _qsa_like_mask(q_len, k_len)
+    out = _unfused_qsplit_sdpa(
+        q, k, v, None, SCALE_256, mask, None, _stock_sdpa256, 96
+    )
+    ref = _dense_ref_bool(q, k, v, SCALE_256, mask)
+    mx.eval(out, ref)
+    assert not mx.any(mx.isnan(out)).item()
+    assert _max_abs(out, ref) < 2e-2
+
+
+def test_qsplit_bool_mask_slices_rows_and_keeps_keys_full(monkeypatch):
+    from omlx.patches.sdpa256_attention import _unfused_qsplit_sdpa
+
+    q_len, k_len, q_sub = 256, 1024, 96
+    q, _, _ = _qkv(q_len, q_len)
+    _, k, v = _qkv(k_len, k_len)
+    mask = _qsa_like_mask(q_len, k_len)
+    seen = []
+
+    def recording_sdpa(qs, ks, vs, cache, scale, m, sinks):
+        seen.append((qs.shape[-2], ks.shape[-2], m.shape[-2], m.shape[-1]))
+        return mx.fast.scaled_dot_product_attention(qs, ks, vs, scale=scale, mask=m)
+
+    out = _unfused_qsplit_sdpa(
+        q, k, v, None, SCALE_256, mask, None, recording_sdpa, q_sub
+    )
+    mx.eval(out)
+    assert out.shape == q.shape
+    assert len(seen) == (q_len + q_sub - 1) // q_sub
+    for q_rows, k_width, m_rows, m_cols in seen:
+        assert k_width == k_len  # never narrowed for array masks
+        assert m_rows == q_rows  # mask rows sliced to the sub-tile
+        assert m_cols == k_len
+
+
+def test_route_bool_mask_never_takes_qsplit(_sdpa256_provider_reset):
+    """Array-mask q-split cannot narrow keys to a causal end, so each
+    sub-call still spans full kv_len AND the hysteresis ratchet walks q_sub
+    down between calls, producing many distinct slab sizes the Metal pool
+    cannot reuse (measured live: +7.3GB pool growth by kv_len=14336 and a
+    guard rejection at 14k tokens). Bool masks go unfused when the full
+    call fits, else straight to tiled."""
+    from omlx.memory_monitor import estimate_unfused_sdpa_call_bytes
+
+    sdpa256 = _sdpa256_provider_reset
+    q, k, _ = _qkv(2048, 16384)
+    bool_mask = mx.ones((1, 1, 2048, 16384), dtype=mx.bool_)
+    owner = _HeadroomOwner(1 << 40)
+    sdpa256.set_unfused_headroom_provider(owner.headroom)
+    assert sdpa256._should_route(q, k, None, bool_mask, None) == ("unfused", 0)
+
+    need = estimate_unfused_sdpa_call_bytes(24, 2048, 16384, 256, q.dtype.size)
+    # One byte short of the full call: causal would q-split here — bool
+    # masks must fall straight to tiled.
+    owner.value = need - 1
+    assert sdpa256._should_route(q, k, None, "causal", None)[0] == "qsplit"
+    assert sdpa256._should_route(q, k, None, bool_mask, None) == ("tiled", 0)
+
+
+def test_should_route_gate_bool_and_float_masks():
+    """Bool array masks are routable (memory-safe tiled default without a
+    provider); additive float masks remain unroutable."""
+    from omlx.patches import sdpa256_attention as sdpa256
+
+    q, k, _ = _qkv(2048, 16384)
+    bool_mask = mx.ones((1, 1, 2048, 16384), dtype=mx.bool_)
+    assert sdpa256._should_route(q, k, None, bool_mask, None) == ("tiled", 0)
+    float_mask = mx.zeros((2048, 16384))
+    assert sdpa256._should_route(q, k, None, float_mask, None) == ("unfused", 0)
+    # bool mask + sinks still unroutable
+    assert sdpa256._should_route(q, k, None, bool_mask, mx.zeros((4,))) == (
+        "unfused",
+        0,
+    )
+    # bool mask + quantized cache still unroutable
+
+    class _QuantCache:
+        bits = 4
+
+    assert sdpa256._should_route(q, k, _QuantCache(), bool_mask, None) == (
+        "unfused",
+        0,
+    )
+
+
 def test_qsplit_calls_original_sdpa_per_subtile():
     """Confirms the loop actually shrinks each call's query axis instead of
     passing the full tensor through once -- a no-op wrapper would still

--- a/tests/test_sdpa256_attention.py
+++ b/tests/test_sdpa256_attention.py
@@ -82,40 +82,190 @@ def test_flash_sdpa256_memory_is_sub_quadratic():
     assert peaks[1] < 6 * peaks[0]
 
 
+# --- q-split correctness --------------------------------------------------
+
+
+def _stock_sdpa256(q, k, v, cache, scale, mask, sinks):
+    return mx.fast.scaled_dot_product_attention(q, k, v, scale=scale, mask=mask)
+
+
+@pytest.mark.parametrize("q_len,k_len,q_sub", [(2048, 2048, 512), (4096, 4096, 384)])
+def test_qsplit_square_causal_matches_reference(q_len, k_len, q_sub):
+    from omlx.patches.sdpa256_attention import _unfused_qsplit_sdpa
+
+    q, k, v = _qkv(q_len, k_len)
+    out = _unfused_qsplit_sdpa(
+        q, k, v, None, SCALE_256, "causal", None, _stock_sdpa256, q_sub
+    )
+    ref = mx.fast.scaled_dot_product_attention(q, k, v, scale=SCALE_256, mask="causal")
+    mx.eval(out, ref)
+    assert out.shape == ref.shape
+    assert _max_abs(out, ref) < 2e-2
+
+
+@pytest.mark.parametrize(
+    "q_len,k_len,q_sub,tol",
+    [(128, 4096, 64, 2e-2), (2048, 8192, 500, 2e-2), (2048, 20480, 384, 1e-1)],
+)
+def test_qsplit_chunked_prefill_offset_causal_matches_reference(q_len, k_len, q_sub, tol):
+    """Chunked prefill (k_len > q_len, cached prefix) at a q_sub that does
+    not evenly divide q_len -- exercises the ragged final sub-tile.
+
+    The largest case uses a looser tolerance: fp16 softmax/accumulation
+    error over a much longer kv_len grows with the reduction length and is
+    hardware-dependent (summation order differs across Metal GPU
+    generations/drivers) -- confirmed exact (0.0 max abs diff) on one
+    machine but ~0.067 on CI's runner for the identical seeded inputs,
+    i.e. genuine cross-hardware fp16 variance, not an algorithm bug. 1e-1
+    stays far below the O(1) error a real q-split correctness bug (wrong
+    offset, dropped rows, mis-narrowed keys) would produce."""
+    from omlx.patches.sdpa256_attention import _unfused_qsplit_sdpa
+
+    q, _, _ = _qkv(q_len, q_len)
+    _, k, v = _qkv(k_len, k_len)
+    out = _unfused_qsplit_sdpa(
+        q, k, v, None, SCALE_256, "causal", None, _stock_sdpa256, q_sub
+    )
+    ref = mx.fast.scaled_dot_product_attention(q, k, v, scale=SCALE_256, mask="causal")
+    mx.eval(out, ref)
+    assert out.shape == ref.shape
+    assert _max_abs(out, ref) < tol
+
+
+def test_qsplit_matches_flash_sdpa256():
+    """Both alternate routes for the same shape must agree with each other,
+    not just the reference -- catches a routing bug that happens to pass
+    the reference check via coincidental cancellation."""
+    from omlx.patches.sdpa256_attention import _flash_sdpa256, _unfused_qsplit_sdpa
+
+    q, k, v = _qkv(2048, 8192)
+    qsplit_out = _unfused_qsplit_sdpa(
+        q, k, v, None, SCALE_256, "causal", None, _stock_sdpa256, 384
+    )
+    tiled_out = _flash_sdpa256(q, k, v, SCALE_256, "causal")
+    mx.eval(qsplit_out, tiled_out)
+    assert _max_abs(qsplit_out, tiled_out) < 2e-2
+
+
+def test_qsplit_no_mask_matches_reference():
+    from omlx.patches.sdpa256_attention import _unfused_qsplit_sdpa
+
+    q, k, v = _qkv(1024, 1024)
+    out = _unfused_qsplit_sdpa(
+        q, k, v, None, SCALE_256, None, None, _stock_sdpa256, 384
+    )
+    ref = mx.fast.scaled_dot_product_attention(q, k, v, scale=SCALE_256, mask=None)
+    mx.eval(out, ref)
+    assert _max_abs(out, ref) < 2e-2
+
+
+def test_qsplit_calls_original_sdpa_per_subtile():
+    """Confirms the loop actually shrinks each call's query axis instead of
+    passing the full tensor through once -- a no-op wrapper would still
+    pass the reference-match tests above."""
+    from omlx.patches.sdpa256_attention import _unfused_qsplit_sdpa
+
+    calls = []
+
+    def counting_sdpa(q, k, v, cache, scale, mask, sinks):
+        calls.append((q.shape[-2], k.shape[-2]))
+        return mx.fast.scaled_dot_product_attention(q, k, v, scale=scale, mask=mask)
+
+    q, k, v = _qkv(2048, 2048)
+    mx.eval(
+        _unfused_qsplit_sdpa(
+            q, k, v, None, SCALE_256, "causal", None, counting_sdpa, 512
+        )
+    )
+    assert len(calls) == 4  # 2048 / 512
+    assert [c[0] for c in calls] == [512, 512, 512, 512]  # query rows per call
+    assert [c[1] for c in calls] == [512, 1024, 1536, 2048]  # narrowed kv per call
+
+
+def test_qsplit_evals_each_subtile_before_the_next(monkeypatch):
+    """Regression for the pool-growth fix: without an eval between
+    sub-tiles, MLX's laziness lets every sub-call's graph -- including its
+    own score-matrix transient -- stay unmaterialized and pile up
+    simultaneously instead of being bounded to one sub-tile at a time (the
+    assumption q_sub's sizing depends on). A live run showed q-split
+    engaging without actually preventing the memory trip it was sized to
+    avoid; this asserts the eval that fixes it is actually called, once per
+    sub-tile, before the next sub-tile's (larger) call is issued."""
+    import mlx.core as real_mx
+
+    from omlx.patches.sdpa256_attention import _unfused_qsplit_sdpa
+
+    q, k, v = _qkv(2048, 2048)
+    original_eval = real_mx.eval
+    eval_order = []
+
+    def tracking_eval(*arrays):
+        eval_order.append("eval")
+        return original_eval(*arrays)
+
+    def counting_sdpa(q, k, v, cache, scale, mask, sinks):
+        eval_order.append("call")
+        return real_mx.fast.scaled_dot_product_attention(
+            q, k, v, scale=scale, mask=mask
+        )
+
+    monkeypatch.setattr(
+        "omlx.patches.sdpa256_attention.mx.eval", tracking_eval
+    )
+    original_eval(
+        _unfused_qsplit_sdpa(
+            q, k, v, None, SCALE_256, "causal", None, counting_sdpa, 512
+        )
+    )
+    assert eval_order == ["call", "eval"] * 4
+
+
 # --- route gate ----------------------------------------------------------
 
 
 def test_should_route_gate():
+    """No headroom provider is registered here, so any shape that reaches
+    the routing decision at all lands on tiled (the memory-safe default) --
+    the point of this test is the shape gates upstream of that decision."""
     from omlx.patches import sdpa256_attention as sdpa256
 
     q, k, _ = _qkv(2048, 16384)  # 256, prefill, long
-    assert sdpa256._should_route(q, k, None, "causal", None) is True
-    assert sdpa256._should_route(q, k, None, None, None) is True
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
+    assert sdpa256._should_route(q, k, None, None, None) == ("tiled", 0)
     # decode (qL==1) -> fused vector kernel handles 256
     qd, kd, _ = _qkv(1, 16384)
-    assert sdpa256._should_route(qd, kd, None, "causal", None) is False
+    assert sdpa256._should_route(qd, kd, None, "causal", None) == ("unfused", 0)
     # decode-shaped multi-row (MTP verify, qL = 1 + depth <= 9) -> stock path;
     # the per-tile eval sync collapses long-context MTP tok/s (issue #2127)
     for q_len in (2, 4, 9, 15):
         qv, kv, _ = _qkv(q_len, 16384)
-        assert sdpa256._should_route(qv, kv, None, "causal", None) is False
+        assert sdpa256._should_route(qv, kv, None, "causal", None) == ("unfused", 0)
     qv, kv, _ = _qkv(16, 16384)
-    assert sdpa256._should_route(qv, kv, None, "causal", None) is True
+    assert sdpa256._should_route(qv, kv, None, "causal", None) == ("tiled", 0)
     # short kv -> keep the faster fallback
     qs, ks, _ = _qkv(2048, 4096)
-    assert sdpa256._should_route(qs, ks, None, "causal", None) is False
+    assert sdpa256._should_route(qs, ks, None, "causal", None) == ("unfused", 0)
     # wrong head_dim
     qh, kh, _ = _qkv(2048, 16384, head_dim=128)
-    assert sdpa256._should_route(qh, kh, None, "causal", None) is False
+    assert sdpa256._should_route(qh, kh, None, "causal", None) == ("unfused", 0)
     # array mask / sinks -> passthrough
-    assert sdpa256._should_route(q, k, None, mx.zeros((2048, 16384)), None) is False
-    assert sdpa256._should_route(q, k, None, "causal", mx.zeros((4,))) is False
+    assert sdpa256._should_route(q, k, None, mx.zeros((2048, 16384)), None) == (
+        "unfused",
+        0,
+    )
+    assert sdpa256._should_route(q, k, None, "causal", mx.zeros((4,))) == (
+        "unfused",
+        0,
+    )
 
     # quantized KV cache (has .bits) -> passthrough to the quant-aware SDPA
     class _QuantCache:
         bits = 4
 
-    assert sdpa256._should_route(q, k, _QuantCache(), "causal", None) is False
+    assert sdpa256._should_route(q, k, _QuantCache(), "causal", None) == (
+        "unfused",
+        0,
+    )
 
 
 # --- patched dispatcher passthrough vs route -----------------------------
@@ -193,6 +343,7 @@ def test_estimator_switches_to_ol_when_registered():
     monitor._num_attention_heads = 24
     monitor._num_kv_heads = 4
     monitor._score_dtype_size = 2
+    monitor._tiled_prefill_override = None
 
     chunk, kv = 2048, 200_000
     # Ensure not registered first (isolate from import-time state).
@@ -224,6 +375,7 @@ def test_unfused_call_bytes_shared_with_guard_estimator():
     monitor._num_attention_heads = 24
     monitor._num_kv_heads = 4
     monitor._score_dtype_size = 2
+    monitor._tiled_prefill_override = None
 
     mm._SDPA_TILED_PREFILL_HEAD_DIMS.pop(256, None)
     assert monitor._estimate_sdpa_activation_bytes(2048, 200_000) == (
@@ -240,7 +392,7 @@ class _HeadroomOwner:
     def __init__(self, value):
         self.value = value
 
-    def headroom(self):
+    def headroom(self, kv_len):
         return self.value
 
 
@@ -251,7 +403,8 @@ def _sdpa256_provider_reset(monkeypatch):
 
     monkeypatch.setattr(sdpa256, "_HEADROOM_PROVIDER", None, raising=False)
     monkeypatch.setattr(sdpa256, "_FORCE_TILED", None, raising=False)
-    monkeypatch.setattr(sdpa256, "_TILED_ROUTE_LOGGED", set(), raising=False)
+    monkeypatch.setattr(sdpa256, "_QSPLIT_ENABLED", True, raising=False)
+    monkeypatch.setattr(sdpa256, "_LAST_ROUTE_DECISION_NO_CACHE", None, raising=False)
     return sdpa256
 
 
@@ -262,19 +415,136 @@ def test_route_prefers_stock_when_unfused_fits(_sdpa256_provider_reset):
     q, k, _ = _qkv(2048, 16384)
     owner = _HeadroomOwner(1 << 40)  # ~1 TB headroom: unfused clearly fits
     sdpa256.set_unfused_headroom_provider(owner.headroom)
-    assert sdpa256._should_route(q, k, None, "causal", None) is False
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("unfused", 0)
 
     # Exactly at the estimated transient the unfused path still fits...
     need = estimate_unfused_sdpa_call_bytes(24, 2048, 16384, 256, q.dtype.size)
     owner.value = need
-    assert sdpa256._should_route(q, k, None, "causal", None) is False
-    # ...one byte short -> tiled.
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("unfused", 0)
+    # ...one byte short -> the full call doesn't fit, but a narrower q-split
+    # slice still does, so it stays on the fast kernel instead of falling
+    # all the way to tiled.
     owner.value = need - 1
-    assert sdpa256._should_route(q, k, None, "causal", None) is True
+    route, q_sub = sdpa256._should_route(q, k, None, "causal", None)
+    assert route == "qsplit"
+    assert sdpa256._QSPLIT_MIN_Q <= q_sub < 2048
+
+    # Headroom below even the q-split floor (128 rows) -> tiled.
+    per_row = need // 2048
+    owner.value = sdpa256._QSPLIT_MIN_Q * per_row - 1
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
 
     # Negative headroom = no active ceiling -> memory-safe default.
     owner.value = -1
-    assert sdpa256._should_route(q, k, None, "causal", None) is True
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
+
+
+def test_route_qsplit_disabled_falls_straight_to_tiled(_sdpa256_provider_reset):
+    """OMLX_SDPA256_QSPLIT=0 restores pre-q-split behavior: once the full
+    unfused call doesn't fit, go straight to tiled without trying a
+    narrower slice."""
+    sdpa256 = _sdpa256_provider_reset
+    sdpa256._QSPLIT_ENABLED = False
+    from omlx.memory_monitor import estimate_unfused_sdpa_call_bytes
+
+    q, k, _ = _qkv(2048, 16384)
+    need = estimate_unfused_sdpa_call_bytes(24, 2048, 16384, 256, q.dtype.size)
+    owner = _HeadroomOwner(need - 1)
+    sdpa256.set_unfused_headroom_provider(owner.headroom)
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
+
+
+def test_route_hysteresis_never_climbs_back_to_unfused(_sdpa256_provider_reset):
+    """Once a request's cache has needed q-split or tiled, later chunks must
+    not flip back to full unfused even if that chunk's own estimate looks
+    like it fits -- kv_len is monotone within a request, so a route shed
+    earlier reflects pressure that cannot have relaxed. Regression for a
+    live run that flickered qsplit->unfused 16 seconds before the reactive
+    memory guard aborted the request."""
+    sdpa256 = _sdpa256_provider_reset
+
+    class _Cache:
+        pass
+
+    cache = _Cache()
+    q, k, _ = _qkv(2048, 16384)
+    owner = _HeadroomOwner(1 << 40)  # ample headroom: fast path every time
+    sdpa256.set_unfused_headroom_provider(owner.headroom)
+
+    # First call: plenty of headroom, stays unfused, no downgrade recorded.
+    assert sdpa256._should_route(q, k, cache, "causal", None) == ("unfused", 0)
+    assert getattr(cache, "_sdpa256_q_sub_ceiling", None) is None
+
+    # Headroom tightens (simulating real pressure) and the route sheds to
+    # tiled; the cache now carries a permanent downgrade marker.
+    owner.value = 0
+    assert sdpa256._should_route(q, k, cache, "causal", None) == ("tiled", 0)
+    assert cache._sdpa256_q_sub_ceiling == 0
+
+    # Headroom "recovers" (e.g. a momentarily generous estimate) -- without
+    # hysteresis this would flip back to unfused. It must not.
+    owner.value = 1 << 40
+    assert sdpa256._should_route(q, k, cache, "causal", None) != ("unfused", 0)
+
+    # A fresh request (new cache object) is unaffected by the first
+    # request's downgrade.
+    fresh_cache = _Cache()
+    assert sdpa256._should_route(q, k, fresh_cache, "causal", None) == (
+        "unfused",
+        0,
+    )
+
+
+def test_route_hysteresis_caps_q_sub_not_just_the_route_label(
+    _sdpa256_provider_reset,
+):
+    """A request downgraded to qsplit must not have q_sub float back up to
+    q_len (a full-size transient, byte-for-byte identical to unfused) just
+    because a later chunk's headroom estimate looks momentarily generous
+    again -- capping only the route *label* while leaving q_sub uncapped
+    was verified live to reproduce exactly that: a single qsplit sub-call
+    the same size as the plain unfused call it was supposed to avoid."""
+    from omlx.memory_monitor import estimate_unfused_sdpa_call_bytes
+
+    sdpa256 = _sdpa256_provider_reset
+
+    class _Cache:
+        pass
+
+    cache = _Cache()
+    q, k, _ = _qkv(2048, 16384)
+    need = estimate_unfused_sdpa_call_bytes(24, 2048, 16384, 256, q.dtype.size)
+    per_row = need // 2048
+
+    # First call: headroom fits ~1024 rows, not the full 2048 -> qsplit,
+    # ceiling latches to that q_sub.
+    owner = _HeadroomOwner(1024 * per_row)
+    sdpa256.set_unfused_headroom_provider(owner.headroom)
+    route, q_sub = sdpa256._should_route(q, k, cache, "causal", None)
+    assert route == "qsplit"
+    assert q_sub == 1024
+    assert cache._sdpa256_q_sub_ceiling == 1024
+
+    # Headroom "recovers" to ample -- without capping q_sub itself, this
+    # would compute q_sub=2048 (== q_len), a full-size transient.
+    owner.value = 1 << 40
+    route, q_sub = sdpa256._should_route(q, k, cache, "causal", None)
+    assert route == "qsplit"
+    assert q_sub <= 1024
+    assert cache._sdpa256_q_sub_ceiling <= 1024
+
+    # Headroom tightens further -> ceiling ratchets down, never back up.
+    owner.value = 256 * per_row
+    route, q_sub = sdpa256._should_route(q, k, cache, "causal", None)
+    assert route == "qsplit"
+    assert q_sub == 256
+    assert cache._sdpa256_q_sub_ceiling == 256
+
+    # Recovers again -- still held at the smallest q_sub ever proven safe.
+    owner.value = 1 << 40
+    route, q_sub = sdpa256._should_route(q, k, cache, "causal", None)
+    assert route == "qsplit"
+    assert q_sub <= 256
 
 
 def test_route_defaults_to_tiled_when_provider_owner_dies(_sdpa256_provider_reset):
@@ -284,23 +554,23 @@ def test_route_defaults_to_tiled_when_provider_owner_dies(_sdpa256_provider_rese
     q, k, _ = _qkv(2048, 16384)
     owner = _HeadroomOwner(1 << 40)
     sdpa256.set_unfused_headroom_provider(owner.headroom)
-    assert sdpa256._should_route(q, k, None, "causal", None) is False
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("unfused", 0)
     del owner
     gc.collect()
-    assert sdpa256._should_route(q, k, None, "causal", None) is True
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
 
 
 def test_route_defaults_to_tiled_when_provider_raises(_sdpa256_provider_reset):
     sdpa256 = _sdpa256_provider_reset
 
     class _Boom:
-        def headroom(self):
+        def headroom(self, kv_len):
             raise RuntimeError("no headroom info")
 
     boom = _Boom()
     sdpa256.set_unfused_headroom_provider(boom.headroom)
     q, k, _ = _qkv(2048, 16384)
-    assert sdpa256._should_route(q, k, None, "causal", None) is True
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
 
 
 def test_force_tiled_override(_sdpa256_provider_reset, monkeypatch):
@@ -310,11 +580,11 @@ def test_force_tiled_override(_sdpa256_provider_reset, monkeypatch):
     sdpa256.set_unfused_headroom_provider(owner.headroom)
     # 1: always tiled even though unfused fits.
     monkeypatch.setattr(sdpa256, "_FORCE_TILED", True, raising=False)
-    assert sdpa256._should_route(q, k, None, "causal", None) is True
-    # 0: never tiled even without headroom info.
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
+    # 0: never tiled (or q-split) even without headroom info.
     monkeypatch.setattr(sdpa256, "_FORCE_TILED", False, raising=False)
     monkeypatch.setattr(sdpa256, "_HEADROOM_PROVIDER", None, raising=False)
-    assert sdpa256._should_route(q, k, None, "causal", None) is False
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("unfused", 0)
 
 
 def test_parse_force_tiled_env(monkeypatch):
@@ -328,15 +598,48 @@ def test_parse_force_tiled_env(monkeypatch):
     assert sdpa256._parse_force_tiled_env() is False
 
 
+def test_parse_qsplit_env(monkeypatch):
+    from omlx.patches import sdpa256_attention as sdpa256
+
+    monkeypatch.delenv("OMLX_SDPA256_QSPLIT", raising=False)
+    assert sdpa256._parse_qsplit_env() is True
+    monkeypatch.setenv("OMLX_SDPA256_QSPLIT", "1")
+    assert sdpa256._parse_qsplit_env() is True
+    monkeypatch.setenv("OMLX_SDPA256_QSPLIT", "0")
+    assert sdpa256._parse_qsplit_env() is False
+
+
+def test_max_q_sub_for_headroom():
+    from omlx.memory_monitor import estimate_unfused_sdpa_call_bytes
+    from omlx.patches.sdpa256_attention import _max_q_sub_for_headroom
+
+    n_q, kv_len, hd, dtype_size = 24, 16384, 256, 2.0
+    # Headroom for exactly N rows must accept N and reject N+1.
+    for n_rows in (1, 37, 512, 2048):
+        headroom = estimate_unfused_sdpa_call_bytes(
+            n_q, n_rows, kv_len, hd, dtype_size
+        )
+        assert _max_q_sub_for_headroom(n_q, kv_len, hd, dtype_size, headroom) == n_rows
+        assert (
+            _max_q_sub_for_headroom(n_q, kv_len, hd, dtype_size, headroom - 1)
+            == n_rows - 1
+        )
+    assert _max_q_sub_for_headroom(n_q, kv_len, hd, dtype_size, 0) == 0
+    assert _max_q_sub_for_headroom(n_q, kv_len, hd, dtype_size, -1) == 0
+
+
 # --- tiled-route engagement logging (issue #2283) --------------------------
 
 
-def _tiled_log_records(caplog):
-    return [
+def _route_log_records(caplog, route=None):
+    records = [
         r
         for r in caplog.records
-        if r.levelname == "INFO" and "tiled" in r.getMessage()
+        if r.levelname == "INFO" and r.getMessage().startswith("sdpa256: route -> ")
     ]
+    if route is None:
+        return records
+    return [r for r in records if r.getMessage().startswith(f"sdpa256: route -> {route}")]
 
 
 def test_tiled_route_logs_once_when_no_provider(_sdpa256_provider_reset, caplog):
@@ -345,30 +648,64 @@ def test_tiled_route_logs_once_when_no_provider(_sdpa256_provider_reset, caplog)
     sdpa256 = _sdpa256_provider_reset
     q, k, _ = _qkv(2048, 16384)
     with caplog.at_level(logging.INFO, logger=sdpa256.__name__):
-        assert sdpa256._should_route(q, k, None, "causal", None) is True
-        records = _tiled_log_records(caplog)
+        assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
+        records = _route_log_records(caplog)
         assert len(records) == 1
         msg = records[0].getMessage()
         assert "no guard headroom provider" in msg
         assert "OMLX_SDPA256_TILED" in msg
-        # Second engagement for the same reason: no new record.
-        assert sdpa256._should_route(q, k, None, "causal", None) is True
-        assert len(_tiled_log_records(caplog)) == 1
+        # Second engagement, same decision: no new record (transition-only).
+        assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
+        assert len(_route_log_records(caplog)) == 1
 
 
 def test_tiled_route_logs_headroom_numbers(_sdpa256_provider_reset, caplog):
     sdpa256 = _sdpa256_provider_reset
     q, k, _ = _qkv(2048, 16384)
-    owner = _HeadroomOwner(1)  # 1 byte of headroom: unfused can't fit
+    owner = _HeadroomOwner(1)  # 1 byte of headroom: not even q-split fits
     sdpa256.set_unfused_headroom_provider(owner.headroom)
     with caplog.at_level(logging.INFO, logger=sdpa256.__name__):
-        assert sdpa256._should_route(q, k, None, "causal", None) is True
-    records = _tiled_log_records(caplog)
+        assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
+    records = _route_log_records(caplog, "tiled")
     assert len(records) == 1
     msg = records[0].getMessage()
-    assert "exceeds live guard headroom" in msg
+    assert "exceeds" in msg
     assert "kv_len=16384" in msg
     assert "MiB" in msg
+
+
+def test_route_dedup_is_keyed_per_cache_not_module_global(
+    _sdpa256_provider_reset, caplog
+):
+    """E5: the model passes one cache per full-attention layer. A single
+    module-global last-decision meant interleaved calls from different
+    layers (or different concurrent requests) flapped the transition log on
+    every call instead of only on real transitions -- each cache's own
+    decision now dedups independently, keyed on that cache object.
+    See docs/qwen35-hardening-and-optimization.md E5."""
+    sdpa256 = _sdpa256_provider_reset
+    q, k, _ = _qkv(2048, 16384)
+    owner = _HeadroomOwner(1 << 40)  # unfused clearly fits
+    sdpa256.set_unfused_headroom_provider(owner.headroom)
+
+    class _FakeCache:
+        pass
+
+    layer_a = _FakeCache()
+    layer_b = _FakeCache()
+
+    with caplog.at_level(logging.INFO, logger=sdpa256.__name__):
+        # Interleaved calls from two different layers, same decision each
+        # time -- a module-global would see this as alternating (A, B, A,
+        # B, ...) and log every single call. Per-cache keying logs each
+        # cache's FIRST call only.
+        assert sdpa256._should_route(q, k, layer_a, "causal", None) == ("unfused", 0)
+        assert sdpa256._should_route(q, k, layer_b, "causal", None) == ("unfused", 0)
+        assert sdpa256._should_route(q, k, layer_a, "causal", None) == ("unfused", 0)
+        assert sdpa256._should_route(q, k, layer_b, "causal", None) == ("unfused", 0)
+
+    records = _route_log_records(caplog, "unfused")
+    assert len(records) == 2  # one per cache, not one per call
 
 
 def test_tiled_route_logs_forced_env(_sdpa256_provider_reset, caplog, monkeypatch):
@@ -376,68 +713,225 @@ def test_tiled_route_logs_forced_env(_sdpa256_provider_reset, caplog, monkeypatc
     monkeypatch.setattr(sdpa256, "_FORCE_TILED", True, raising=False)
     q, k, _ = _qkv(2048, 16384)
     with caplog.at_level(logging.INFO, logger=sdpa256.__name__):
-        assert sdpa256._should_route(q, k, None, "causal", None) is True
-    records = _tiled_log_records(caplog)
+        assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
+    records = _route_log_records(caplog, "tiled")
     assert len(records) == 1
     assert "OMLX_SDPA256_TILED=1" in records[0].getMessage()
 
 
-def test_unfused_route_logs_nothing(_sdpa256_provider_reset, caplog):
+def test_unfused_route_logs_nothing_extra(_sdpa256_provider_reset, caplog):
+    """The unfused route still logs its own transition (useful for
+    confirming a request stayed on the fast path), but must not produce a
+    *tiled*-labeled record."""
     sdpa256 = _sdpa256_provider_reset
     q, k, _ = _qkv(2048, 16384)
     owner = _HeadroomOwner(1 << 40)  # ample headroom: fast path
     sdpa256.set_unfused_headroom_provider(owner.headroom)
     with caplog.at_level(logging.INFO, logger=sdpa256.__name__):
-        assert sdpa256._should_route(q, k, None, "causal", None) is False
-    assert _tiled_log_records(caplog) == []
+        assert sdpa256._should_route(q, k, None, "causal", None) == ("unfused", 0)
+    assert _route_log_records(caplog, "tiled") == []
+    assert len(_route_log_records(caplog, "unfused")) == 1
 
 
-def test_scheduler_headroom_provider_math():
-    """_sdpa256_unfused_headroom mirrors the adaptive throttle target:
-    hard ceiling x headroom safety, clamped by the abort cap, minus usage."""
-    from omlx.scheduler import _SDPA256_UNBOUNDED_HEADROOM, Scheduler
+def test_qsplit_route_logs_transition(_sdpa256_provider_reset, caplog):
+    sdpa256 = _sdpa256_provider_reset
+    from omlx.memory_monitor import estimate_unfused_sdpa_call_bytes
 
-    gib = 1024**3
+    q, k, _ = _qkv(2048, 16384)
+    need = estimate_unfused_sdpa_call_bytes(24, 2048, 16384, 256, q.dtype.size)
+    owner = _HeadroomOwner(need - 1)
+    sdpa256.set_unfused_headroom_provider(owner.headroom)
+    with caplog.at_level(logging.INFO, logger=sdpa256.__name__):
+        route, q_sub = sdpa256._should_route(q, k, None, "causal", None)
+        assert route == "qsplit"
+    records = _route_log_records(caplog, "qsplit")
+    assert len(records) == 1
+    msg = records[0].getMessage()
+    assert f"q_sub={q_sub}" in msg
+    assert "kv_len=16384" in msg
+
+
+def _sdpa256_headroom_fake(gib, usage_bytes=None):
+    """Shared fake scaffold for _sdpa256_unfused_headroom tests. usage_bytes
+    fixed (usage doesn't vary with the credit flag) unless a subclass
+    overrides _current_usage_bytes to record calls."""
+    from omlx.scheduler import Scheduler
 
     class _Fake:
         _memory_hard_limit_bytes = 0
+        _memory_hard_watermark_bytes = 0
         _memory_abort_limit_bytes = 0
         _memory_limits_propagated = False
         _prefill_memory_guard = False
         _sdpa256_unguarded_logged = False
+        _sdpa256_last_kv_len = None
         _prefill_headroom_safety = 0.90
         _PREFILL_HEADROOM_SAFETY = 0.90
         _prefill_abort_margin = 0.95
         _prefill_abort_cap = Scheduler._prefill_abort_cap
+        _admission_limit_bytes = Scheduler._admission_limit_bytes
 
-        def _current_usage_bytes(self):
-            return 10 * gib
+        def _current_usage_bytes(self, *, credit_cache_memory=False):
+            return usage_bytes
 
-    fake = _Fake()
+    return _Fake()
+
+
+def test_scheduler_headroom_provider_math():
+    """_sdpa256_unfused_headroom targets _admission_limit_bytes (the same
+    hard-watermark line the reactive enforcer kills at) x headroom safety,
+    minus usage, then charges 2x by halving the result (see
+    test_sdpa256_headroom_charges_2x_transient for that specifically).
+    Usage is held fixed regardless of the credit flag -- the credit-toggle
+    behavior itself is covered separately by
+    test_sdpa256_headroom_credits_pool_only_on_repeated_shape."""
+    from omlx.scheduler import _SDPA256_UNBOUNDED_HEADROOM, Scheduler
+
+    gib = 1024**3
+    fake = _sdpa256_headroom_fake(gib, usage_bytes=10 * gib)
+    kv_len = 16384
     # Nothing propagated yet: guard state is unknown, so the negative
     # sentinel keeps the tiled default even though the flag reads False.
-    assert Scheduler._sdpa256_unfused_headroom(fake) == -1
+    assert Scheduler._sdpa256_unfused_headroom(fake, kv_len) == -1
 
     # Enforcer has spoken and the guard is explicitly off: the user opted
     # out of memory management, so the route gets unbounded headroom and
     # keeps the unfused fast path (#2283).
     fake._memory_limits_propagated = True
     assert (
-        Scheduler._sdpa256_unfused_headroom(fake) == _SDPA256_UNBOUNDED_HEADROOM
+        Scheduler._sdpa256_unfused_headroom(fake, kv_len)
+        == _SDPA256_UNBOUNDED_HEADROOM
     )
 
     # Guard on but the ceiling has not landed yet (startup race): stay on
     # the memory-safe default.
     fake._prefill_memory_guard = True
-    assert Scheduler._sdpa256_unfused_headroom(fake) == -1
+    assert Scheduler._sdpa256_unfused_headroom(fake, kv_len) == -1
 
-    # Throttle target binds: abort cap (100 * 0.95) > target (100 * 0.90).
+    # Watermark not propagated yet: _admission_limit_bytes falls back to
+    # the hard limit alone.
     fake._memory_hard_limit_bytes = 100 * gib
-    assert Scheduler._sdpa256_unfused_headroom(fake) == int(100 * gib * 0.90) - 10 * gib
+    target = int(100 * gib * 0.90)
+    assert Scheduler._sdpa256_unfused_headroom(fake, kv_len) == (
+        target - 10 * gib
+    ) // 2
 
-    # Abort cap binds when lower than the throttle target.
-    fake._memory_abort_limit_bytes = 80 * gib
-    assert Scheduler._sdpa256_unfused_headroom(fake) == int(80 * gib * 0.95) - 10 * gib
+    # Watermark binds once propagated and lower than the hard limit -- the
+    # same line the reactive enforcer actually kills at.
+    fake._memory_hard_watermark_bytes = 85 * gib
+    target = int(85 * gib * 0.90)
+    assert Scheduler._sdpa256_unfused_headroom(fake, kv_len) == (
+        target - 10 * gib
+    ) // 2
+
+
+def test_sdpa256_headroom_charges_2x_transient():
+    """A call only clears the route gate when its transient fits HALF the
+    raw (target - usage) headroom, not the whole thing -- pricing in the
+    same-size predecessor transient that kv_len monotonicity guarantees is
+    still sitting unreclaimed in the pool (chunk k-1's transient can never
+    be reused by chunk k's strictly larger one, and reclaim can't run
+    mid-chunk). Proven necessary, not just defensive, by a live run where
+    the 1x-charge version still rode the fast path to the same real-memory
+    abort point as the original bug."""
+    from omlx.scheduler import Scheduler
+
+    gib = 1024**3
+    fake = _sdpa256_headroom_fake(gib, usage_bytes=10 * gib)
+    fake._memory_limits_propagated = True
+    fake._prefill_memory_guard = True
+    fake._memory_hard_limit_bytes = 100 * gib
+
+    raw_headroom = int(100 * gib * 0.90) - 10 * gib
+    charged = Scheduler._sdpa256_unfused_headroom(fake, 16384)
+    assert charged == raw_headroom // 2
+    assert charged < raw_headroom
+
+
+def test_sdpa256_headroom_credits_pool_only_on_repeated_shape():
+    """Regression for the pool-growth memory regression found via a live
+    258k-token run: crediting mx.get_cache_memory() unconditionally let the
+    router keep choosing the big-transient unfused/qsplit route as the
+    retained pool inflated, so the *uncredited* reactive hard-watermark
+    guard tripped abruptly instead of the old code's clean predictive 400.
+    Within one chunk every full-attention layer shares one (kv_len, q_len)
+    shape, so only a same-kv_len repeat call is guaranteed a same-size freed
+    transient to reuse -- the first call at a new, larger kv_len is not."""
+    from omlx.scheduler import Scheduler
+
+    gib = 1024**3
+
+    class _Fake:
+        _memory_hard_limit_bytes = 100 * gib
+        _memory_hard_watermark_bytes = 0
+        _memory_abort_limit_bytes = 0
+        _memory_limits_propagated = True
+        _prefill_memory_guard = True
+        _sdpa256_unguarded_logged = False
+        _sdpa256_last_kv_len = None
+        _prefill_headroom_safety = 0.90
+        _PREFILL_HEADROOM_SAFETY = 0.90
+        _prefill_abort_margin = 0.95
+        _prefill_abort_cap = Scheduler._prefill_abort_cap
+        _admission_limit_bytes = Scheduler._admission_limit_bytes
+
+        def __init__(self):
+            self.credit_calls = []
+
+        def _current_usage_bytes(self, *, credit_cache_memory=False):
+            self.credit_calls.append(credit_cache_memory)
+            return 10 * gib
+
+    fake = _Fake()
+    # First call at kv_len=A: no same-shape call has run yet -> uncredited.
+    Scheduler._sdpa256_unfused_headroom(fake, 16384)
+    # Second call, same kv_len=A (e.g. layer 2 of the same chunk): a
+    # same-size transient was already freed by the first call -> credited.
+    Scheduler._sdpa256_unfused_headroom(fake, 16384)
+    # Third call, new larger kv_len=B (next chunk): nothing this size has
+    # been freed yet -> uncredited again, even though the pool has entries.
+    Scheduler._sdpa256_unfused_headroom(fake, 18432)
+    # Fourth call, repeats kv_len=B -> credited.
+    Scheduler._sdpa256_unfused_headroom(fake, 18432)
+
+    assert fake.credit_calls == [False, True, False, True]
+
+
+def test_current_usage_bytes_credits_cache_memory_on_the_phys_side(monkeypatch):
+    """credit_cache_memory=True subtracts mx.get_cache_memory() from the
+    phys-footprint side only -- it must never pull the result below
+    mx.get_active_memory() (which never included pooled memory), and must
+    have no effect at all when active already wins the max()."""
+    from omlx.scheduler import Scheduler
+
+    gib = 1024**3
+
+    class _Fake:
+        _last_mlx_active_memory_bytes = 0
+        _hot_cache_cpu_bytes = staticmethod(lambda: 0)
+
+    fake = _Fake()
+
+    monkeypatch.setattr("omlx.scheduler.get_phys_footprint", lambda: 40 * gib)
+    monkeypatch.setattr(mx, "get_active_memory", lambda: 5 * gib)
+
+    # phys (40GiB) dominates active (5GiB); a pool of 15GiB should credit
+    # back, landing well above active but below the uncredited phys.
+    monkeypatch.setattr(mx, "get_cache_memory", lambda: 15 * gib)
+    uncredited = Scheduler._current_usage_bytes(fake, credit_cache_memory=False)
+    credited = Scheduler._current_usage_bytes(fake, credit_cache_memory=True)
+    assert uncredited == 40 * gib
+    assert credited == 25 * gib
+
+    # An oversized pool credit must floor at active, not go negative or
+    # below the true active-memory sample.
+    monkeypatch.setattr(mx, "get_cache_memory", lambda: 100 * gib)
+    assert Scheduler._current_usage_bytes(fake, credit_cache_memory=True) == 5 * gib
+
+    # active already dominates phys: crediting has nothing to do.
+    monkeypatch.setattr(mx, "get_active_memory", lambda: 45 * gib)
+    monkeypatch.setattr(mx, "get_cache_memory", lambda: 15 * gib)
+    assert Scheduler._current_usage_bytes(fake, credit_cache_memory=True) == 45 * gib
 
 
 def test_unguarded_fast_path_logs_once(caplog):
@@ -455,11 +949,11 @@ def test_unguarded_fast_path_logs_once(caplog):
     fake = _Fake()
     with caplog.at_level(logging.INFO, logger="omlx.scheduler"):
         assert (
-            Scheduler._sdpa256_unfused_headroom(fake)
+            Scheduler._sdpa256_unfused_headroom(fake, 16384)
             == _SDPA256_UNBOUNDED_HEADROOM
         )
         assert (
-            Scheduler._sdpa256_unfused_headroom(fake)
+            Scheduler._sdpa256_unfused_headroom(fake, 16384)
             == _SDPA256_UNBOUNDED_HEADROOM
         )
     records = [
@@ -494,7 +988,7 @@ def test_scheduler_init_registers_headroom_provider(_sdpa256_provider_reset):
     assert bound is not None
     assert bound.__self__ is scheduler
     # Ceiling not propagated yet -> negative sentinel keeps the tiled default.
-    assert bound() == -1
+    assert bound(16384) == -1
 
 
 # --- mlx-vlm coverage (issue: VLM engine head-256 prefill unprotected) ----

--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -328,6 +328,54 @@ def test_batch_tq_dequantize():
     assert dv.shape[2] == 9
 
 
+@pytest.mark.parametrize("bits", [1.0, 4.0, 8.0])
+def test_batch_tq_finalize_matches_dequantized_roll_exactly(bits):
+    """finalize() rolls the quantized state directly (§F3/4.5) instead of
+    dequantize -> dynamic_roll -> requantize. dequantize is a pure per-token
+    unpack (bit-unpack + fixed codebook lookup + fixed rotation, no
+    cross-token state), so it must commute exactly with the token-axis
+    reindex: dequantize(finalize(state)) == dynamic_roll(dequantize(state)).
+    The old requantize-on-the-way-back-in step had no reason to be exact;
+    this asserts the new path is.
+    """
+    from mlx_lm.models.cache import dynamic_roll
+
+    batch = BatchTurboQuantKVCache([0, 0], bits=bits)
+    keys = mx.random.normal((2, 2, 8, 32))
+    values = mx.random.normal((2, 2, 8, 32))
+    batch.update_and_fetch(keys, values)
+
+    ref_k, ref_v = batch.dequantize()
+
+    right_padding = [3, 5]
+    batch.prepare(right_padding=right_padding)
+    batch.finalize()
+
+    rolled_k, rolled_v = batch.dequantize()
+    shift = mx.array(right_padding)
+    expected_k = dynamic_roll(ref_k, shift[:, None], axis=2)
+    expected_v = dynamic_roll(ref_v, shift[:, None], axis=2)
+
+    assert mx.array_equal(rolled_k, expected_k).item()
+    assert mx.array_equal(rolled_v, expected_v).item()
+    assert batch.offset[0].item() == 8 - right_padding[0]
+    assert batch.offset[1].item() == 8 - right_padding[1]
+    assert batch.left_padding[0].item() == right_padding[0]
+    assert batch.left_padding[1].item() == right_padding[1]
+
+
+def test_batch_tq_finalize_no_right_padding_is_noop():
+    batch = BatchTurboQuantKVCache([0], bits=4.0)
+    batch.update_and_fetch(
+        mx.random.normal((1, 2, 8, 32)), mx.random.normal((1, 2, 8, 32))
+    )
+    before_k, before_v = batch.dequantize()
+    batch.finalize()  # _right_padding is None -> must be a no-op
+    after_k, after_v = batch.dequantize()
+    assert mx.array_equal(before_k, after_k).item()
+    assert mx.array_equal(before_v, after_v).item()
+
+
 def test_batch_tq_state_property():
     batch = BatchTurboQuantKVCache([2, 0], bits=4.0)
     s = batch.state
@@ -507,9 +555,11 @@ def test_attention_patch_falls_back_when_quantized_prefill_fails(monkeypatch):
         raise RuntimeError("forced quantized prefill failure")
 
     original_dequantize = TurboQuantKVCache.dequantize
+    dequant_kwargs = {}
 
     def spy_dequantize(self, *args, **kwargs):
         calls["dequantize"] += 1
+        dequant_kwargs.update(kwargs)
         return original_dequantize(self, *args, **kwargs)
 
     monkeypatch.setattr(
@@ -527,6 +577,10 @@ def test_attention_patch_falls_back_when_quantized_prefill_fails(monkeypatch):
 
     assert out.shape == queries.shape
     assert calls == {"quantized": 1, "dequantize": 1}
+    # F4: must pass the request's own views, not dequantize the ENTIRE
+    # resident cache (the default when keys_state/values_state are omitted)
+    # -- see docs/qwen35-hardening-and-optimization.md F4.
+    assert dequant_kwargs == {"keys_state": ks, "values_state": vs}
 
 
 @pytest.mark.parametrize("q_len", [2, 4, 9])

--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -526,11 +526,114 @@ def test_attention_patch_routes_long_tq_prefill_to_quantized_attention(monkeypat
     )
 
     assert out.shape == queries.shape
-    assert prefill_calls == [(ks, vs)]
+    # Above the long-prefill threshold the tiled route runs FIRST:
+    # prefill_attention materializes untiled O(L*T) score slabs and must
+    # not be attempted before it (it ACCEPTS array masks, so "try it and
+    # fall through on None" only worked for str masks).
+    assert prefill_calls == []
     assert len(calls) == 1
     assert calls[0][0] is ks
     assert calls[0][1] is vs
     assert calls[0][2] == 256
+
+
+def test_attention_patch_long_array_mask_prefill_never_hits_slab_path(monkeypatch):
+    """The O(L*T) hazard test: prefill_attention accepts BOOLEAN array masks
+    (e.g. Qwen4-Exp QSA's block-sparse selection) and materializes untiled
+    fp32 score slabs, so above the long-prefill threshold it must never be
+    reached — the tiled quantized_attention (which slices masks per key
+    chunk via _apply_attention_mask) handles the call."""
+    from mlx_lm.models import base as mlx_base
+
+    from omlx.patches import turboquant_attention as tq_attention
+
+    tq_attention.apply_turboquant_attention_patch()
+    monkeypatch.setattr(tq_attention, "_LONG_PREFILL_QUANTIZED_THRESHOLD", 4)
+
+    fp_cache = KVCache()
+    fp_cache.update_and_fetch(
+        mx.random.normal((1, 2, 8, 32)),
+        mx.random.normal((1, 2, 8, 32)),
+    )
+    tq = TurboQuantKVCache.from_cache(fp_cache, bits=4.0)
+    ks, vs = tq.state
+    prefill_calls = []
+    quantized_calls = []
+
+    def fake_prefill_attention(self, *args, **kwargs):
+        prefill_calls.append(kwargs)
+        return None
+
+    def fake_quantized_attention(
+        self, queries, keys_state=None, values_state=None, scale=1.0, mask=None
+    ):
+        quantized_calls.append(mask)
+        return mx.zeros_like(queries)
+
+    monkeypatch.setattr(
+        TurboQuantKVCache, "prefill_attention", fake_prefill_attention
+    )
+    monkeypatch.setattr(
+        TurboQuantKVCache, "quantized_attention", fake_quantized_attention
+    )
+
+    queries = mx.random.normal((1, 4, 2, 32))
+    bool_mask = mx.ones((1, 1, 2, 8), dtype=mx.bool_)
+    out = mlx_base.scaled_dot_product_attention(
+        queries, ks, vs, tq, scale=32**-0.5, mask=bool_mask
+    )
+
+    assert out.shape == queries.shape
+    assert prefill_calls == []
+    assert len(quantized_calls) == 1
+    assert quantized_calls[0] is bool_mask
+
+
+def test_attention_patch_short_prefill_keeps_prefill_attention_first(monkeypatch):
+    """Below the long-prefill threshold the single-dispatch fast path is
+    unchanged: prefill_attention first, no tiled attempt."""
+    from mlx_lm.models import base as mlx_base
+
+    from omlx.patches import turboquant_attention as tq_attention
+
+    tq_attention.apply_turboquant_attention_patch()
+    monkeypatch.setattr(tq_attention, "_LONG_PREFILL_QUANTIZED_THRESHOLD", 4096)
+
+    fp_cache = KVCache()
+    fp_cache.update_and_fetch(
+        mx.random.normal((1, 2, 8, 32)),
+        mx.random.normal((1, 2, 8, 32)),
+    )
+    tq = TurboQuantKVCache.from_cache(fp_cache, bits=4.0)
+    ks, vs = tq.state
+    prefill_calls = []
+    quantized_calls = []
+
+    def fake_prefill_attention(
+        self, queries, keys_state=None, values_state=None, scale=1.0, mask=None
+    ):
+        prefill_calls.append(mask)
+        return mx.zeros_like(queries)
+
+    def fake_quantized_attention(self, *args, **kwargs):
+        quantized_calls.append(kwargs)
+        return None
+
+    monkeypatch.setattr(
+        TurboQuantKVCache, "prefill_attention", fake_prefill_attention
+    )
+    monkeypatch.setattr(
+        TurboQuantKVCache, "quantized_attention", fake_quantized_attention
+    )
+
+    queries = mx.random.normal((1, 4, 2, 32))
+    out = mlx_base.scaled_dot_product_attention(
+        queries, ks, vs, tq, scale=32**-0.5, mask=None
+    )
+
+    assert out.shape == queries.shape
+    assert len(prefill_calls) == 1
+    assert quantized_calls == []
 
 
 def test_attention_patch_falls_back_when_quantized_prefill_fails(monkeypatch):
@@ -548,11 +651,15 @@ def test_attention_patch_falls_back_when_quantized_prefill_fails(monkeypatch):
     )
     tq = TurboQuantKVCache.from_cache(fp_cache, bits=4.0)
     ks, vs = tq.state
-    calls = {"quantized": 0, "dequantize": 0}
+    calls = {"quantized": 0, "prefill": 0, "dequantize": 0}
 
     def failing_quantized_attention(self, *args, **kwargs):
         calls["quantized"] += 1
         raise RuntimeError("forced quantized prefill failure")
+
+    def none_prefill_attention(self, *args, **kwargs):
+        calls["prefill"] += 1
+        return None
 
     original_dequantize = TurboQuantKVCache.dequantize
     dequant_kwargs = {}
@@ -567,6 +674,11 @@ def test_attention_patch_falls_back_when_quantized_prefill_fails(monkeypatch):
         "quantized_attention",
         failing_quantized_attention,
     )
+    monkeypatch.setattr(
+        TurboQuantKVCache,
+        "prefill_attention",
+        none_prefill_attention,
+    )
     monkeypatch.setattr(TurboQuantKVCache, "dequantize", spy_dequantize)
 
     queries = mx.random.normal((1, 4, 2, 32))
@@ -576,7 +688,8 @@ def test_attention_patch_falls_back_when_quantized_prefill_fails(monkeypatch):
     mx.eval(out)
 
     assert out.shape == queries.shape
-    assert calls == {"quantized": 1, "dequantize": 1}
+    # Tiled-first failed -> prefill_attention gets its chance -> dequantize.
+    assert calls == {"quantized": 1, "prefill": 1, "dequantize": 1}
     # F4: must pass the request's own views, not dequantize the ENTIRE
     # resident cache (the default when keys_state/values_state are omitted)
     # -- see docs/qwen35-hardening-and-optimization.md F4.


### PR DESCRIPTION
## Summary

Two independent fixes for Qwen4-Exp (Qwen3.8-Flash-Next) long-context prefill, which previously hard-aborted around ~43k tokens on a 64GB Mac despite the architecture's 262144-token native context window. After both fixes, verified ceiling on the same hardware is ~96,000-100,000 tokens clean (~2x).

- **`sdpa256_attention.py`**: teach the tiled/streaming SDPA routes to accept boolean array masks (QSA's sparse-attention indexer produces one past ~2048 tokens). Previously any non-causal array mask was routed to stock MLX's unfused O(L·T) fallback, materializing full `[heads, L, T]` score slabs that scale linearly with context and dominated the memory budget. Also disables q-split for array masks (it can't narrow keys the way causal masks allow; combined with the admission hysteresis ratchet this thrashed the Metal buffer pool).
- **`turboquant_attention.py`**: try the tiled `quantized_attention` route before the slab-building `prefill_attention` above the long-prefill threshold, matching the ordering the scheduler's cost estimator already assumes.
- **`scheduler.py` / `boundary_snapshot_store.py`**: `QSAKVCache` and `QSAQuantizedKVCache` were missing from `_KNOWN_SLICEABLE_CACHE_TYPES`, so every boundary/prompt-cache snapshot captured the model's full K/V+index prefix instead of an incremental slice — quadratic cost in context length (~1.1GB per snapshot at 40k tokens). This was the dominant remaining cost after the sdpa256 fix alone, and explains why the measured ceiling after that fix undershot the initial prediction. Also adds a diagnostic warning for any future sliceable-cache-type omission of the same shape, plus a lockstep test against the handler registry.

The first commit on this branch squash-ports pre-existing work (q-split prefill fast path, hysteresis ratchet, TurboQuant dense-fallback fix, ANE-prefill-aware paged SSD cache signatures) that had accumulated on our internal fork but was never itself upstreamed — it's a prerequisite for the actual fix commit to apply cleanly and is a pure port, no new behavior.

## Test plan

- [x] Full existing test suite: 10,524 passed, 0 failed, 106 skipped (pre-existing skips), 77 deselected (slow/integration, as configured)
- [x] 8 new bool-mask numerics tests for the sdpa256 tiled-mask routing, including the QSA-specific edge case of a row whose first tile is fully masked (compared against dense fp32 reference, ≤5e-3 tolerance)
- [x] New regression-guard test (`test_boundary_snapshot_qsa.py`) locking `_KNOWN_SLICEABLE_CACHE_TYPES` to the handler registry so the next sliceable cache class can't silently regress the same way
- [x] Live validation on real hardware (M4 Pro, 64GB): empirical stepped-context ladder with unique/non-cached prompt content at each step (no prefix-cache reuse), before and after each fix, confirming the measured ceiling improvement end-to-end — clean prefill at 43k/58k/77k/96k tokens, clean guard rejection (no crash) at ~125k
- [x] Coherence check: needle-in-prose retrieval correct at 6k, 10k, and 41,529 tokens through the new tiled routing path

## Notes for reviewers

- `Fix 2` (real KV quantization for QSA caches, to push toward the full 262k native ceiling) was scoped and investigated but not implemented — the naive approach (call the vendored `to_quantized()`) doesn't work: the quantized cache class has no `merge()` (breaks batch generator insert) and MTP verify slices tuple keys (breaks, and MTP is on for this model family). Left as follow-up.
- The prerequisite-port commit is large but mechanical (a direct diff replay of already-reviewed internal-fork history) — the actual new logic is entirely in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_5f72bb11-5f96-454f-8071-e7412e896f13