### PR TITLE
fix: isolate cross-engine monkey-patches between DFlash and Lightning MTP (#2972)

### DIFF
--- a/omlx/patches/dflash_lifecycle.py
+++ b/omlx/patches/dflash_lifecycle.py
@@ -65,6 +65,20 @@ def _wrap_installer(mod: Any, fn_name: str, flag_name: str) -> bool:
 
     def wrapped(module_target: Any) -> Any:
         cls = type(module_target)
+        current = cls.__dict__.get("__call__")
+        if getattr(cls, flag_name, False) and getattr(
+            current, "_omlx_mtp_call_marker", False
+        ):
+            # A Native-MTP self-heal replaced dflash's hook while the
+            # idempotency flag stayed set (issue #2972): dflash's installer
+            # would skip re-installing and the engine would run without its
+            # speculative hook. Clear the stale flag and re-snapshot the
+            # current (MTP) __call__ as the base to restore/fall back to.
+            try:
+                delattr(cls, flag_name)
+            except AttributeError:
+                pass
+            _DFLASH_BACKUP[cls] = {"call": current, "flag": flag_name}
         if not getattr(cls, flag_name, False):
             # First time dflash installs on this class — snapshot the
             # current __call__ so restore can put it back unchanged.
@@ -105,12 +119,48 @@ def _install_batch_cache_guard(cls: type) -> None:
     def guarded_call(
         self: Any, x: Any, mask: Any = None, cache: Any = None, **kwargs: Any
     ) -> Any:
-        if isinstance(getattr(cache, "offset", None), mx.array):
-            return pre_dflash_call(self, x, mask=mask, cache=cache, **kwargs)
+        # Resolve the fallback base dynamically: a Native-MTP load may
+        # legitimately swap the non-dflash implementation underneath this
+        # guard while a DFlash engine stays resident (issue #2972).
+        live = _DFLASH_BACKUP.get(cls)
+        base = live["call"] if live is not None else pre_dflash_call
+        if kwargs.get("n_confirmed") or isinstance(
+            getattr(cache, "offset", None), mx.array
+        ):
+            return base(self, x, mask=mask, cache=cache, **kwargs)
         return dflash_call(self, x, mask=mask, cache=cache, **kwargs)
 
     guarded_call._omlx_dflash_batch_guard = True  # type: ignore[attr-defined]
     cls.__call__ = guarded_call  # type: ignore[method-assign]
+
+
+def dflash_owns_call(cls: type) -> bool:
+    """True iff the armed batch-cache guard currently owns ``cls.__call__``."""
+    return getattr(cls.__dict__.get("__call__"), "_omlx_dflash_batch_guard", False)
+
+
+def get_backup_base(cls: type) -> Any:
+    """Return the non-dflash base ``__call__`` recorded for ``cls``, if any."""
+    info = _DFLASH_BACKUP.get(cls)
+    return None if info is None else info["call"]
+
+
+def swap_backup_base(cls: type, new_call: Any) -> bool:
+    """Swap the non-dflash base implementation under an armed guard.
+
+    Used by the Native-MTP self-heal (issue #2972): instead of clobbering
+    the dflash guard on a shared class, the MTP patch installs its
+    ``__call__`` as the guard's fallback base. DFlash traffic (int-offset
+    caches, no ``n_confirmed``) keeps the speculative hook; everything
+    else — batch caches and MTP verify forwards — runs the new base.
+    ``restore_dflash_class_patches()`` then restores this base, keeping
+    MTP ownership intact after the DFlash engine stops.
+    """
+    info = _DFLASH_BACKUP.get(cls)
+    if info is None:
+        return False
+    info["call"] = new_call
+    return True
 
 
 def install_dflash_lifecycle_wrap() -> bool:

--- a/omlx/patches/mlx_lm_mtp/qwen35_model.py
+++ b/omlx/patches/mlx_lm_mtp/qwen35_model.py
@@ -238,6 +238,23 @@ def _patch_gated_delta_net(q35: Any) -> None:
     if _is_our_method(cls, "__call__", "_omlx_mtp_call_marker"):
         return
 
+    # dflash coexistence (issue #2972): if the dflash batch-cache guard owns
+    # ``cls.__call__``, do not clobber it — that silently strips the resident
+    # DFlash engine's speculative hook and its generations degenerate into
+    # repetition loops. Instead install our body as the guard's fallback
+    # base: dflash traffic keeps its hook, MTP/batched traffic gets ours.
+    try:
+        from ..dflash_lifecycle import (
+            dflash_owns_call,
+            get_backup_base,
+            swap_backup_base,
+        )
+    except ImportError:
+        dflash_owns_call = None  # type: ignore[assignment]
+    if dflash_owns_call is not None and dflash_owns_call(cls):
+        if getattr(get_backup_base(cls), "_omlx_mtp_call_marker", False):
+            return  # our body already sits under the dflash guard
+
     import mlx.core as mx
     import mlx.nn as nn
     from mlx.nn.layers.distributed import sum_gradients
@@ -356,7 +373,13 @@ def _patch_gated_delta_net(q35: Any) -> None:
 
     cls._process_chunk = _process_chunk
     __call__._omlx_mtp_call_marker = True
-    cls.__call__ = __call__
+    if dflash_owns_call is not None and dflash_owns_call(cls):
+        # Compose with the armed dflash guard instead of replacing it
+        # (issue #2972): our body becomes the guard's fallback base.
+        if not swap_backup_base(cls, __call__):
+            cls.__call__ = __call__
+    else:
+        cls.__call__ = __call__
 
 
 # ---------------------------------------------------------------------------

--- a/omlx/patches/mlx_vlm_mtp/qwen35_vlm_runtime.py
+++ b/omlx/patches/mlx_vlm_mtp/qwen35_vlm_runtime.py
@@ -273,6 +273,12 @@ def _patch_vlm_language_model(q35_lang: Any) -> None:
         from . import is_mtp_attach_enabled
         from ..mlx_lm_mtp import is_mtp_active
 
+        if type(self) is not cls:
+            # Subclasses (e.g. the qwen4_exp vendor LanguageModel, which
+            # inherits from this class) own their MTP wiring; running the
+            # Qwen3.5 attach here would bolt a q35 MTPModule onto a
+            # foreign architecture (issue #2972, reverse leg).
+            return original_init(self, args, config)
         original_init(self, args, config)
         # Attach MTPModule when the config declares MTP heads so mlx-vlm's
         # load_weights (which skips Model.sanitize for is_mlx_format
@@ -314,6 +320,12 @@ def _patch_vlm_language_model(q35_lang: Any) -> None:
         is accepted and discarded — the mlx-vlm path uses post-hoc
         ``rollback_speculative_cache`` instead of a confirmed/draft split.
         """
+        if type(self) is not cls:
+            # Subclasses (qwen4_exp vendor) reach here via super().__call__
+            # and implement their own return_hidden / capture contract.
+            # Reshaping their kwargs here collapses the raw hyper-stream
+            # hidden that Qwen4 Lightning MTP requires (issue #2972).
+            return original_call(self, inputs, inputs_embeds, mask, cache, **kwargs)
         return_hidden = kwargs.pop("return_hidden", False)
         return_shared_kv = kwargs.pop("return_shared_kv", False)
         kwargs.pop("n_confirmed", None)


### PR DESCRIPTION
Fixes the cross-engine contamination reported in #2972, in **both directions**. Full investigation, deterministic reproduction recipes, and validation evidence are in the issue thread ([repro](https://github.com/jundot/omlx/issues/2972#issuecomment-5460717869), [leg 1 root cause](https://github.com/jundot/omlx/issues/2972#issuecomment-5460815228), [leg 2 root cause](https://github.com/jundot/omlx/issues/2972#issuecomment-5461101649)).

## Leg 1 — Lightning MTP load degenerates a resident DFlash engine

The `GatedDeltaNet` self-heal in `mlx_lm_mtp/qwen35_model.py` didn't recognize the dflash batch-cache guard (#2252) on `cls.__call__` and clobbered it, silently stripping the resident DFlash engine's speculative hook → hard repetition loops. The stale dflash idempotency flag then made **new** DFlash engines skip hook installation, so they were broken from birth.

**Fix (compose, don't clobber):**
- `guarded_call` resolves its fallback base dynamically from `_DFLASH_BACKUP` and routes `n_confirmed` calls to the base
- the MTP self-heal installs its body as the guard's fallback base (`swap_backup_base`) when dflash owns the class
- `_wrap_installer` repairs the stale idempotency flag

## Leg 2 — Qwen3.5 VLM load breaks qwen4_exp Lightning MTP

The `qwen4_exp` vendor `LanguageModel` inherits from the q35 `LanguageModel` and reaches stock behavior via `super().__call__`. Loading any q35 VLM model (a load alone suffices) runs `_patch_vlm_language_model`, whose replacement `__call__` pops the caller's `capture_layer_ids=[]` and forces `[last_layer_idx]` — collapsing the raw hyper-stream hidden `(B, T, hc_count·H)` the Qwen4 MTP head requires down to `(B, T, H)` → `Qwen4 Lightning MTP expects hidden shape [...]`. The patched `__init__` would also bolt a q35 `MTPModule` onto the foreign architecture.

**Fix:** exact-type guards (`type(self) is not cls`) in the patched `__init__`/`__call__` — the patch serves plain q35 instances; subclasses keep stock behavior.

## Validation (M5 Max 128 GB, 0.6.3 stable + these patches)

- Both previously deterministic reproductions pass.
- Interleaving a DFlash target (`Qwen3.8-27B-8bit` + DFlash2 draft), a q35 Lightning-MTP model (`Qwen3.8-27B-oQ4e-mtp`), and a qwen4_exp model (`Qwen3.8-Flash-Next-oQ4e-mtp`) in **one process, no restarts** stays clean in all directions: zero degeneration across 12+ DFlash generations, MTP acceptance 75–92%, speculative speeds preserved.
- Single-engine setups are behaviorally unchanged (guards only alter the multi-engine paths).
