### PR TITLE
scheduler: recover boundary-aligned live cache store for hybrid GDN (skew-guard fallback)

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -7201,6 +7201,61 @@ class Scheduler:
             )
             return None
 
+    def _verify_live_boundary_aligned(
+        self, request_id: str, uid: int, boundary_tokens: int
+    ) -> list[dict[str, Any]] | None:
+        """Return extracted cache state iff the live cache is exactly at a block
+        boundary, else None.
+
+        Recovery path for the store-time ``_BoundaryStoreUnavailable`` case: when
+        every decode-time boundary capture was skipped (MTP skew guard) but the
+        request finished on a block boundary, the live recurrent/rotating state
+        sits at that boundary and is safe to persist. The leaf cache ``offset``
+        must equal the boundary token count exactly — mirroring
+        ``_extract_boundary_snapshot``'s positional-consistency guard — so we
+        never label an off-boundary state with a block-boundary count.
+        """
+        if self.batch_generator is None or uid is None or uid < 0:
+            return None
+        try:
+            with self._phase_timer("store_cache_boundary_verify"):
+                _safe_sync_stream(self._stream)
+                with mx.stream(self._stream):
+                    result = self.batch_generator.extract_cache([uid])
+            if uid not in result:
+                logger.debug(
+                    "Cannot verify live cache for %s: uid %s not present",
+                    request_id,
+                    uid,
+                )
+                return None
+            cache_list, _tokens = result[uid]
+            for c in cache_list:
+                offset = _first_leaf_cache_offset(c)
+                if offset is None:
+                    continue
+                if offset != boundary_tokens:
+                    logger.debug(
+                        "Live cache for %s is off-boundary (offset %d != boundary %d); "
+                        "skipping recovery store",
+                        request_id,
+                        offset,
+                        boundary_tokens,
+                    )
+                    return None
+                break
+            extracted_cache, _ = self._extract_cache_states(cache_list)
+            if not extracted_cache:
+                return None
+            return extracted_cache
+        except Exception as e:
+            logger.debug(
+                "Failed to verify live cache for boundary store %s: %s",
+                request_id,
+                e,
+            )
+            return None
+
     def _prepare_prompt_boundary_cache_store(
         self,
         request_id: str,
@@ -11156,7 +11211,63 @@ class Scheduler:
                                             # the current decode offset (which
                                             # speculative decode can leave off
                                             # the emitted count entirely).
-                                            raise _BoundaryStoreUnavailable()
+                                            #
+                                            # Recovery: when every decode-time
+                                            # capture was skipped (MTP skew
+                                            # guard) but the request itself
+                                            # finished on a block boundary, the
+                                            # live extracted cache is exactly
+                                            # that boundary-aligned snapshot —
+                                            # storing it is safe and recovers
+                                            # prefix reuse instead of throwing
+                                            # away a usable recurrent state.
+                                            block_size = (
+                                                self.config.paged_cache_block_size
+                                            )
+                                            live_cache = None
+                                            if (
+                                                block_size > 0
+                                                and len(cacheable_sequence)
+                                                % block_size
+                                                == 0
+                                            ):
+                                                # Only trust the live state when
+                                                # its leaf cache offset actually
+                                                # sits on the boundary (emitted
+                                                # length alone can be fooled by
+                                                # the MTP emit queue). uid_for_store
+                                                # may be unset when this request
+                                                # carried its own _extracted_cache,
+                                                # so resolve it here.
+                                                live_uid = (
+                                                    self.request_id_to_uid.get(
+                                                        request_id, -1
+                                                    )
+                                                )
+                                                live_cache = (
+                                                    self._verify_live_boundary_aligned(
+                                                        request_id,
+                                                        live_uid,
+                                                        len(cacheable_sequence),
+                                                    )
+                                                )
+                                            if live_cache:
+                                                token_sequence_to_store = (
+                                                    cacheable_sequence
+                                                )
+                                                cache_to_store = live_cache
+                                                intermediate_snapshots = None
+                                                logger.info(
+                                                    "Using live boundary-aligned "
+                                                    "cache for %s: request finished "
+                                                    "on block boundary "
+                                                    "(%d/%d tokens)",
+                                                    request_id,
+                                                    len(cacheable_sequence),
+                                                    len(full_token_sequence),
+                                                )
+                                            else:
+                                                raise _BoundaryStoreUnavailable()
                                         if boundary_override is not None:
                                             (
                                                 token_sequence_to_store,

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -2664,6 +2664,77 @@ class TestSchedulerBoundarySnapshots:
             "unreused_common_prefix_tokens": 3,
         }
 
+    def test_cleanup_finished_recovery_stores_boundary_aligned_live_cache(
+        self, mock_model, mock_tokenizer
+    ):
+        """Fix A recovery: when every decode-time capture was skipped by the
+        MTP skew guard but the request finished on a block boundary, the
+        scheduler stores the verified boundary-aligned live cache instead of
+        dropping it — preserving prefix-cache reuse on the next turn."""
+        config = SchedulerConfig(paged_cache_block_size=4)
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer, config=config)
+        scheduler.block_aware_cache = MagicMock()
+        scheduler.paged_cache_manager = None
+        scheduler._boundary_snapshot_required = True
+
+        request = Request(
+            request_id="req-recover",
+            prompt="hello",
+            sampling_params=SamplingParams(),
+        )
+        request.prompt_token_ids = [1, 2, 3, 4]
+        request.num_prompt_tokens = 4
+        request.output_token_ids = [5, 6, 7, 8]  # Total = 8 (2 full blocks)
+        request._extracted_cache = [{"state": "live-cache"}]
+        request._model_cache_config = "live-config"
+
+        scheduler.running["req-recover"] = request
+        scheduler.requests["req-recover"] = request
+        # Live cache verifies as boundary-aligned (offset == 8 == total).
+        scheduler._verify_live_boundary_aligned = MagicMock(
+            return_value=[{"state": "boundary-live-cache"}]
+        )
+
+        scheduler._cleanup_finished({"req-recover"})
+
+        scheduler.block_aware_cache.store_cache.assert_called_once()
+        args, kwargs = scheduler.block_aware_cache.store_cache.call_args
+        assert args[0] == "req-recover"
+        assert args[1] == [1, 2, 3, 4, 5, 6, 7, 8]  # full boundary-aligned sequence
+
+    def test_cleanup_finished_recovery_skips_off_boundary_live_cache(
+        self, mock_model, mock_tokenizer
+    ):
+        """Fix A recovery must NOT store when the request finished off a block
+        boundary — the live recurrent state cannot be labeled with a boundary
+        token count and would corrupt later prefix hits."""
+        config = SchedulerConfig(paged_cache_block_size=4)
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer, config=config)
+        scheduler.block_aware_cache = MagicMock()
+        scheduler.paged_cache_manager = None
+        scheduler._boundary_snapshot_required = True
+
+        request = Request(
+            request_id="req-off-boundary",
+            prompt="hello",
+            sampling_params=SamplingParams(),
+        )
+        request.prompt_token_ids = [1, 2, 3, 4]
+        request.num_prompt_tokens = 4
+        request.output_token_ids = [5, 6, 7]  # Total = 7 (not a full block)
+        request._extracted_cache = [{"state": "live-cache"}]
+        request._model_cache_config = "live-config"
+
+        scheduler.running["req-off-boundary"] = request
+        scheduler.requests["req-off-boundary"] = request
+
+        scheduler._cleanup_finished({"req-off-boundary"})
+
+        scheduler.block_aware_cache.store_cache.assert_not_called()
+        scheduler.block_aware_cache.clear_request_entry.assert_called_with(
+            "req-off-boundary"
+        )
+
     def test_cleanup_finished_skips_output_tokens_for_reasoning_model(
         self, mock_model, mock_tokenizer
     ):


### PR DESCRIPTION
## Summary

Fixes the growing-context prefix-cache gap for hybrid GDN (non-sliceable) models: when the speculative-decode skew guard skips every decode-time boundary capture, the store path raised `_BoundaryStoreUnavailable` and **dropped** the recurrent state, so an agent context that grows turn-over-turn never persisted a reusable prefix and re-prefilled the full context every turn (`served cached_tokens=0`).

This adds a **store-time recovery**: if the request happened to finish exactly on a block boundary, verify the live cache's leaf offset sits on that boundary and store it instead of giving up.

Closes the "forced boundary-aligned snapshot" ask raised in #2384.

## Root cause

On hybrid models, cache state is non-sliceable. The store path only persists a prefix from a boundary-aligned snapshot. When the MTP skew guard skips all decode-time captures, no such snapshot exists, so the code bailed out:

```python
# scheduler.py, _cleanup_finished
raise _BoundaryStoreUnavailable()
```

...and the recurrent state was discarded. But if the request *finished* on a block boundary, the live extracted cache is already exactly a boundary-aligned snapshot — it is safe to store and recovers prefix reuse.

## Change

- New `_verify_live_boundary_aligned(request_id, uid, boundary_tokens)` that extracts the live cache and returns it **only** when the leaf cache offset equals the boundary token count exactly — mirroring `_extract_boundary_snapshot`'s positional-consistency guard, so an off-boundary state is never mislabeled with a block-boundary count.
- In `_cleanup_finished`, before raising `_BoundaryStoreUnavailable`, attempt the recovery when `len(cacheable_sequence) % block_size == 0`. On success, store the verified live cache; on failure, fall through to the existing raise (no behavior change otherwise).
- Adds two tests: on-boundary (stores) and off-boundary (skips).

## Why the safety guard matters

The emitted length alone can be fooled by the MTP emit queue, so the recovery trusts the live state only when the actual leaf cache `offset` equals the boundary token count. If it does not, the code returns `None` and the existing drop behavior is preserved — no risk of corrupting later prefix hits.

## Verification

- `pytest tests/test_scheduler.py -k boundary` → 22 passed
- New tests: `test_cleanup_finished_recovery_stores_boundary_aligned_live_cache` and the off-boundary skip case → 2 passed
- Rebased cleanly on `main` (no conflicts; upstream has not yet addressed this path).

## Notes for reviewers

- This is the recovery half of the question posed in #2384 ("is there room to store a forced boundary-aligned snapshot so growing agent context gets real prefix reuse?").
- It is orthogonal to the DFlash sidecar path that `d0lphin` diagnosed in #2384 — that is a separate read-side gap; this targets the store-side drop in the scheduler for the paged/base cache path.