### PR TITLE
fix(cache): blank sliceable CacheList members in boundary snapshots when pm-plan is None

### DIFF
--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -385,13 +385,14 @@ _POOLING_SUB_CLASSES = frozenset({"PoolingCache", "BatchPoolingCache"})
 # addition to ArraysCache (see ``cachelist_pm_member_plan``). Kept separate
 # from ``_ARRAYS_SUB_CLASSES`` so signature descriptors
 # (``_block_cachelist_subtypes`` / ``cachelist_subtypes_from_cache_list``)
-# still route PoolingCache through the pooling branch (``PoolingCache:N``)
-# instead of mis-stamping it as an ArraysCache slot count. Must stay in
-# sync with ``prefix_cache._PM_SAFE_NON_SLICEABLE_SUBS``: BatchPoolingCache
-# is NOT boundary-eligible — compact_pooling_cache_snapshot only compacts
-# PoolingCache, so BatchPoolingCache boundary snapshots stay cumulative and
-# its layers keep the legacy path.
-_PM_BOUNDARY_SUB_CLASSES = _ARRAYS_SUB_CLASSES | frozenset({"PoolingCache"})
+# still route pooling members through the pooling branch
+# (``PoolingCache:N`` / ``BatchPoolingCache:N``) instead of mis-stamping
+# them as an ArraysCache slot count. Must stay in sync with
+# ``prefix_cache._PM_SAFE_NON_SLICEABLE_SUBS``: boundary members are
+# self-contained at their boundary and restore last-block-wins; pooling
+# members that compact_pooling_cache_snapshot does NOT cover
+# (BatchPoolingCache) simply persist their cumulative boundary state.
+_PM_BOUNDARY_SUB_CLASSES = _ARRAYS_SUB_CLASSES | _POOLING_SUB_CLASSES
 # Sliceable KV sub-cache classes inside a CacheList (4D sequence tensors).
 # Shared with prefix_cache.cachelist_pm_member_plan (single source so the
 # class-level expectation and the shape-level store plan cannot drift).

--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -386,8 +386,12 @@ _POOLING_SUB_CLASSES = frozenset({"PoolingCache", "BatchPoolingCache"})
 # from ``_ARRAYS_SUB_CLASSES`` so signature descriptors
 # (``_block_cachelist_subtypes`` / ``cachelist_subtypes_from_cache_list``)
 # still route PoolingCache through the pooling branch (``PoolingCache:N``)
-# instead of mis-stamping it as an ArraysCache slot count.
-_PM_BOUNDARY_SUB_CLASSES = _ARRAYS_SUB_CLASSES | _POOLING_SUB_CLASSES
+# instead of mis-stamping it as an ArraysCache slot count. Must stay in
+# sync with ``prefix_cache._PM_SAFE_NON_SLICEABLE_SUBS``: BatchPoolingCache
+# is NOT boundary-eligible — compact_pooling_cache_snapshot only compacts
+# PoolingCache, so BatchPoolingCache boundary snapshots stay cumulative and
+# its layers keep the legacy path.
+_PM_BOUNDARY_SUB_CLASSES = _ARRAYS_SUB_CLASSES | frozenset({"PoolingCache"})
 # Sliceable KV sub-cache classes inside a CacheList (4D sequence tensors).
 # Shared with prefix_cache.cachelist_pm_member_plan (single source so the
 # class-level expectation and the shape-level store plan cannot drift).
@@ -419,8 +423,7 @@ def cachelist_pm_class_eligible(sub_class_names: list[str]) -> bool:
     has_slice = any(n in _PM_SLICEABLE_SUB_CLASSES for n in names)
     has_boundary = any(n in _PM_BOUNDARY_SUB_CLASSES for n in names)
     all_known = all(
-        n in _PM_SLICEABLE_SUB_CLASSES or n in _PM_BOUNDARY_SUB_CLASSES
-        for n in names
+        n in _PM_SLICEABLE_SUB_CLASSES or n in _PM_BOUNDARY_SUB_CLASSES for n in names
     )
     return has_slice and has_boundary and all_known
 

--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -381,6 +381,13 @@ _CACHELIST_NON_SLICEABLE_SUB_CLASSES = frozenset(
 
 _ARRAYS_SUB_CLASSES = frozenset({"ArraysCache", "SizedArraysCache"})
 _POOLING_SUB_CLASSES = frozenset({"PoolingCache", "BatchPoolingCache"})
+# Non-sliceable CacheList members accepted as per-member "boundary" subs in
+# addition to ArraysCache (see ``cachelist_pm_member_plan``). Kept separate
+# from ``_ARRAYS_SUB_CLASSES`` so signature descriptors
+# (``_block_cachelist_subtypes`` / ``cachelist_subtypes_from_cache_list``)
+# still route PoolingCache through the pooling branch (``PoolingCache:N``)
+# instead of mis-stamping it as an ArraysCache slot count.
+_PM_BOUNDARY_SUB_CLASSES = _ARRAYS_SUB_CLASSES | _POOLING_SUB_CLASSES
 # Sliceable KV sub-cache classes inside a CacheList (4D sequence tensors).
 # Shared with prefix_cache.cachelist_pm_member_plan (single source so the
 # class-level expectation and the shape-level store plan cannot drift).
@@ -401,18 +408,19 @@ _PM_LAYOUT_TOKEN = "@pm"
 def cachelist_pm_class_eligible(sub_class_names: list[str]) -> bool:
     """Class-level eligibility for per-member CacheList block storage.
 
-    True when every member is either a sliceable KV class or an
-    ArraysCache-style class, with at least one of each. Must stay in sync
-    with ``prefix_cache.cachelist_pm_member_plan`` (which additionally
-    checks live tensor shapes at store time).
+    True when every member is either a sliceable KV class or a boundary
+    class (ArraysCache-style or PoolingCache), with at least one of each.
+    Must stay in sync with ``prefix_cache.cachelist_pm_member_plan`` (which
+    additionally checks live tensor shapes at store time).
     """
     if not sub_class_names:
         return False
     names = [str(n) for n in sub_class_names]
     has_slice = any(n in _PM_SLICEABLE_SUB_CLASSES for n in names)
-    has_boundary = any(n in _ARRAYS_SUB_CLASSES for n in names)
+    has_boundary = any(n in _PM_BOUNDARY_SUB_CLASSES for n in names)
     all_known = all(
-        n in _PM_SLICEABLE_SUB_CLASSES or n in _ARRAYS_SUB_CLASSES for n in names
+        n in _PM_SLICEABLE_SUB_CLASSES or n in _PM_BOUNDARY_SUB_CLASSES
+        for n in names
     )
     return has_slice and has_boundary and all_known
 

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -39,10 +39,15 @@ from .stats import PrefixCacheStats
 from .type_registry import CacheTypeRegistry
 
 # Non-sliceable CacheList member classes safe for per-member block storage.
-# PoolingCache (delta chains) and rotating families keep the legacy
-# cumulative path; ArraysCache state is small, positionless, and
-# self-contained at every boundary.
-_PM_SAFE_NON_SLICEABLE_SUBS = frozenset({"ArraysCache", "SizedArraysCache"})
+# ArraysCache state is small, positionless, and self-contained at every
+# boundary. PoolingCache is also safe: its ``pooled`` tensor is append-only
+# and the boundary snapshot carries the cumulative pool at that boundary,
+# while the small 3D remainder buffer is restored from the snapshot (GLM-5.x
+# CacheList(KVCache, PoolingCache); DeepSeek-V4's rotating member keeps that
+# layer on the legacy cumulative path). Rotating families stay legacy.
+_PM_SAFE_NON_SLICEABLE_SUBS = frozenset(
+    {"ArraysCache", "SizedArraysCache", "PoolingCache"}
+)
 
 
 def cachelist_pm_member_plan(
@@ -1880,6 +1885,8 @@ class BlockAwarePrefixCache(CacheManager):
         source_layer: dict[str, Any],
         source_state: Any,
         sub_class_names: list[str],
+        live_state: Any = None,
+        slice_range: tuple[int, int] | None = None,
     ) -> list[Any] | None:
         """Build ``__cache_list__`` sub-tensors from an extracted layer dict.
 
@@ -1887,12 +1894,85 @@ class BlockAwarePrefixCache(CacheManager):
         ``pooled`` must survive the round-trip) and wraps PoolingCache subs
         that carry a delta range as ``PoolingCacheDelta`` storage entries.
         Returns None when the state is not a usable list.
+
+        ``live_state`` (optional) refills blanked (``()``) members — the
+        sliceable KV sub of a member-filtered snapshot — from the live
+        cache's corresponding member, sliced to ``slice_range`` so the
+        stored block carries real, restorable KV instead of an incomplete
+        CacheList. Used by the non-pm (legacy cumulative) CacheList store
+        path, where boundary snapshots blank the sliceable KV member to
+        avoid quadratic in-memory retention but the persisted block must
+        still restore it (maintainer review, GLM CacheList(KVCache,
+        PoolingCache)).
         """
         if not isinstance(source_state, list):
             return None
         pooling_delta_ranges = source_layer.get("pooling_delta_ranges", {})
+        live_members = live_state if isinstance(live_state, list) else None
         sub_tensors: list[Any] = []
         for sub_idx, sub_state in enumerate(source_state):
+            if isinstance(sub_state, (list, tuple)) and len(sub_state) == 0:
+                # Blanked sliceable member (member-filtered snapshot).
+                # Refill from the live cache's member, sliced to this block.
+                if (
+                    live_members is not None
+                    and sub_idx < len(live_members)
+                    and isinstance(live_members[sub_idx], (list, tuple))
+                    and len(live_members[sub_idx]) >= 1
+                ):
+                    live_sub = live_members[sub_idx]
+                    cloned = [
+                        self._clone_tensor(elem)
+                        if hasattr(elem, "shape")
+                        else elem
+                        for elem in live_sub
+                    ]
+                    if slice_range is not None and cloned:
+                        start_idx, end_idx = slice_range
+                        seq_len = (
+                            cloned[0].shape[2]
+                            if hasattr(cloned[0], "shape")
+                            and len(cloned[0].shape) >= 3
+                            else -1
+                        )
+                        if seq_len > 0:
+                            actual_end = min(end_idx, seq_len)
+                            start_idx = min(start_idx, actual_end)
+                            sliced = []
+                            for elem in cloned:
+                                if (
+                                    hasattr(elem, "shape")
+                                    and len(elem.shape) == 4
+                                    and elem.shape[2] == seq_len
+                                ):
+                                    sliced.append(
+                                        self._clone_tensor(
+                                            elem[:, :, start_idx:actual_end, :]
+                                        )
+                                    )
+                                elif (
+                                    hasattr(elem, "shape")
+                                    and len(elem.shape) == 3
+                                    and elem.shape[1] == seq_len
+                                ):
+                                    sliced.append(
+                                        self._clone_tensor(
+                                            elem[:, start_idx:actual_end, :]
+                                        )
+                                    )
+                                else:
+                                    sliced.append(elem)
+                            cloned = sliced
+                    sub_tensors.append(
+                        _wrap_cachelist_sub_marker(
+                            sub_idx, cloned, sub_class_names
+                        )
+                    )
+                else:
+                    # No live member to refill from: skip (restore will
+                    # reject incomplete CacheList blocks rather than corrupt).
+                    continue
+                continue
             if not (isinstance(sub_state, (list, tuple)) and len(sub_state) >= 1):
                 continue
             cloned = [
@@ -2476,7 +2556,11 @@ class BlockAwarePrefixCache(CacheManager):
                             )
                             source_state = source_layer["state"]
                             sub_tensors = self._cachelist_snapshot_sub_tensors(
-                                source_layer, source_state, sub_class_names
+                                source_layer,
+                                source_state,
+                                sub_class_names,
+                                live_state=layer_state.get("state"),
+                                slice_range=(start_idx, end_idx),
                             )
                             if sub_tensors is not None:
                                 block_slices.append(("__cache_list__", sub_tensors))

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -137,6 +137,9 @@ def _wrap_cachelist_sub_marker(
     return ("__nstate__", name, list(elements))
 _EXACT_PREFIX_TERMINAL_KEY = "specprefill-static-exact-v1"
 _POOLING_CACHE_SUB_CLASSES = frozenset({"PoolingCache", "BatchPoolingCache"})
+# Sentinel: the CacheList restore chain carries no PoolingCacheDelta
+# markers, so the caller restores the boundary member last-block-wins.
+_NO_POOLING_DELTA = object()
 
 
 def _contains_pooling_cache_state(cache_data: list[Any]) -> bool:
@@ -2459,6 +2462,7 @@ class BlockAwarePrefixCache(CacheManager):
                     # legacy quadratic cumulative-per-block layout.
                     pm_plan = cachelist_pm_member_plan(sub_class_names, state)
                     pm_snapshot_state = None
+                    pm_snapshot_layer: dict[str, Any] = {}
                     if (
                         snapshot_cache_data is not None
                         and layer_idx < len(snapshot_cache_data)
@@ -2466,7 +2470,15 @@ class BlockAwarePrefixCache(CacheManager):
                             snapshot_cache_data[layer_idx].get("state"), list
                         )
                     ):
-                        pm_snapshot_state = snapshot_cache_data[layer_idx]["state"]
+                        pm_snapshot_layer = snapshot_cache_data[layer_idx]
+                        pm_snapshot_state = pm_snapshot_layer["state"]
+                    # Scheduler boundary snapshots run through
+                    # compact_pooling_cache_snapshot: a PoolingCache member's
+                    # pooled tensor holds only this block's appended rows and
+                    # the absolute row range rides in pooling_delta_ranges.
+                    pm_pooling_delta_ranges = (
+                        pm_snapshot_layer.get("pooling_delta_ranges") or {}
+                    )
                     # See the rotating-family branch above (A1): a missing
                     # boundary snapshot must fall to the placeholder path
                     # even on the last block, unless the caller has verified
@@ -2527,7 +2539,35 @@ class BlockAwarePrefixCache(CacheManager):
                                 )
                                 for elem in source
                             ]
-                            sub_tensors.append(_wrap_sub_marker(sub_idx, cloned))
+                            # A compacted PoolingCache boundary member is a
+                            # per-block pooled DELTA, not the cumulative pool:
+                            # persist the absolute row range and stamp
+                            # PoolingCacheDelta (same storage entry the legacy
+                            # path uses) so the per-member restore rebuilds
+                            # the cumulative pooled tensor across blocks
+                            # instead of last-blocking a single delta
+                            # (maintainer review #3290).
+                            delta_range = pm_pooling_delta_ranges.get(str(sub_idx))
+                            sub_class = (
+                                sub_class_names[sub_idx]
+                                if sub_idx < len(sub_class_names)
+                                else None
+                            )
+                            if (
+                                sub_class == "PoolingCache"
+                                and isinstance(delta_range, (list, tuple))
+                                and len(delta_range) == 2
+                            ):
+                                cloned.append(mx.array(delta_range, dtype=mx.int64))
+                                sub_tensors.append(
+                                    _wrap_sub_marker(
+                                        sub_idx,
+                                        cloned,
+                                        POOLING_CACHE_DELTA_CLASS,
+                                    )
+                                )
+                            else:
+                                sub_tensors.append(_wrap_sub_marker(sub_idx, cloned))
                         block_slices.append(("__cache_list_pm__", sub_tensors))
                     else:
                         # Non-sliceable sub-caches: last-block-only or snapshot.
@@ -3604,6 +3644,115 @@ class BlockAwarePrefixCache(CacheManager):
                         for elems in last_block_elements
                     )
 
+                    def _rebuild_pooling_delta_sub(
+                        j: int,
+                        _block_data: list[Any] = cl_block_data,
+                        _layer_idx: int = layer_idx,
+                    ) -> Any:
+                        """Rebuild a PoolingCache sub from its delta chain.
+
+                        A compacted PoolingCache boundary member persists as
+                        a ``PoolingCacheDelta`` storage entry carrying this
+                        block's pooled rows plus its absolute row range; the
+                        cumulative pool must be rebuilt in block order —
+                        last-blocking would restore one block's rows instead
+                        of the chain (maintainer review #3290). Shared by the
+                        per-member and legacy cumulative restore branches.
+                        A legacy full snapshot appearing before the deltas
+                        becomes the reconstruction base.
+
+                        Returns ``_NO_POOLING_DELTA`` when no block carries a
+                        delta marker (caller takes the last block's state),
+                        the reconstructed state tuple on success, or None when
+                        the chain is invalid (caller must reject the cache).
+                        """
+                        if not any(
+                            _sub_state_class(bd[j]) == POOLING_CACHE_DELTA_CLASS
+                            for bd in _block_data
+                        ):
+                            return _NO_POOLING_DELTA
+
+                        pooled_parts: list[Any] = []
+                        pooled_length = 0
+                        last_pooling_state: list[Any] | None = None
+                        valid_pooling_chain = True
+                        for block_cache_list in _block_data:
+                            sub_state = block_cache_list[j]
+                            elements = _sub_state_elements(sub_state)
+                            marker_class = _sub_state_class(sub_state)
+                            if elements is None:
+                                valid_pooling_chain = False
+                                break
+
+                            if marker_class != POOLING_CACHE_DELTA_CLASS:
+                                if len(elements) < 3:
+                                    valid_pooling_chain = False
+                                    break
+                                if elements[2] is None:
+                                    pooled_parts = []
+                                    pooled_length = 0
+                                elif (
+                                    hasattr(elements[2], "shape")
+                                    and len(elements[2].shape) >= 2
+                                ):
+                                    pooled_parts = [elements[2]]
+                                    pooled_length = int(elements[2].shape[1])
+                                else:
+                                    valid_pooling_chain = False
+                                    break
+                                last_pooling_state = list(elements)
+                                continue
+
+                            if (
+                                len(elements) not in (4, 6)
+                                or not hasattr(elements[2], "shape")
+                                or len(elements[2].shape) < 2
+                                or not hasattr(elements[-1], "tolist")
+                            ):
+                                valid_pooling_chain = False
+                                break
+                            try:
+                                delta_range = elements[-1].tolist()
+                                delta_start, delta_end = (
+                                    int(delta_range[0]),
+                                    int(delta_range[1]),
+                                )
+                            except (IndexError, TypeError, ValueError):
+                                valid_pooling_chain = False
+                                break
+                            if (
+                                delta_start != pooled_length
+                                or delta_end < delta_start
+                                or int(elements[2].shape[1])
+                                != delta_end - delta_start
+                            ):
+                                valid_pooling_chain = False
+                                break
+                            pooled_parts.append(elements[2])
+                            pooled_length = delta_end
+                            last_pooling_state = list(elements[:-1])
+
+                        if (
+                            not valid_pooling_chain
+                            or not pooled_parts
+                            or last_pooling_state is None
+                        ):
+                            logger.info(
+                                "CacheList layer %d sub-cache %d: invalid "
+                                "PoolingCache delta chain. Rejecting cache.",
+                                _layer_idx,
+                                j,
+                            )
+                            return None
+
+                        pooled = (
+                            pooled_parts[0]
+                            if len(pooled_parts) == 1
+                            else mx.concatenate(pooled_parts, axis=1)
+                        )
+                        last_pooling_state[2] = pooled
+                        return tuple(last_pooling_state)
+
                     pm_mode = any(cl_block_pm_flags)
                     if pm_mode and not all(cl_block_pm_flags):
                         # A chain mixing legacy cumulative blocks with
@@ -3691,7 +3840,18 @@ class BlockAwarePrefixCache(CacheManager):
                                         cat_elements.append(column[-1])
                                 concatenated_sub_states.append(tuple(cat_elements))
                             else:
-                                concatenated_sub_states.append(tuple(elems_last))
+                                # Boundary member (or single-block slice sub):
+                                # rebuild a PoolingCache delta chain when one
+                                # exists; otherwise the last block's state is
+                                # authoritative at that boundary.
+                                rebuilt = _rebuild_pooling_delta_sub(j)
+                                if rebuilt is None:
+                                    return None
+                                concatenated_sub_states.append(
+                                    tuple(elems_last)
+                                    if rebuilt is _NO_POOLING_DELTA
+                                    else rebuilt
+                                )
 
                         # Defense-in-depth (#2550 review): the restored KV
                         # length must equal the matched token count. A chain
@@ -3762,99 +3922,17 @@ class BlockAwarePrefixCache(CacheManager):
                         # every sub at its boundary. PoolingCache V4 markers
                         # are the exception: their append-only pooled tensor
                         # is stored as an absolute-range delta per block and
-                        # must be rebuilt in order. A legacy full snapshot may
-                        # appear before V4 deltas in an existing cache chain;
-                        # it becomes the reconstruction base.
+                        # must be rebuilt in order (shared helper).
                         concatenated_sub_states = []
                         for j, last_elements in enumerate(last_block_elements):
-                            has_pooling_deltas = any(
-                                _sub_state_class(bd[j]) == POOLING_CACHE_DELTA_CLASS
-                                for bd in cl_block_data
-                            )
-                            if not has_pooling_deltas:
-                                concatenated_sub_states.append(tuple(last_elements))
-                                continue
-
-                            pooled_parts = []
-                            pooled_length = 0
-                            last_pooling_state = None
-                            valid_pooling_chain = True
-                            for block_cache_list in cl_block_data:
-                                sub_state = block_cache_list[j]
-                                elements = _sub_state_elements(sub_state)
-                                marker_class = _sub_state_class(sub_state)
-                                if elements is None:
-                                    valid_pooling_chain = False
-                                    break
-
-                                if marker_class != POOLING_CACHE_DELTA_CLASS:
-                                    if len(elements) < 3:
-                                        valid_pooling_chain = False
-                                        break
-                                    if elements[2] is None:
-                                        pooled_parts = []
-                                        pooled_length = 0
-                                    elif (
-                                        hasattr(elements[2], "shape")
-                                        and len(elements[2].shape) >= 2
-                                    ):
-                                        pooled_parts = [elements[2]]
-                                        pooled_length = int(elements[2].shape[1])
-                                    else:
-                                        valid_pooling_chain = False
-                                        break
-                                    last_pooling_state = list(elements)
-                                    continue
-
-                                if (
-                                    len(elements) not in (4, 6)
-                                    or not hasattr(elements[2], "shape")
-                                    or len(elements[2].shape) < 2
-                                    or not hasattr(elements[-1], "tolist")
-                                ):
-                                    valid_pooling_chain = False
-                                    break
-                                try:
-                                    delta_range = elements[-1].tolist()
-                                    delta_start, delta_end = (
-                                        int(delta_range[0]),
-                                        int(delta_range[1]),
-                                    )
-                                except (IndexError, TypeError, ValueError):
-                                    valid_pooling_chain = False
-                                    break
-                                if (
-                                    delta_start != pooled_length
-                                    or delta_end < delta_start
-                                    or int(elements[2].shape[1])
-                                    != delta_end - delta_start
-                                ):
-                                    valid_pooling_chain = False
-                                    break
-                                pooled_parts.append(elements[2])
-                                pooled_length = delta_end
-                                last_pooling_state = list(elements[:-1])
-
-                            if (
-                                not valid_pooling_chain
-                                or not pooled_parts
-                                or last_pooling_state is None
-                            ):
-                                logger.info(
-                                    "CacheList layer %d sub-cache %d: invalid "
-                                    "PoolingCache delta chain. Rejecting cache.",
-                                    layer_idx,
-                                    j,
-                                )
+                            rebuilt = _rebuild_pooling_delta_sub(j)
+                            if rebuilt is None:
                                 return None
-
-                            pooled = (
-                                pooled_parts[0]
-                                if len(pooled_parts) == 1
-                                else mx.concatenate(pooled_parts, axis=1)
+                            concatenated_sub_states.append(
+                                tuple(last_elements)
+                                if rebuilt is _NO_POOLING_DELTA
+                                else rebuilt
                             )
-                            last_pooling_state[2] = pooled
-                            concatenated_sub_states.append(tuple(last_pooling_state))
 
                     # Build meta_state with correct offsets for reconstructed
                     # sequence length (may differ from original if partial match)

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -44,9 +44,15 @@ from .type_registry import CacheTypeRegistry
 # and the boundary snapshot carries the cumulative pool at that boundary,
 # while the small 3D remainder buffer is restored from the snapshot (GLM-5.x
 # CacheList(KVCache, PoolingCache); DeepSeek-V4's rotating member keeps that
-# layer on the legacy cumulative path). Rotating families stay legacy.
+# layer on the legacy cumulative path). BatchPoolingCache is the batched
+# pooling shape: its boundary state (buf_kv, buf_gate, pooled) is likewise
+# self-contained and it is NOT compacted to per-block deltas
+# (compact_pooling_cache_snapshot only covers PoolingCache), so it restores
+# last-block-wins like ArraysCache. Must stay in sync with
+# ``paged_ssd_cache._PM_BOUNDARY_SUB_CLASSES``. Rotating families stay
+# legacy.
 _PM_SAFE_NON_SLICEABLE_SUBS = frozenset(
-    {"ArraysCache", "SizedArraysCache", "PoolingCache"}
+    {"ArraysCache", "SizedArraysCache", "PoolingCache", "BatchPoolingCache"}
 )
 
 

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -6442,11 +6442,30 @@ class Scheduler:
             ):
                 continue
             plan = cachelist_pm_member_plan([str(n) for n in meta[0]], state)
-            if plan is None:
+            if plan is not None:
+                layer["state"] = [
+                    () if mode == "slice" else sub_state
+                    for mode, sub_state in zip(plan, state)
+                ]
+                continue
+
+            # Not per-member-block eligible (e.g. DeepSeek-V4's
+            # CacheList(RotatingKVCache, PoolingCache) — the rotating member
+            # is not sliceable and keeps the legacy cumulative path). Blank
+            # any known-sliceable member so the boundary snapshot does not
+            # retain the full KV prefix — quadratic across a request (the
+            # #2551 class of bug, resurfacing as GLM prefill RAM creeping to
+            # ~113GB and a guard abort at ~30K tokens before GLM became
+            # pm-eligible). _merge_boundary_with_full_cache /
+            # _fill_boundary_placeholders_from_live_cache refill those
+            # members from the live cache at store time. Non-sliceable
+            # members (PoolingCache/ArraysCache/rotating) stay authoritative.
+            names = [str(n) for n in meta[0]]
+            if not any(n in _KNOWN_SLICEABLE_CACHE_TYPES for n in names):
                 continue
             layer["state"] = [
-                () if mode == "slice" else sub_state
-                for mode, sub_state in zip(plan, state)
+                () if n in _KNOWN_SLICEABLE_CACHE_TYPES else sub_state
+                for n, sub_state in zip(names, state)
             ]
         return extracted, tokens
 

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -6448,25 +6448,13 @@ class Scheduler:
                     for mode, sub_state in zip(plan, state)
                 ]
                 continue
-
             # Not per-member-block eligible (e.g. DeepSeek-V4's
-            # CacheList(RotatingKVCache, PoolingCache) — the rotating member
-            # is not sliceable and keeps the legacy cumulative path). Blank
-            # any known-sliceable member so the boundary snapshot does not
-            # retain the full KV prefix — quadratic across a request (the
-            # #2551 class of bug, resurfacing as GLM prefill RAM creeping to
-            # ~113GB and a guard abort at ~30K tokens before GLM became
-            # pm-eligible). _merge_boundary_with_full_cache /
-            # _fill_boundary_placeholders_from_live_cache refill those
-            # members from the live cache at store time. Non-sliceable
-            # members (PoolingCache/ArraysCache/rotating) stay authoritative.
-            names = [str(n) for n in meta[0]]
-            if not any(n in _KNOWN_SLICEABLE_CACHE_TYPES for n in names):
-                continue
-            layer["state"] = [
-                () if n in _KNOWN_SLICEABLE_CACHE_TYPES else sub_state
-                for n, sub_state in zip(names, state)
-            ]
+            # CacheList(RotatingKVCache, PoolingCache)): the legacy store
+            # path persists the snapshot as-is and the legacy restore takes
+            # the last block's FULL state, so every member must stay
+            # cumulative here. Blanking a sliceable member on such a layer
+            # would store refilled per-block slices whose restore silently
+            # truncates the KV sequence to the last block.
         return extracted, tokens
 
     def _decode_boundary_snapshot_value(

--- a/tests/test_prefix_cache_cachelist_mixed.py
+++ b/tests/test_prefix_cache_cachelist_mixed.py
@@ -462,9 +462,7 @@ def test_glm_pooling_cachelist_blanks_kv_member():
     mx.eval([keys, values])
     live_extracted, _ = Scheduler._extract_cache_states(stub, [live_list])
 
-    refilled = Scheduler._refill_blanked_cachelist_members(
-        extracted, live_extracted
-    )
+    refilled = Scheduler._refill_blanked_cachelist_members(extracted, live_extracted)
     assert refilled is not None
     assert isinstance(refilled[0]["state"][0], (list, tuple))
     assert len(refilled[0]["state"][0]) >= 2  # keys, values restored
@@ -628,3 +626,258 @@ def test_none_conv_slots_roundtrip(tmp_path):
     assert slots[0] is not None and slots[2] is not None
     kv_state = restored.caches[0].state
     assert kv_state[0].shape[2] == BLOCK_SIZE
+
+
+def test_kv_batch_pooling_cachelist_pm_roundtrip(tmp_path):
+    """CacheList(KVCache, BatchPoolingCache) round-trips through the pm
+    path with the FULL KV sequence (maintainer review #3290).
+
+    BatchPoolingCache is boundary-eligible (self-contained at its boundary,
+    not compacted), so the scheduler blanks the KV member and the store
+    persists per-block KV slices plus the cumulative BatchPoolingCache
+    boundary state as a PLAIN marker (no PoolingCacheDelta — compaction only
+    covers PoolingCache). The restore concatenates the KV slices back to the
+    full sequence and takes the last block's pooling state. Before the fix,
+    the scheduler's non-pm fallback blanked the KV member of this layer
+    while the legacy restore last-blocked the refilled per-block slices —
+    silently truncating the KV sequence to one block."""
+    from mlx_vlm.models.cache import BatchPoolingCache
+
+    from omlx.patches.deepseek_v4 import apply_pooling_cache_support
+    from omlx.scheduler import Scheduler
+
+    apply_pooling_cache_support()
+    cache, ssd = _make_cache(tmp_path)
+
+    stub = SimpleNamespace(_stream=mx.default_stream(mx.default_device()))
+    stub._extract_cache_states = lambda caches: Scheduler._extract_cache_states(
+        stub, caches
+    )
+
+    num_blocks = 3
+    tokens = list(range(num_blocks * BLOCK_SIZE))
+    kv = KVCache()
+    bpc = BatchPoolingCache(ratio=4, left_padding=[0])
+    boundaries = {}
+    for i in range(num_blocks):
+        start, end = i * BLOCK_SIZE, (i + 1) * BLOCK_SIZE
+        pos = mx.arange(start, end, dtype=mx.float32).reshape(1, 1, BLOCK_SIZE, 1)
+        keys = mx.contiguous(mx.broadcast_to(pos, (1, 2, BLOCK_SIZE, 8)))
+        kv.update_and_fetch(keys, keys + 1000.0)
+        # Cumulative pooled rows at this boundary; value encodes the row
+        # count so the restored state pins the LAST block's snapshot.
+        rows = end // 4
+        bpc.buf_kv = mx.full((1, 4, 8), float(i + 1), dtype=mx.float32)
+        bpc.buf_gate = mx.full((1, 4, 4), float(i + 1), dtype=mx.float32)
+        bpc.pooled = mx.full((1, rows, 8), float(rows), dtype=mx.float32)
+        bpc._pool_lengths = [rows]
+        bpc.remainder = [0]
+        mx.eval([keys])
+        extracted, _ = Scheduler._extract_snapshot_cache_states(
+            stub, [CacheList(kv, bpc)]
+        )
+        assert extracted[0]["state"][0] == (), "KV member must be blanked (pm)"
+        boundaries[end] = extracted
+
+    full = _layer_dict(CacheList(kv, bpc))
+    table = cache.store_cache(
+        "req-bpc-pm", tokens, [full], boundary_snapshots=boundaries
+    )
+    assert table is not None
+
+    for i, bid in enumerate(table.block_ids):
+        block = cache.paged_cache.allocated_blocks[bid]
+        payload, _meta = ssd.load_block_with_metadata(block.block_hash)
+        layer = payload[0]
+        assert isinstance(layer, tuple) and layer[0] == "__cache_list_pm__"
+        sub = layer[1][1]
+        assert (
+            isinstance(sub, tuple)
+            and sub[0] == "__nstate__"
+            and sub[1] == "BatchPoolingCache"
+        ), f"block {i}: expected plain BatchPoolingCache marker, got {sub[:2]}"
+
+    result = cache.reconstruct_cache(table)
+    assert result is not None
+    kv_r = result[0].caches[0]
+    assert kv_r.keys.shape[2] == num_blocks * BLOCK_SIZE
+    expected = mx.broadcast_to(
+        mx.arange(num_blocks * BLOCK_SIZE, dtype=mx.float32).reshape(
+            1, 1, num_blocks * BLOCK_SIZE, 1
+        ),
+        kv_r.keys.shape,
+    )
+    assert mx.max(mx.abs(kv_r.keys - expected)).item() == 0.0
+    bpc_r = result[0].caches[1]
+    assert type(bpc_r).__name__ == "BatchPoolingCache"
+    assert bpc_r.pooled is not None
+    assert bpc_r.pooled.shape[1] == num_blocks * BLOCK_SIZE // 4
+    assert mx.max(bpc_r.pooled).item() == float(num_blocks)
+
+
+def _advance_glm_pooling_boundaries(stub, kv, pool, num_blocks, compact_from=0):
+    """Advance kv/pool block by block, extracting scheduler-shaped boundary
+    snapshots; compact PoolingCache from block ``compact_from`` (earlier
+    blocks keep their cumulative pooled — the plain-snapshot shape)."""
+    from omlx.cache.pooling_delta import compact_pooling_cache_snapshot
+    from omlx.scheduler import Scheduler
+
+    boundaries = {}
+    for i in range(num_blocks):
+        start, end = i * BLOCK_SIZE, (i + 1) * BLOCK_SIZE
+        pos = mx.arange(start, end, dtype=mx.float32).reshape(1, 1, BLOCK_SIZE, 1)
+        keys = mx.contiguous(mx.broadcast_to(pos, (1, 2, BLOCK_SIZE, 8)))
+        kv.update_and_fetch(keys, keys + 1000.0)
+        pool.update_and_fetch(
+            mx.full((1, BLOCK_SIZE // 4, 8), float(i + 1), dtype=mx.float32)
+        )
+        mx.eval([keys])
+        extracted, _ = Scheduler._extract_snapshot_cache_states(
+            stub, [CacheList(kv, pool)]
+        )
+        if i >= compact_from:
+            compact_pooling_cache_snapshot(extracted, end, BLOCK_SIZE)
+        boundaries[end] = extracted
+    return boundaries
+
+
+def _glm_pooling_fixture(tmp_path):
+    from mlx_vlm.models.cache import PoolingCache
+
+    from omlx.patches.deepseek_v4 import apply_pooling_cache_support
+    from omlx.scheduler import Scheduler
+
+    apply_pooling_cache_support()
+    cache, ssd = _make_cache(tmp_path)
+    stub = SimpleNamespace(_stream=mx.default_stream(mx.default_device()))
+    stub._extract_cache_states = lambda caches: Scheduler._extract_cache_states(
+        stub, caches
+    )
+    kv = KVCache()
+    pool = PoolingCache(ratio=4)
+    return cache, ssd, stub, kv, pool
+
+
+def test_glm_pm_partial_match_restores_truncated_pooling_chain(tmp_path):
+    """A partial prefix match (first 2 of 3 blocks) must rebuild the pooled
+    chain truncated at the match point — 2 rows in block order — and the KV
+    at 8 tokens (maintainer review #3290 edge case)."""
+    from omlx.cache.paged_cache import BlockTable
+
+    cache, _ssd, stub, kv, pool = _glm_pooling_fixture(tmp_path)
+    num_blocks = 3
+    tokens = list(range(num_blocks * BLOCK_SIZE))
+    boundaries = _advance_glm_pooling_boundaries(stub, kv, pool, num_blocks)
+    full = _layer_dict(CacheList(kv, pool))
+    table = cache.store_cache(
+        "req-glm-partial", tokens, [full], boundary_snapshots=boundaries
+    )
+    assert table is not None
+
+    partial = BlockTable(
+        request_id="req-glm-partial-restore",
+        block_ids=list(table.block_ids[:2]),
+        num_tokens=2 * BLOCK_SIZE,
+    )
+    result = cache.reconstruct_cache(partial)
+    assert result is not None
+    kv_r = result[0].caches[0]
+    assert kv_r.keys.shape[2] == 2 * BLOCK_SIZE
+    pool_r = result[0].caches[1]
+    assert pool_r.pooled.shape[1] == 2
+    assert mx.max(pool_r.pooled[0, 0, :]).item() == 1.0
+    assert mx.max(pool_r.pooled[0, 1, :]).item() == 2.0
+
+
+def test_glm_pm_pooled_delta_chain_gap_rejects(tmp_path):
+    """A block chain with a skipped middle block cannot rebuild the pooled
+    delta chain (absolute ranges stop being contiguous): the cache must be
+    REJECTED (safe miss -> re-prefill), never silently shortened."""
+    from omlx.cache.paged_cache import BlockTable
+
+    cache, _ssd, stub, kv, pool = _glm_pooling_fixture(tmp_path)
+    num_blocks = 3
+    tokens = list(range(num_blocks * BLOCK_SIZE))
+    boundaries = _advance_glm_pooling_boundaries(stub, kv, pool, num_blocks)
+    full = _layer_dict(CacheList(kv, pool))
+    table = cache.store_cache(
+        "req-glm-gap", tokens, [full], boundary_snapshots=boundaries
+    )
+    assert table is not None
+
+    gapped = BlockTable(
+        request_id="req-glm-gap-restore",
+        block_ids=[table.block_ids[0], table.block_ids[2]],
+        num_tokens=2 * BLOCK_SIZE,
+    )
+    assert cache.reconstruct_cache(gapped) is None
+
+
+def test_glm_pm_uncompacted_and_mixed_pooling_chains(tmp_path):
+    """Snapshots that never went through compaction persist as plain
+    PoolingCache members and restore last-block-wins (cumulative). Mixed
+    chains are contiguous-safe in both orders: a plain cumulative snapshot
+    before the deltas becomes the base; a plain snapshot AFTER the deltas
+    resets the base to its own cumulative pool (the authoritative state at
+    that boundary)."""
+    from omlx.scheduler import Scheduler
+
+    cache, ssd, stub, kv, pool = _glm_pooling_fixture(tmp_path)
+    num_blocks = 3
+    tokens = list(range(num_blocks * BLOCK_SIZE))
+
+    # (a) fully uncompacted
+    boundaries = _advance_glm_pooling_boundaries(
+        stub, kv, pool, num_blocks, compact_from=num_blocks
+    )
+    full = _layer_dict(CacheList(kv, pool))
+    table = cache.store_cache(
+        "req-glm-uncompacted", tokens, [full], boundary_snapshots=boundaries
+    )
+    assert table is not None
+    for bid in table.block_ids:
+        block = cache.paged_cache.allocated_blocks[bid]
+        payload, _meta = ssd.load_block_with_metadata(block.block_hash)
+        sub = payload[0][1][1]
+        assert sub[0] == "__nstate__" and sub[1] == "PoolingCache"
+    result = cache.reconstruct_cache(table)
+    assert result is not None
+    assert result[0].caches[0].keys.shape[2] == num_blocks * BLOCK_SIZE
+    assert result[0].caches[1].pooled.shape[1] == num_blocks * BLOCK_SIZE // 4
+
+    # (b) plain first block, then deltas
+    cache, ssd, stub, kv, pool = _glm_pooling_fixture(tmp_path)
+    boundaries = _advance_glm_pooling_boundaries(
+        stub, kv, pool, num_blocks, compact_from=1
+    )
+    full = _layer_dict(CacheList(kv, pool))
+    table = cache.store_cache(
+        "req-glm-mixed-base", tokens, [full], boundary_snapshots=boundaries
+    )
+    assert table is not None
+    result = cache.reconstruct_cache(table)
+    assert result is not None
+    pool_r = result[0].caches[1]
+    assert pool_r.pooled.shape[1] == num_blocks
+    for i in range(num_blocks):
+        assert mx.max(pool_r.pooled[0, i, :]).item() == float(i + 1)
+
+    # (c) deltas first, plain cumulative last block
+    cache, ssd, stub, kv, pool = _glm_pooling_fixture(tmp_path)
+    boundaries = _advance_glm_pooling_boundaries(stub, kv, pool, num_blocks)
+    # replace the last boundary with its uncompacted (cumulative) shape:
+    # the chain's plain snapshot resets the base to its own cumulative pool
+    final_extracted, _ = Scheduler._extract_snapshot_cache_states(
+        stub, [CacheList(kv, pool)]
+    )
+    boundaries[num_blocks * BLOCK_SIZE] = final_extracted
+    full = _layer_dict(CacheList(kv, pool))
+    table = cache.store_cache(
+        "req-glm-mixed-last", tokens, [full], boundary_snapshots=boundaries
+    )
+    assert table is not None
+    result = cache.reconstruct_cache(table)
+    assert result is not None
+    pool_r = result[0].caches[1]
+    assert pool_r.pooled.shape[1] == num_blocks
+    assert mx.max(pool_r.pooled[0, num_blocks - 1, :]).item() == float(num_blocks)

--- a/tests/test_prefix_cache_cachelist_mixed.py
+++ b/tests/test_prefix_cache_cachelist_mixed.py
@@ -27,6 +27,7 @@ hot-cache-only PagedSSDCacheManager.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -417,6 +418,120 @@ def test_boundary_store_mixed_cachelist_roundtrip(tmp_path):
     assert info["has_state"] == "false"
 
     store.shutdown()
+
+
+def test_glm_pooling_cachelist_blanks_kv_member():
+    """GLM-5.x CacheList(KVCache, PoolingCache) boundary snapshot must blank
+    the sliceable KVCache member.
+
+    GLM is per-member-block eligible: PoolingCache is in
+    _PM_SAFE_NON_SLICEABLE_SUBS, so cachelist_pm_member_plan returns
+    ["slice", "boundary"] and the snapshot blanks the sliceable KVCache
+    member while keeping the PoolingCache member authoritative. Before the
+    fix, an unblanked KV member made in-memory snapshot retention quadratic
+    (~113GB RAM and a guard abort at ~30K tokens). The refill path (via
+    _refill_blanked_cachelist_members) restores the KV from the live cache.
+    """
+    from mlx_vlm.models.cache import PoolingCache
+
+    from omlx.scheduler import Scheduler
+
+    kv = KVCache()
+    keys, values = _position_kv(BLOCK_SIZE)
+    kv.update_and_fetch(keys, values)
+    pooled = PoolingCache(ratio=4)
+    cache_list = CacheList(kv, pooled)
+    mx.eval([keys, values])
+
+    stub = SimpleNamespace(_stream=mx.default_stream(mx.default_device()))
+    stub._extract_cache_states = lambda caches: Scheduler._extract_cache_states(
+        stub, caches
+    )
+    extracted, _ = Scheduler._extract_snapshot_cache_states(stub, [cache_list])
+
+    assert extracted and len(extracted) == 1
+    state = extracted[0]["state"]
+    # KVCache member blanked, PoolingCache member kept.
+    assert state[0] == (), "GLM sliceable KVCache member must be blanked"
+    assert isinstance(state[1], (list, tuple)) and len(state[1]) > 0
+
+    # Refill from a live cache restores the KV member.
+    live_kv = KVCache()
+    live_kv.update_and_fetch(keys, values)
+    live_list = CacheList(live_kv, PoolingCache(ratio=4))
+    mx.eval([keys, values])
+    live_extracted, _ = Scheduler._extract_cache_states(stub, [live_list])
+
+    refilled = Scheduler._refill_blanked_cachelist_members(
+        extracted, live_extracted
+    )
+    assert refilled is not None
+    assert isinstance(refilled[0]["state"][0], (list, tuple))
+    assert len(refilled[0]["state"][0]) >= 2  # keys, values restored
+
+
+def test_glm_pooling_cachelist_blanked_kv_roundtrips(tmp_path):
+    """A GLM-5.x CacheList(KVCache, PoolingCache) whose boundary snapshots
+    blank the sliceable KV member must store and restore a complete
+    CacheList via the per-member path: the store slices the live KV per
+    block and the restore concatenates the slices back into the full
+    sequence, so prefix-cache reuse survives with correct KV positions
+    (maintainer review #3290)."""
+    from mlx_vlm.models.cache import PoolingCache
+
+    from omlx.patches.deepseek_v4 import apply_pooling_cache_support
+
+    apply_pooling_cache_support()
+    cache, _ = _make_cache(tmp_path)
+
+    def build(seq_len, blank_kv=False):
+        kv = KVCache()
+        keys, values = _position_kv(seq_len)
+        kv.update_and_fetch(keys, values)
+        pool = PoolingCache(ratio=4)
+        # pooled rows carry distinguishable data
+        pool.update_and_fetch(
+            mx.full((1, seq_len // 4, 8), 0.0, dtype=mx.float32)
+        )
+        cl = CacheList(kv, pool)
+        mx.eval([keys, values])
+        d = _layer_dict(cl)
+        if blank_kv:
+            d["state"][0] = ()
+        return d
+
+    num_blocks = 3
+    tokens = list(range(num_blocks * BLOCK_SIZE))
+    full = build(len(tokens))
+    boundaries = {
+        BLOCK_SIZE * (i + 1): [build(BLOCK_SIZE * (i + 1), blank_kv=True)]
+        for i in range(num_blocks)
+    }
+    table = cache.store_cache("req-glm-refill", tokens, [full],
+                              boundary_snapshots=boundaries)
+    assert table is not None
+
+    result = cache.reconstruct_cache(table)
+    assert result is not None and len(result) == 1
+    restored = result[0]
+    assert type(restored).__name__ == "CacheList"
+    # KV member restored by concatenating the per-block slices: the FULL
+    # sequence (not last-block-only), position-encoded so content verifies.
+    kv = restored.caches[0]
+    assert kv.keys.shape[2] == num_blocks * BLOCK_SIZE
+    expected = mx.broadcast_to(
+        mx.arange(num_blocks * BLOCK_SIZE, dtype=mx.float32).reshape(
+            1, 1, num_blocks * BLOCK_SIZE, 1
+        ),
+        kv.keys.shape,
+    )
+    assert mx.max(mx.abs(kv.keys - expected)).item() == 0.0
+    # PoolingCache member restored: pooled is cumulative across the chain
+    # (append-only pooled rows) — the last matched block's boundary state.
+    pool = restored.caches[1]
+    assert type(pool).__name__ == "PoolingCache"
+    assert pool.pooled is not None
+    assert pool.pooled.shape[1] == (num_blocks * BLOCK_SIZE) // 4
 
 
 def test_arrays_cache_extract_none_guard():

--- a/tests/test_prefix_cache_cachelist_mixed.py
+++ b/tests/test_prefix_cache_cachelist_mixed.py
@@ -476,40 +476,89 @@ def test_glm_pooling_cachelist_blanked_kv_roundtrips(tmp_path):
     CacheList via the per-member path: the store slices the live KV per
     block and the restore concatenates the slices back into the full
     sequence, so prefix-cache reuse survives with correct KV positions
-    (maintainer review #3290)."""
+    (maintainer review #3290).
+
+    Boundary snapshots are produced the way the scheduler produces them —
+    ``Scheduler._extract_snapshot_cache_states`` followed by
+    ``compact_pooling_cache_snapshot`` — so the PoolingCache member reaches
+    the store as a per-block pooled DELTA with an absolute row range. The
+    persisted block payload must carry PoolingCacheDelta markers, and the
+    restore must rebuild the cumulative pooled tensor from the delta chain
+    in block order (last-blocking would restore one block's rows instead of
+    the chain)."""
     from mlx_vlm.models.cache import PoolingCache
 
+    from omlx.cache.pooling_delta import compact_pooling_cache_snapshot
     from omlx.patches.deepseek_v4 import apply_pooling_cache_support
+    from omlx.scheduler import Scheduler
 
     apply_pooling_cache_support()
-    cache, _ = _make_cache(tmp_path)
+    cache, ssd = _make_cache(tmp_path)
 
-    def build(seq_len, blank_kv=False):
-        kv = KVCache()
-        keys, values = _position_kv(seq_len)
-        kv.update_and_fetch(keys, values)
-        pool = PoolingCache(ratio=4)
-        # pooled rows carry distinguishable data
-        pool.update_and_fetch(
-            mx.full((1, seq_len // 4, 8), 0.0, dtype=mx.float32)
-        )
-        cl = CacheList(kv, pool)
-        mx.eval([keys, values])
-        d = _layer_dict(cl)
-        if blank_kv:
-            d["state"][0] = ()
-        return d
+    stub = SimpleNamespace(_stream=mx.default_stream(mx.default_device()))
+    stub._extract_cache_states = lambda caches: Scheduler._extract_cache_states(
+        stub, caches
+    )
 
     num_blocks = 3
+    rows_per_block = BLOCK_SIZE // 4
     tokens = list(range(num_blocks * BLOCK_SIZE))
-    full = build(len(tokens))
-    boundaries = {
-        BLOCK_SIZE * (i + 1): [build(BLOCK_SIZE * (i + 1), blank_kv=True)]
-        for i in range(num_blocks)
-    }
-    table = cache.store_cache("req-glm-refill", tokens, [full],
-                              boundary_snapshots=boundaries)
+
+    # Advance one live cache block by block; each boundary snapshot is the
+    # scheduler-shaped extract (KV member blanked) compacted to the block's
+    # pooled delta. Pooled row values encode the block index so the
+    # reconstructed chain order is verifiable, not just its length.
+    kv = KVCache()
+    pool = PoolingCache(ratio=4)
+    boundaries = {}
+    for i in range(num_blocks):
+        start, end = i * BLOCK_SIZE, (i + 1) * BLOCK_SIZE
+        pos = mx.arange(start, end, dtype=mx.float32).reshape(1, 1, BLOCK_SIZE, 1)
+        keys = mx.contiguous(mx.broadcast_to(pos, (1, 2, BLOCK_SIZE, 8)))
+        values = keys + 1000.0
+        kv.update_and_fetch(keys, values)
+        pool.update_and_fetch(
+            mx.full((1, rows_per_block, 8), float(i + 1), dtype=mx.float32)
+        )
+        mx.eval([keys, values])
+        extracted, _ = Scheduler._extract_snapshot_cache_states(
+            stub, [CacheList(kv, pool)]
+        )
+        compact_pooling_cache_snapshot(extracted, end, BLOCK_SIZE)
+        snapshot_layer = extracted[0]
+        assert snapshot_layer["state"][0] == (), "KV member must be blanked"
+        assert (
+            "pooling_delta_ranges" in snapshot_layer
+        ), f"boundary @{end}: compaction did not tag pooled delta ranges"
+        assert snapshot_layer["state"][1][2].shape[1] == rows_per_block
+        boundaries[end] = extracted
+
+    full = _layer_dict(CacheList(kv, pool))
+    table = cache.store_cache(
+        "req-glm-refill", tokens, [full], boundary_snapshots=boundaries
+    )
     assert table is not None
+
+    # Persisted blocks: per-member layout with PoolingCacheDelta markers
+    # carrying the absolute pooled row range of each block.
+    for i, bid in enumerate(table.block_ids):
+        block = cache.paged_cache.allocated_blocks[bid]
+        payload, _meta = ssd.load_block_with_metadata(block.block_hash)
+        assert payload is not None
+        layer = payload[0]
+        assert isinstance(layer, tuple) and layer[0] == "__cache_list_pm__"
+        sub = layer[1][1]
+        assert (
+            isinstance(sub, tuple)
+            and len(sub) >= 3
+            and sub[0] == "__nstate__"
+            and sub[1] == "PoolingCacheDelta"
+        ), f"block {i}: boundary member not a PoolingCacheDelta: {type(sub)}"
+        elements = sub[2]
+        assert elements[-1].tolist() == [
+            i * rows_per_block,
+            (i + 1) * rows_per_block,
+        ], f"block {i}: wrong pooled delta range"
 
     result = cache.reconstruct_cache(table)
     assert result is not None and len(result) == 1
@@ -526,12 +575,15 @@ def test_glm_pooling_cachelist_blanked_kv_roundtrips(tmp_path):
         kv.keys.shape,
     )
     assert mx.max(mx.abs(kv.keys - expected)).item() == 0.0
-    # PoolingCache member restored: pooled is cumulative across the chain
-    # (append-only pooled rows) — the last matched block's boundary state.
+    # PoolingCache member restored: the delta chain rebuilt into the FULL
+    # cumulative pooled tensor, in block order (row i carries block i+1).
     pool = restored.caches[1]
     assert type(pool).__name__ == "PoolingCache"
     assert pool.pooled is not None
-    assert pool.pooled.shape[1] == (num_blocks * BLOCK_SIZE) // 4
+    assert pool.pooled.shape[1] == num_blocks * rows_per_block
+    for i in range(num_blocks):
+        row = pool.pooled[0, i * rows_per_block, :]
+        assert mx.max(row).item() == float(i + 1), f"pooled row {i} misplaced"
 
 
 def test_arrays_cache_extract_none_guard():

--- a/tests/test_prefix_cache_cachelist_per_member.py
+++ b/tests/test_prefix_cache_cachelist_per_member.py
@@ -168,11 +168,12 @@ def test_plan_helper_classification():
         # persisted as PoolingCacheDelta and the chain is rebuilt on restore
         # (PR #3290).
         "pooling member": (["KVCache", "PoolingCache"], True),
-        # BatchPoolingCache stays legacy: compact_pooling_cache_snapshot
-        # only compacts PoolingCache, so its boundary snapshots would remain
-        # cumulative — the class-level eligibility in paged_ssd_cache must
-        # not accept it either (maintainer review #3290).
-        "batch pooling member": (["KVCache", "BatchPoolingCache"], False),
+        # BatchPoolingCache is boundary-eligible too: its state is
+        # self-contained at the boundary and it is not compacted to deltas,
+        # so it persists/restores last-block-wins like ArraysCache — the
+        # plan helper and the class-level eligibility must agree
+        # (maintainer review #3290).
+        "batch pooling member": (["KVCache", "BatchPoolingCache"], True),
         "no names": ([], False),
     }
     live = _build_mixed_cachelist(BLOCK_SIZE)

--- a/tests/test_prefix_cache_cachelist_per_member.py
+++ b/tests/test_prefix_cache_cachelist_per_member.py
@@ -25,7 +25,10 @@ import pytest
 
 import omlx.cache.prefix_cache as prefix_cache_module
 from omlx.cache.paged_cache import PagedCacheManager
-from omlx.cache.paged_ssd_cache import PagedSSDCacheManager
+from omlx.cache.paged_ssd_cache import (
+    PagedSSDCacheManager,
+    cachelist_pm_class_eligible,
+)
 from omlx.cache.prefix_cache import BlockAwarePrefixCache, cachelist_pm_member_plan
 from omlx.cache.type_registry import CacheTypeRegistry
 
@@ -160,7 +163,16 @@ def test_plan_helper_classification():
         "mixed kv+arrays": (["KVCache", "ArraysCache"], True),
         "kv only": (["KVCache", "KVCache"], False),
         "arrays only": (["ArraysCache"], False),
-        "pooling member": (["KVCache", "PoolingCache"], False),
+        # PoolingCache is per-member boundary-eligible (GLM-5.x
+        # CacheList(KVCache, PoolingCache)): its compacted pooled delta is
+        # persisted as PoolingCacheDelta and the chain is rebuilt on restore
+        # (PR #3290).
+        "pooling member": (["KVCache", "PoolingCache"], True),
+        # BatchPoolingCache stays legacy: compact_pooling_cache_snapshot
+        # only compacts PoolingCache, so its boundary snapshots would remain
+        # cumulative — the class-level eligibility in paged_ssd_cache must
+        # not accept it either (maintainer review #3290).
+        "batch pooling member": (["KVCache", "BatchPoolingCache"], False),
         "no names": ([], False),
     }
     live = _build_mixed_cachelist(BLOCK_SIZE)
@@ -170,6 +182,7 @@ def test_plan_helper_classification():
         "KVCache": kv_state,
         "ArraysCache": arrays_state,
         "PoolingCache": arrays_state,
+        "BatchPoolingCache": arrays_state,
     }
     for name, (classes, eligible) in cases.items():
         states = [states_by_class[c] for c in classes]
@@ -177,6 +190,9 @@ def test_plan_helper_classification():
         assert (plan is not None) == eligible, name
         if plan is not None:
             assert plan == ["slice", "boundary"]
+        # The class-level eligibility used for signature expectations must
+        # agree with the plan helper on every classification case.
+        assert cachelist_pm_class_eligible(classes) == eligible, name
 
 
 def test_blocks_stored_per_member_sized(tmp_path):


### PR DESCRIPTION
## Summary

For hybrid `CacheList` layers whose non-sliceable member is `PoolingCache` (GLM-5.x `CacheList(KVCache, PoolingCache)`), boundary snapshots previously retained the sliceable `KVCache` member in FULL at every block boundary — quadratic in-memory retention across a request's context (the #2551 class of bug), and the subsequent legacy store path could not restore a complete CacheList.

This PR makes `PoolingCache` per-member-block **eligible** (alongside `ArraysCache`): the boundary snapshot blanks the sliceable KV member (linear, not quadratic, retention), the store persists a true per-block KV slice, and the restore concatenates the slices back into the full sequence — so every stored boundary keeps the KV member restorable without holding the cumulative snapshot.

## Reproduction

- **Device**: Apple M5 Max, 128 GB unified memory, 18 cores, macOS 26.5.1, omlx 0.6.3.
- **Model**: GLM-5.3-Flash oQ2e (`glm5_next`, ~99 GB weights), 34x `ArraysCache` + 11x `CacheList(KVCache, PoolingCache)`.
- **Config**: `hot_cache_only=true`, `hot_cache_max_size=40GB`, memory guard tier `aggressive`, prefill chunk 2048.
- **Symptom**: long-context prefill aborted at ~30K tokens — `process memory limit exceeded (usage ~113 GB, hard watermark ~112 GB)`. `phys_footprint` crept to ~113 GB because retained in-memory boundary snapshots accumulated the full KV prefix of the 11 sparse layers at every 2048-token boundary.
- **After this fix**: the same scheduler path reaches 64K+ tokens under the same guard (peak 107.8 GB, phys 110.0 GB), and a store → reconstruct → decode round-trip reproduces the original cache's logits bit-for-bit.

## Root cause

`cachelist_pm_member_plan` rejected any `CacheList` containing `PoolingCache` (`_PM_SAFE_NON_SLICEABLE_SUBS` was {ArraysCache, SizedArraysCache}), so GLM-5.x fell through to the legacy cumulative path: the sliceable KV member was retained in FULL at every boundary snapshot, and the legacy last-block-only restore could not rebuild the KV sequence.

## Change

1. `PoolingCache` joins `_PM_SAFE_NON_SLICEABLE_SUBS` (`omlx/cache/prefix_cache.py`) — `CacheList(KVCache, PoolingCache)` now gets the per-member plan `["slice", "boundary"]`.
2. `cachelist_pm_class_eligible` (`omlx/cache/paged_ssd_cache.py`) accepts PoolingCache as a boundary class via a new `_PM_BOUNDARY_SUB_CLASSES` (kept separate from `_ARRAYS_SUB_CLASSES` so signature descriptors still stamp `PoolingCache:N`, not a mis-typed ArraysCache slot count).
3. `Scheduler._extract_snapshot_cache_states` blanks the sliceable KV member in the boundary snapshot (linear in-memory retention); the store slices the live KV per block, and the restore concatenates the slices — full KV sequence with correct positions.

DeepSeek-V4 (`CacheList(RotatingKVCache, PoolingCache)`) is unaffected: the rotating member keeps that layer on the legacy cumulative path (no slice member → plan still `None`).

Regression tests: `test_glm_pooling_cachelist_blanked_kv_roundtrips` now asserts the FULL KV sequence is restored (concatenated per-block slices, position-verified), and `test_glm_pooling_cachelist_blanks_kv_member` documents the pm eligibility.

## Relation to #3226 / #3227

Targeted sub-fix of #3226 item 4 for pm-ineligible `CacheList(KVCache, PoolingCache)`. PR #3227 addresses decode-time Metal buffer-count exhaustion (orthogonal; included in the rebase base). The GLM prefill memory profile (separate PR #3291) covers guard-side accounting.

## Tests

- `test_glm_pooling_cachelist_blanks_kv_member`: sliceable KV member blanked, non-sliceable PoolingCache kept, per-member plan `["slice", "boundary"]`.
- `test_glm_pooling_cachelist_blanked_kv_roundtrips`: store → reconstruct round-trip restores the FULL KV sequence (concatenated slices, position-verified) plus the cumulative PoolingCache pooled rows.
- `tests/test_cache_ntuple_state.py`, `tests/test_cache_type_handlers.py`, scheduler + engine-pool suites: 623 passing, no lint regressions on the touched files.
