### PR TITLE
feat(api): OpenAI-compatible image generation and editing (FLUX.2 Klein)

### DIFF
--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -9172,6 +9172,13 @@
                 if (activity.chunk_count != null) parts.push(activity.chunk_count + ' chunks');
                 if (activity.output_bytes != null) parts.push(this.formatByteCount(activity.output_bytes));
                 if (activity.file_size_bytes != null && activity.file_size_bytes > 0) parts.push(this.formatByteCount(activity.file_size_bytes));
+                // Step-based engines (image diffusion): "12/28 steps · 4.3 steps/s".
+                if (activity.current_step != null && activity.total_steps != null) {
+                    parts.push(activity.current_step + '/' + activity.total_steps + ' steps');
+                }
+                if (activity.steps_per_second != null && activity.steps_per_second > 0) {
+                    parts.push(activity.steps_per_second.toFixed(1) + ' steps/s');
+                }
                 return parts.join(' · ');
             },
 

--- a/omlx/admin/templates/dashboard/_status.html
+++ b/omlx/admin/templates/dashboard/_status.html
@@ -311,6 +311,15 @@
                                                     </span>
                                                     <span x-show="formatActivityMetadata(activity)" class="text-[10px] text-neutral-400 whitespace-nowrap ml-2" x-text="formatActivityMetadata(activity)"></span>
                                                     <span x-show="activity.elapsed_seconds != null" class="text-[10px] text-neutral-400 whitespace-nowrap ml-1" x-text="formatDurationShort(activity.elapsed_seconds)"></span>
+                                                    <!-- Step progress (image diffusion and other step-based engines) -->
+                                                    <span x-show="activity.current_step != null && activity.total_steps > 0" class="inline-flex items-center gap-1.5 ml-1">
+                                                        <span class="w-20 h-1.5 bg-neutral-100 rounded-full overflow-hidden">
+                                                            <span class="block h-full bg-green-400 rounded-full transition-all duration-300"
+                                                                  :style="'width: ' + Math.min(100, activity.current_step / activity.total_steps * 100) + '%'"></span>
+                                                        </span>
+                                                        <span class="text-[10px] text-green-500 font-medium"
+                                                              x-text="Math.round(activity.current_step / activity.total_steps * 100) + '%'"></span>
+                                                    </span>
                                                 </div>
                                             </template>
                                         </div>

--- a/omlx/api/image_models.py
+++ b/omlx/api/image_models.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Request/response models for the OpenAI-compatible image API.
+
+Tunable generation parameters (seed, num_inference_steps, guidance, ...) are
+request-body fields validated by the engine's parameter models — there are
+no per-model server-side defaults for image generation.
+"""
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ImageGenerationRequest(BaseModel):
+    """OpenAI-compatible text-to-image request."""
+
+    model_config = ConfigDict(extra="allow")
+
+    model: str
+    prompt: str
+    n: int | None = Field(default=1, ge=1, le=4)
+    size: str | None = None
+    response_format: Literal["b64_json"] = "b64_json"
+
+
+class ImageEditRequest(BaseModel):
+    """OpenAI-compatible image edit request (JSON form).
+
+    Input images are base64 data URIs, plain strings, or
+    ``{"image_url": ...}`` objects (the ``image_url`` of a remote URL is
+    not fetched — only data URIs are accepted).
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    model: str
+    prompt: str
+    n: int | None = Field(default=1, ge=1, le=4)
+    size: str | None = None
+    response_format: Literal["b64_json"] = "b64_json"
+    image: str | dict[str, Any] | list[str | dict[str, Any]] | None = None
+    images: list[str | dict[str, Any]] | None = None
+
+
+class ImageResponse(BaseModel):
+    """One generated image.
+
+    ``seed`` is an oMLX extension: the seed that produced this image
+    (caller-supplied or freshly generated), so clients can reproduce it.
+    """
+
+    b64_json: str
+    seed: int | None = None
+
+
+class ImageResponseEnvelope(BaseModel):
+    created: int
+    data: list[ImageResponse]
+
+
+class ImageGenerationResponse(ImageResponseEnvelope):
+    """Response of POST /v1/images/generations."""
+
+
+class ImageEditResponse(ImageResponseEnvelope):
+    """Response of POST /v1/images/edits."""

--- a/omlx/api/image_routes.py
+++ b/omlx/api/image_routes.py
@@ -1,0 +1,376 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+OpenAI-compatible image endpoints (FLUX.2 Klein via mflux):
+
+- POST /v1/images/generations — text-to-image (and img2img via Klein's
+  native image_path when an input image is supplied)
+- POST /v1/images/edits       — edits (JSON data URIs or multipart files)
+
+All tunables (seed, num_inference_steps, guidance, image_strength) are
+request parameters validated by the engine — no per-model server defaults.
+"""
+
+import base64
+import binascii
+import logging
+import os
+import random
+import tempfile
+import time
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import ValidationError
+
+from ..server_metrics import get_server_metrics
+from ..utils.formatting import make_json_safe
+from .image_models import (
+    ImageEditRequest,
+    ImageEditResponse,
+    ImageGenerationRequest,
+    ImageGenerationResponse,
+    ImageResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# Client-tunable parameters forwarded to the engine after validation.
+_EDIT_DEFAULT_STRENGTH = 0.5
+
+
+def _get_engine_pool():
+    """Active EnginePool (lazy import; patchable in tests)."""
+    from omlx.server import _server_state
+
+    pool = _server_state.engine_pool
+    if pool is None:
+        raise HTTPException(status_code=503, detail="Server not initialized")
+    return pool
+
+
+def _resolve_model(model_id: str) -> str:
+    from omlx.server import resolve_model_id
+
+    return resolve_model_id(model_id) or model_id
+
+
+async def _get_image_engine(model_id: str):
+    """Resolve an image model through the pool, or 404/400."""
+    resolved = _resolve_model(model_id)
+    try:
+        engine = await _get_engine_pool().get_engine(resolved)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Model '{resolved}' not found or failed to load: {exc}",
+        ) from exc
+    if not hasattr(engine, "generate"):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Model '{resolved}' is not an image generation model",
+        )
+    return resolved, engine
+
+
+def _record_image_request(model_id: str) -> None:
+    """Count the request without inventing token numbers for images."""
+    try:
+        get_server_metrics().record_request_complete(
+            prompt_tokens=0, completion_tokens=0, cached_tokens=0, model_id=model_id
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to record image metrics for %s: %s", model_id, exc)
+
+
+# ---------------------------------------------------------------------------
+# Parameter parsing
+# ---------------------------------------------------------------------------
+
+
+def _size_to_dims(size: str) -> tuple[int, int]:
+    """Parse '1024x768' into (width, height); fall back to 1024x1024."""
+    try:
+        width, height = size.lower().split("x", 1)
+        return int(width), int(height)
+    except ValueError:
+        return 1024, 1024
+
+
+def _tunable_params(body: dict[str, Any]) -> dict[str, Any]:
+    """Extract the tunable request parameters (None values dropped)."""
+    params: dict[str, Any] = {}
+    for key in (
+        "seed",
+        "num_inference_steps",
+        "guidance",
+        "image_strength",
+        "use_kv_cache",
+        "width",
+        "height",
+    ):
+        if body.get(key) is not None:
+            params[key] = body[key]
+    size = body.get("size")
+    if isinstance(size, str) and size:
+        params["width"], params["height"] = _size_to_dims(size)
+    return params
+
+
+# ---------------------------------------------------------------------------
+# Image reference handling (data URI / multipart → temp files)
+# ---------------------------------------------------------------------------
+
+
+def _decode_data_uri(value: str) -> bytes:
+    prefix, separator, encoded = value.strip().partition(",")
+    low = prefix.lower()
+    if separator != "," or not low.startswith("data:image/") or ";base64" not in low:
+        raise HTTPException(
+            400,
+            detail="Image references must be base64 data URIs (data:image/...;base64,...).",
+        )
+    try:
+        return base64.b64decode(encoded, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise HTTPException(
+            400, detail="Image data URI contains invalid base64 data."
+        ) from exc
+
+
+def _guess_image_suffix(data: bytes) -> str:
+    if data[:3] == b"\xff\xd8\xff":
+        return ".jpg"
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return ".png"
+    if data[:6] in (b"GIF87a", b"GIF89a"):
+        return ".gif"
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return ".webp"
+    return ".png"
+
+
+def _write_temp_image(data: bytes) -> str:
+    fd, tmp_path = tempfile.mkstemp(suffix=_guess_image_suffix(data))
+    with os.fdopen(fd, "wb") as f:
+        f.write(data)
+    return tmp_path
+
+
+def _extract_data_uris(body: dict[str, Any]) -> list[str]:
+    """Collect image references from ``image``/``images`` body fields."""
+    refs: list[str] = []
+    raw = body.get("images") or body.get("image")
+    if isinstance(raw, (str, dict)):
+        raw = [raw]
+    for item in raw or []:
+        if isinstance(item, str):
+            refs.append(item)
+        elif isinstance(item, dict):
+            url = item.get("image_url") or item.get("url")
+            if url:
+                refs.append(str(url))
+    return refs
+
+
+def _cleanup_temp_images(paths: list[str]) -> None:
+    tmpdir = os.path.realpath(tempfile.gettempdir())
+    for path in paths:
+        try:
+            real = os.path.realpath(path)
+            if os.path.commonpath([real, tmpdir]) == tmpdir:
+                os.unlink(real)
+        except (OSError, ValueError):
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+def _validate_params(engine, kind: str, body: dict[str, Any]):
+    tunables = _tunable_params(body)
+    tunables["prompt"] = body["prompt"]
+    try:
+        if kind == "generate":
+            return engine.validate_generate(tunables)
+        return engine.validate_edit(tunables)
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=422, detail=make_json_safe(exc.errors())
+        ) from exc
+
+
+async def _generate_images(
+    engine,
+    resolved_model: str,
+    body: dict[str, Any],
+    image_paths: list[str] | None = None,
+):
+    """Run n generations and return the base64 response items.
+
+    Each image gets its own seed: ``seed + i`` when the caller supplied one,
+    otherwise a fresh random seed — always reported back in the response.
+    """
+    n = body.get("n") or 1
+    caller_seed = body.get("seed")
+    params = _validate_params(engine, "edit" if image_paths else "generate", body)
+
+    results: list[ImageResponse] = []
+    for i in range(n):
+        seed = (
+            caller_seed + i if caller_seed is not None else random.randint(0, 2**32 - 1)
+        )
+        params.seed = seed
+        if image_paths:
+            img_bytes = await engine.edit(params, image_paths)
+        else:
+            img_bytes = await engine.generate(params)
+        results.append(
+            ImageResponse(
+                b64_json=base64.b64encode(img_bytes).decode("utf-8"), seed=seed
+            )
+        )
+    return results
+
+
+@router.post("/v1/images/generations", response_model=ImageGenerationResponse)
+async def generate_image(request: ImageGenerationRequest):
+    body = request.model_dump(exclude_none=True)
+    body.update({k: v for k, v in request.model_extra.items() if v is not None})
+    body["prompt"] = request.prompt
+
+    resolved_model, engine = await _get_image_engine(request.model)
+    try:
+        data = await _generate_images(engine, resolved_model, body)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Image generation failed")
+        raise HTTPException(
+            status_code=500, detail=f"Image generation failed: {exc}"
+        ) from exc
+
+    _record_image_request(resolved_model)
+    return ImageGenerationResponse(created=int(time.time()), data=data)
+
+
+@router.post("/v1/images/edits", response_model=ImageEditResponse)
+async def edit_image(request: Request):
+    """Image edits: JSON body with data-URI images, or multipart file parts
+    named ``image`` / ``image[]``."""
+    if "multipart/form-data" in (request.headers.get("content-type") or "").lower():
+        return await _edit_image_multipart(request)
+    return await _edit_image_json(request)
+
+
+async def _edit_image_json(request: Request) -> ImageEditResponse:
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise HTTPException(
+            status_code=422, detail=f"Invalid JSON body: {exc}"
+        ) from exc
+    try:
+        ImageEditRequest.model_validate(body)
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=422, detail=make_json_safe(exc.errors())
+        ) from exc
+
+    refs = _extract_data_uris(body)
+    if not refs:
+        raise HTTPException(
+            status_code=400,
+            detail="An input image is required — send 'images' as base64 data URIs.",
+        )
+
+    resolved_model, engine = await _get_image_engine(body["model"])
+    image_paths = [_write_temp_image(_decode_data_uri(ref)) for ref in refs]
+    try:
+        return await _run_edit(engine, resolved_model, body, image_paths)
+    finally:
+        _cleanup_temp_images(image_paths)
+
+
+async def _edit_image_multipart(request: Request) -> ImageEditResponse:
+    form = await request.form()
+    model = form.get("model")
+    prompt = form.get("prompt")
+    if not model or not str(prompt).strip():
+        raise HTTPException(
+            status_code=400,
+            detail="'model' and a non-empty 'prompt' form fields are required.",
+        )
+
+    image_paths: list[str] = []
+    for part in form.getlist("image") + form.getlist("image[]"):
+        data = await part.read() if hasattr(part, "read") else b""
+        if data:
+            image_paths.append(_write_temp_image(data))
+    if not image_paths:
+        raise HTTPException(
+            status_code=400,
+            detail="An image file part ('image' or 'image[]') is required for image editing.",
+        )
+
+    def _num(key: str, cast):
+        raw = form.get(key)
+        if raw in (None, ""):
+            return None
+        try:
+            return cast(raw)
+        except (TypeError, ValueError):
+            return None
+
+    body: dict[str, Any] = {
+        "model": str(model),
+        "prompt": str(prompt),
+        "n": _num("n", int) or 1,
+        "seed": _num("seed", int),
+        "size": form.get("size"),
+        "num_inference_steps": _num("num_inference_steps", int),
+        "guidance": _num("guidance", float),
+        "image_strength": _num("image_strength", float),
+        "use_kv_cache": (
+            None
+            if form.get("use_kv_cache") in (None, "")
+            else str(form.get("use_kv_cache")).lower() in ("1", "true", "yes", "on")
+        ),
+    }
+
+    resolved_model, engine = await _get_image_engine(str(model))
+    try:
+        return await _run_edit(engine, resolved_model, body, image_paths)
+    finally:
+        _cleanup_temp_images(image_paths)
+
+
+async def _run_edit(
+    engine, resolved_model: str, body: dict[str, Any], image_paths: list[str]
+) -> ImageEditResponse:
+    if getattr(engine, "edits_params", None) is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Model '{resolved_model}' does not support image editing",
+        )
+    if body.get("image_strength") is None:
+        body["image_strength"] = _EDIT_DEFAULT_STRENGTH
+    try:
+        data = await _generate_images(
+            engine, resolved_model, body, image_paths=image_paths
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Image edit failed")
+        raise HTTPException(
+            status_code=500, detail=f"Image edit failed: {exc}"
+        ) from exc
+
+    _record_image_request(resolved_model)
+    return ImageEditResponse(created=int(time.time()), data=data)

--- a/omlx/engine/image/__init__.py
+++ b/omlx/engine/image/__init__.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Image generation engines for oMLX (mflux, FLUX.2 Klein).
+"""
+
+from typing import Any
+
+from ...utils.mflux import resolve_mflux_config, resolve_mflux_family
+from .base import BaseImageEngine
+from .flux2 import Flux2KleinEditImageEngine, Flux2KleinImageEngine
+
+__all__ = ["BaseImageEngine", "REGISTRY", "get_image_engine"]
+
+#: mflux family class name → engine class.
+REGISTRY: dict[str, type[BaseImageEngine]] = {
+    "Flux2Klein": Flux2KleinImageEngine,
+    "Flux2KleinEdit": Flux2KleinEditImageEngine,
+}
+
+
+def get_image_engine(model_name: str, **kwargs: Any) -> BaseImageEngine:
+    """Instantiate the engine for an mflux model directory."""
+    model_config = resolve_mflux_config(model_name)
+    family_cls = resolve_mflux_family(model_config)
+    engine_cls = REGISTRY.get(family_cls.__name__)
+    if engine_cls is None:
+        raise ValueError(
+            f"Unsupported image model family '{family_cls.__name__}' "
+            f"for model '{model_name}' — only FLUX.2 Klein is supported."
+        )
+    return engine_cls(model_name=model_name, **kwargs)

--- a/omlx/engine/image/base.py
+++ b/omlx/engine/image/base.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Base image engine wrapping an mflux model.
+
+Concrete families (see ``omlx/engine/image/``) declare their Pydantic
+parameter models (``generates_params`` / ``edits_params``); the request
+parameters they expose are validated against those models before mflux's
+``generate_image`` is called. mflux is imported lazily in ``start()`` so
+this module imports cleanly without the optional dependency.
+"""
+
+import asyncio
+import contextlib
+import gc
+import io
+import logging
+import time
+from typing import Any
+
+import mlx.core as mx
+from PIL import Image
+from pydantic import BaseModel
+
+from ...engine_core import get_mlx_executor
+from ..base import BaseNonStreamingEngine
+
+logger = logging.getLogger(__name__)
+
+
+def _mflux_progress(t: int, config: Any, time_steps: Any) -> tuple[int, int]:
+    """Compute (current_step, total_steps) for an mflux InLoopCallback."""
+    init = getattr(config, "init_time_step", 0) or 0
+    total = getattr(config, "num_inference_steps", None)
+    if time_steps is not None:
+        with contextlib.suppress(TypeError):
+            total = len(time_steps)
+    if total is None or total <= 0:
+        total = 1
+    step = max(1, min(total, (t + 1 - init) if init else (t + 1)))
+    return step, total
+
+
+class BaseImageEngine(BaseNonStreamingEngine):
+    """Base engine for image generation (no streaming, non-chat)."""
+
+    #: Pydantic model validating text-to-image request parameters.
+    generates_params: type[BaseModel]
+    #: Pydantic model validating edit request parameters, or None if the
+    #: family cannot edit.
+    edits_params: type[BaseModel] | None = None
+
+    def __init__(self, model_name: str, **kwargs: Any) -> None:
+        super().__init__()
+        self._model_name = model_name
+        self._model: Any = None
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    def supports_native_streaming(self) -> bool:
+        return False
+
+    def validate_generate(self, body: dict[str, Any]) -> BaseModel:
+        return self.generates_params.model_validate(body)
+
+    def validate_edit(self, body: dict[str, Any]) -> BaseModel:
+        if self.edits_params is None:
+            raise ValueError(f"Model {self._model_name} does not support image editing")
+        return self.edits_params.model_validate(body)
+
+    def edit_kwargs(self, image_paths: list[str]) -> dict[str, Any]:
+        """Map resolved input images to this family's mflux kwargs."""
+        return {"image_paths": image_paths} if image_paths else {}
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        if self._model is not None:
+            return
+
+        logger.info(f"Starting ImageEngine: {self._model_name}")
+
+        model_name = self._model_name
+
+        def _load_sync():
+            from ...utils.mflux import resolve_mflux_config, resolve_mflux_family
+
+            model_config = resolve_mflux_config(model_name)
+            family_cls = resolve_mflux_family(model_config)
+            logger.info(
+                f"Loading mflux model as {family_cls.__name__} from {model_name}"
+            )
+            return family_cls(model_path=model_name, model_config=model_config)
+
+        loop = asyncio.get_running_loop()
+        try:
+            self._model = await loop.run_in_executor(get_mlx_executor(), _load_sync)
+        except ImportError as exc:
+            raise ImportError(
+                "mflux is required for image generation. "
+                'Install it with: pip install "omlx[image]"'
+            ) from exc
+        except Exception as exc:
+            raise RuntimeError(
+                f"Failed to load image model {model_name}: {exc}"
+            ) from exc
+
+        logger.info(f"ImageEngine started: {self._model_name}")
+
+    async def stop(self) -> None:
+        if self._model is None:
+            return
+
+        logger.info(f"Stopping ImageEngine: {self._model_name}")
+        self._model = None
+
+        gc.collect()
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            get_mlx_executor(), lambda: (mx.synchronize(), mx.clear_cache())
+        )
+
+    # ------------------------------------------------------------------
+    # Progress
+    # ------------------------------------------------------------------
+
+    def _register_progress_callback(self, activity_id: str) -> tuple[Any, Any]:
+        """Register a step-progress callback; returns (cb, registry) or (None, None)."""
+        model = self._model
+        callbacks = getattr(model, "callbacks", None)
+        if callbacks is None or not hasattr(callbacks, "register"):
+            return None, None
+        try:
+            from mflux.callbacks.callback import InLoopCallback
+
+            parent = self
+            started = time.monotonic()
+
+            class _Progress(InLoopCallback):
+                def call_in_loop(
+                    self,
+                    t: int,
+                    seed: int,
+                    prompt: str,
+                    latents: Any,
+                    config: Any,
+                    time_steps: Any,
+                ) -> None:
+                    step, total = _mflux_progress(t, config, time_steps)
+                    elapsed = time.monotonic() - started
+                    parent._update_activity(
+                        activity_id,
+                        current_step=step,
+                        total_steps=total,
+                        steps_per_second=(step / elapsed) if elapsed > 0 else None,
+                    )
+
+            progress_cb = _Progress()
+            callbacks.register(progress_cb)
+            return progress_cb, callbacks
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Could not register mflux progress callback: %s", exc)
+            return None, None
+
+    def _unregister_progress_callback(self, progress_cb: Any, callbacks: Any) -> None:
+        if progress_cb is None or callbacks is None:
+            return
+        try:
+            if hasattr(callbacks, "in_loop") and progress_cb in callbacks.in_loop:
+                callbacks.in_loop.remove(progress_cb)
+        except Exception:  # noqa: BLE001
+            pass
+
+    # ------------------------------------------------------------------
+    # Run
+    # ------------------------------------------------------------------
+
+    def _run_sync(self, activity_id: str, gen_kwargs: dict[str, Any]) -> bytes:
+        """Run mflux ``generate_image`` and return PNG bytes."""
+        model = self._model
+        progress_cb, callbacks = self._register_progress_callback(activity_id)
+        try:
+            result = model.generate_image(**gen_kwargs)
+        finally:
+            self._unregister_progress_callback(progress_cb, callbacks)
+
+        img = result if isinstance(result, Image.Image) else result.image
+        buffer = io.BytesIO()
+        img.save(buffer, format="PNG")
+        return buffer.getvalue()
+
+    async def _execute(
+        self, params: BaseModel, kind: str, extra_kwargs: dict[str, Any]
+    ) -> bytes:
+        if self._model is None:
+            raise RuntimeError("Engine not started. Call start() first.")
+
+        gen_kwargs = {**params.model_dump(exclude_none=True), **extra_kwargs}
+        logger.info(
+            "Image %s: model=%s, prompt_len=%d, seed=%s",
+            kind,
+            self._model_name,
+            len(gen_kwargs.get("prompt", "")),
+            gen_kwargs.get("seed"),
+        )
+
+        t0 = time.monotonic()
+        activity_id = self._begin_activity(
+            f"{'generating' if kind == 'generation' else 'editing'} image",
+            detail=f"Image {kind}",
+        )
+        try:
+            loop = asyncio.get_running_loop()
+            result = await loop.run_in_executor(
+                get_mlx_executor(), lambda: self._run_sync(activity_id, gen_kwargs)
+            )
+            logger.info(
+                "Image %s done: model=%s, %.2fs, %d bytes output",
+                kind,
+                self._model_name,
+                time.monotonic() - t0,
+                len(result),
+            )
+            return result
+        finally:
+            await self._finish_activity(activity_id)
+
+    async def generate(self, params: BaseModel) -> bytes:
+        return await self._execute(params, "generation", {})
+
+    async def edit(self, params: BaseModel, image_paths: list[str]) -> bytes:
+        if self.edits_params is None:
+            raise ValueError(f"Model {self._model_name} does not support image editing")
+        return await self._execute(params, "edit", self.edit_kwargs(image_paths))
+
+    def get_stats(self) -> dict[str, Any]:
+        return {"model_name": self._model_name, "is_loaded": self._model is not None}
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}(model={self._model_name})"

--- a/omlx/engine/image/flux2.py
+++ b/omlx/engine/image/flux2.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+FLUX.2 Klein engines.
+
+Wraps mflux's ``Flux2Klein`` (text-to-image, plus native img2img via
+``image_path``) and ``Flux2KleinEdit`` (multi-image editing via
+``image_paths``). FLUX models do not take a negative prompt.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .base import BaseImageEngine
+
+
+class FluxGenerateParams(BaseModel):
+    """Text-to-image request parameters (FLUX.2 Klein)."""
+
+    prompt: str
+    seed: int | None = None
+    num_inference_steps: int | None = Field(default=None, ge=1, le=1000)
+    height: int | None = Field(default=None, ge=16)
+    width: int | None = Field(default=None, ge=16)
+    guidance: float | None = Field(default=None, ge=0.0, le=20.0)
+
+
+class FluxEditParams(FluxGenerateParams):
+    """Edit request parameters (input images arrive separately as image parts
+    / data URIs and are injected post-validation by the route)."""
+
+    image_strength: float | None = Field(default=None, ge=0.0, le=1.0)
+    use_kv_cache: bool | None = None
+
+
+class Flux2KleinImageEngine(BaseImageEngine):
+    """FLUX.2 Klein engine (txt2img / img2img through ``image_path``)."""
+
+    generates_params = FluxGenerateParams
+    edits_params = FluxEditParams
+
+    def edit_kwargs(self, image_paths: list[str]) -> dict[str, Any]:
+        # Klein does img2img natively: the model takes a single image_path.
+        return {"image_path": image_paths[0]} if image_paths else {}
+
+
+class Flux2KleinEditImageEngine(BaseImageEngine):
+    """FLUX.2 Klein edit engine (multi-image editing through ``image_paths``)."""
+
+    generates_params = FluxGenerateParams
+    edits_params = FluxEditParams

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -34,6 +34,7 @@ import mlx.core as mx
 
 from .engine import BaseEngine, BatchedEngine
 from .engine.embedding import EmbeddingEngine
+from .engine.image import BaseImageEngine, get_image_engine
 from .engine.reranker import RerankerEngine
 from .engine.sts import STSEngine
 from .engine.stt import STTEngine
@@ -50,7 +51,12 @@ from .exceptions import (
     ModelUnavailableError,
     describe_ceiling_binding,
 )
-from .model_discovery import discover_models, format_size, is_realtime_stt_model
+from .model_discovery import (
+    _is_mflux_image_model,
+    discover_models,
+    format_size,
+    is_realtime_stt_model,
+)
 from .scheduler import SchedulerConfig
 from .utils.proc_memory import get_phys_footprint
 
@@ -185,7 +191,7 @@ class EngineEntry:
     model_id: str  # Directory name (e.g., "llama-3b")
     model_path: str  # Full path to model directory
     model_type: Literal[
-        "llm", "vlm", "embedding", "reranker", "audio_stt", "audio_tts", "audio_sts"
+        "llm", "vlm", "embedding", "reranker", "audio_stt", "audio_tts", "audio_sts", "image"
     ]  # Model type
     engine_type: Literal[
         "batched",
@@ -196,6 +202,7 @@ class EngineEntry:
         "audio_stt",
         "audio_tts",
         "audio_sts",
+        "image",
     ]  # Engine type to use
     estimated_size: int  # Pre-calculated from safetensors (bytes)
     text_only_size: int = 0  # Language-only estimate for VLM checkpoints (0 = n/a)
@@ -218,6 +225,7 @@ class EngineEntry:
     is_helper: bool = False  # Speculative-decoding drafter (dFlash/Assistant/MTP)
     engine: (
         BaseEngine
+        | BaseImageEngine
         | EmbeddingEngine
         | RerankerEngine
         | STTEngine
@@ -824,6 +832,7 @@ class EnginePool:
         "audio_stt": "audio_stt",
         "audio_tts": "audio_tts",
         "audio_sts": "audio_sts",
+        "image": "image",
     }
 
     @staticmethod
@@ -1051,7 +1060,9 @@ class EnginePool:
     ) -> None:
         """Drop stale unloaded entries whose backing model directory vanished."""
         model_path = Path(entry.model_path)
-        if model_path.exists() and (model_path / "config.json").exists():
+        if model_path.exists() and (
+            (model_path / "config.json").exists() or _is_mflux_image_model(model_path)
+        ):
             return
 
         if entry.engine is None:
@@ -2679,6 +2690,8 @@ class EnginePool:
                         model_name=entry.model_path,
                         config_model_type=entry.config_model_type,
                     )
+                elif entry.engine_type == "image":
+                    engine = get_image_engine(model_name=entry.model_path)
                 else:
                     engine = BatchedEngine(
                         model_name=entry.model_path,

--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -25,8 +25,8 @@ from typing import Literal
 
 logger = logging.getLogger(__name__)
 
-ModelType = Literal["llm", "vlm", "embedding", "reranker", "audio_stt", "audio_tts", "audio_sts"]
-EngineType = Literal["batched", "vlm", "embedding", "reranker", "audio_stt", "audio_tts", "audio_sts"]
+ModelType = Literal["llm", "vlm", "embedding", "reranker", "audio_stt", "audio_tts", "audio_sts", "image"]
+EngineType = Literal["batched", "vlm", "embedding", "reranker", "audio_stt", "audio_tts", "audio_sts", "image"]
 
 # Known VLM (Vision-Language Model) types from mlx-vlm
 VLM_MODEL_TYPES = {
@@ -608,6 +608,10 @@ def detect_model_type(model_path: Path) -> ModelType:
     """
     config_path = model_path / "config.json"
     if not config_path.exists():
+        # mflux image models ship no root config.json — classify their
+        # component layout before the LLM fallback.
+        if _is_mflux_image_model(model_path):
+            return "image"
         return "llm"
 
     try:
@@ -1076,14 +1080,31 @@ def estimate_text_only_model_size(model_path: Path) -> int:
     return 0
 
 
+def _is_mflux_image_model(path: Path) -> bool:
+    """mflux diffusion checkpoint: no root config.json, component layout
+    (text_encoder/ + vae/, transformer/ optional) or a diffusers-style
+    model_index.json."""
+    try:
+        if (path / "config.json").exists():
+            return False
+        if (path / "model_index.json").exists():
+            return True
+        return (path / "text_encoder").is_dir() and (path / "vae").is_dir()
+    except OSError:
+        return False
+
+
 def _is_adapter_dir(path: Path) -> bool:
     """Check if a directory contains a LoRA/PEFT adapter (has adapter_config.json)."""
     return (path / "adapter_config.json").exists()
 
 
 def _is_model_dir(path: Path) -> bool:
-    """Check if a directory contains a valid model (has config.json)."""
-    return (path / "config.json").exists() and not _is_adapter_dir(path)
+    """Check if a directory contains a valid model (config.json, or the
+    mflux image component layout)."""
+    if _is_adapter_dir(path):
+        return False
+    return (path / "config.json").exists() or _is_mflux_image_model(path)
 
 
 _SHARD_FILE_RE = re.compile(r"-(\d+)-of-(\d+)\.safetensors$")
@@ -1480,6 +1501,8 @@ def _register_model(
             engine_type = "audio_tts"
         elif model_type == "audio_sts":
             engine_type = "audio_sts"
+        elif model_type == "image":
+            engine_type = "image"
         else:
             engine_type = "batched"
         estimated_size = estimate_model_size(model_dir)

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -638,6 +638,18 @@ try:
 except ImportError:
     pass
 
+# Include image routes only when mflux is installed (image_routes.py itself
+# imports only fastapi/stdlib, so the dependency must be probed here).
+try:
+    import mflux as _  # noqa: F401
+
+    from .api.image_routes import router as image_router
+
+    app.include_router(image_router, dependencies=[Depends(verify_api_key)])
+    del _
+except ImportError:
+    pass
+
 # Include admin routes
 from .admin.auth import _RedirectToLogin, require_admin
 from .admin.routes import router as admin_router

--- a/omlx/utils/formatting.py
+++ b/omlx/utils/formatting.py
@@ -19,3 +19,14 @@ def format_bytes(bytes_value: int) -> str:
         return f"{bytes_value / 1024:.2f} KB"
     else:
         return f"{bytes_value} B"
+
+
+def make_json_safe(obj: object) -> object:
+    """Recursively convert non-JSON-serializable objects (like Exceptions) to strings."""
+    if isinstance(obj, Exception):
+        return str(obj)
+    if isinstance(obj, dict):
+        return {k: make_json_safe(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [make_json_safe(item) for item in obj]
+    return obj

--- a/omlx/utils/mflux.py
+++ b/omlx/utils/mflux.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+mflux helpers for the image API (FLUX.2 Klein only).
+
+mflux is imported lazily inside these functions so the module imports
+cleanly when mflux is not installed.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_mflux_config(model_name: str):
+    """Resolve the mflux ``ModelConfig`` for a model directory (name-based)."""
+    from mflux.models.common.config import ModelConfig
+
+    dir_name = model_name.rstrip("/").rsplit("/", 1)[-1]
+    return ModelConfig.from_name(model_name=dir_name)
+
+
+def resolve_mflux_family(model_config):
+    """Resolve the mflux variant class (txt2img or edit) for a ModelConfig.
+
+    Edit checkpoints are identified by an ``edit`` marker in the resolved
+    name or aliases (e.g. ``flux2-klein-9b-edit``).
+    """
+    from mflux.models.flux2.variants import Flux2Klein, Flux2KleinEdit
+
+    haystack = " ".join(
+        [
+            (model_config.model_name or "").lower(),
+            *(a.lower() for a in model_config.aliases),
+        ]
+    )
+    if "flux2-klein" in haystack and "edit" in haystack:
+        return Flux2KleinEdit
+    if "flux2-klein" in haystack:
+        return Flux2Klein
+
+    raise ValueError(
+        f"Unsupported mflux model '{model_config.model_name}' — only "
+        "FLUX.2 Klein checkpoints are supported by the image API."
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,10 @@ audio = [
     # python; uvicorn's ws="auto" picks it up when installed.
     "wsproto==1.2.0",
 ]
+image = [
+    # mflux - FLUX.2 image generation on MLX
+    "mflux>=0.19",
+]
 paroquant = [
     # ParoQuant runtime loader for paroquant-quantized models. Installed
     # with --no-deps semantics here because the official [mlx] extra pulls

--- a/tests/test_image_api.py
+++ b/tests/test_image_api.py
@@ -1,0 +1,346 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the OpenAI-compatible image API (FLUX.2 Klein via mflux).
+
+Fake engines stand in for mflux — no model download or diffusion run.
+"""
+
+import base64
+import io
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from PIL import Image
+
+from omlx.api.image_routes import router
+from omlx.engine.image import REGISTRY, get_image_engine
+from omlx.engine.image.flux2 import (
+    Flux2KleinEditImageEngine,
+    Flux2KleinImageEngine,
+)
+from omlx.model_discovery import (
+    _is_mflux_image_model,
+    _is_model_dir,
+    detect_model_type,
+)
+from omlx.utils.mflux import resolve_mflux_config, resolve_mflux_family
+
+
+def _png_bytes(size=(8, 8)):
+    buf = io.BytesIO()
+    Image.new("RGB", size, (1, 2, 3)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _data_uri(data: bytes) -> str:
+    return "data:image/png;base64," + base64.b64encode(data).decode()
+
+
+class FakeKleinModel:
+    """Stands in for mflux Flux2Klein / Flux2KleinEdit."""
+
+    def __init__(self):
+        self.calls = []
+
+    def generate_image(self, **kwargs):
+        self.calls.append(kwargs)
+        result = MagicMock()
+        result.image = Image.open(io.BytesIO(_png_bytes()))
+        return result
+
+
+def _engine(cls=Flux2KleinImageEngine, model_name="flux2-klein-9b"):
+    engine = cls(model_name=model_name)
+    engine._model = FakeKleinModel()
+    return engine
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+@contextmanager
+def serving(engine):
+    """Patch route deps: fake pool serving ``engine``, identity model ids."""
+    pool = MagicMock()
+    pool.get_engine = AsyncMock(return_value=engine)
+    with (
+        patch("omlx.api.image_routes._get_engine_pool", return_value=pool),
+        patch("omlx.api.image_routes._resolve_model", side_effect=lambda m: m),
+        patch("omlx.api.image_routes.get_server_metrics"),
+    ):
+        yield engine
+
+
+# ---------------------------------------------------------------------------
+# Discovery & resolution
+# ---------------------------------------------------------------------------
+
+
+def test_mflux_component_dir_is_detected_as_image_model(tmp_path):
+    (tmp_path / "text_encoder").mkdir()
+    (tmp_path / "vae").mkdir()
+    (tmp_path / "transformer").mkdir()
+    assert _is_mflux_image_model(tmp_path)
+    assert _is_model_dir(tmp_path)
+    assert detect_model_type(tmp_path) == "image"
+
+
+def test_llm_dir_not_image_model(tmp_path):
+    (tmp_path / "config.json").write_text('{"model_type": "llama"}')
+    assert not _is_mflux_image_model(tmp_path)
+    assert detect_model_type(tmp_path) == "llm"
+
+
+def test_model_index_json_counts_as_image_model(tmp_path):
+    (tmp_path / "model_index.json").write_text("{}")
+    assert _is_mflux_image_model(tmp_path)
+    assert detect_model_type(tmp_path) == "image"
+
+
+def test_family_resolution_txt2img_edit_and_reject():
+    assert resolve_mflux_family(resolve_mflux_config("flux2-klein-9b")) is not None
+    fam = resolve_mflux_family(resolve_mflux_config("flux2-klein-9b-edit"))
+    assert fam.__name__ == "Flux2KleinEdit"
+    with pytest.raises(ValueError, match="FLUX"):
+        resolve_mflux_family(
+            SimpleNamespace(model_name="Qwen/Qwen-Image-2512", aliases=[])
+        )
+
+
+def test_registry_maps_flux_families_only():
+    assert set(REGISTRY) == {"Flux2Klein", "Flux2KleinEdit"}
+    eng = get_image_engine("/models/flux2-klein-9b")
+    assert isinstance(eng, Flux2KleinImageEngine)
+    eng = get_image_engine("/models/flux2-klein-9b-edit")
+    assert isinstance(eng, Flux2KleinEditImageEngine)
+
+
+# ---------------------------------------------------------------------------
+# Generations
+# ---------------------------------------------------------------------------
+
+
+def test_generation_returns_b64_png_and_seed(client):
+    engine = _engine()
+    with serving(engine):
+        r = client.post(
+            "/v1/images/generations",
+            json={
+                "model": "flux2-klein-9b",
+                "prompt": "a cat",
+                "seed": 7,
+                "size": "1024x768",
+            },
+        )
+    assert r.status_code == 200
+    item = r.json()["data"][0]
+    assert base64.b64decode(item["b64_json"])[:8] == b"\x89PNG\r\n\x1a\n"
+    assert item["seed"] == 7
+    call = engine._model.calls[0]
+    assert (call["width"], call["height"]) == (1024, 768)
+
+
+def test_generation_n_seeds_increment_and_extra_params_forwarded(client):
+    engine = _engine()
+    with serving(engine):
+        r = client.post(
+            "/v1/images/generations",
+            json={
+                "model": "flux2-klein-9b",
+                "prompt": "a dog",
+                "n": 3,
+                "seed": 100,
+                "num_inference_steps": 28,
+                "guidance": 2.5,
+                "user": "junk-is-ignored",
+            },
+        )
+    assert r.status_code == 200
+    assert [d["seed"] for d in r.json()["data"]] == [100, 101, 102]
+    assert all(
+        c["num_inference_steps"] == 28 and c["guidance"] == 2.5
+        for c in engine._model.calls
+    )
+    assert "user" not in engine._model.calls[0]
+
+
+def test_generation_without_seed_reports_random_seeds(client):
+    engine = _engine()
+    with serving(engine):
+        r = client.post(
+            "/v1/images/generations",
+            json={"model": "flux2-klein-9b", "prompt": "x"},
+        )
+    assert r.status_code == 200
+    seeds = [d["seed"] for d in r.json()["data"]]
+    assert len(seeds) == 1 and isinstance(seeds[0], int)
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {"model": "m"},  # missing prompt
+        {"model": "m", "prompt": "x", "num_inference_steps": 0},
+        {"model": "m", "prompt": "x", "n": 9},
+        {"model": "m", "prompt": "x", "width": 7},
+    ],
+)
+def test_generation_validation_errors(client, body):
+    engine = _engine()
+    with serving(engine):
+        r = client.post("/v1/images/generations", json=body)
+    assert r.status_code == 422
+
+
+def test_model_load_failure_is_404(client):
+    pool = MagicMock()
+    pool.get_engine = AsyncMock(side_effect=RuntimeError("no weights"))
+    with (
+        patch("omlx.api.image_routes._get_engine_pool", return_value=pool),
+        patch("omlx.api.image_routes._resolve_model", side_effect=lambda m: m),
+    ):
+        r = client.post("/v1/images/generations", json={"model": "gone", "prompt": "x"})
+    assert r.status_code == 404
+
+
+def test_generation_failure_is_500(client):
+    engine = _engine()
+    engine._model.generate_image = MagicMock(side_effect=RuntimeError("Metal OOM"))
+    with serving(engine):
+        r = client.post(
+            "/v1/images/generations", json={"model": "flux2-klein-9b", "prompt": "x"}
+        )
+    assert r.status_code == 500
+    assert "Metal OOM" in r.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Edits
+# ---------------------------------------------------------------------------
+
+
+def test_edit_json_resolves_data_uris_and_cleans_up(client):
+    engine = _engine(Flux2KleinEditImageEngine)
+    uris = [_data_uri(_png_bytes()), _data_uri(_png_bytes())]
+    with serving(engine):
+        r = client.post(
+            "/v1/images/edits",
+            json={
+                "model": "flux2-klein-9b-edit",
+                "prompt": "add a hat",
+                "images": uris,
+            },
+        )
+    assert r.status_code == 200
+    assert base64.b64decode(r.json()["data"][0]["b64_json"])[:8] == b"\x89PNG\r\n\x1a\n"
+    paths = engine._model.calls[0]["image_paths"]
+    assert len(paths) == 2
+    assert not any(Path(p).exists() for p in paths)  # temp files cleaned
+
+
+def test_edit_json_accepts_image_url_objects_and_image_field(client):
+    engine = _engine(Flux2KleinEditImageEngine)
+    body = {
+        "model": "flux2-klein-9b-edit",
+        "prompt": "x",
+        "images": [{"image_url": _data_uri(_png_bytes())}],
+        "image_strength": 0.8,
+    }
+    with serving(engine):
+        r = client.post("/v1/images/edits", json=body)
+    assert r.status_code == 200
+    call = engine._model.calls[0]
+    assert call["image_strength"] == 0.8
+    assert "image_path" not in call
+
+
+def test_edit_klein_txt2img_engine_uses_single_image_path(client):
+    engine = _engine(Flux2KleinImageEngine)
+    body = {
+        "model": "flux2-klein-9b",
+        "prompt": "x",
+        "images": [_data_uri(_png_bytes())],
+    }
+    with serving(engine):
+        r = client.post("/v1/images/edits", json=body)
+    assert r.status_code == 200
+    call = engine._model.calls[0]
+    assert "image_path" in call and "image_paths" not in call
+
+
+def test_edit_requires_input_image(client):
+    engine = _engine(Flux2KleinEditImageEngine)
+    with serving(engine):
+        r = client.post("/v1/images/edits", json={"model": "x", "prompt": "p"})
+    assert r.status_code == 400
+
+
+def test_edit_rejects_non_data_uri_images(client):
+    engine = _engine(Flux2KleinEditImageEngine)
+    body = {"model": "x", "prompt": "p", "images": ["https://example.com/a.png"]}
+    with serving(engine):
+        r = client.post("/v1/images/edits", json=body)
+    assert r.status_code == 400
+
+
+def test_edit_multipart_openai_wire_format(client):
+    engine = _engine(Flux2KleinEditImageEngine)
+    with serving(engine):
+        r = client.post(
+            "/v1/images/edits",
+            data={
+                "model": "flux2-klein-9b-edit",
+                "prompt": "restyle",
+                "n": "2",
+                "seed": "5",
+                "guidance": "3.5",
+            },
+            files=[("image", ("a.png", _png_bytes(), "image/png"))],
+        )
+    assert r.status_code == 200
+    data = r.json()["data"]
+    assert [d["seed"] for d in data] == [5, 6]
+    call = engine._model.calls[0]
+    assert call["guidance"] == 3.5
+    assert call["image_strength"] == 0.5  # default applied
+
+
+def test_edit_multipart_bracket_field_and_empty_prompt(client):
+    engine = _engine(Flux2KleinEditImageEngine)
+    with serving(engine):
+        ok = client.post(
+            "/v1/images/edits",
+            data={"model": "m", "prompt": "p"},
+            files=[("image[]", ("a.jpg", _png_bytes(), "image/jpeg"))],
+        )
+        bad = client.post(
+            "/v1/images/edits",
+            data={"model": "m", "prompt": "  "},
+            files=[("image", ("a.png", _png_bytes(), "image/png"))],
+        )
+    assert ok.status_code == 200
+    assert bad.status_code == 400
+
+
+def test_edit_multipart_without_file_is_400(client):
+    engine = _engine(Flux2KleinEditImageEngine)
+    raw = (
+        b'--X\r\nContent-Disposition: form-data; name="model"\r\n\r\nm\r\n'
+        b'--X\r\nContent-Disposition: form-data; name="prompt"\r\n\r\np\r\n'
+        b"--X--\r\n"
+    )
+    with serving(engine):
+        r = client.post(
+            "/v1/images/edits",
+            content=raw,
+            headers={"content-type": "multipart/form-data; boundary=X"},
+        )
+    assert r.status_code == 400


### PR DESCRIPTION
## What

`POST /v1/images/generations` and `POST /v1/images/edits`, backed by [mflux](https://github.com/mflux-community/mflux), **FLUX.2 Klein only** (FLUX.1 is deprecated and intentionally not wired).

- **Generations** — text-to-image; Klein also does native img2img, so an input image on the edit endpoint routes through its `image_path`.
- **Edits** — multi-image editing (`image_paths`) for `*-edit` checkpoints.
- Edit inputs accept both OpenAI wire formats: JSON with base64 data URIs (`image` / `images`, plain strings or `{"image_url": ...}`) and multipart file parts (`image` / `image[]`, Open WebUI-compatible). Remote URLs are not fetched — only data URIs.

All tunables are request-body parameters validated by per-family Pydantic models — **no per-model server-side image defaults**, mirroring the audio API's footprint (FLUX has no negative prompt):

```
prompt (required) · n (1-4) · size ("1024x768") · seed
num_inference_steps · guidance · image_strength (edit) · use_kv_cache (edit)
```

Per-image seeds are always reported back (`data[].seed`, an oMLX extension): `seed + i` when supplied, fresh random otherwise.

## How

- Engines (`omlx/engine/image/`) import mflux lazily; runs execute on the shared mlx executor; the router mounts only when mflux is installed (`[image]` extra, `mflux>=0.19`).
- Input images decode to temp files with magic-byte suffix detection, cleaned up in `finally`.
- Discovery classifies mflux component layouts (no root `config.json`; `text_encoder/` + `vae/` or a `model_index.json`) as `image` so they join the pool.
- Dashboard: step progress (bar + `steps/s`) in the activity row via the existing activity pipeline — generic `current_step`/`total_steps` keys, no new admin settings.

## Scope note

Qwen-Image / FLUX.1 / Z-Image / Ideogram / Krea / FIBO / ERNIE were explored but cut from this PR; each will be a measured follow-up. Nothing else in the server touches image paths when the extra isn't installed.

## Testing

- New `tests/test_image_api.py` (22): discovery, family resolution, generations/edits happy paths (fake engine), seed semantics, validation 422, 404/400/500 mapping, temp-file cleanup, both wire formats.
- Full suite green: **10560 passed**, zero new lint findings vs `main`.
