### PR TITLE
feat(qwen4/ane): Experimental Qwen4 ANE offload

### DIFF
--- a/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
@@ -1160,7 +1160,7 @@ private struct ExperimentalSection: View {
                                   defaultValue: "Qwen ANE Prefill",
                                   comment: "Row label for private Qwen ANE/GPU prefill acceleration"),
                     sublabel: String(localized: "settings.experimental.qwen_ane.sub",
-                                     defaultValue: "Split fixed-shape Qwen 3.5/3.6/3.8 prompt processing across both ANEs and the GPU. Experimental private API; takes effect after the model reloads.",
+                                     defaultValue: "Split fixed-shape Qwen 3.5/3.6/3.8/Qwen4 prompt processing across ANE, CPU, and GPU. Qwen4 accelerates fixed shared-expert and GDN projections; routed experts remain on GPU. Experimental private API; takes effect after the model reloads.",
                                      comment: "Sublabel describing Qwen ANE/GPU prefill acceleration")) {
                     Toggle("", isOn: vm.bindProfile($vm.qwen35AnePrefillEnabled))
                         .labelsHidden().toggleStyle(.switch)

--- a/apps/omlx-mac/Sources/AppView/ViewModels/ModelSettingsScreenVM.swift
+++ b/apps/omlx-mac/Sources/AppView/ViewModels/ModelSettingsScreenVM.swift
@@ -267,7 +267,7 @@ final class ModelSettingsScreenVM {
     var turboquantKvEnabled: Bool = false
     var turboquantKvBits: String = "4"
 
-    // Experimental: private Qwen3.5/3.6/3.8 ANE/GPU fixed-shape prefill.
+    // Experimental: private Qwen3.5+/Qwen4 ANE/CPU/GPU fixed-shape prefill.
     // These defaults are the measured M3 Ultra optimum for the 2,048-token
     // benchmark path. The feature itself remains opt-in.
     var qwen35AnePrefillEnabled: Bool = false
@@ -1011,6 +1011,7 @@ final class ModelSettingsScreenVM {
         return type.hasPrefix("qwen3_5")
             || type.hasPrefix("qwen3_6")
             || type.hasPrefix("qwen3_8")
+            || type.hasPrefix("qwen4_exp")
     }
 
     /// MTP can't co-exist with DFlash or TurboQuant KV. The toggle uses

--- a/apps/omlx-mac/Sources/Net/DTO/ModelsDTO.swift
+++ b/apps/omlx-mac/Sources/Net/DTO/ModelsDTO.swift
@@ -108,7 +108,7 @@ struct ModelSettingsDTO: Codable, Equatable, Sendable {
     // Experimental: TurboQuant KV cache
     let turboquantKvEnabled: Bool?
     let turboquantKvBits: Double?
-    // Experimental: private Qwen3.5/3.6/3.8 ANE/GPU prefill
+    // Experimental: private Qwen3.5+/Qwen4 ANE/CPU/GPU prefill
     let qwen35AnePrefillEnabled: Bool?
     let qwen35AnePrefillSequenceLength: Int?
     let qwen35AnePrefillTailPaddingMinTokens: Int?
@@ -191,7 +191,7 @@ struct ModelSettingsPatch: Encodable, Equatable, Sendable {
     // Experimental: TurboQuant KV
     var turboquantKvEnabled: Bool? = nil
     var turboquantKvBits: Double? = nil
-    // Experimental: private Qwen3.5/3.6/3.8 ANE/GPU prefill
+    // Experimental: private Qwen3.5+/Qwen4 ANE/CPU/GPU prefill
     var qwen35AnePrefillEnabled: Bool? = nil
     var qwen35AnePrefillSequenceLength: Int? = nil
     var qwen35AnePrefillTailPaddingMinTokens: Int? = nil

--- a/apps/omlx-mac/Tests/oMLXTests/ModelSettingsScreenVMTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/ModelSettingsScreenVMTests.swift
@@ -221,6 +221,9 @@ final class ModelSettingsScreenVMTests: XCTestCase {
         vm.model = makeModel(id: "qwen", configModelType: "qwen3_8")
         XCTAssertTrue(vm.isQwen35AnePrefillModel)
 
+        vm.model = makeModel(id: "qwen4", configModelType: "qwen4_exp")
+        XCTAssertTrue(vm.isQwen35AnePrefillModel)
+
         vm.model = makeModel(id: "other", configModelType: "gemma4")
         XCTAssertFalse(vm.isQwen35AnePrefillModel)
     }

--- a/benchmarks/qwen_ane_offload_microbench.py
+++ b/benchmarks/qwen_ane_offload_microbench.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Microbenchmark Qwen3.5+/Qwen4 ANE offload on real checkpoint projections.
+
+Only one shared-expert MLP and one GDN projection bundle are loaded. This
+keeps the benchmark focused on heterogeneous offload viability without loading
+Qwen4's large routed-expert and PLE tensors.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+from collections.abc import Callable
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm.models.activations import swiglu
+
+from omlx.custom_kernels.qwen35_prefill import fast
+from omlx.patches import qwen35_ane_prefill as patch
+
+
+def _cosine(left: mx.array, right: mx.array) -> float:
+    left = left.astype(mx.float32).reshape(-1)
+    right = right.astype(mx.float32).reshape(-1)
+    value = mx.sum(left * right) / (
+        mx.sqrt(mx.sum(left * left)) * mx.sqrt(mx.sum(right * right))
+    )
+    mx.eval(value)
+    return float(value.item())
+
+
+def _compare(reference: Any, candidate: Any) -> dict[str, float]:
+    reference_values = reference if isinstance(reference, tuple) else (reference,)
+    candidate_values = candidate if isinstance(candidate, tuple) else (candidate,)
+    cosines = []
+    max_errors = []
+    for expected, actual in zip(reference_values, candidate_values, strict=True):
+        difference = actual.astype(mx.float32) - expected.astype(mx.float32)
+        mx.eval(difference)
+        cosines.append(_cosine(expected, actual))
+        max_errors.append(float(mx.max(mx.abs(difference)).item()))
+    return {
+        "minimum_cosine": min(cosines),
+        "maximum_absolute_error": max(max_errors),
+    }
+
+
+def _measure(factory: Callable[[], Any], repeats: int) -> tuple[float, Any]:
+    output = factory()
+    mx.eval(*(output if isinstance(output, tuple) else (output,)))
+    mx.synchronize()
+    samples = []
+    for _ in range(repeats):
+        started = time.perf_counter()
+        output = factory()
+        mx.eval(*(output if isinstance(output, tuple) else (output,)))
+        mx.synchronize()
+        samples.append(time.perf_counter() - started)
+    return statistics.median(samples), output
+
+
+class _Checkpoint:
+    def __init__(self, root: Path):
+        self.root = root
+        self.config = json.loads((root / "config.json").read_text())
+        index = json.loads((root / "model.safetensors.index.json").read_text())
+        self.weight_map = index["weight_map"]
+        self.files: dict[str, dict[str, mx.array]] = {}
+
+    def tensor(self, key: str) -> mx.array:
+        filename = self.weight_map[key]
+        if filename not in self.files:
+            self.files[filename] = mx.load(str(self.root / filename))
+        return self.files[filename][key]
+
+    def linear(self, prefix: str) -> nn.QuantizedLinear:
+        quantization = self.config.get("quantization_config") or {}
+        spec = {
+            key: quantization[key]
+            for key in ("bits", "group_size", "mode")
+            if key in quantization
+        }
+        override = quantization.get(prefix)
+        if isinstance(override, dict):
+            spec.update(override)
+        if "bits" not in spec or "group_size" not in spec:
+            raise ValueError(f"{prefix} is not an affine quantized projection")
+        bits = int(spec["bits"])
+        group_size = int(spec["group_size"])
+        weight = self.tensor(f"{prefix}.weight")
+        output_dim = int(weight.shape[0])
+        input_dim = int(weight.shape[1]) * 32 // bits
+        linear = nn.QuantizedLinear(
+            input_dim,
+            output_dim,
+            bias=False,
+            group_size=group_size,
+            bits=bits,
+            mode=str(spec.get("mode", "affine")),
+        )
+        linear.weight = weight
+        linear.scales = self.tensor(f"{prefix}.scales")
+        linear.biases = self.tensor(f"{prefix}.biases")
+        return linear
+
+
+def _compile_mlp(
+    checkpoint: _Checkpoint,
+    layer: int,
+    sequence_length: int,
+    fraction: float,
+) -> tuple[Any, patch._AnePrefillConfig, patch._CombinedMLPState]:
+    prefix = f"language_model.model.layers.{layer}.mlp.shared_expert"
+    mlp = SimpleNamespace(
+        gate_proj=checkpoint.linear(f"{prefix}.gate_proj"),
+        up_proj=checkpoint.linear(f"{prefix}.up_proj"),
+        down_proj=checkpoint.linear(f"{prefix}.down_proj"),
+    )
+    config = patch._AnePrefillConfig(
+        sequence_length=sequence_length,
+        fraction=fraction,
+        variant=8,
+        dual_ane=True,
+    )
+    prepared = patch._prepare_pair_for_bank(mlp, config)
+    if prepared is None:
+        raise RuntimeError("The selected Qwen shared expert is not ANE eligible")
+    state, dense0, dense1 = prepared
+    if dense1 is None:
+        raise RuntimeError("Dual-ANE shared-expert preparation was incomplete")
+    banked = patch._compile_dual_banks([dense0], [dense1], sequence_length)
+    if banked is None:
+        raise RuntimeError("The shared-expert ANE bank could not be compiled")
+    models0, models1, _ = banked
+    state = patch.replace(state, model=models0[0], model1=models1[0])
+    mlp._omlx_ane_prefill_config = config
+    mlp._omlx_ane_prefill_state = state
+    return mlp, config, state
+
+
+def _compile_gdn(
+    checkpoint: _Checkpoint,
+    layer: int,
+    sequence_length: int,
+    fraction: float,
+) -> tuple[Any, patch._AneGDNConfig, patch._CombinedGDNState]:
+    prefix = f"language_model.model.layers.{layer}.linear_attn"
+    gdn = SimpleNamespace(
+        in_proj_qkv=checkpoint.linear(f"{prefix}.in_proj_qkv"),
+        in_proj_z=checkpoint.linear(f"{prefix}.in_proj_z"),
+        in_proj_b=checkpoint.linear(f"{prefix}.in_proj_b"),
+        in_proj_a=checkpoint.linear(f"{prefix}.in_proj_a"),
+    )
+    floor = patch._min_viable_gdn_fraction(gdn, 128)
+    if floor is None:
+        raise RuntimeError("The selected Qwen GDN is not ANE eligible")
+    fraction = max(fraction, floor)
+    config = patch._AneGDNConfig(
+        sequence_length=sequence_length,
+        fraction=fraction,
+        variant=8,
+        dual_ane=True,
+    )
+    prepared = patch._prepare_gdn_for_bank(gdn, config)
+    if prepared is None:
+        raise RuntimeError("The selected Qwen GDN could not be prepared")
+    state, dense0, dense1 = prepared
+    if dense1 is None:
+        raise RuntimeError("Dual-ANE GDN preparation was incomplete")
+    banked = patch._compile_dual_banks([dense0], [dense1], sequence_length)
+    if banked is None:
+        raise RuntimeError("The GDN ANE bank could not be compiled")
+    models0, models1, _ = banked
+    state = patch.replace(state, model=models0[0], model1=models1[0])
+    gdn._omlx_ane_gdn_config = config
+    gdn._omlx_ane_gdn_state = state
+    return gdn, config, state
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("model", type=Path)
+    parser.add_argument("--layer", type=int, default=0)
+    parser.add_argument("--tokens", type=int, default=2048)
+    parser.add_argument("--repeats", type=int, default=5)
+    parser.add_argument("--mlp-fraction", type=float, default=0.40)
+    parser.add_argument("--gdn-fraction", type=float, default=0.40)
+    parser.add_argument(
+        "--components", nargs="+", choices=("mlp", "gdn"), default=("mlp", "gdn")
+    )
+    args = parser.parse_args()
+    if not fast.qwen35_ane_available():
+        raise RuntimeError("The private ANE runtime is unavailable")
+    if not fast.qwen35_ane_bank_compiler_available():
+        raise RuntimeError("The ANE procedure-bank compiler is unavailable")
+
+    checkpoint = _Checkpoint(args.model)
+    model_type = str(checkpoint.config.get("model_type") or "")
+    if not patch.qwen_ane_model_type_supported(model_type):
+        raise ValueError(f"Unsupported Qwen ANE architecture: {model_type}")
+
+    results: dict[str, Any] = {
+        "model": str(args.model),
+        "model_type": model_type,
+        "layer": args.layer,
+        "tokens": args.tokens,
+        "repeats": args.repeats,
+    }
+
+    if "mlp" in args.components:
+        started = time.perf_counter()
+        mlp, config, state = _compile_mlp(
+            checkpoint, args.layer, args.tokens, args.mlp_fraction
+        )
+        compile_seconds = time.perf_counter() - started
+        input_dim = int(mlp.gate_proj.weight.shape[1]) * 32 // int(mlp.gate_proj.bits)
+        x = mx.random.normal((1, args.tokens, input_dim)).astype(
+            mlp.gate_proj.scales.dtype
+        )
+        def baseline():
+            return mlp.down_proj(swiglu(mlp.gate_proj(x), mlp.up_proj(x)))
+
+        def hybrid():
+            return patch._backend_exact(mlp, x, False)
+
+        gpu_seconds, gpu_output = _measure(baseline, args.repeats)
+        ane_seconds, ane_output = _measure(hybrid, args.repeats)
+        results["mlp"] = {
+            "bits": int(mlp.gate_proj.bits),
+            "group_size": int(mlp.gate_proj.group_size),
+            "source_dtype": str(mlp.gate_proj.scales.dtype),
+            "ane_fraction_effective": state.ane_outputs
+            / int(mlp.gate_proj.weight.shape[0]),
+            "gpu_median_ms": gpu_seconds * 1e3,
+            "ane_gpu_median_ms": ane_seconds * 1e3,
+            "speedup": gpu_seconds / ane_seconds,
+            "compile_seconds": compile_seconds,
+            "accuracy": _compare(gpu_output, ane_output),
+            "cpu_offload_eligible": mlp.gate_proj.scales.dtype == mx.float16,
+        }
+        del config
+
+    if "gdn" in args.components:
+        started = time.perf_counter()
+        gdn, config, state = _compile_gdn(
+            checkpoint, args.layer, args.tokens, args.gdn_fraction
+        )
+        compile_seconds = time.perf_counter() - started
+        qkv = gdn.in_proj_qkv
+        input_dim = int(qkv.weight.shape[1]) * 32 // int(qkv.bits)
+        x = mx.random.normal((1, args.tokens, input_dim)).astype(qkv.scales.dtype)
+        def baseline():
+            return tuple(
+                patch._tail_qmm_or_linear(linear, x, 8)
+                for linear in (
+                    gdn.in_proj_qkv,
+                    gdn.in_proj_z,
+                    gdn.in_proj_b,
+                    gdn.in_proj_a,
+                )
+            )
+
+        def hybrid():
+            return patch._gdn_backend_exact(gdn, x, False)
+
+        gpu_seconds, gpu_output = _measure(baseline, args.repeats)
+        ane_seconds, ane_output = _measure(hybrid, args.repeats)
+        total_outputs = state.z_outputs + state.qkv_outputs
+        results["gdn"] = {
+            "bits": int(qkv.bits),
+            "group_size": int(qkv.group_size),
+            "source_dtype": str(qkv.scales.dtype),
+            "ane_fraction_effective": state.z_outputs / total_outputs,
+            "gpu_median_ms": gpu_seconds * 1e3,
+            "ane_gpu_median_ms": ane_seconds * 1e3,
+            "speedup": gpu_seconds / ane_seconds,
+            "compile_seconds": compile_seconds,
+            "accuracy": _compare(gpu_output, ane_output),
+            "cpu_offload_eligible": qkv.scales.dtype == mx.float16,
+        }
+
+    print(json.dumps(results, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/omlx/admin/ane_tuning.py
+++ b/omlx/admin/ane_tuning.py
@@ -538,6 +538,20 @@ def _ane_is_active(engine: Any) -> bool:
     )
 
 
+def _force_lm_for_tuning(engine_pool: Any, model_id: str) -> bool:
+    """Keep Qwen4 on its VLM-only architecture instead of probing mlx-lm.
+
+    Qwen4-Exp owns PLE, QSA, hyper-connections, and its embedded MTP head in
+    the vendored mlx-vlm implementation. Asking the pool for ``force_lm``
+    first causes a doomed text-engine load before every fallback/reload and can
+    discard the architecture whose shared expert is being calibrated.
+    """
+    entry = getattr(engine_pool, "_entries", {}).get(model_id)
+    model_type = str(getattr(entry, "config_model_type", "") or "")
+    normalized = model_type.strip().lower().replace("-", "_")
+    return not normalized.startswith("qwen4_exp")
+
+
 async def _measure_candidate(
     run: ANETuningRun,
     engine_pool: Any,
@@ -547,7 +561,7 @@ async def _measure_candidate(
     settings = _settings_for_candidate(base_settings, run.request, candidate)
     engine = await engine_pool.get_engine(
         run.request.model_id,
-        force_lm=True,
+        force_lm=_force_lm_for_tuning(engine_pool, run.request.model_id),
         runtime_settings=settings,
     )
     if candidate.enabled and not _ane_is_active(engine):
@@ -1635,12 +1649,17 @@ def _calibrate_components_sync(
     dual_ane = bool(getattr(base_settings, "qwen35_ane_prefill_dual_ane", True))
 
     model = _loaded_model(engine)
-    modules = list(model.modules()) if hasattr(model, "modules") else []
-    mlp = next((module for module in modules if patch._eligible_pair(module)), None)
+    mlp = next(
+        (module for module in patch._candidate_mlps(model) if patch._eligible_pair(module)),
+        None,
+    )
     if mlp is None:
         raise RuntimeError("No eligible Qwen MLP layer is available for calibration")
     gdn = (
-        next((module for module in modules if patch._eligible_gdn(module)), None)
+        next(
+            (module for module in patch._candidate_gdns(model) if patch._eligible_gdn(module)),
+            None,
+        )
         if run.request.allow_ane_gdn
         else None
     )
@@ -2068,7 +2087,7 @@ async def run_tuning(run: ANETuningRun, engine_pool: Any) -> None:
         gpu_settings = _settings_for_candidate(base_settings, run.request, baseline)
         engine = await engine_pool.get_engine(
             run.request.model_id,
-            force_lm=True,
+            force_lm=_force_lm_for_tuning(engine_pool, run.request.model_id),
             runtime_settings=gpu_settings,
         )
         active_slot = _GATE_SLOT

--- a/omlx/admin/i18n/en.json
+++ b/omlx/admin/i18n/en.json
@@ -627,7 +627,7 @@
   "modal.model_settings.turboquant_kv_hint": "Compress KV cache using vector quantization. Lower bits = more compression, higher bits = better quality. Supports 2 to 8 bits.",
   "modal.model_settings.turboquant_kv_bits_label": "Bits per channel",
   "modal.model_settings.qwen_ane": "Qwen ANE Prompt Processing",
-  "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5/3.6/3.8 prompt-processing work across both ANEs and the GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
+  "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5+/Qwen4 prompt-processing work across ANE, CPU, and GPU. Qwen4 uses fixed shared-expert and GDN projections; routed experts stay on GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
   "modal.model_settings.qwen_ane_prompt_block": "Prompt block",
   "modal.model_settings.qwen_ane_tail_padding": "Pad tails from",
   "modal.model_settings.qwen_ane_mlp_fraction": "MLP on ANE",

--- a/omlx/admin/i18n/es.json
+++ b/omlx/admin/i18n/es.json
@@ -627,7 +627,7 @@
   "modal.model_settings.turboquant_kv_hint": "Comprimir caché KV usando cuantización vectorial. Bits más bajos = más compresión, bits más altos = mejor calidad. Soporta de 2 a 8 bits.",
   "modal.model_settings.turboquant_kv_bits_label": "Bits por canal",
   "modal.model_settings.qwen_ane": "Qwen ANE Prompt Processing",
-  "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5/3.6/3.8 prompt-processing work across both ANEs and the GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
+  "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5+/Qwen4 prompt-processing work across ANE, CPU, and GPU. Qwen4 uses fixed shared-expert and GDN projections; routed experts stay on GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
   "modal.model_settings.qwen_ane_prompt_block": "Prompt block",
   "modal.model_settings.qwen_ane_tail_padding": "Pad tails from",
   "modal.model_settings.qwen_ane_mlp_fraction": "MLP on ANE",

--- a/omlx/admin/i18n/fr.json
+++ b/omlx/admin/i18n/fr.json
@@ -627,7 +627,7 @@
   "modal.model_settings.turboquant_kv_hint": "Compressez le cache KV en utilisant la quantification vectorielle. Bits inférieurs = plus de compression, bits supérieurs = meilleure qualité. Supporte 2 à 8 bits.",
   "modal.model_settings.turboquant_kv_bits_label": "Bits par canal",
   "modal.model_settings.qwen_ane": "Qwen ANE Prompt Processing",
-  "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5/3.6/3.8 prompt-processing work across both ANEs and the GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
+  "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5+/Qwen4 prompt-processing work across ANE, CPU, and GPU. Qwen4 uses fixed shared-expert and GDN projections; routed experts stay on GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
   "modal.model_settings.qwen_ane_prompt_block": "Prompt block",
   "modal.model_settings.qwen_ane_tail_padding": "Pad tails from",
   "modal.model_settings.qwen_ane_mlp_fraction": "MLP on ANE",

--- a/omlx/admin/i18n/ja.json
+++ b/omlx/admin/i18n/ja.json
@@ -627,7 +627,7 @@
   "modal.model_settings.turboquant_kv_hint": "Compress KV cache using vector quantization. Reduces memory ~60-75% with near-lossless quality for long context.",
   "modal.model_settings.turboquant_kv_bits_label": "Bits per channel",
   "modal.model_settings.qwen_ane": "Qwen ANE Prompt Processing",
-  "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5/3.6/3.8 prompt-processing work across both ANEs and the GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
+  "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5+/Qwen4 prompt-processing work across ANE, CPU, and GPU. Qwen4 uses fixed shared-expert and GDN projections; routed experts stay on GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
   "modal.model_settings.qwen_ane_prompt_block": "Prompt block",
   "modal.model_settings.qwen_ane_tail_padding": "Pad tails from",
   "modal.model_settings.qwen_ane_mlp_fraction": "MLP on ANE",

--- a/omlx/admin/i18n/ko.json
+++ b/omlx/admin/i18n/ko.json
@@ -627,7 +627,7 @@
   "modal.model_settings.turboquant_kv_hint": "Compress KV cache using vector quantization. Reduces memory ~60-75% with near-lossless quality for long context.",
   "modal.model_settings.turboquant_kv_bits_label": "Bits per channel",
   "modal.model_settings.qwen_ane": "Qwen ANE Prompt Processing",
-  "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5/3.6/3.8 prompt-processing work across both ANEs and the GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
+  "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5+/Qwen4 prompt-processing work across ANE, CPU, and GPU. Qwen4 uses fixed shared-expert and GDN projections; routed experts stay on GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
   "modal.model_settings.qwen_ane_prompt_block": "Prompt block",
   "modal.model_settings.qwen_ane_tail_padding": "Pad tails from",
   "modal.model_settings.qwen_ane_mlp_fraction": "MLP on ANE",

--- a/omlx/admin/i18n/pt-BR.json
+++ b/omlx/admin/i18n/pt-BR.json
@@ -627,7 +627,7 @@
   "modal.model_settings.turboquant_kv_hint": "Comprimir o cache KV usando quantização vetorial. Menos bits = mais compressão, mais bits = melhor qualidade. Suporta de 2 a 8 bits.",
   "modal.model_settings.turboquant_kv_bits_label": "Bits por canal",
   "modal.model_settings.qwen_ane": "Qwen ANE Prompt Processing",
-  "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5/3.6/3.8 prompt-processing work across both ANEs and the GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
+  "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5+/Qwen4 prompt-processing work across ANE, CPU, and GPU. Qwen4 uses fixed shared-expert and GDN projections; routed experts stay on GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
   "modal.model_settings.qwen_ane_prompt_block": "Prompt block",
   "modal.model_settings.qwen_ane_tail_padding": "Pad tails from",
   "modal.model_settings.qwen_ane_mlp_fraction": "MLP on ANE",

--- a/omlx/admin/i18n/ru.json
+++ b/omlx/admin/i18n/ru.json
@@ -627,7 +627,7 @@
   "modal.model_settings.turboquant_kv_hint": "Сжимайте KV-кэш с помощью векторного квантования. Меньшее число бит = сильнее сжатие, большее = лучше качество. Поддерживает от 2 до 8 бит.",
   "modal.model_settings.turboquant_kv_bits_label": "Битов на канал",
   "modal.model_settings.qwen_ane": "Qwen ANE Prompt Processing",
-  "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5/3.6/3.8 prompt-processing work across both ANEs and the GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
+  "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5+/Qwen4 prompt-processing work across ANE, CPU, and GPU. Qwen4 uses fixed shared-expert and GDN projections; routed experts stay on GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
   "modal.model_settings.qwen_ane_prompt_block": "Prompt block",
   "modal.model_settings.qwen_ane_tail_padding": "Pad tails from",
   "modal.model_settings.qwen_ane_mlp_fraction": "MLP on ANE",

--- a/omlx/admin/i18n/zh-TW.json
+++ b/omlx/admin/i18n/zh-TW.json
@@ -627,7 +627,7 @@
   "modal.model_settings.turboquant_kv_hint": "使用向量量化壓縮 KV 快取。較低位元 = 更多壓縮，較高位元 = 更佳品質。支援 2 到 8 位元。",
   "modal.model_settings.turboquant_kv_bits_label": "每通道位元數",
   "modal.model_settings.qwen_ane": "Qwen ANE Prompt Processing",
-  "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5/3.6/3.8 prompt-processing work across both ANEs and the GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
+  "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5+/Qwen4 prompt-processing work across ANE, CPU, and GPU. Qwen4 uses fixed shared-expert and GDN projections; routed experts stay on GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
   "modal.model_settings.qwen_ane_prompt_block": "Prompt block",
   "modal.model_settings.qwen_ane_tail_padding": "Pad tails from",
   "modal.model_settings.qwen_ane_mlp_fraction": "MLP on ANE",

--- a/omlx/admin/i18n/zh.json
+++ b/omlx/admin/i18n/zh.json
@@ -627,7 +627,7 @@
   "modal.model_settings.turboquant_kv_hint": "使用向量量化压缩 KV Cache。位数越低压缩越多，位数越高质量越好。支持 2 到 8 位。",
   "modal.model_settings.turboquant_kv_bits_label": "每通道位数",
   "modal.model_settings.qwen_ane": "Qwen ANE Prompt Processing",
-  "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5/3.6/3.8 prompt-processing work across both ANEs and the GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
+  "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5+/Qwen4 prompt-processing work across ANE, CPU, and GPU. Qwen4 uses fixed shared-expert and GDN projections; routed experts stay on GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
   "modal.model_settings.qwen_ane_prompt_block": "Prompt block",
   "modal.model_settings.qwen_ane_tail_padding": "Pad tails from",
   "modal.model_settings.qwen_ane_mlp_fraction": "MLP on ANE",

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -135,7 +135,7 @@ class ModelSettingsRequest(BaseModel):
     # TurboQuant KV cache (mlx-vlm backend)
     turboquant_kv_enabled: bool | None = None
     turboquant_kv_bits: float | None = None
-    # Private Qwen3.5/3.6/3.8 ANE/GPU fixed-shape prefill
+    # Private Qwen3.5+/Qwen4 ANE/CPU/GPU fixed-shape prefill
     qwen35_ane_prefill_enabled: bool | None = None
     qwen35_ane_prefill_sequence_length: int | None = None
     qwen35_ane_prefill_tail_padding_min_tokens: int | None = None
@@ -2376,19 +2376,22 @@ async def update_model_settings(
         current_settings.turboquant_kv_enabled = request.turboquant_kv_enabled or False
     if "turboquant_kv_bits" in sent:
         current_settings.turboquant_kv_bits = request.turboquant_kv_bits or 4
-    # Private Qwen3.5/3.6/3.8 ANE/GPU fixed-shape prefill. These are all load-time
+    # Private Qwen3.5+ ANE/CPU/GPU fixed-shape prefill. These are all load-time
     # controls; the runtime signature below causes a loaded model to be
     # re-created when the user applies a changed profile.
     if "qwen35_ane_prefill_enabled" in sent:
         enabled = bool(request.qwen35_ane_prefill_enabled)
         config_type = str(getattr(entry, "config_model_type", "") or "")
         config_type = config_type.lower().replace("-", "_")
-        if enabled and not config_type.startswith(
-            ("qwen3_5", "qwen3_6", "qwen3_8")
-        ):
+        from ..patches.qwen35_ane_prefill import qwen_ane_model_type_supported
+
+        if enabled and not qwen_ane_model_type_supported(config_type):
             raise HTTPException(
                 status_code=400,
-                detail="ANE prefill is available only for Qwen3.5/3.6/3.8 models.",
+                detail=(
+                    "ANE prefill is available only for validated "
+                    "Qwen3.5/3.6/3.8/Qwen4 models."
+                ),
             )
         current_settings.qwen35_ane_prefill_enabled = enabled
     if "qwen35_ane_prefill_sequence_length" in sent:

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -5,7 +5,7 @@
     const DSA_MODEL_TYPES = new Set([
         'deepseek_v32', 'glm_moe_dsa',
     ]);
-    const QWEN35_ANE_CONFIG_PREFIXES = ['qwen3_5', 'qwen3_6', 'qwen3_8'];
+    const QWEN35_ANE_CONFIG_PREFIXES = ['qwen3_5', 'qwen3_6', 'qwen3_8', 'qwen4_exp'];
     const DIFFUSION_CONFIG_MODEL_TYPES = new Set([
         'diffusion_gemma',
     ]);

--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -740,7 +740,7 @@
                                 <!-- Experimental Features -->
                                 <h4 class="text-xs font-bold uppercase tracking-widest text-neutral-400 mb-3">{{ t('modal.model_settings.experimental_label') }}</h4>
 
-                                <!-- Qwen 3.5/3.6/3.8 private ANE/GPU prompt processing -->
+                                <!-- Qwen 3.5+/Qwen4 private ANE/CPU/GPU prompt processing -->
                                 <template x-if="isQwen35AnePrefillModel(selectedModel)">
                                     <div class="p-4 bg-neutral-50 rounded-xl space-y-4 mb-3">
                                         <div class="flex items-start justify-between gap-3">

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -110,8 +110,9 @@ class ModelSettings:
         turboquant_kv_enabled: Enable TurboQuant KV cache compression.
         turboquant_kv_bits: TurboQuant bit depth (2/2.5/3/3.5/4/6/8).
         turboquant_skip_last: Skip last KVCache layer to prevent corruption.
-        qwen35_ane_prefill_enabled: Enable private fixed-shape Qwen3.5/3.6/3.8
-            ANE/GPU prompt processing.
+        qwen35_ane_prefill_enabled: Enable private fixed-shape
+            Qwen3.5/3.6/3.8/Qwen4 ANE/CPU/GPU prompt processing. The legacy
+            setting name is retained for profile compatibility.
         qwen35_ane_prefill_sequence_length: Exact flattened token count routed
             through the eagerly compiled ANE programs.
         qwen35_ane_prefill_tail_padding_min_tokens: Smallest residual tokenwise
@@ -234,7 +235,7 @@ class ModelSettings:
         True  # Skip last KVCache layer (prevents corruption on sensitive models)
     )
 
-    # Experimental private-API ANE/GPU prefill for dense Qwen3.5/3.6/3.8 MLPs.
+    # Experimental private-API ANE/CPU/GPU prefill for Qwen3.5+ and Qwen4.
     # Off by default because the fixed-shape ANE models add load-time/runtime
     # cache memory and rely on undocumented AppleNeuralEngine interfaces.
     qwen35_ane_prefill_enabled: bool = False

--- a/omlx/patches/qwen35_ane_prefill.py
+++ b/omlx/patches/qwen35_ane_prefill.py
@@ -1,8 +1,10 @@
-"""Opt-in ANE/GPU hybrid prefill for dense Qwen3.5/3.6/3.8 MLPs.
+"""Opt-in ANE/CPU/GPU hybrid prefill for Qwen3.5+ projection blocks.
 
 The private ANE runtime only accepts fixed shapes, so this backend is attached
 to a specific loaded model and sequence length. Unsupported layers, flattened
-token counts, dtypes, and decode/verify calls fall through unchanged.
+token counts, dtypes, and decode/verify calls fall through unchanged. Qwen4's
+routed experts stay on Metal; its fixed shared expert and Gated DeltaNet input
+projections reuse the same output-row partitioning backend.
 """
 
 from __future__ import annotations
@@ -31,6 +33,7 @@ _PATCHED_CLASSES: set[type] = set()
 _VLM_HOOK_INSTALLED = False
 _VLM_GDN_HOOK_INSTALLED = False
 _GDN_MODULES: weakref.WeakValueDictionary[int, Any] = weakref.WeakValueDictionary()
+_QWEN_ANE_MODEL_TYPE_PREFIXES = ("qwen3_5", "qwen3_6", "qwen3_8", "qwen4_exp")
 # Legacy extensions compile one program per slice, and the private runtime on
 # the reference M3 Ultra accepts 120 resident programs. Current extensions pack
 # all slices into one multi-procedure program per ANE instance and bypass this
@@ -58,6 +61,120 @@ _ANE_BANK_RETRY_MAX_MEMORY_FRACTION = 0.70
 _ANE_BANK_RETRY_SETTLE_SECONDS = 0.5
 
 
+def _ane_bank_max_memory_fraction() -> float:
+    """Return the process-footprint ceiling used by ANE bank compilation.
+
+    The conservative 70% default protects ordinary fully-resident loads from
+    the ANE driver's delayed program-release accounting. Qwen4 PLE mmap mode
+    can legitimately start above that line while still leaving substantial
+    absolute headroom, so an explicit per-process override lets the tuner use
+    that already-selected residency policy without weakening the default for
+    every model. Keep the override below 90% so a typo cannot erase the
+    emergency margin entirely.
+    """
+    raw = os.environ.get(
+        "OMLX_QWEN35_ANE_BANK_MAX_MEMORY_FRACTION", ""
+    ).strip()
+    if not raw:
+        return _ANE_BANK_RETRY_MAX_MEMORY_FRACTION
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(
+            "Ignoring non-numeric "
+            "OMLX_QWEN35_ANE_BANK_MAX_MEMORY_FRACTION=%r",
+            raw,
+        )
+        return _ANE_BANK_RETRY_MAX_MEMORY_FRACTION
+    if not _ANE_BANK_RETRY_MAX_MEMORY_FRACTION <= value <= 0.90:
+        logger.warning(
+            "Ignoring out-of-range "
+            "OMLX_QWEN35_ANE_BANK_MAX_MEMORY_FRACTION=%r; expected %.2f..0.90",
+            raw,
+            _ANE_BANK_RETRY_MAX_MEMORY_FRACTION,
+        )
+        return _ANE_BANK_RETRY_MAX_MEMORY_FRACTION
+    return value
+
+
+def qwen_ane_model_type_supported(model_type: str | None) -> bool:
+    """Return whether ``model_type`` has a validated fixed projection layout."""
+    normalized = str(model_type or "").strip().lower().replace("-", "_")
+    return normalized.startswith(_QWEN_ANE_MODEL_TYPE_PREFIXES)
+
+
+def _model_architecture(model: Any) -> str:
+    """Best-effort architecture name for loaded LM and VLM wrapper shapes."""
+    objects = [
+        model,
+        getattr(model, "config", None),
+        getattr(model, "args", None),
+        getattr(model, "language_model", None),
+    ]
+    language_model = objects[-1]
+    if language_model is not None:
+        objects.extend(
+            [
+                getattr(language_model, "config", None),
+                getattr(language_model, "args", None),
+            ]
+        )
+    config = getattr(model, "config", None)
+    if config is not None:
+        objects.append(getattr(config, "text_config", None))
+    for value in objects:
+        model_type = getattr(value, "model_type", None)
+        if model_type:
+            return str(model_type).strip().lower().replace("-", "_")
+    return ""
+
+
+def _qwen4_decoder_layers(model: Any) -> list[Any] | None:
+    """Return only Qwen4's serving decoder layers, excluding its MTP head."""
+    if not _model_architecture(model).startswith("qwen4_exp"):
+        return None
+    language_model = getattr(model, "language_model", None)
+    for owner in (language_model, model):
+        body = getattr(owner, "model", None) if owner is not None else None
+        layers = getattr(body, "layers", None)
+        if layers is not None:
+            return list(layers)
+    return None
+
+
+def _candidate_mlps(model: Any) -> list[Any]:
+    """Find fixed SwiGLU blocks that are safe to keep in resident ANE banks."""
+    layers = _qwen4_decoder_layers(model)
+    if layers is not None:
+        candidates = []
+        for layer in layers:
+            block = getattr(layer, "mlp", None)
+            shared = getattr(block, "shared_expert", None)
+            if shared is not None:
+                candidates.append(shared)
+        return candidates
+    return [
+        module
+        for module in (model.modules() if hasattr(model, "modules") else ())
+        if all(
+            hasattr(module, name)
+            for name in ("gate_proj", "up_proj", "down_proj")
+        )
+    ]
+
+
+def _candidate_gdns(model: Any) -> list[Any]:
+    """Find serving GDN blocks without walking Qwen4's speculative MTP head."""
+    layers = _qwen4_decoder_layers(model)
+    if layers is not None:
+        return [
+            module
+            for layer in layers
+            if (module := getattr(layer, "linear_attn", None)) is not None
+        ]
+    return list(model.modules()) if hasattr(model, "modules") else []
+
+
 def _ane_bank_memory_footprint_snapshot() -> tuple[int, int]:
     """``(current phys_footprint, total system memory)`` in bytes for the
     headroom gate and its skip-warning log, so "why did ANE bank compile
@@ -79,7 +196,7 @@ def _ane_bank_memory_headroom_ok() -> bool:
     current, total = _ane_bank_memory_footprint_snapshot()
     if total <= 0:
         return True
-    return current < total * _ANE_BANK_RETRY_MAX_MEMORY_FRACTION
+    return current < total * _ane_bank_max_memory_fraction()
 
 
 @dataclass(frozen=True)
@@ -2116,6 +2233,19 @@ def _install_dispatch() -> bool:
     except Exception:
         logger.debug("mlx-vlm Qwen ANE dispatch hook unavailable", exc_info=True)
 
+    # Qwen4-Exp reuses Qwen3.5's fixed shared-expert class and subclasses its
+    # GDN implementation. Importing the architecture here makes that contract
+    # explicit and keeps the shared expert wrapped across mlx-vlm revisions.
+    try:
+        importlib.import_module("mlx_vlm.models.qwen4_exp.language")
+        qwen4_moe = importlib.import_module("mlx_vlm.models.qwen3_5_moe.language")
+        shared_expert_cls = getattr(qwen4_moe, "Qwen3_5MoeMLP", None)
+        if shared_expert_cls is not None:
+            _wrap_class(shared_expert_cls)
+            installed = True
+    except Exception:
+        logger.debug("mlx-vlm Qwen4 ANE dispatch hook unavailable", exc_info=True)
+
     try:
         lm = importlib.import_module("mlx_lm.models.qwen3_5")
         cls = getattr(lm, "MLP", None)
@@ -2196,6 +2326,7 @@ def _bank_split_ladder(
     for attempt in range(4):
         if not _ane_bank_memory_headroom_ok():
             current, total = _ane_bank_memory_footprint_snapshot()
+            max_memory_fraction = _ane_bank_max_memory_fraction()
             logger.warning(
                 "Skipping ANE procedure bank compile attempt %d/4: phys "
                 "footprint %.2f GiB / %.2f GiB total already past the "
@@ -2204,7 +2335,7 @@ def _bank_split_ladder(
                 attempt + 1,
                 current / (1 << 30),
                 total / (1 << 30),
-                _ANE_BANK_RETRY_MAX_MEMORY_FRACTION * 100,
+                max_memory_fraction * 100,
             )
             return None
         spans = (
@@ -2319,6 +2450,7 @@ def _compile_single_banks(
     for attempt in range(4):
         if not _ane_bank_memory_headroom_ok():
             current, total = _ane_bank_memory_footprint_snapshot()
+            max_memory_fraction = _ane_bank_max_memory_fraction()
             logger.warning(
                 "Skipping single-ANE procedure bank compile attempt %d/4: "
                 "phys footprint %.2f GiB / %.2f GiB total already past the "
@@ -2327,7 +2459,7 @@ def _compile_single_banks(
                 attempt + 1,
                 current / (1 << 30),
                 total / (1 << 30),
-                _ANE_BANK_RETRY_MAX_MEMORY_FRACTION * 100,
+                max_memory_fraction * 100,
             )
             return None
         spans = (
@@ -2557,7 +2689,7 @@ def _enable_dual_procedure_banks(
                 prepared_mlps.append((module, state))
 
         if gdn and gdn_max_layers:
-            for module in model.modules() if hasattr(model, "modules") else ():
+            for module in _candidate_gdns(model):
                 if len(prepared_gdns) >= gdn_max_layers:
                     break
                 if not _eligible_gdn(module):
@@ -3060,7 +3192,7 @@ def _enable_fused_gdn_banks(
     )
     prepared: list[tuple[Any, _CombinedGDNState, mx.array, mx.array]] = []
     with _COMPILE_LOCK:
-        for module in model.modules() if hasattr(model, "modules") else ():
+        for module in _candidate_gdns(model):
             if len(prepared) >= max_layers:
                 break
             if not _eligible_gdn(module):
@@ -3200,6 +3332,7 @@ def enable_qwen35_ane_prefill(
         tail_padding_min_tokens=tail_padding_min_tokens,
     )
     model._omlx_ane_tail_padding_min_tokens = tail_padding_min_tokens
+    model._omlx_ane_architecture = _model_architecture(model)
     if ane_down_fraction > 0 and not dual_ane:
         logger.warning(
             "Experimental ANE down projection currently requires dual ANE; "
@@ -3207,12 +3340,7 @@ def enable_qwen35_ane_prefill(
         )
     candidates = []
     scanned_mlp = 0
-    modules = model.modules() if hasattr(model, "modules") else ()
-    for module in modules:
-        if not all(
-            hasattr(module, name) for name in ("gate_proj", "up_proj", "down_proj")
-        ):
-            continue
+    for module in _candidate_mlps(model):
         scanned_mlp += 1
         if not _eligible_pair(module):
             continue
@@ -3418,7 +3546,7 @@ def enable_qwen35_ane_prefill(
             cpu_shared_resource=config.cpu_shared_resource,
             tail_padding_min_tokens=config.tail_padding_min_tokens,
         )
-        for module in model.modules() if hasattr(model, "modules") else ():
+        for module in _candidate_gdns(model):
             if gdn_count >= gdn_max_layers:
                 break
             requested_programs = 2 if dual_ane else 1

--- a/tests/test_admin_model_settings.py
+++ b/tests/test_admin_model_settings.py
@@ -334,3 +334,18 @@ async def test_qwen_ane_prefill_rejects_other_model_families():
             ModelSettings(),
             admin_routes.ModelSettingsRequest(qwen35_ane_prefill_enabled=True),
         )
+
+
+@pytest.mark.asyncio
+async def test_qwen_ane_prefill_accepts_qwen4_exp():
+    pool, entry = _failed_pool()
+    entry.config_model_type = "qwen4_exp"
+    settings = ModelSettings()
+
+    await _update_settings(
+        pool,
+        settings,
+        admin_routes.ModelSettingsRequest(qwen35_ane_prefill_enabled=True),
+    )
+
+    assert settings.qwen35_ane_prefill_enabled is True

--- a/tests/test_admin_model_settings_template.py
+++ b/tests/test_admin_model_settings_template.py
@@ -191,7 +191,7 @@ def test_qwen_ane_model_specific_controls_are_fully_wired():
     }
 
     assert 'x-if="isQwen35AnePrefillModel(selectedModel)"' in html
-    assert "'qwen3_5', 'qwen3_6', 'qwen3_8'" in script
+    assert "'qwen3_5', 'qwen3_6', 'qwen3_8', 'qwen4_exp'" in script
     for field in fields:
         assert f"modelSettings.{field}" in html
         assert f"{field}:" in script
@@ -208,7 +208,7 @@ def test_qwen_ane_numeric_controls_accept_arbitrary_valid_values():
     html = _model_settings_template()
     section = _section(
         html,
-        "<!-- Qwen 3.5/3.6/3.8 private ANE/GPU prompt processing -->",
+        "<!-- Qwen 3.5+/Qwen4 private ANE/CPU/GPU prompt processing -->",
         "<!-- TurboQuant KV Cache -->",
     )
 

--- a/tests/test_ane_tuning.py
+++ b/tests/test_ane_tuning.py
@@ -42,6 +42,18 @@ def test_cpu_worker_search_space_is_independent_of_saved_settings():
     assert ane_tuning._FINALIST_SAMPLES == 9
 
 
+def test_qwen4_tuner_preserves_vlm_architecture():
+    qwen4_pool = SimpleNamespace(
+        _entries={"qwen4": SimpleNamespace(config_model_type="qwen4_exp")}
+    )
+    qwen35_pool = SimpleNamespace(
+        _entries={"qwen35": SimpleNamespace(config_model_type="qwen3_5")}
+    )
+
+    assert ane_tuning._force_lm_for_tuning(qwen4_pool, "qwen4") is False
+    assert ane_tuning._force_lm_for_tuning(qwen35_pool, "qwen35") is True
+
+
 def test_candidate_settings_are_transient_copy():
     base = ModelSettings(qwen35_ane_prefill_tail_padding_min_tokens=1500)
     request = ane_tuning.ANETuningRequest(model_id="qwen", sequence_length=2048)

--- a/tests/test_qwen35_ane_prefill.py
+++ b/tests/test_qwen35_ane_prefill.py
@@ -130,6 +130,40 @@ class _Model(nn.Module):
         self.layers = [_MLP() for _ in range(count)]
 
 
+def test_qwen4_candidate_walk_uses_shared_experts_and_excludes_mtp_head():
+    shared = _MLP()
+    gdn = SimpleNamespace(in_proj_qkv=object())
+    mtp_shared = _MLP()
+    model = SimpleNamespace(
+        config=SimpleNamespace(model_type="qwen4_exp"),
+        language_model=SimpleNamespace(
+            model=SimpleNamespace(
+                layers=[
+                    SimpleNamespace(
+                        mlp=SimpleNamespace(shared_expert=shared),
+                        linear_attn=gdn,
+                    )
+                ]
+            )
+        ),
+        mtp=SimpleNamespace(
+            layers=[SimpleNamespace(mlp=SimpleNamespace(shared_expert=mtp_shared))]
+        ),
+    )
+
+    assert ane_patch._candidate_mlps(model) == [shared]
+    assert ane_patch._candidate_gdns(model) == [gdn]
+    assert all(module is not mtp_shared for module in ane_patch._candidate_mlps(model))
+
+
+@pytest.mark.parametrize(
+    "model_type",
+    ["qwen3_5", "qwen3-6-moe", "qwen3_8", "qwen4_exp", "qwen4_exp_text"],
+)
+def test_qwen_ane_model_type_support_includes_qwen4(model_type):
+    assert ane_patch.qwen_ane_model_type_supported(model_type)
+
+
 class _GDN(nn.Module):
     def __init__(self):
         super().__init__()
@@ -862,6 +896,9 @@ def test_ane_bank_memory_headroom_ok_math(monkeypatch):
     total system memory (the same ledger jetsam uses), not oMLX's own
     configured ceiling, since it has to work even before any ceiling has
     propagated."""
+    monkeypatch.delenv(
+        "OMLX_QWEN35_ANE_BANK_MAX_MEMORY_FRACTION", raising=False
+    )
     import omlx.utils.hardware as hardware
     import omlx.utils.proc_memory as proc_memory
 
@@ -877,6 +914,32 @@ def test_ane_bank_memory_headroom_ok_math(monkeypatch):
     # total==0 (measurement unavailable): default to allowing the attempt.
     monkeypatch.setattr(hardware, "get_total_memory_bytes", lambda: 0)
     assert ane_patch._ane_bank_memory_headroom_ok() is True
+
+
+def test_ane_bank_memory_headroom_explicit_ple_override(monkeypatch):
+    monkeypatch.setattr(
+        ane_patch,
+        "_ane_bank_memory_footprint_snapshot",
+        lambda: (75, 100),
+    )
+    monkeypatch.setenv(
+        "OMLX_QWEN35_ANE_BANK_MAX_MEMORY_FRACTION", "0.80"
+    )
+
+    assert ane_patch._ane_bank_memory_headroom_ok() is True
+
+
+def test_ane_bank_memory_headroom_rejects_unsafe_override(monkeypatch):
+    monkeypatch.setattr(
+        ane_patch,
+        "_ane_bank_memory_footprint_snapshot",
+        lambda: (75, 100),
+    )
+    monkeypatch.setenv(
+        "OMLX_QWEN35_ANE_BANK_MAX_MEMORY_FRACTION", "0.95"
+    )
+
+    assert ane_patch._ane_bank_memory_headroom_ok() is False
 
 
 def test_ane_bank_memory_headroom_ok_defaults_true_on_error(monkeypatch):


### PR DESCRIPTION
## Summary

This PR ports the existing Qwen3.5/3.6/3.8 fixed-shape ANE/CPU/GPU prefill path to the experimental `qwen4_exp` architecture while preserving model profiles and tuner functionality.

Qwen4 offload is deliberately limited to projections with a stable dense layout: the fixed shared expert and Gated DeltaNet (GDN) inputs. Routed MoE experts remain on the GPU, and the embedded MTP head is excluded from ANE bank discovery and compilation.

## What changed

- Added centralized Qwen ANE architecture detection with `qwen4_exp` support.
- Added Qwen4-aware module discovery that walks serving decoder layers only:
  - `mlp.shared_expert` is eligible for MLP offload.
  - `linear_attn` is eligible for GDN input-projection offload.
  - Routed experts and MTP-only layers are excluded.
- Installed the ANE dispatch hook for the Qwen4 implementation, which reuses the compatible Qwen3.5 MLP and GDN building blocks.
- Updated procedure-bank preparation and fallback paths to use the architecture-aware candidate lists.
- Kept Qwen4 tuning on the mlx-vlm engine so PLE, QSA, hyper-connections, and the embedded MTP implementation remain intact instead of probing the unsupported mlx-lm path first.
- Updated representative-layer calibration to use the same Qwen4 candidate selection as production loading.
- Added an opt-in `OMLX_QWEN35_ANE_BANK_MAX_MEMORY_FRACTION` override for mmap/PLE-heavy tuning runs. The existing 70% default remains unchanged, and overrides are constrained to 70–90%.
- Exposed Qwen4 compatibility in the admin API, web dashboard, macOS settings screen, DTO documentation, and localized settings copy.
- Retained the existing `qwen35_ane_prefill_*` setting names so saved profiles and tuner recommendations remain backward compatible.
- Added `benchmarks/qwen_ane_offload_microbench.py`, which loads real checkpoint projections without materializing Qwen4's routed experts or PLE tensors and compares GPU execution with the hybrid ANE/GPU path.

## Microbenchmark results

Measured with `Qwen3.8-Flash-Next-oQ4e-mtp`, a 2,048-token input, dual ANE, and real checkpoint weights:

| Projection | GPU median | Hybrid median | Speedup | Minimum cosine |
| --- | ---: | ---: | ---: | ---: |
| q4 GDN | 10.654 ms | 7.961 ms | 1.338x | 0.999807 |
| q5 GDN | 10.832 ms | 8.274 ms | 1.309x | 0.999920 |
| q6 GDN | 10.239 ms | 8.197 ms | 1.249x | 0.999902 |
| q8 shared expert | 1.695 ms | 2.109 ms | 0.804x | 0.999756 |

The results support GDN offload across the q4/q5/q6 projection variants in this checkpoint. The narrow q8 shared expert is slower when offloaded in isolation, so the full-model tuner remains responsible for accepting or rejecting the aggregate split.

CPU sharing remains implemented, but this checkpoint is not CPU-offload eligible because its quantization scales are BF16; the existing CPU path requires FP16 scales/checkpoint clones.

## Validation

- 259 targeted Python tests passed across ANE prefill, tuning, Qwen4 compatibility/loading/residency, MTP gating, native CPU sharing, and admin settings.
- Added coverage for Qwen4 architecture matching, shared-expert/GDN discovery, MTP exclusion, VLM-only tuner loading, admin settings acceptance, and the bounded PLE memory override.
- Ruff passed for the changed implementation, benchmark, and relevant tests.
- `git diff --check` passed.
- The macOS app and test targets compiled successfully. The GUI test runner was interrupted after stalling during launch, with no compilation failure reported.

## Notes

- The feature remains opt-in and depends on private Apple Neural Engine APIs.
- The projection microbenchmark is intentionally scoped to offload viability; it avoids loading the full routed-expert and PLE footprint.
- Existing Qwen3.5/3.6/3.8 behavior and profile keys are preserved.
