### PR TITLE
fix(engine_pool): keep the Qwen4 PLE table resident across a model swap

### DIFF
--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -285,6 +285,7 @@ class EnginePool:
         self._get_final_ceiling: object | None = None  # Set by server
         self._get_admission_ceiling: object | None = None  # Set by server
         self._get_admission_soft_target: object | None = None  # Set by server
+        self._get_residency_ceiling: object | None = None  # Set by server
         self._settings_manager: object | None = None  # Set by server
         self._cluster_registry: ClusterRegistry | None = None  # Set by server
         self._suppress_ttl: bool = False  # Suppress TTL during benchmarks
@@ -396,10 +397,28 @@ class EnginePool:
                 exc_info=True,
             )
             return False, False, None
-        ceiling = self._fallback_admission_ceiling()
+        # Residency is a throughput decision, so it uses the ceiling that does
+        # not move with instantaneous pressure. Asking the admission ceiling
+        # here read vm_stat right after the previous model unloaded, before the
+        # OS had returned its pages: the ceiling dipped, a table that fits got
+        # forced to SSD, and the swapped-in model ran at 14.1 instead of 35.3
+        # tok/s for the rest of its life in the process.
+        ceiling = self._residency_ceiling()
+        if ceiling <= 0:
+            ceiling = self._fallback_admission_ceiling()
         if ceiling <= 0:
             ceiling = self._current_ceiling()
         forced = estimate.force_ssd_offload(ceiling)
+        if forced:
+            logger.warning(
+                "Qwen4-Exp PLE forced to SSD for %s: resident %.1fGB exceeds the "
+                "%.1fGB residency ceiling (mmap needs %.1fGB). Decode will be "
+                "roughly 2.5x slower than a resident load.",
+                entry.model_id,
+                estimate.resident_bytes / 1e9,
+                ceiling / 1e9,
+                estimate.mmap_bytes / 1e9,
+            )
         requested = bool(
             settings is not None and getattr(settings, "qwen4_ple_ssd_offload", False)
         )
@@ -463,6 +482,22 @@ class EnginePool:
         pools admit unconditionally).
         """
         cb = self._get_admission_ceiling
+        if cb is None:
+            return 0
+        try:
+            return int(cb())
+        except Exception:  # noqa: BLE001
+            return 0
+
+    def _residency_ceiling(self) -> int:
+        """Stable ceiling for the resident-vs-mmap call (#PLE residency).
+
+        Wired to `enforcer.get_residency_ceiling`, which drops the vm_stat
+        component so a model swap does not push a table that fits onto SSD.
+        Returns 0 when no callback is wired up; callers fall back to the
+        admission ceiling.
+        """
+        cb = self._get_residency_ceiling
         if cb is None:
             return 0
         try:

--- a/omlx/process_memory_enforcer.py
+++ b/omlx/process_memory_enforcer.py
@@ -707,6 +707,28 @@ class ProcessMemoryEnforcer:
             return self._get_hard_limit_bytes()
         return self._get_static_ceiling()
 
+    def get_residency_ceiling(self) -> int:
+        """Stable ceiling for *where weights live*, not for admitting a load.
+
+        Admission must respect memory free right now — overcommitting thrashes
+        the machine. Choosing whether a model's PLE table stays resident or
+        falls back to mmap is a throughput call, and the instantaneous ceiling
+        is actively wrong for it: engine_pool asks right after the previous
+        model unloaded, before the OS has returned its pages, so ``dynamic``
+        dips and a table that fits gets pushed to SSD for the rest of that
+        engine's life. Measured on a model swap here: 35.3 -> 14.1 tok/s.
+
+        Uses only the two components that don't move with instantaneous
+        pressure. Returns 0 when the guard is off, like the other accessors.
+        """
+        breakdown = self._get_ceiling_breakdown()
+        candidates = [
+            value
+            for value in (breakdown["static"], breakdown["metal_cap"])
+            if value > 0
+        ]
+        return min(candidates) if candidates else 0
+
     def get_admission_soft_target(self) -> int:
         """Soft watermark that pre-load admission evicts down to (#2319).
 

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -499,6 +499,11 @@ async def lifespan(app: FastAPI):
         _server_state.engine_pool._get_admission_soft_target = (
             enforcer.get_admission_soft_target
         )
+        # Resident-vs-mmap is a throughput call and must not read the
+        # instantaneous ceiling, which dips right after a model swap.
+        _server_state.engine_pool._get_residency_ceiling = (
+            enforcer.get_residency_ceiling
+        )
         enforcer.start()
 
     # Startup: Preload pinned models in the background so uvicorn binds the

--- a/tests/test_qwen4_exp_residency.py
+++ b/tests/test_qwen4_exp_residency.py
@@ -66,3 +66,48 @@ def test_offload_is_forced_only_when_it_makes_the_model_fit(tmp_path):
     assert estimate.force_ssd_offload(between_modes) is True
     assert estimate.force_ssd_offload(estimate.resident_bytes) is False
     assert estimate.force_ssd_offload(max(0, estimate.mmap_bytes - 1)) is False
+
+
+def test_residency_uses_the_stable_ceiling_not_the_instantaneous_one(tmp_path):
+    """A model swap must not push a table that fits onto SSD.
+
+    engine_pool used to ask the admission ceiling, which reads vm_stat. On a
+    swap that reading lands right after the previous model unloaded, before
+    the OS returned its pages, so the ceiling dips below the resident size and
+    the table is forced to SSD for the rest of that engine's life. Measured
+    cost of that mistake on this machine: 35.3 -> 14.1 tok/s.
+    """
+    from omlx.engine_pool import EngineEntry, EnginePool
+
+    model = tmp_path / "qwen4"
+    model.mkdir()
+    ple_key = "model.language_model.ngram_embedding.shard_0.weight"
+    _write_safetensors(model / "model.safetensors", {ple_key: 100})
+    (model / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {ple_key: "model.safetensors"}})
+    )
+    estimate = qwen4_exp_residency_estimate(model)
+
+    pool = EnginePool.__new__(EnginePool)
+    pool._get_admission_ceiling = None
+    pool._get_admission_soft_target = None
+    pool._get_final_ceiling = None
+    entry = EngineEntry.__new__(EngineEntry)
+    entry.model_id = "qwen4"
+    entry.model_path = str(model)
+    entry.config_model_type = "qwen4_exp"
+
+    # The instantaneous ceiling has dipped between the two modes — exactly the
+    # window right after a swap. The stable ceiling still clears resident.
+    deprimido = (estimate.resident_bytes + estimate.mmap_bytes) // 2
+    pool._get_admission_ceiling = lambda: deprimido
+    pool._get_residency_ceiling = lambda: estimate.resident_bytes
+
+    enabled, forced, _ = pool._qwen4_ple_offload_status(entry, None)
+    assert forced is False, "a dip in the instantaneous ceiling must not force SSD"
+    assert enabled is False
+
+    # With no stable ceiling wired up we still fall back to the old behaviour.
+    pool._get_residency_ceiling = None
+    _, forced_sem_cb, _ = pool._qwen4_ple_offload_status(entry, None)
+    assert forced_sem_cb is True


### PR DESCRIPTION
Swapping models from the admin panel costs 2.5x decode throughput on a `qwen4_exp` model, until the server is restarted. The persisted settings say nothing is wrong — `qwen4_ple_ssd_offload` stays `false` throughout.

`_qwen4_ple_offload_status` asks the admission ceiling, which is `min(static, dynamic, metal_cap)`. The `dynamic` component reads `vm_stat` at that moment, and on a swap that reading lands after the outgoing engine released its arrays but before the OS returned the pages:

```
Unloaded antigo, freed=99.01GB, active_memory: 1.02KB (settled)
Admitting fp16: committed baseline 104.84GB fits ceiling 121.60GB
Qwen4-Exp PLE mode: mmap
Loaded fp16 (actual: 548.38MB, local estimate: 73.55GB, full model: 104.84GB)

clean load   ceiling 121.60GB -> resident
after swap   ceiling 100.78GB -> forced to SSD
```

`force_ssd_offload` fires (resident 115GB doesn't fit 100.78, mmap 73.55GB does), and `_effective_qwen4_model_settings` applies it to a copy, so nothing surfaces. The `73.55GB` in the load line is the estimate's `mmap_bytes`.

Admission needs memory free right now; residency does not. `get_residency_ceiling()` drops the `vm_stat` component, and the forced decision now logs a warning naming the ceiling.

Paired, novel prompts, `cached_tokens=0` on all six runs, 400 generated tokens, temp 0, M1 Ultra 128GB:

```
before   clean 35.3 tok/s (112GB, resident)  ·  after swap 14.1 tok/s (78GB, SSD)
after    clean 26.0/32.0/33.4 -> 30.5        ·  after swap 31.3/26.9/28.8 -> 29.0
```

The distributions now overlap (26.0-33.4 against 26.9-31.3). Absolutes are lower than the "before" row because those prompts are novel and the n-gram drafter has nothing to copy — only the within-round comparison holds.

Only the incoming model's type is checked, so this needs an incoming `qwen4_exp` whose resident estimate clears the stable ceiling but not the depressed one, plus anything large unloading right before. Two qwen4_exp models are not required.

305 tests pass across residency, engine pool and memory enforcer. The new test feeds a depressed instantaneous ceiling with a roomy stable one and asserts the table stays resident; its second half asserts the old behaviour returns when no callback is wired.
