### PR TITLE
fix(audio): unblock realtime STT for voxtral_realtime models

### DIFF
--- a/Formula/omlx.rb
+++ b/Formula/omlx.rb
@@ -25,11 +25,15 @@ class Omlx < Formula
     skip_clean "libexec" if MacOS.version >= "27"
   end
 
-  # mlx-audio pins mlx-lm==0.31.1 which conflicts with omlx's git-pinned
-  # mlx-lm. Fetch source separately so we can patch the pin before install.
+  # mlx-audio is installed from a pinned commit instead of omlx's [audio]
+  # extra (brew installs omlx without extras): the pin must include
+  # voxtral_realtime create_streaming_session (upstream f679861) or the
+  # realtime STT WebSocket rejects every session while /v1/models/status
+  # advertises it (#3231). 40bc168 is the newest commit whose declared deps
+  # stay compatible with omlx's transformers<5.13 pin.
   resource "mlx-audio" do
     url "https://github.com/Blaizzy/mlx-audio.git",
-      revision: "51753266e0a4f766fd5e6fbc46652224efc23981"
+      revision: "40bc1680eaa47b8f3d5992bbb2913f08c3d1a123"
   end
 
   # Kokoro's English G2P path uses misaki + spaCy. Bundle the spaCy
@@ -110,11 +114,20 @@ class Omlx < Formula
       end
     end
 
-    # Install mlx-audio with patched mlx-lm pin to avoid version conflict
+    # Install mlx-audio from the pinned commit. Its declared mlx-lm>=0.31.1
+    # is satisfied by omlx's git-pinned 0.31.3, so no pin patching needed.
     resource("mlx-audio").stage do
-      inreplace "pyproject.toml", '"mlx-lm==0.31.1"', '"mlx-lm>=0.31.1"'
       system(*pip_install, ".[all]")
     end
+
+    # Since upstream 40bc168, misaki/spacy & co are optional installs that
+    # mlx-audio no longer pulls transitively. Install the G2P and
+    # audio-analysis deps omlx needs at runtime explicitly (mirrors omlx's
+    # [bundle] extra; the spacy model wheel below completes the Kokoro path).
+    system(*pip_install,
+           "misaki>=0.9.4", "num2words>=0.5.14", "spacy>=3.8.4",
+           "phonemizer-fork>=3.3.2", "espeakng-loader>=0.2.4",
+           "librosa>=0.10.0", "numba>=0.59.0", "pyloudnorm>=0.1.0")
 
     # Install the spaCy English model required by misaki for Kokoro TTS.
     # Homebrew's cached resource path is hash-prefixed, which pip rejects

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -243,6 +243,23 @@ class EngineEntry:
     load_failure_at: float | None = None
 
 
+def _realtime_stt_capable(entry: EngineEntry) -> bool:
+    """Whether an entry advertises realtime STT to status consumers (#3231).
+
+    Unloaded models get the static config classification. Once the engine is
+    loaded, the engine-level probe wins, so the flag never promises a
+    capability the realtime WS handshake would reject (e.g. a bundled
+    mlx-audio whose voxtral Model predates ``create_streaming_session``).
+    """
+    if not is_realtime_stt_model(entry.model_type, entry.config_model_type):
+        return False
+    engine = entry.engine
+    if engine is not None:
+        probe = getattr(engine, "supports_realtime_stt", None)
+        return bool(probe()) if callable(probe) else False
+    return True
+
+
 class EnginePool:
     """
     Manages multiple model engines with LRU-based memory management.
@@ -3076,9 +3093,7 @@ class EnginePool:
                     "engine_type": e.engine_type,
                     "model_type": e.model_type,
                     "config_model_type": e.config_model_type,
-                    "realtime_stt": is_realtime_stt_model(
-                        e.model_type, e.config_model_type
-                    ),
+                    "realtime_stt": _realtime_stt_capable(e),
                     "model_context_length": e.model_context_length,
                     "is_helper": e.is_helper,
                     "thinking_default": e.thinking_default,

--- a/packaging/build.py
+++ b/packaging/build.py
@@ -703,8 +703,10 @@ def build_venvstacks():
         resolved_toml.unlink()
 
     # Install mlx-audio separately: build wheel from git, install --no-deps.
-    # mlx-audio pins mlx-lm==0.31.1 which conflicts with our git-pinned mlx-lm,
-    # so it can't go through venvstacks' uv resolver.
+    # mlx-audio's declared dependency set drifts against our git-pinned
+    # mlx-lm (strict ==0.31.1 became >=0.31.1 by 40bc168, but the resolver
+    # still can't see our git pin), so it can't go through venvstacks' uv
+    # resolver; pyproject.toml lists the transitives we actually need.
     _install_mlx_audio(EXPORT_DIR)
 
     # Install paroquant --no-deps. The official [mlx] extra requires
@@ -730,8 +732,13 @@ def build_venvstacks():
     return EXPORT_DIR
 
 
-# mlx-audio git commit — aligned with pyproject.toml [audio] extra
-_MLX_AUDIO_GIT = "git+https://github.com/Blaizzy/mlx-audio@51753266e0a4f766fd5e6fbc46652224efc23981"
+# mlx-audio git commit — aligned with pyproject.toml [audio] extra.
+# Must include voxtral_realtime create_streaming_session (upstream f679861);
+# see #3231. 40bc168 (2026-07-04) is the newest commit whose declared deps
+# stay compatible with our transformers<5.13 pin (upstream raised the floor
+# to >=5.14 in 3e9e8aa). resample_audio is back on mlx_audio.utils here, so
+# the mlx_audio_compat shim becomes a no-op (kept for older dev checkouts).
+_MLX_AUDIO_GIT = "git+https://github.com/Blaizzy/mlx-audio@40bc1680eaa47b8f3d5992bbb2913f08c3d1a123"
 
 
 def _install_mlx_audio(export_dir: Path):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,11 +152,19 @@ modelscope = [
     "modelscope>=1.10.0",
 ]
 audio = [
-    # mlx-audio from commit (5175326) with tts/stt/sts extras
-    # tts extra: misaki, num2words, spacy, phonemizer-fork, espeakng-loader, sentencepiece
-    # stt extra: tiktoken, mistral-common[audio]
-    # sts extra: tts deps + stt deps + webrtcvad
-    "mlx-audio[tts,stt,sts] @ git+https://github.com/Blaizzy/mlx-audio@51753266e0a4f766fd5e6fbc46652224efc23981",
+    # mlx-audio from commit (40bc168, 2026-07-04) with tts/stt/sts extras
+    # tts extra: mistral-common[audio], sentencepiece (misaki & co are
+    #   optional upstream by now; kept explicit in [bundle] for Kokoro TTS)
+    # stt extra: sentencepiece (tiktoken + mistral-common[audio] declared here)
+    # sts extra: sentencepiece + webrtcvad
+    # Must include voxtral_realtime create_streaming_session (VoxtralStreamingSession,
+    # added upstream in f679861, 2026-04-19): the realtime STT WS gates on it via
+    # hasattr; older pins load the model but reject every realtime session (#3231).
+    # 40bc168 is the newest commit whose declared deps stay compatible with
+    # our transformers>=5.12.1,<5.13 pin (upstream raised the floor to >=5.14
+    # in 3e9e8aa, 2026-07-29); its deps also declare mlx-lm>=0.31.1, matching
+    # our git-pinned 0.31.3.
+    "mlx-audio[tts,stt,sts] @ git+https://github.com/Blaizzy/mlx-audio@40bc1680eaa47b8f3d5992bbb2913f08c3d1a123",
     # WebSocket protocol impl for uvicorn (realtime STT endpoint). Pure
     # python; uvicorn's ws="auto" picks it up when installed.
     "wsproto==1.2.0",
@@ -174,12 +182,10 @@ paroquant = [
 # version-free. End-users don't `pip install omlx[bundle]`; this is for
 # the macOS .app build pipeline.
 #
-# mlx-audio[tts,stt,sts]'s 12 transitive deps appear explicitly because
-# venvstacks 0.7.0's internal `uv pip compile` runs with --no-config and
-# doesn't propagate pyproject.toml's `tool.uv.override-dependencies`,
-# so it can't resolve mlx-audio's `mlx-lm==0.31.1` pin against our
-# git-pinned mlx-lm (v0.31.3). build.py installs mlx-audio + paroquant
-# separately via --no-deps post-resolution.
+# mlx-audio's runtime deps appear explicitly because build.py installs
+# mlx-audio itself with --no-deps after venvstacks 0.7.0's resolution
+# (its internal `uv pip compile` runs with --no-config and can't see our
+# git-pinned mlx-lm), so the layer's requirements list must name them here.
 bundle = [
     "mcp>=2.0.0,<3",
     "modelscope>=1.10.0",
@@ -266,8 +272,9 @@ include = ["omlx*"]
 "omlx.custom_kernels.qwen35_prefill" = ["*.metallib", "*.dylib", "*.so"]
 
 [tool.uv]
-# mlx and mlx-lm are git-pinned; override transitive pins
-# (e.g. mlx-audio -> mlx-lm==0.31.1) so the resolver accepts them.
+# mlx and mlx-lm are git-pinned; override transitive pins (e.g. mlx-audio's
+# mlx-lm requirement — strict ==0.31.1 before 40bc168) so the resolver
+# accepts them.
 override-dependencies = [
     "mlx==0.32.0",
     "mlx-lm @ git+https://github.com/ml-explore/mlx-lm@ab1806e8f5d6aa035973af194a1b9198ab4754dc",

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -14,6 +14,7 @@ from omlx.engine_pool import (
     EngineEntry,
     EnginePool,
     _qwen35_cpu_share_estimated_bytes,
+    _realtime_stt_capable,
 )
 from omlx.exceptions import (
     InsufficientMemoryError,
@@ -468,6 +469,72 @@ class TestEnginePoolStatus:
         pool.discover_models(str(small_mock_model_dir))
 
         assert pool.get_loaded_model_ids() == []
+
+
+class TestRealtimeSttFlag:
+    """Tests for the realtime_stt status flag (#3231).
+
+    The flag must never promise a capability the realtime WS handshake
+    would reject: static config classification for unloaded models, the
+    engine's honest ``supports_realtime_stt`` probe once loaded.
+    """
+
+    @staticmethod
+    def _stt_entry(config_model_type: str, engine=None) -> EngineEntry:
+        return EngineEntry(
+            model_id="stt-model",
+            model_path="/path/to/stt-model",
+            model_type="audio_stt",
+            engine_type="simple",
+            estimated_size=1000,
+            config_model_type=config_model_type,
+            engine=engine,
+        )
+
+    def test_unloaded_voxtral_realtime_classified_realtime(self):
+        """Unloaded models fall back to static config classification."""
+        assert _realtime_stt_capable(self._stt_entry("voxtral_realtime")) is True
+        assert _realtime_stt_capable(self._stt_entry("whisper")) is True
+
+    def test_unloaded_non_realtime_config(self):
+        assert _realtime_stt_capable(self._stt_entry("qwen3_asr")) is False
+
+    def test_loaded_engine_probe_wins(self):
+        """A loaded engine whose backend lacks the streaming API reports False
+        even though config_model_type is realtime-classified (#3231)."""
+
+        class _Engine:
+            def __init__(self, capable: bool):
+                self._capable = capable
+
+            def supports_realtime_stt(self) -> bool:
+                return self._capable
+
+        assert (
+            _realtime_stt_capable(
+                self._stt_entry("voxtral_realtime", _Engine(capable=False))
+            )
+            is False
+        )
+        assert (
+            _realtime_stt_capable(
+                self._stt_entry("voxtral_realtime", _Engine(capable=True))
+            )
+            is True
+        )
+
+    def test_loaded_engine_without_probe_is_not_realtime(self):
+        """Defensive: an engine type without the probe never advertises it."""
+
+        class _Engine:
+            pass
+
+        assert (
+            _realtime_stt_capable(
+                self._stt_entry("voxtral_realtime", _Engine())
+            )
+            is False
+        )
 
 
 class TestEngineEntry:


### PR DESCRIPTION
Fixes #3231

## Root cause

`/v1/models/status` classifies `config_model_type=voxtral_realtime` as realtime-capable statically (`REALTIME_STT_MODEL_TYPES`), but the realtime WS handshake probes the loaded engine via `hasattr(model, "create_streaming_session")`. The pinned mlx-audio commit (`5175326`, 2026-04-07) predates the streaming API (upstream `f679861`, 2026-04-19 — "feat(voxtral_realtime): live input streaming"), so the two checks disagree: status advertises `realtime_stt: true` while the handshake rejects every session.

Note the model-loading path itself is correct — the checkpoint's `config.json` declares `model_type: voxtral_realtime` and mlx-audio's remap loads the right class; that class just had no session API at the pinned commit.

## Changes

- **`pyproject.toml` / `packaging/build.py`** — bump the mlx-audio pin `5175326` → `40bc168` (2026-07-04). It has the streaming API and still declares `transformers>=5.5.0,<5.13.0` / `mlx-lm>=0.31.1`, compatible with our `transformers>=5.12.1,<5.13` pin and git-pinned mlx-lm 0.31.3. Later commits aren't resolvable yet: upstream raised the transformers floor to `>=5.14.0` in `3e9e8aa` (2026-07-29).
- **`omlx/engine_pool.py`** — new `_realtime_stt_capable()`: unloaded models keep the static classification; once an engine is loaded, the engine's honest `supports_realtime_stt()` probe wins, so the status flag can never promise a capability the handshake would reject (the side suggestion from the issue).
- **`Formula/omlx.rb`** — same pin bump for the brew path; drop the `mlx-lm==0.31.1` `inreplace` (now natively `>=0.31.1`, the inreplace would fail) and explicitly install `misaki`/`spacy`/`librosa`/`numba`/`pyloudnorm`/`num2words`/`phonemizer-fork`/`espeakng-loader`, which upstream moved out of its dependency set (formula previously got them transitively; Kokoro G2P and the spacy model check need them).
- **`tests/test_engine_pool.py`** — regression tests for the `realtime_stt` flag semantics (unloaded → static classification; loaded → engine probe wins; engine without the probe → `False`).

## Verification

- `uv sync --extra audio` resolves end-to-end with the new pin (the old one couldn't, due to the strict `mlx-lm==0.31.1` conflict), and the installed mlx-audio exposes `create_streaming_session` / `VoxtralStreamingSession` with signatures matching `_VoxtralRealtimeBackend` (`feed`/`step(max_decode_tokens=...)`/`close`/`done`); transformers stays at 5.12.1.
- All mlx-audio APIs omlx imports verified present at the pinned commit (stt/tts utils, whisper `StreamingConfig`/`StreamingDecoder`/`log_mel_spectrogram`, qwen3_asr `split_audio_into_chunks`, the four STS model classes, voxtral batch `Model`).
- 436 tests pass: `test_audio_realtime.py`, `test_engine_pool.py`, `test_audio_discovery.py`, `test_model_discovery.py`, `test_status_endpoint.py` (base includes current upstream/main).

Not covered here (needs hardware/model download): an end-to-end realtime WS round-trip against `Voxtral-Mini-4B-Realtime-2602-4bit` and the macOS app build via `packaging/build.py`.