### PR TITLE
fix(dflash): gate on resolved model types instead of a 'qwen' substring

### DIFF
--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -88,7 +88,17 @@ def is_dflash_compatible(model_path: str | Path) -> tuple[bool, str]:
 
     model_type = str(cfg.get("model_type") or "").lower()
 
-    is_qwen = "qwen" in model_type
+    # Substring match let every "qwen*" through, including qwen4_exp — the
+    # dashboard offered the toggle, the loader then raised
+    # "Model type qwen4_exp not supported" and engine_pool swallowed it, so
+    # the operator saw the switch turn on and silently fall back (v8 F2.7).
+    # The list is what mlx_lm actually resolves for dflash.
+    is_qwen = model_type in (
+        "qwen2", "qwen2_moe",
+        "qwen3", "qwen3_moe",
+        "qwen3_next",
+        "qwen3_5", "qwen3_5_moe",
+    )
     is_gemma4 = model_type in ("gemma4", "gemma4_text", "gemma4_unified")
     is_laguna = model_type == "laguna"
     is_muse = model_type in ("muse_glimmer", "muse_glimmer_text")

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -812,6 +812,20 @@ class TestDFlashCompatibility:
         compatible, reason = is_dflash_compatible(tmp_path)
         assert compatible is True
 
+    def test_qwen4_exp_is_incompatible(self, tmp_path):
+        # v8 F2.7: o portao usava substring ("qwen" in model_type) e deixava
+        # passar qwen4_exp; o carregador entao levantava "Model type qwen4_exp
+        # not supported" e o pool engolia o erro — o painel ligava e caia no
+        # motor padrao sem o operador ver.
+        try:
+            from omlx.engine.dflash import is_dflash_compatible
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+        self._write_config(tmp_path, "qwen4_exp")
+        compatible, reason = is_dflash_compatible(tmp_path)
+        assert compatible is False
+        assert reason != ""
+
     def test_llama_is_incompatible(self, tmp_path):
         try:
             from omlx.engine.dflash import is_dflash_compatible


### PR DESCRIPTION
`is_dflash_compatible` decides with a substring:

```python
model_type = str(cfg.get("model_type") or "").lower()
is_qwen = "qwen" in model_type
```

Every `qwen*` passes, `qwen4_exp` included. mlx_lm resolves no DFlash path for it, so the loader raises `Model type qwen4_exp not supported`, `engine_pool` catches it and falls back to the standard engine. The gate returns compatible, the settings route accepts the write, and the operator sees the toggle stay on while nothing behind it changed.

In #2175 you wrote that the gate is not display-only — the settings route 400s on an incompatible model — and that merging a gate change alone "would make the dashboard advertise compatibility the runtime cannot deliver yet". That is the state `qwen4_exp` is in today, from the other direction: the gate lets it through and the runtime cannot deliver.

This replaces the substring with the list mlx_lm actually resolves, so an unsupported type is refused at the gate with the usual 400 instead of failing silently after the load. The shape matches the neighbouring branches, which already enumerate (`is_gemma4 = model_type in (...)`).

Checked against the current pin: `qwen3_5` and `qwen3_next` keep passing, `qwen4_exp` now reports incompatible. `tests/test_dflash_engine.py` gains a case pinning both directions — 116 tests pass in that file.
