### PR TITLE
Pick eviction victims by size, not age alone

### DIFF
--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -1599,7 +1599,9 @@ class EnginePool:
                     projected = current + admission_size
                     if projected <= evict_target:
                         break
-                    victim = self._find_lru_victim()
+                    victim = self._find_lru_victim(
+                        bytes_needed=projected - evict_target
+                    )
                     if victim is not None:
                         logger.info(
                             f"Evicting '{victim}' to fit '{model_id}' "
@@ -1793,7 +1795,41 @@ class EnginePool:
         finally:
             await self.release_engine(model_id)
 
-    def _find_lru_victim(self) -> str | None:
+    def _eviction_freeable_size(self, entry: EngineEntry) -> int:
+        """Bytes that unloading ``entry`` would actually reclaim."""
+        if entry.actual_size is not None:
+            return entry.actual_size
+        return self._entry_resident_size(entry)
+
+    def _pick_eviction_victim(
+        self,
+        candidates: list[tuple[float, int, str]],
+        bytes_needed: int,
+    ) -> str | None:
+        """Choose one victim from ``(last_access, freeable_bytes, model_id)``.
+
+        Plain LRU is size-blind. On a host serving models that differ by an
+        order of magnitude (a 1.7GB TTS model next to a 68GB LLM) it can
+        unload several small idle models -- each of which must be reloaded
+        later -- before the caller's loop frees enough for one request.
+
+        Prefer the coldest model that on its own covers ``bytes_needed`` so a
+        pressure event disturbs a single model. When nothing is big enough,
+        take the largest so the loop converges in fewer rounds. Passing
+        ``bytes_needed <= 0`` keeps the original pure-LRU behaviour.
+        """
+        if not candidates:
+            return None
+        if bytes_needed > 0:
+            sufficient = [c for c in candidates if c[1] >= bytes_needed]
+            if sufficient:
+                # Tuple order puts last_access first: coldest wins, and the
+                # remaining fields keep the choice deterministic on ties.
+                return min(sufficient)[2]
+            return max(candidates, key=lambda c: c[1])[2]
+        return min(candidates)[2]
+
+    def _find_lru_victim(self, bytes_needed: int = 0) -> str | None:
         """
         Find the least recently used non-pinned loaded model.
 
@@ -1812,11 +1848,8 @@ class EnginePool:
             if self._entry_has_active_requests(e):
                 logger.debug(f"Skipping victim '{mid}': has active requests")
                 continue
-            candidates.append((e.last_access, mid))
-        if not candidates:
-            return None
-        candidates.sort()  # Sort by last_access (oldest first)
-        return candidates[0][1]
+            candidates.append((e.last_access, self._eviction_freeable_size(e), mid))
+        return self._pick_eviction_victim(candidates, bytes_needed)
 
     async def _unload_other_dflash_engines(self, model_id: str) -> None:
         """Unload other idle DFlash engines before starting a new one.
@@ -1888,17 +1921,18 @@ class EnginePool:
                 return False
         return True
 
-    def _find_lru_prefill_eviction_victim(self, *, exclude_model_id: str) -> str | None:
+    def _find_lru_prefill_eviction_victim(
+        self, *, exclude_model_id: str, bytes_needed: int = 0
+    ) -> str | None:
         candidates = []
         for mid, entry in self._entries.items():
             if mid == exclude_model_id:
                 continue
             if self._is_idle_for_prefill_eviction(entry):
-                candidates.append((entry.last_access, mid))
-        if not candidates:
-            return None
-        candidates.sort()
-        return candidates[0][1]
+                candidates.append(
+                    (entry.last_access, self._eviction_freeable_size(entry), mid)
+                )
+        return self._pick_eviction_victim(candidates, bytes_needed)
 
     async def _evict_idle_lru_for_prefill(
         self,
@@ -1936,7 +1970,8 @@ class EnginePool:
                     return evicted_any or reclaim_attempted or ane_release_attempted
 
                 victim = self._find_lru_prefill_eviction_victim(
-                    exclude_model_id=exclude_model_id
+                    exclude_model_id=exclude_model_id,
+                    bytes_needed=current + predicted - target,
                 )
                 if victim is None:
                     # No idle model left to evict -- the "No idle model

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -965,6 +965,55 @@ class TestEnginePoolLRU:
         victim = pool_with_entries._find_lru_victim()
         assert victim == "model-a"
 
+    def _loaded(self, pool, mid, *, last_access, size):
+        """Mark an entry loaded with a known age and freeable size."""
+        engine = MagicMock()
+        engine.has_active_requests.return_value = False
+        entry = pool._entries[mid]
+        entry.engine = engine
+        entry.last_access = last_access
+        entry.actual_size = size
+        return entry
+
+    def test_victim_prefers_coldest_that_alone_frees_enough(
+        self, pool_with_entries
+    ):
+        """A single sufficient model is evicted instead of several small ones.
+
+        Pure LRU would take model-a (coldest) and free only 100 bytes, leaving
+        the caller's loop to come back and unload model-b as well.
+        """
+        self._loaded(pool_with_entries, "model-a", last_access=100, size=100)
+        self._loaded(pool_with_entries, "model-b", last_access=200, size=5000)
+
+        victim = pool_with_entries._find_lru_victim(bytes_needed=1000)
+        assert victim == "model-b"
+
+    def test_victim_is_coldest_among_sufficient(self, pool_with_entries):
+        """When several models each suffice, age still decides."""
+        self._loaded(pool_with_entries, "model-a", last_access=100, size=4000)
+        self._loaded(pool_with_entries, "model-b", last_access=200, size=5000)
+
+        victim = pool_with_entries._find_lru_victim(bytes_needed=1000)
+        assert victim == "model-a"
+
+    def test_victim_falls_back_to_largest_when_none_suffices(
+        self, pool_with_entries
+    ):
+        """No single model covers the need, so free the most per eviction."""
+        self._loaded(pool_with_entries, "model-a", last_access=100, size=100)
+        self._loaded(pool_with_entries, "model-b", last_access=200, size=900)
+
+        victim = pool_with_entries._find_lru_victim(bytes_needed=5000)
+        assert victim == "model-b"
+
+    def test_victim_without_bytes_needed_is_plain_lru(self, pool_with_entries):
+        """Callers that pass nothing keep the original size-blind behaviour."""
+        self._loaded(pool_with_entries, "model-a", last_access=100, size=100)
+        self._loaded(pool_with_entries, "model-b", last_access=200, size=5000)
+
+        assert pool_with_entries._find_lru_victim() == "model-a"
+
     def test_pinned_model_skipped_for_eviction(self, pool_with_entries):
         """Test that pinned models are skipped during eviction."""
         # model-a is pinned and older


### PR DESCRIPTION
## Problem

`_find_lru_victim` and `_find_lru_prefill_eviction_victim` sort candidates purely by `last_access`, so victim selection never looks at how much memory a model would actually free. The callers loop until enough headroom exists, so this converges — but on a host serving models that differ by an order of magnitude it disturbs far more models than necessary, and each one has to be reloaded later.

Concretely, with a 1.7GB TTS model, an 8GB LLM and a 17GB LLM all idle and 20GB needed, the loop evicts all three (26.7GB) when the 17GB model alone would have sufficed.

I hit this on a 128GB M-series box running a 68GB LLM alongside a 17GB fallback, a 7B VLM and a 1.7B TTS model.

## Change

Both selectors now build `(last_access, freeable_bytes, model_id)` and defer to a shared `_pick_eviction_victim`:

- prefer the **coldest model that on its own covers `bytes_needed`**, so a pressure event disturbs a single model;
- fall back to the **largest** when nothing is big enough, so the caller's loop converges in fewer rounds.

Freeable size reuses `entry.actual_size` where the loader has measured it and `_entry_resident_size` otherwise, so no new bookkeeping is introduced.

`bytes_needed` defaults to `0`, which reproduces the previous pure-LRU selection exactly. The two call sites pass the headroom they had already computed (`projected - evict_target`, `current + predicted - target`).

## Tests

Four cases added to `TestLRUEviction`:

- a single sufficient model is chosen over the coldest insufficient one;
- among several sufficient models, age still decides;
- falls back to the largest when none suffices;
- omitting `bytes_needed` keeps plain LRU.

All four pass. The pre-existing failures in `tests/test_engine_pool.py` in my environment (missing async plugin) are identical with and without this change — I diffed the failure lists to confirm nothing new breaks.