### PR TITLE
feat(integrations): run Copilot BYOK launches offline

### DIFF
--- a/omlx/integrations/copilot.py
+++ b/omlx/integrations/copilot.py
@@ -9,7 +9,7 @@ from omlx.utils.install import get_cli_command_prefix
 
 
 class CopilotIntegration(Integration):
-    """Copilot integration using custom provider BYOK environment variables."""
+    """Copilot integration using custom provider BYOK offline mode."""
 
     def __init__(self):
         super().__init__(
@@ -30,6 +30,7 @@ class CopilotIntegration(Integration):
         env = self._scrubbed_env()
         env["COPILOT_PROVIDER_BASE_URL"] = ctx.openai_base_url
         env["COPILOT_PROVIDER_TYPE"] = "openai"
+        env["COPILOT_OFFLINE"] = "true"
 
         # Copilot CLI appears to have issues with the completions endpoint, responses appears to work as expected.
         env["COPILOT_PROVIDER_WIRE_API"] = "responses"

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1967,6 +1967,7 @@ class TestCopilotIntegration:
         assert captured["argv"] == ["copilot"]
         assert env["COPILOT_PROVIDER_BASE_URL"] == "http://127.0.0.1:8000/v1"
         assert env["COPILOT_PROVIDER_TYPE"] == "openai"
+        assert env["COPILOT_OFFLINE"] == "true"
         assert env["COPILOT_PROVIDER_WIRE_API"] == "responses"
         assert env["COPILOT_PROVIDER_BEARER_TOKEN"] == "secret"
         assert env["COPILOT_MODEL"] == "qwen3.5"
@@ -2007,6 +2008,7 @@ class TestCopilotIntegration:
             copilot.launch(ctx(port=8000, api_key="key", model=""))
 
         env = captured["env"]
+        assert env["COPILOT_OFFLINE"] == "true"
         assert "COPILOT_MODEL" not in env
         assert "COPILOT_PROVIDER_MODEL_ID" not in env
         assert "COPILOT_PROVIDER_WIRE_MODEL" not in env


### PR DESCRIPTION
## Summary

- set `COPILOT_OFFLINE=true` when launching Copilot CLI with the custom oMLX BYOK provider
- prevent provider fallback to GitHub-hosted services
- cover the launch environment in integration tests

## Validation

- `UV_PYTHON=python3.12 uv run --python python3.12 pytest tests/test_integrations.py -q`
- `UV_PYTHON=python3.12 uv run --python python3.12 ruff check omlx/integrations/copilot.py tests/test_integrations.py`