### PR TITLE
fix: complete engine unload after cancellation

### DIFF
--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -299,6 +299,7 @@ class EnginePool:
         self._load_time_observations: int = 0
         self._lease_release_tasks: set[asyncio.Task[None]] = set()
         self._pending_unload_tasks: dict[str, asyncio.Task[None]] = {}
+        self._engine_unload_tasks: dict[str, asyncio.Task[None]] = {}
         self._shutting_down = False
         self.configure_hot_cache_budget()
 
@@ -2223,7 +2224,83 @@ class EnginePool:
                 return True
         return False
 
+    async def _run_deferred_mlx_cleanup_if_idle(self) -> None:
+        """Run cleanup deferred by an unload once all leased work has drained."""
+        if not self._deferred_mlx_cleanup:
+            return
+        if any(
+            entry.is_loading
+            or entry.in_use > 0
+            or self._entry_has_active_requests(entry)
+            for entry in self._entries.values()
+            if entry.engine is not None or entry.is_loading
+        ):
+            return
+
+        gc.collect()
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(get_mlx_executor(), _clear_mlx_cache_sync)
+        self._deferred_mlx_cleanup = False
+        self._wake_process_memory_enforcer()
+
+    def _finish_engine_unload_task(
+        self,
+        model_id: str,
+        task: asyncio.Task[None],
+    ) -> None:
+        if self._engine_unload_tasks.get(model_id) is task:
+            self._engine_unload_tasks.pop(model_id, None)
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            logger.error("Engine unload task was cancelled for '%s'", model_id)
+        except Exception:
+            logger.exception("Engine unload task failed for '%s'", model_id)
+
+    async def _drain_engine_unload_tasks(self) -> None:
+        while self._engine_unload_tasks:
+            tasks = tuple(self._engine_unload_tasks.values())
+            await asyncio.gather(*tasks, return_exceptions=True)
+
     async def _unload_engine(self, model_id: str) -> None:
+        """Run one cancellation-safe unload for a model.
+
+        Model teardown has cancellation points after the pool entry is cleared
+        but before GC, Metal cache reclaim, and memory accounting finish. Letting
+        caller cancellation stop there can strand an engine's tensors with no
+        registry entry capable of unloading them later. Keep the teardown in a
+        dedicated single-flight task and delay cancellation propagation until it
+        has completed.
+        """
+        task = self._engine_unload_tasks.get(model_id)
+        if task is None:
+            task = asyncio.create_task(
+                self._unload_engine_impl(model_id),
+                name=f"engine-unload:{model_id}",
+            )
+            self._engine_unload_tasks[model_id] = task
+            task.add_done_callback(
+                lambda completed, mid=model_id: self._finish_engine_unload_task(
+                    mid, completed
+                )
+            )
+
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            # Preserve the caller's cancellation, but only after teardown has
+            # reached a consistent state. This also keeps any caller-held pool
+            # lock in place until the unload task finishes.
+            while not task.done():
+                try:
+                    await asyncio.shield(task)
+                except asyncio.CancelledError:
+                    continue
+                except Exception:
+                    break
+            raise
+
+    async def _unload_engine_impl(self, model_id: str) -> None:
         """
         Immediately stop and unload an engine with memory settle barrier.
 
@@ -3032,6 +3109,7 @@ class EnginePool:
         if pending_tasks:
             await asyncio.gather(*pending_tasks, return_exceptions=True)
         await self._drain_lease_release_tasks()
+        await self._drain_engine_unload_tasks()
         async with self._lock:
             for model_id in list(self._entries.keys()):
                 entry = self._entries.get(model_id)

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -2224,25 +2224,6 @@ class EnginePool:
                 return True
         return False
 
-    async def _run_deferred_mlx_cleanup_if_idle(self) -> None:
-        """Run cleanup deferred by an unload once all leased work has drained."""
-        if not self._deferred_mlx_cleanup:
-            return
-        if any(
-            entry.is_loading
-            or entry.in_use > 0
-            or self._entry_has_active_requests(entry)
-            for entry in self._entries.values()
-            if entry.engine is not None or entry.is_loading
-        ):
-            return
-
-        gc.collect()
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(get_mlx_executor(), _clear_mlx_cache_sync)
-        self._deferred_mlx_cleanup = False
-        self._wake_process_memory_enforcer()
-
     def _finish_engine_unload_task(
         self,
         model_id: str,

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -2978,6 +2978,75 @@ class TestMemorySettleBarrier:
         assert pool._current_model_memory == initial_memory - est_size
 
     @pytest.mark.asyncio
+    async def test_unload_finishes_after_caller_cancellation(
+        self, pool_with_loaded_model
+    ):
+        """Cancellation cannot strand tensors after the entry is detached."""
+        pool = pool_with_loaded_model
+        entry = pool._entries["model-a"]
+        stop_started = asyncio.Event()
+        allow_stop = asyncio.Event()
+
+        async def blocking_stop():
+            stop_started.set()
+            await allow_stop.wait()
+
+        entry.engine.stop.side_effect = blocking_stop
+        active_memory_values = iter([10 * 1024**3, 5 * 1024**3])
+
+        with (
+            patch("omlx.engine_pool.mx") as mock_mx,
+            patch("omlx.engine_pool.get_mlx_executor", return_value=None),
+        ):
+            mock_mx.get_active_memory.side_effect = lambda: next(
+                active_memory_values, 5 * 1024**3
+            )
+            caller = asyncio.create_task(pool._unload_engine("model-a"))
+            await stop_started.wait()
+
+            caller.cancel()
+            await asyncio.sleep(0)
+            assert not caller.done()
+
+            caller.cancel()
+            await asyncio.sleep(0)
+            assert not caller.done()
+
+            allow_stop.set()
+            with pytest.raises(asyncio.CancelledError):
+                await caller
+
+        assert entry.engine is None
+        assert pool._current_model_memory == 0
+        assert pool._engine_unload_tasks == {}
+
+    @pytest.mark.asyncio
+    async def test_unload_failure_does_not_replace_caller_cancellation(
+        self, pool_with_loaded_model
+    ):
+        """A teardown failure is logged without masking caller cancellation."""
+        pool = pool_with_loaded_model
+        unload_started = asyncio.Event()
+        allow_failure = asyncio.Event()
+
+        async def failing_unload(_model_id):
+            unload_started.set()
+            await allow_failure.wait()
+            raise RuntimeError("teardown failed")
+
+        pool._unload_engine_impl = failing_unload
+        caller = asyncio.create_task(pool._unload_engine("model-a"))
+        await unload_started.wait()
+
+        caller.cancel()
+        allow_failure.set()
+        with pytest.raises(asyncio.CancelledError):
+            await caller
+        await asyncio.sleep(0)
+
+        assert pool._engine_unload_tasks == {}
+
+    @pytest.mark.asyncio
     async def test_settle_takes_multiple_rounds(self, pool_with_loaded_model):
         """Test settle barrier succeeds after multiple rounds of GC."""
         pool = pool_with_loaded_model


### PR DESCRIPTION
## Summary

- run each model unload as a cancellation-safe single-flight task
- delay caller cancellation until teardown reaches a consistent state
- drain outstanding unload tasks during pool shutdown
- cover repeated cancellation and teardown failure behavior

## Validation

- `UV_PYTHON=python3.12 uv run --python python3.12 pytest tests/test_engine_pool.py -q`
- focused disconnect and broader unload/eviction/shutdown tests
- independent concurrency and deadlock review