### PR TITLE
fix(engine): create MLX streams on their worker threads

### DIFF
--- a/omlx/engine_core.py
+++ b/omlx/engine_core.py
@@ -129,6 +129,15 @@ def _init_mlx_thread() -> None:
     logger.info(f"MLX executor thread initialized: generation_stream = {stream}")
 
 
+def _create_mlx_thread_stream() -> Any:
+    """Create the per-engine stream on the MLX executor thread that owns it."""
+    stream = mx.new_stream(mx.default_device())
+    if hasattr(mx, "set_default_stream"):
+        mx.set_default_stream(stream)
+    logger.info("MLX engine thread initialized: stream = %s", stream)
+    return stream
+
+
 def get_mlx_executor() -> concurrent.futures.ThreadPoolExecutor:
     """Get or create the global MLX executor (lazy singleton).
 
@@ -235,12 +244,13 @@ class EngineCore:
 
         # Per-engine executor with dedicated mx.Stream (#1248).
         # Each EngineCore gets its own thread + GPU stream so different
-        # models can run scheduler.step() concurrently.
-        self._mlx_stream = mx.new_thread_local_stream(mx.default_device())
+        # models can run scheduler.step() concurrently. The stream must be
+        # created on the executor thread that uses it.
         self._mlx_executor = concurrent.futures.ThreadPoolExecutor(
             max_workers=1,
             thread_name_prefix=f"mlx-engine-{self._engine_id[:8]}",
         )
+        self._mlx_stream = self._mlx_executor.submit(_create_mlx_thread_stream).result()
 
         # Create scheduler with per-engine stream
         scheduler_config = self.config.scheduler_config or SchedulerConfig()
@@ -1046,39 +1056,43 @@ class EngineCore:
         Returns:
             List of RequestOutput in same order as prompts
         """
-        import uuid as uuid_module
-
-        from .request import Request
-
         if sampling_params is None:
             sampling_params = SamplingParams()
 
-        # Add all requests to scheduler
-        request_ids = []
-        for prompt in prompts:
-            request_id = str(uuid_module.uuid4())
-            request = Request(
-                request_id=request_id,
-                prompt=prompt,
-                sampling_params=sampling_params,
-            )
-            self.scheduler.add_request(request)
-            request_ids.append(request_id)
+        def _run_batch_sync() -> List[RequestOutput]:
+            import uuid as uuid_module
 
-        # Process until all done - direct scheduler access, no async overhead
-        results: Dict[str, RequestOutput] = {}
-        while self.scheduler.has_requests():
-            output = self.scheduler.step()
-            for req_output in output.outputs:
-                if req_output.finished:
-                    results[req_output.request_id] = req_output
+            from .request import Request
 
-        # Cleanup
-        for rid in request_ids:
-            self.scheduler.remove_finished_request(rid)
+            # Add all requests to scheduler
+            request_ids = []
+            for prompt in prompts:
+                request_id = str(uuid_module.uuid4())
+                request = Request(
+                    request_id=request_id,
+                    prompt=prompt,
+                    sampling_params=sampling_params,
+                )
+                self.scheduler.add_request(request)
+                request_ids.append(request_id)
 
-        # Return in original order
-        return [results[rid] for rid in request_ids]
+            # Process until all done on the engine's MLX worker thread, where
+            # self._mlx_stream is valid.
+            results: Dict[str, RequestOutput] = {}
+            while self.scheduler.has_requests():
+                output = self.scheduler.step()
+                for req_output in output.outputs:
+                    if req_output.finished:
+                        results[req_output.request_id] = req_output
+
+            # Cleanup
+            for rid in request_ids:
+                self.scheduler.remove_finished_request(rid)
+
+            # Return in original order
+            return [results[rid] for rid in request_ids]
+
+        return self._mlx_executor.submit(_run_batch_sync).result()
 
     def get_stats(self) -> Dict[str, Any]:
         """Get engine statistics."""

--- a/tests/test_per_engine_threads.py
+++ b/tests/test_per_engine_threads.py
@@ -1,6 +1,7 @@
 """Tests for per-engine thread isolation (issue #1248)."""
 
 import concurrent.futures
+import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -249,6 +250,94 @@ class TestPerEngineExecutor:
             assert engine.scheduler._stream is engine._mlx_stream
 
             engine.close()
+
+    def test_engine_stream_created_on_executor_thread(self):
+        """The per-engine MLX stream must be owned by the worker thread."""
+        mock_model = MagicMock()
+        mock_model.model_type = "test"
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.eos_token_id = 0
+        main_thread_id = threading.get_ident()
+        stream = object()
+        created_on = []
+
+        def create_stream():
+            created_on.append((threading.get_ident(), threading.current_thread().name))
+            return stream
+
+        with patch("omlx.engine_core.get_registry") as mock_registry, patch(
+            "omlx.engine_core._create_mlx_thread_stream", side_effect=create_stream
+        ):
+            mock_registry.return_value.acquire.return_value = True
+
+            engine = EngineCore(mock_model, mock_tokenizer)
+            try:
+                assert engine._mlx_stream is stream
+                assert engine.scheduler._stream is stream
+                assert created_on
+                thread_id, thread_name = created_on[0]
+                assert thread_id != main_thread_id
+                assert thread_name.startswith("mlx-engine-")
+            finally:
+                engine.close()
+
+    def test_generate_batch_sync_runs_on_engine_thread(self):
+        """Synchronous generation must retain the engine stream's affinity."""
+        mock_model = MagicMock()
+        mock_model.model_type = "test"
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.eos_token_id = 0
+        caller_thread_id = threading.get_ident()
+
+        class SyncScheduler:
+            def __init__(self):
+                self.pending = []
+                self.thread_ids = []
+
+            def add_request(self, request):
+                self.thread_ids.append(threading.get_ident())
+                self.pending.append(request)
+
+            def has_requests(self):
+                return bool(self.pending)
+
+            def step(self):
+                self.thread_ids.append(threading.get_ident())
+                request = self.pending.pop(0)
+                return SimpleNamespace(
+                    outputs=[
+                        SimpleNamespace(
+                            request_id=request.request_id,
+                            finished=True,
+                        )
+                    ]
+                )
+
+            def remove_finished_request(self, request_id):
+                self.thread_ids.append(threading.get_ident())
+
+            def shutdown(self):
+                pass
+
+            def deep_reset(self):
+                pass
+
+        with patch("omlx.engine_core.get_registry") as mock_registry:
+            mock_registry.return_value.acquire.return_value = True
+            engine = EngineCore(mock_model, mock_tokenizer)
+            scheduler = SyncScheduler()
+            engine.scheduler = scheduler
+            worker_thread_id = engine._mlx_executor.submit(threading.get_ident).result()
+
+            try:
+                results = engine.generate_batch_sync(["one", "two"])
+
+                assert len(results) == 2
+                assert scheduler.thread_ids
+                assert all(thread_id == worker_thread_id for thread_id in scheduler.thread_ids)
+                assert worker_thread_id != caller_thread_id
+            finally:
+                engine.close()
 
     def test_close_clears_compile_cache_then_shuts_down(self):
         """Normal path (compile-cache clear available): close() clears the


### PR DESCRIPTION
## Summary

- create each engine MLX stream on the dedicated executor thread that uses it
- set that thread default stream before scheduler work begins
- run synchronous batch generation on the same worker to preserve stream affinity
- add focused thread-ownership regressions

## Validation

- UV_PYTHON=python3.12 uv run --python python3.12 pytest tests/test_per_engine_threads.py -v
- UV_PYTHON=python3.12 uv run --python python3.12 pytest tests/test_engine_core.py tests/test_scheduler.py -q
- independent MLX 0.32 stream-affinity review