### PR TITLE
fix(engine): resolve bare DFlash draft model names against the local pool

### DIFF
--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -243,6 +243,23 @@ class EngineEntry:
     load_failure_at: float | None = None
 
 
+def _resolve_local_draft_model_path(
+    pool_entries: dict[str, EngineEntry], draft_ref: str | None
+) -> str | None:
+    """Resolve a bare local draft model name against the discovered pool.
+
+    Mirrors the ``vlm_mtp_draft_model`` resolution (see the VLM MTP load
+    path): a reference that matches a discovered local model id is replaced
+    by its absolute model path, so the value is never passed to dflash-mlx
+    as a Hub repo id (issue #3019). Unmatched values -- HF repo ids or
+    absolute paths -- pass through unchanged.
+    """
+    if not draft_ref:
+        return draft_ref
+    entry = pool_entries.get(draft_ref)
+    return entry.model_path if entry else draft_ref
+
+
 class EnginePool:
     """
     Manages multiple model engines with LRU-based memory management.
@@ -2576,9 +2593,18 @@ class EnginePool:
                     try:
                         from .engine.dflash import DFlashEngine
 
+                        # Bare local model names (the form the admin UI
+                        # accepts) must resolve against the discovered pool
+                        # before reaching dflash-mlx, which otherwise treats
+                        # them as Hub repo ids and calls snapshot_download()
+                        # (issue #3019). Mirrors the vlm_mtp_draft_model
+                        # resolution below; unmatched values pass through.
+                        draft_model_path = _resolve_local_draft_model_path(
+                            self._entries, dflash_draft
+                        )
                         engine = DFlashEngine(
                             model_name=entry.model_path,
-                            draft_model_path=dflash_draft,
+                            draft_model_path=draft_model_path,
                             draft_quant_enabled=getattr(
                                 model_settings, "dflash_draft_quant_enabled", False
                             ),
@@ -2599,7 +2625,7 @@ class EnginePool:
                             ),
                         )
                         logger.info(
-                            f"DFlash enabled for {model_id}, draft={dflash_draft}"
+                            f"DFlash enabled for {model_id}, draft={draft_model_path}"
                         )
                     except ImportError:
                         logger.warning(

--- a/tests/test_dflash_draft_resolution.py
+++ b/tests/test_dflash_draft_resolution.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the DFlash draft-model path resolution (issue #3019).
+
+A bare local model name (``dflash_draft_model="Qwen3.8-27B-DFlash2"``, the
+form the admin UI accepts) must resolve against the discovered pool before
+reaching dflash-mlx, which otherwise treats it as a Hub repo id and calls
+``snapshot_download()`` -- silently falling back to the plain engine on
+networks where huggingface.co is unreachable.
+"""
+
+from __future__ import annotations
+
+from omlx.engine_pool import EngineEntry, _resolve_local_draft_model_path
+
+
+def _make_entry(model_id: str, model_path: str) -> EngineEntry:
+    return EngineEntry(
+        model_id=model_id,
+        model_path=model_path,
+        model_type="llm",
+        engine_type="batched",
+        estimated_size=0,
+    )
+
+
+class TestResolveLocalDraftModelPath:
+    def test_bare_name_hits_pool_entry(self):
+        """A bare local name matching a discovered model resolves to its path."""
+        pool = {
+            "Qwen3.8-27B-DFlash2": _make_entry(
+                "Qwen3.8-27B-DFlash2", "/models/Qwen3.8-27B-DFlash2"
+            )
+        }
+        assert (
+            _resolve_local_draft_model_path(pool, "Qwen3.8-27B-DFlash2")
+            == "/models/Qwen3.8-27B-DFlash2"
+        )
+
+    def test_unmatched_repo_id_passes_through(self):
+        """HF repo ids are a legitimate input and must stay untouched."""
+        pool = {
+            "Qwen3.8-27B-DFlash2": _make_entry(
+                "Qwen3.8-27B-DFlash2", "/models/Qwen3.8-27B-DFlash2"
+            )
+        }
+        assert (
+            _resolve_local_draft_model_path(pool, "jundot/Qwen3.8-27B-DFlash2")
+            == "jundot/Qwen3.8-27B-DFlash2"
+        )
+
+    def test_unmatched_bare_name_passes_through(self):
+        """No entry -> original value, so dflash-mlx keeps its own fallback."""
+        assert _resolve_local_draft_model_path({}, "Qwen3.8-27B-DFlash2") == (
+            "Qwen3.8-27B-DFlash2"
+        )
+
+    def test_absolute_path_passes_through(self):
+        assert _resolve_local_draft_model_path(
+            {}, "/models/Qwen3.8-27B-DFlash2"
+        ) == "/models/Qwen3.8-27B-DFlash2"
+
+    def test_empty_and_none_return_unchanged(self):
+        pool = {"any": _make_entry("any", "/models/any")}
+        assert _resolve_local_draft_model_path(pool, None) is None
+        assert _resolve_local_draft_model_path(pool, "") == ""


### PR DESCRIPTION
## Problem

`dflash_draft_model` accepts the same **bare local model name** form the admin UI (and `vlm_mtp_draft_model`) accept, e.g. `Qwen3.8-27B-DFlash2` for a directory under the models root. But the DFlash branch passed that string straight through to dflash-mlx, which only tries `Path(ref).expanduser().exists()` (relative to the server cwd) and then falls back to `snapshot_download(repo_id=ref)`.

On networks where huggingface.co is unreachable the download times out, the engine **silently falls back to the plain batched/VLM engine**, and the benchmark upload still tags the run with the `dflash` acceleration flag — results are indistinguishable from a real DFlash run (#3019).

## Fix

Resolve `dflash_draft_model` against the discovered engine pool (`self._entries`) **before** constructing `DFlashEngine`, mirroring the existing `vlm_mtp_draft_model` resolution (`engine_pool.py` VLM MTP load path):

- value matches a discovered local model id → replaced by its absolute `model_path`
- unmatched values (HF repo ids, absolute paths, unknown bare names) → pass through unchanged, so existing Hub-based usage is untouched

Extracted as `_resolve_local_draft_model_path()` for direct unit coverage.

## Verification

- **Unit tests** (new `tests/test_dflash_draft_resolution.py`, 5 cases): pool hit → absolute path; unmatched repo id / bare name / absolute path → unchanged; empty/None → unchanged. All pass.
- **Related subset**: `test_dflash_engine` + `test_dflash_lifecycle` + `test_cluster_engine_pool` + new tests — 149 passed.
- **Full gate**: `pytest tests/ -m "not slow and not integration"` → 10569 passed, 6 failed, all six are the known environment-only failures already tracked (cluster SSH supervisor ×2, cluster seams, GDN sidecar ×2, vlm_mtp thinking-budget e2e — reproduced independently of this change).
- **Smoke** (`--base-path` server, `dflash_draft_model: "Qwen3___5-0___8B-8bit"` bare local name):
  - Before this change the log would show `draft=Qwen3___5-0___8B-8bit` (bare) and then a `snapshot_download` ConnectTimeout.
  - After: `INFO omlx.engine_pool - DFlash enabled for Qwen3___5-0___8B-8bit, draft=/Users/y/models/mlx-community/Qwen3___5-0___8B-8bit` — resolved to the absolute local path, no network attempt.

Closes #3019

## Follow-up question (PR-B) — needs your call

The fallback itself remains **silent**: when DFlash fails to start for *any* reason, only a WARNING log is emitted, `/api/status` exposes nothing, and the benchmark upload still tags the run `dflash` because the flag is read from `model_settings.dflash_enabled`, not from what actually loaded. This is exactly what made the root cause here hard to spot.

Open question for the maintainer / reporter: would a follow-up PR be wanted that

1. records the fallback reason on the engine entry / run snapshot when DFlash fails, and
2. stops the benchmark upload from claiming `dflash` acceleration when the run was actually served by the plain engine (flag computed from effective engine, not settings)?

Risk consideration: the upload projection is built from the run-start settings snapshot (models may be unloaded by upload time), so the flag would need to follow the snapshot; changing tag semantics could affect existing recorded benchmark rows. If this is considered out of scope or risky, I'm happy to leave the one-line WARNING as the contract.
