### PR TITLE
fix(memory): warn when a custom ceiling is set but tier is not custom

### DIFF
--- a/omlx/process_memory_enforcer.py
+++ b/omlx/process_memory_enforcer.py
@@ -367,6 +367,22 @@ class ProcessMemoryEnforcer:
         self._memory_guard_custom_ceiling_bytes = max(
             0, int(memory_guard_custom_ceiling_gb * 1024**3)
         )
+        if (
+            memory_guard_custom_ceiling_gb > 0
+            and self._memory_guard_tier != "custom"
+        ):
+            # Users editing settings.json directly have no way to discover
+            # that the custom ceiling only applies to tier == "custom" (it
+            # is documented only in this __init__ docstring), so a mis-set
+            # ceiling silently no-ops and the enforcer runs on its computed
+            # limit instead (issue #2928). Warn loudly at construction.
+            logger.warning(
+                "Custom ceiling %.1f GB is set but ignored because "
+                "memory_guard_tier is '%s' (custom ceiling is only used "
+                "when tier='custom')",
+                memory_guard_custom_ceiling_gb,
+                self._memory_guard_tier,
+            )
         self._active_poll_interval = poll_interval
         self._loaded_idle_poll_interval = 10.0
         self._unloaded_idle_poll_interval = 30.0

--- a/tests/test_process_memory_enforcer.py
+++ b/tests/test_process_memory_enforcer.py
@@ -2,6 +2,7 @@
 """Tests for ProcessMemoryEnforcer."""
 
 import asyncio
+import logging
 from contextlib import suppress
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -2977,3 +2978,52 @@ class TestPressureReclaimGrace:
             await enforcer._check_and_enforce()
         shrink.assert_called_once()
         engine.abort_all_requests.assert_awaited_once()
+
+
+class TestCustomCeilingWarning:
+    """Construction-time warning when a custom ceiling can never apply.
+
+    ``memory_guard_custom_ceiling_gb`` is only consumed by the enforcer
+    when ``memory_guard_tier == "custom"`` (issue #2928). Users editing
+    settings.json directly have no other way to discover that, so a mis-set
+    ceiling silently no-ops and the enforcer runs on its computed limit.
+    """
+
+    def test_custom_ceiling_ignored_warns_when_tier_is_not_custom(
+        self, caplog, mock_engine_pool
+    ):
+        with caplog.at_level(
+            logging.WARNING, logger="omlx.process_memory_enforcer"
+        ):
+            _make_enforcer(
+                mock_engine_pool,
+                tier="balanced",
+                memory_guard_custom_ceiling_gb=60.0,
+            )
+        assert any(
+            "Custom ceiling" in r.message for r in caplog.records
+        )
+
+    def test_custom_tier_consumes_ceiling_without_warning(
+        self, caplog, mock_engine_pool
+    ):
+        with caplog.at_level(
+            logging.WARNING, logger="omlx.process_memory_enforcer"
+        ):
+            _make_enforcer(
+                mock_engine_pool,
+                tier="custom",
+                memory_guard_custom_ceiling_gb=60.0,
+            )
+        assert not any(
+            "Custom ceiling" in r.message for r in caplog.records
+        )
+
+    def test_zero_ceiling_no_warning(self, caplog, mock_engine_pool):
+        with caplog.at_level(
+            logging.WARNING, logger="omlx.process_memory_enforcer"
+        ):
+            _make_enforcer(mock_engine_pool, tier="balanced")
+        assert not any(
+            "Custom ceiling" in r.message for r in caplog.records
+        )


### PR DESCRIPTION
## Problem

`memory_guard_custom_ceiling_gb` is only consumed when `memory_guard_tier == "custom"`. That semantic lives solely in the `ProcessMemoryEnforcer.__init__` docstring, so a user editing `settings.json` directly can set a ceiling that is **silently ignored**: the enforcer runs on its computed limit instead, and nothing warns about it. In the reporter's case (issue #2928; the linked jetsam timeline in #1691) a leaking server ballooned to 208 GB on a 256 GB machine because the intended 60 GB ceiling never participated in any computation — at `tier=balanced` the ceiling is derived from live system memory (191.8 GB in the report), so every watermark stayed far below the leak.

## Fix

Log a **WARNING** at enforcer construction when a custom ceiling is set but the tier is not `"custom"`, so the misconfiguration is visible at startup instead of after the fact:

```
Custom ceiling 60.0 GB is set but ignored because memory_guard_tier is 'balanced' (custom ceiling is only used when tier='custom')
```

No behavior change otherwise. The tier is **deliberately NOT auto-switched** to `"custom"`: silently changing protection behavior would be worse than silently ignoring the setting (e.g. a too-small ceiling would start rejecting model loads the user never intended to restrict). If a user wants the 60 GB ceiling to matter, they set `memory_guard_tier: "custom"` — now they can see that from the log.

## Verification

- **Unit tests** (new `TestCustomCeilingWarning`): balanced+ceiling → warning; custom+ceiling → **no** warning (no false positives for correct configs); ceiling=0 → no warning. All pass; full enforcer/memory suite **254 passed**.
- **Full gate**: `pytest tests/ -m "not slow and not integration"` → 10567 passed, 6 failed — all six are the known environment-only failures already tracked (cluster SSH supervisor ×2, cluster seams, GDN sidecar ×2, vlm_mtp thinking-budget e2e; reproduced independently of this change)
- **Smoke**: real `--base-path` server with `tier=balanced` + `ceiling=60` logs the warning at startup with the exact wording above

Closes #2928

## Open question

The issue optionally suggests also surfacing the mismatch in the admin Memory settings UI (hint/grey-out on the custom-ceiling field when `tier != custom`). I left that out of this PR on purpose — say the word and I'll add it (note: UI strings go through the 9-language i18n pipeline per repo convention, so it is a slightly larger change).
