### PR TITLE
macOS: Show live serving activity and stats

### DIFF
--- a/apps/omlx-mac/Resources/Localizable.xcstrings
+++ b/apps/omlx-mac/Resources/Localizable.xcstrings
@@ -1091,6 +1091,30 @@
         }
       }
     },
+    "menubar.metric.metrics" : {
+      "comment" : "Header above scalar counters in an AVG or ALL serving metric popover",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serving Stats"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Статистика обслуживания"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服务统计"
+          }
+        }
+      }
+    },
     "menubar.metric.server_off" : {
       "comment" : "Note in a menubar metric popover while the server is not running",
       "extractionState" : "manual",
@@ -1111,6 +1135,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "服务器已关闭"
+          }
+        }
+      }
+    },
+    "menubar.metric.unavailable" : {
+      "comment" : "Note in an AVG or ALL popover when its scoped stats are unavailable",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serving stats are unavailable"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Статистика обслуживания недоступна"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服务统计不可用"
           }
         }
       }

--- a/apps/omlx-mac/Resources/Localizable.xcstrings
+++ b/apps/omlx-mac/Resources/Localizable.xcstrings
@@ -11,6 +11,174 @@
         }
       }
     },
+    "activity.badge.done" : {
+      "comment" : "Label on a request row that finished and is leaving the list",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Done"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Готово"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已完成"
+          }
+        }
+      }
+    },
+    "activity.badge.generating" : {
+      "comment" : "Pill on a model row emitting tokens",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generating"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Генерация"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "生成中"
+          }
+        }
+      }
+    },
+    "activity.badge.prefill" : {
+      "comment" : "Pill on a model row processing a prompt",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prefill"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Префилл"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "预填充"
+          }
+        }
+      }
+    },
+    "activity.badge.queued" : {
+      "comment" : "Pill on a model row whose requests are all still queued",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Queued"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В очереди"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "排队中"
+          }
+        }
+      }
+    },
+    "activity.badge.working" : {
+      "comment" : "Pill on a model row running a non-streaming request",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Working"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обработка"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "处理中"
+          }
+        }
+      }
+    },
+    "activity.eta" : {
+      "comment" : "Time remaining on a running prefill; placeholder is a duration",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ left"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "осталось %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "剩余 %@"
+          }
+        }
+      }
+    },
+    "activity.queued_detail" : {
+      "comment" : "Row for requests queued but not started; placeholder is the queue depth",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld waiting"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld в ожидании"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 个等待中"
+          }
+        }
+      }
+    },
     "appearance.model_scope.all" : {
       "comment" : "Models submenu scope option that lists the whole library",
       "extractionState" : "manual",

--- a/apps/omlx-mac/Resources/Localizable.xcstrings
+++ b/apps/omlx-mac/Resources/Localizable.xcstrings
@@ -9048,26 +9048,98 @@
         }
       }
     },
-    "menubar.stats.live_activity" : {
-      "comment" : "Section header inside the Serving Stats submenu for the current active request",
+    "menubar.stats.current_requests" : {
+      "comment" : "Section header inside Serving Stats for active and queued requests",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Live Activity"
+            "value" : "Current Requests"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Текущая активность"
+            "value" : "Текущие запросы"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "实时活动"
+            "value" : "当前请求"
+          }
+        }
+      }
+    },
+    "menubar.stats.more_requests" : {
+      "comment" : "Current Requests row showing active requests omitted from the capped list; placeholder is the count",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld more requests"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Еще %lld запросов"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "还有 %lld 个请求"
+          }
+        }
+      }
+    },
+    "menubar.stats.no_current_requests" : {
+      "comment" : "Disabled empty state in Serving Stats when no requests are active or queued",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No active requests"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет активных запросов"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有活动请求"
+          }
+        }
+      }
+    },
+    "menubar.stats.queued_requests" : {
+      "comment" : "Current Requests row showing how many requests have not started; placeholder is the count",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld queued requests"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld запросов в очереди"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 个请求排队中"
           }
         }
       }

--- a/apps/omlx-mac/Sources/AppView/Screens/ModelsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ModelsScreen.swift
@@ -20,6 +20,7 @@ struct ModelsScreen: View {
         VStack(alignment: .leading, spacing: 0) {
             ActiveModelsSection(
                 models: vm.activeModels,
+                activity: vm.activity,
                 onUnload: { id in vm.unload(id: id, client: services.client) }
             )
 
@@ -77,6 +78,7 @@ struct ModelsScreen: View {
 
 private struct ActiveModelsSection: View {
     let models: [ModelDTO]
+    let activity: ModelActivityPoller
     let onUnload: (String) -> Void
 
     @Environment(\.omlxTheme) private var theme
@@ -106,35 +108,42 @@ private struct ActiveModelsSection: View {
                 }
             } else {
                 ForEach(Array(models.enumerated()), id: \.element.id) { idx, m in
+                    let live = activity.snapshot(for: m.id)
                     FreeRow(isLast: idx == models.count - 1) {
-                        HStack(spacing: 10) {
-                            if m.pinned == true {
-                                Image(systemName: "pin.fill")
-                                    .font(.system(size: 11))
+                        VStack(alignment: .leading, spacing: 6) {
+                            HStack(spacing: 10) {
+                                if m.pinned == true {
+                                    Image(systemName: "pin.fill")
+                                        .font(.system(size: 11))
+                                        .foregroundStyle(theme.textSecondary)
+                                }
+                                Text(m.displayTitle)
+                                    .font(.omlxText(13, weight: .medium))
+                                    .foregroundStyle(theme.text)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                                Spacer(minLength: 8)
+                                ActiveBadge(model: m, live: live)
+                                Text(m.estimatedSizeFormatted ?? formatBytes(m.estimatedSize))
+                                    .font(.omlxMono(11))
                                     .foregroundStyle(theme.textSecondary)
+                                    .frame(minWidth: 60, alignment: .trailing)
+                                Button {
+                                    onUnload(m.id)
+                                } label: {
+                                    Image(systemName: "eject")
+                                        .font(.system(size: 12))
+                                }
+                                .buttonStyle(.omlx(.plain, size: .small))
+                                .help(String(localized: "models.active.unload.help",
+                                             defaultValue: "Unload model",
+                                             comment: "Tooltip on the eject button that unloads an active model"))
                             }
-                            Text(m.displayTitle)
-                                .font(.omlxText(13, weight: .medium))
-                                .foregroundStyle(theme.text)
-                                .lineLimit(1)
-                                .truncationMode(.middle)
-                            Spacer(minLength: 8)
-                            ActiveBadge(model: m)
-                            Text(m.estimatedSizeFormatted ?? formatBytes(m.estimatedSize))
-                                .font(.omlxMono(11))
-                                .foregroundStyle(theme.textSecondary)
-                                .frame(minWidth: 60, alignment: .trailing)
-                            Button {
-                                onUnload(m.id)
-                            } label: {
-                                Image(systemName: "eject")
-                                    .font(.system(size: 12))
+                            if let live, !m.isLoading {
+                                ModelActivityList(snapshot: live)
                             }
-                            .buttonStyle(.omlx(.plain, size: .small))
-                            .help(String(localized: "models.active.unload.help",
-                                         defaultValue: "Unload model",
-                                         comment: "Tooltip on the eject button that unloads an active model"))
                         }
+                        .animation(.easeInOut(duration: 0.18), value: live != nil)
                     }
                 }
             }
@@ -144,11 +153,15 @@ private struct ActiveModelsSection: View {
 
 private struct ActiveBadge: View {
     let model: ModelDTO
+    var live: ModelActivitySnapshot? = nil
+
     @Environment(\.omlxTheme) private var theme
 
     var body: some View {
         if model.isLoading {
             StatusPill(status: .starting)
+        } else if let live, live.isBusy {
+            ModelActivityBadge(snapshot: live)
         } else if model.loaded {
             StatusPill(status: .custom(color: theme.greenDot,
                                        label: String(localized: "models.active.badge.loaded",

--- a/apps/omlx-mac/Sources/AppView/Screens/StatusScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/StatusScreen.swift
@@ -65,7 +65,8 @@ struct StatusScreen: View {
             SectionHeader(String(localized: "status.section.active_now",
                                   defaultValue: "Active Now",
                                   comment: "Section header for the currently active models list"))
-            ActiveNowList(models: vm.stats?.activeModels.models ?? [])
+            ActiveNowList(models: vm.stats?.activeModels.models ?? [],
+                          activity: vm.activity)
 
             SectionHeader(String(localized: "status.section.system",
                                   defaultValue: "System",
@@ -527,6 +528,9 @@ private struct ThermalTrailing: View {
 
 private struct ActiveNowList: View {
     let models: [StatsDTO.ActiveModelDTO]
+    /// Progress polls faster than the 5 s stats read `models` comes from.
+    let activity: ModelActivityPoller
+
     @Environment(\.omlxTheme) private var theme
 
     var body: some View {
@@ -543,14 +547,27 @@ private struct ActiveNowList: View {
                 }
             } else {
                 ForEach(Array(models.enumerated()), id: \.element.id) { index, model in
-                    Row(label: model.id, isLast: index == models.count - 1) {
-                        HStack(spacing: 12) {
-                            modelStateBadge(for: model)
-                            Text(model.estimatedSizeFormatted ?? "—")
-                                .font(.omlxMono(11))
-                                .foregroundStyle(theme.textSecondary)
-                                .frame(minWidth: 60, alignment: .trailing)
+                    let live = activity.snapshot(for: model.id)
+                    FreeRow(isLast: index == models.count - 1) {
+                        VStack(alignment: .leading, spacing: 6) {
+                            HStack(spacing: 12) {
+                                Text(model.id)
+                                    .font(.omlxText(13, weight: .medium))
+                                    .foregroundStyle(theme.text)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                                Spacer(minLength: 12)
+                                modelStateBadge(for: model, live: live)
+                                Text(model.estimatedSizeFormatted ?? "—")
+                                    .font(.omlxMono(11))
+                                    .foregroundStyle(theme.textSecondary)
+                                    .frame(minWidth: 60, alignment: .trailing)
+                            }
+                            if let live, model.isLoading != true {
+                                ModelActivityList(snapshot: live)
+                            }
                         }
+                        .animation(.easeInOut(duration: 0.18), value: live != nil)
                     }
                 }
             }
@@ -558,9 +575,14 @@ private struct ActiveNowList: View {
     }
 
     @ViewBuilder
-    private func modelStateBadge(for model: StatsDTO.ActiveModelDTO) -> some View {
+    private func modelStateBadge(
+        for model: StatsDTO.ActiveModelDTO,
+        live: ModelActivitySnapshot?
+    ) -> some View {
         if model.isLoading == true {
             StatusPill(status: .starting)
+        } else if let live, live.isBusy {
+            ModelActivityBadge(snapshot: live)
         } else if (model.activeRequests ?? 0) > 0 {
             StatusPill(status: .custom(color: theme.greenDot,
                                         label: String(localized: "status.active_now.badge.generating",

--- a/apps/omlx-mac/Sources/AppView/Utils/ModelActivity.swift
+++ b/apps/omlx-mac/Sources/AppView/Utils/ModelActivity.swift
@@ -138,7 +138,7 @@ enum ActivityFormat {
 
     /// Decode rates sit in the tens, prefill rates in the thousands.
     static func rate(_ tokensPerSecond: Double) -> String {
-        if tokensPerSecond >= 1_000 { return String(format: "%.1fk", tokensPerSecond / 1_000) }
+        if tokensPerSecond >= 10_000 { return String(format: "%.1fk", tokensPerSecond / 1_000) }
         if tokensPerSecond >= 100 { return String(format: "%.0f", tokensPerSecond) }
         return String(format: "%.1f", tokensPerSecond)
     }
@@ -240,46 +240,6 @@ struct ActivityLinger {
     }
 }
 
-// MARK: - Speed smoothing
-
-/// The prefill tracker reports the last chunk's rate, which swings hard
-/// between polls and drags `eta` with it. Average the rate and re-derive the
-/// ETA from it so the two agree on screen.
-struct PrefillSpeedSmoother {
-    private var speeds: [String: Double] = [:]
-    private let alpha: Double
-
-    init(alpha: Double = 0.35) {
-        self.alpha = alpha
-    }
-
-    mutating func smoothed(
-        _ entries: [StatsDTO.PrefillProgressDTO]
-    ) -> [StatsDTO.PrefillProgressDTO] {
-        entries.map { entry in
-            guard let id = entry.requestId, let raw = entry.speed, raw > 0 else { return entry }
-            let averaged = speeds[id].map { $0 + alpha * (raw - $0) } ?? raw
-            speeds[id] = averaged
-            let remaining = max(0, (entry.total ?? 0) - (entry.processed ?? 0))
-            return StatsDTO.PrefillProgressDTO(
-                requestId: id, processed: entry.processed, total: entry.total,
-                speed: averaged, eta: Double(remaining) / averaged,
-                elapsed: entry.elapsed, detail: entry.detail
-            )
-        }
-    }
-
-    /// One smoother serves every model, so pruning happens once per poll
-    /// against the union — per model it would evict the others.
-    mutating func retain(ids: Set<String>) {
-        speeds = speeds.filter { ids.contains($0.key) }
-    }
-
-    mutating func reset() {
-        speeds.removeAll()
-    }
-}
-
 // MARK: - Poller
 
 @MainActor
@@ -289,7 +249,6 @@ final class ModelActivityPoller {
 
     @ObservationIgnored private weak var client: OMLXClient?
     @ObservationIgnored private var pollTask: Task<Void, Never>?
-    @ObservationIgnored private var smoother = PrefillSpeedSmoother()
     @ObservationIgnored private var linger = ActivityLinger()
     @ObservationIgnored private var failures = 0
 
@@ -317,7 +276,6 @@ final class ModelActivityPoller {
         pollTask?.cancel()
         pollTask = nil
         snapshots = [:]
-        smoother.reset()
         linger.reset()
         failures = 0
     }
@@ -330,7 +288,6 @@ final class ModelActivityPoller {
             failures += 1
             if failures >= failuresBeforeClearing, !snapshots.isEmpty {
                 snapshots = [:]
-                smoother.reset()
                 linger.reset()
             }
             return
@@ -338,20 +295,13 @@ final class ModelActivityPoller {
         failures = 0
 
         let models = activity.activeModels.models
-        smoother.retain(ids: Set(
-            models.flatMap { ($0.prefilling ?? []).compactMap(\.requestId) }
-        ))
         linger.retain(models: Set(models.map(\.id)))
 
         // Monotonic, so a wall-clock jump cannot retire rows early.
         let now = ProcessInfo.processInfo.systemUptime
         var next: [String: ModelActivitySnapshot] = [:]
         for model in models {
-            let rows = ModelActivitySnapshot.rows(
-                prefilling: smoother.smoothed(model.prefilling ?? []),
-                generating: model.generating ?? [],
-                activities: model.activities ?? []
-            )
+            let rows = ModelActivitySnapshot.rows(for: model)
             next[model.id] = ModelActivitySnapshot(
                 requests: linger.merge(live: rows, for: model.id, now: now),
                 queued: model.waitingRequests ?? 0

--- a/apps/omlx-mac/Sources/AppView/Utils/ModelActivity.swift
+++ b/apps/omlx-mac/Sources/AppView/Utils/ModelActivity.swift
@@ -1,0 +1,357 @@
+// Live per-request activity for the model rows on the Models and Status
+// screens: one row per in-flight request, polled from /admin/api/activity.
+
+import SwiftUI
+
+// MARK: - Rows
+
+struct ModelRequestActivity: Equatable, Sendable, Identifiable {
+    enum Phase: Equatable, Sendable {
+        case prefill, generating, working
+        /// Gone from the payload, still shown briefly. See `ActivityLinger`.
+        case finished
+    }
+
+    let id: String
+    let phase: Phase
+    /// 0…1 for `.prefill` only — decode has no bounded total.
+    let fraction: Double?
+    let percentText: String?
+    let detail: String
+
+    var isLive: Bool { phase != .finished }
+    /// Every OpenAI-style id shares the "chatcmpl-" head; the tail differs.
+    var shortID: String { String(id.suffix(8)) }
+
+    var finished: ModelRequestActivity {
+        ModelRequestActivity(id: id, phase: .finished, fraction: fraction,
+                             percentText: percentText, detail: detail)
+    }
+}
+
+struct ModelActivitySnapshot: Equatable, Sendable {
+    enum BadgePhase: Equatable, Sendable {
+        case prefill, generating, working, queued
+    }
+
+    let requests: [ModelRequestActivity]
+    let queued: Int
+    let badge: String
+    let badgePhase: BadgePhase
+
+    /// Lingering rows are not activity — a model with none live is idle.
+    var isBusy: Bool { requests.contains(where: \.isLive) || queued > 0 }
+
+    init?(requests: [ModelRequestActivity], queued: Int) {
+        guard !requests.isEmpty || queued > 0 else { return nil }
+        self.requests = requests
+        self.queued = max(0, queued)
+        switch requests.first(where: \.isLive)?.phase {
+        case .prefill:    badgePhase = .prefill
+        case .generating: badgePhase = .generating
+        case .working:    badgePhase = .working
+        default:          badgePhase = .queued
+        }
+        badge = ActivityFormat.badge(for: badgePhase)
+    }
+
+    init?(model: StatsDTO.ActiveModelDTO) {
+        self.init(requests: Self.rows(for: model), queued: model.waitingRequests ?? 0)
+    }
+
+    static func rows(for model: StatsDTO.ActiveModelDTO) -> [ModelRequestActivity] {
+        rows(prefilling: model.prefilling ?? [],
+             generating: model.generating ?? [],
+             activities: model.activities ?? [])
+    }
+
+    /// Prefill first: it is the bounded phase, and a fixed order keeps rows
+    /// from reshuffling between polls.
+    static func rows(
+        prefilling: [StatsDTO.PrefillProgressDTO],
+        generating: [StatsDTO.GenerationProgressDTO],
+        activities: [StatsDTO.NonStreamingActivityDTO]
+    ) -> [ModelRequestActivity] {
+        prefilling.map(row(prefill:))
+            + generating.map(row(generating:))
+            + activities.map(row(working:))
+    }
+
+    private static func row(prefill p: StatsDTO.PrefillProgressDTO) -> ModelRequestActivity {
+        let processed = max(0, p.processed ?? 0)
+        let total = max(0, p.total ?? 0)
+        let fraction = total > 0 ? min(1, Double(processed) / Double(total)) : nil
+
+        var parts = ["\(ActivityFormat.tokens(processed)) / \(ActivityFormat.tokens(total)) tok"]
+        if let speed = p.speed, speed > 0 { parts.append("\(ActivityFormat.rate(speed)) tok/s") }
+        if let eta = p.eta, eta >= 0 { parts.append(ActivityFormat.left(eta)) }
+        if let detail = p.detail, !detail.isEmpty { parts.append(detail) }
+
+        return ModelRequestActivity(
+            id: p.requestId ?? "",
+            phase: .prefill,
+            fraction: fraction,
+            percentText: fraction.map { "\(Int(($0 * 100).rounded()))%" },
+            detail: parts.joined(separator: " · ")
+        )
+    }
+
+    private static func row(generating g: StatsDTO.GenerationProgressDTO) -> ModelRequestActivity {
+        var parts = ["\(ActivityFormat.tokens(max(0, g.generatedTokens ?? 0))) tok"]
+        if let speed = g.tokensPerSecond, speed > 0 {
+            parts.append("\(ActivityFormat.rate(speed)) tok/s")
+        }
+        if let elapsed = g.elapsedSeconds { parts.append(ActivityFormat.duration(elapsed)) }
+
+        return ModelRequestActivity(id: g.requestId ?? "", phase: .generating,
+                                    fraction: nil, percentText: nil,
+                                    detail: parts.joined(separator: " · "))
+    }
+
+    private static func row(working a: StatsDTO.NonStreamingActivityDTO) -> ModelRequestActivity {
+        var parts: [String] = []
+        if let label = a.detail ?? a.kind, !label.isEmpty { parts.append(label) }
+        if let elapsed = a.elapsedSeconds { parts.append(ActivityFormat.duration(elapsed)) }
+
+        return ModelRequestActivity(id: a.requestId ?? "", phase: .working,
+                                    fraction: nil, percentText: nil,
+                                    detail: parts.joined(separator: " · "))
+    }
+}
+
+// MARK: - Formatting
+
+enum ActivityFormat {
+    static func tokens(_ count: Int) -> String {
+        if count >= 1_000_000 {
+            let millions = Double(count) / 1_000_000
+            return String(format: millions >= 10 ? "%.0fM" : "%.1fM", millions)
+        }
+        if count >= 1_000 { return "\(Int((Double(count) / 1_000).rounded()))k" }
+        return "\(count)"
+    }
+
+    /// Decode rates sit in the tens, prefill rates in the thousands.
+    static func rate(_ tokensPerSecond: Double) -> String {
+        if tokensPerSecond >= 1_000 { return String(format: "%.1fk", tokensPerSecond / 1_000) }
+        if tokensPerSecond >= 100 { return String(format: "%.0f", tokensPerSecond) }
+        return String(format: "%.1f", tokensPerSecond)
+    }
+
+    static func duration(_ seconds: Double) -> String {
+        let total = max(0, Int(seconds.rounded()))
+        guard total >= 60 else { return "\(total)s" }
+        let (minutes, rest) = (total / 60, total % 60)
+        return rest == 0 ? "\(minutes)m" : "\(minutes)m \(rest)s"
+    }
+
+    static func left(_ seconds: Double) -> String {
+        String(localized: "activity.eta",
+               defaultValue: "\(duration(seconds)) left",
+               comment: "Time remaining on a running prefill; placeholder is a duration")
+    }
+
+    static func queuedDetail(count: Int) -> String {
+        String(localized: "activity.queued_detail",
+               defaultValue: "\(count) waiting",
+               comment: "Row for requests queued but not started; placeholder is the queue depth")
+    }
+
+    static func badge(for phase: ModelActivitySnapshot.BadgePhase) -> String {
+        switch phase {
+        case .prefill:
+            return String(localized: "activity.badge.prefill", defaultValue: "Prefill",
+                          comment: "Pill on a model row processing a prompt")
+        case .generating:
+            return String(localized: "activity.badge.generating", defaultValue: "Generating",
+                          comment: "Pill on a model row emitting tokens")
+        case .working:
+            return String(localized: "activity.badge.working", defaultValue: "Working",
+                          comment: "Pill on a model row running a non-streaming request")
+        case .queued:
+            return String(localized: "activity.badge.queued", defaultValue: "Queued",
+                          comment: "Pill on a model row whose requests are all still queued")
+        }
+    }
+
+    static var doneBadge: String {
+        String(localized: "activity.badge.done", defaultValue: "Done",
+               comment: "Label on a request row that finished and is leaving the list")
+    }
+}
+
+// MARK: - Linger
+
+/// Requests leave the payload the instant they finish, so a short one showed
+/// for a single poll and blinked out. Hold each row briefly after it goes.
+///
+/// Keyed on request id, so the prefill-to-decode handover — same id, new
+/// phase — never produces a ghost row next to the live one.
+struct ActivityLinger {
+    static let duration: TimeInterval = 2.5
+
+    private typealias Held = (row: ModelRequestActivity, expiresAt: TimeInterval)
+
+    private var held: [String: [Held]] = [:]
+    private var lastLive: [String: [ModelRequestActivity]] = [:]
+    private let duration: TimeInterval
+
+    init(duration: TimeInterval = ActivityLinger.duration) {
+        self.duration = duration
+    }
+
+    /// `now` is injected so retirement is testable without a real clock.
+    mutating func merge(
+        live: [ModelRequestActivity],
+        for modelID: String,
+        now: TimeInterval
+    ) -> [ModelRequestActivity] {
+        let liveIDs = Set(live.map(\.id))
+        var current = (held[modelID] ?? []).filter {
+            !liveIDs.contains($0.row.id) && $0.expiresAt > now
+        }
+        let alreadyHeld = Set(current.map(\.row.id))
+        for row in lastLive[modelID] ?? []
+        where !liveIDs.contains(row.id) && !alreadyHeld.contains(row.id) {
+            current.append((row.finished, now + duration))
+        }
+
+        held[modelID] = current.isEmpty ? nil : current
+        lastLive[modelID] = live
+        // Live rows lead, so a finishing row sinks below still-running ones.
+        return live + current.map(\.row)
+    }
+
+    mutating func retain(models: Set<String>) {
+        held = held.filter { models.contains($0.key) }
+        lastLive = lastLive.filter { models.contains($0.key) }
+    }
+
+    mutating func reset() {
+        held.removeAll()
+        lastLive.removeAll()
+    }
+}
+
+// MARK: - Speed smoothing
+
+/// The prefill tracker reports the last chunk's rate, which swings hard
+/// between polls and drags `eta` with it. Average the rate and re-derive the
+/// ETA from it so the two agree on screen.
+struct PrefillSpeedSmoother {
+    private var speeds: [String: Double] = [:]
+    private let alpha: Double
+
+    init(alpha: Double = 0.35) {
+        self.alpha = alpha
+    }
+
+    mutating func smoothed(
+        _ entries: [StatsDTO.PrefillProgressDTO]
+    ) -> [StatsDTO.PrefillProgressDTO] {
+        entries.map { entry in
+            guard let id = entry.requestId, let raw = entry.speed, raw > 0 else { return entry }
+            let averaged = speeds[id].map { $0 + alpha * (raw - $0) } ?? raw
+            speeds[id] = averaged
+            let remaining = max(0, (entry.total ?? 0) - (entry.processed ?? 0))
+            return StatsDTO.PrefillProgressDTO(
+                requestId: id, processed: entry.processed, total: entry.total,
+                speed: averaged, eta: Double(remaining) / averaged,
+                elapsed: entry.elapsed, detail: entry.detail
+            )
+        }
+    }
+
+    /// One smoother serves every model, so pruning happens once per poll
+    /// against the union — per model it would evict the others.
+    mutating func retain(ids: Set<String>) {
+        speeds = speeds.filter { ids.contains($0.key) }
+    }
+
+    mutating func reset() {
+        speeds.removeAll()
+    }
+}
+
+// MARK: - Poller
+
+@MainActor
+@Observable
+final class ModelActivityPoller {
+    private(set) var snapshots: [String: ModelActivitySnapshot] = [:]
+
+    @ObservationIgnored private weak var client: OMLXClient?
+    @ObservationIgnored private var pollTask: Task<Void, Never>?
+    @ObservationIgnored private var smoother = PrefillSpeedSmoother()
+    @ObservationIgnored private var linger = ActivityLinger()
+    @ObservationIgnored private var failures = 0
+
+    /// A bar that moves once every few seconds reads as broken, but an idle
+    /// server does not deserve a request per second.
+    private let activeInterval: TimeInterval = 1.0
+    private let idleInterval: TimeInterval = 3.0
+    /// One timed-out read is not evidence that nothing is running.
+    private let failuresBeforeClearing = 3
+
+    func start(client: OMLXClient) {
+        self.client = client
+        pollTask?.cancel()
+        pollTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                await self.tick()
+                let interval = self.snapshots.isEmpty ? self.idleInterval : self.activeInterval
+                try? await Task.sleep(for: .seconds(interval))
+            }
+        }
+    }
+
+    func stop() {
+        pollTask?.cancel()
+        pollTask = nil
+        snapshots = [:]
+        smoother.reset()
+        linger.reset()
+        failures = 0
+    }
+
+    func snapshot(for modelID: String) -> ModelActivitySnapshot? { snapshots[modelID] }
+
+    private func tick() async {
+        guard let client else { return }
+        guard let activity = try? await client.getActivity() else {
+            failures += 1
+            if failures >= failuresBeforeClearing, !snapshots.isEmpty {
+                snapshots = [:]
+                smoother.reset()
+                linger.reset()
+            }
+            return
+        }
+        failures = 0
+
+        let models = activity.activeModels.models
+        smoother.retain(ids: Set(
+            models.flatMap { ($0.prefilling ?? []).compactMap(\.requestId) }
+        ))
+        linger.retain(models: Set(models.map(\.id)))
+
+        // Monotonic, so a wall-clock jump cannot retire rows early.
+        let now = ProcessInfo.processInfo.systemUptime
+        var next: [String: ModelActivitySnapshot] = [:]
+        for model in models {
+            let rows = ModelActivitySnapshot.rows(
+                prefilling: smoother.smoothed(model.prefilling ?? []),
+                generating: model.generating ?? [],
+                activities: model.activities ?? []
+            )
+            next[model.id] = ModelActivitySnapshot(
+                requests: linger.merge(live: rows, for: model.id, now: now),
+                queued: model.waitingRequests ?? 0
+            )
+        }
+        if next != snapshots { snapshots = next }
+    }
+
+    deinit { pollTask?.cancel() }
+}

--- a/apps/omlx-mac/Sources/AppView/Utils/ModelActivity.swift
+++ b/apps/omlx-mac/Sources/AppView/Utils/ModelActivity.swift
@@ -151,15 +151,17 @@ enum ActivityFormat {
     }
 
     static func left(_ seconds: Double) -> String {
-        String(localized: "activity.eta",
-               defaultValue: "\(duration(seconds)) left",
-               comment: "Time remaining on a running prefill; placeholder is a duration")
+        let format = String(localized: "activity.eta",
+                            defaultValue: "%@ left",
+                            comment: "Time remaining on a running prefill; placeholder is a duration")
+        return String(format: format, locale: .current, duration(seconds))
     }
 
     static func queuedDetail(count: Int) -> String {
-        String(localized: "activity.queued_detail",
-               defaultValue: "\(count) waiting",
-               comment: "Row for requests queued but not started; placeholder is the queue depth")
+        let format = String(localized: "activity.queued_detail",
+                            defaultValue: "%lld waiting",
+                            comment: "Row for requests queued but not started; placeholder is the queue depth")
+        return String(format: format, locale: .current, Int64(count))
     }
 
     static func badge(for phase: ModelActivitySnapshot.BadgePhase) -> String {

--- a/apps/omlx-mac/Sources/AppView/Utils/ModelActivity.swift
+++ b/apps/omlx-mac/Sources/AppView/Utils/ModelActivity.swift
@@ -122,13 +122,18 @@ struct ModelActivitySnapshot: Equatable, Sendable {
 // MARK: - Formatting
 
 enum ActivityFormat {
-    static func tokens(_ count: Int) -> String {
+    static func tokens(_ count: Int, locale: Locale = .current) -> String {
         if count >= 1_000_000 {
             let millions = Double(count) / 1_000_000
             return String(format: millions >= 10 ? "%.0fM" : "%.1fM", millions)
         }
-        if count >= 1_000 { return "\(Int((Double(count) / 1_000).rounded()))k" }
-        return "\(count)"
+        if count >= 100_000 { return "\(Int((Double(count) / 1_000).rounded()))k" }
+        if count >= 10_000 {
+            let thousands = Double(count) / 1_000
+            let compact = String(format: "%.1f", thousands)
+            return "\(compact.hasSuffix(".0") ? String(compact.dropLast(2)) : compact)k"
+        }
+        return count.formatted(.number.grouping(.automatic).locale(locale))
     }
 
     /// Decode rates sit in the tens, prefill rates in the thousands.

--- a/apps/omlx-mac/Sources/AppView/Utils/ModelActivityViews.swift
+++ b/apps/omlx-mac/Sources/AppView/Utils/ModelActivityViews.swift
@@ -56,12 +56,18 @@ private struct ModelActivityRow: View {
                 .frame(width: 60, alignment: .leading)
 
             if let fraction = request.fraction, request.isLive {
-                ProgressBar(progress: fraction, tint: tint)
-                    .frame(width: 70)
-                Text(request.percentText ?? "")
-                    .font(.omlxMono(10.5))
-                    .foregroundStyle(tint)
-                    .frame(width: 32, alignment: .trailing)
+                HStack(spacing: 6) {
+                    Text(ActivityFormat.badge(for: .prefill))
+                        .font(.omlxMono(10.5))
+                        .foregroundStyle(tint)
+                        .lineLimit(1)
+                    ProgressBar(progress: fraction, tint: tint)
+                        .frame(width: 70)
+                    Text(request.percentText ?? "")
+                        .font(.omlxMono(10.5))
+                        .foregroundStyle(tint)
+                        .frame(width: 32, alignment: .trailing)
+                }
             } else {
                 HStack(spacing: 6) {
                     Circle().fill(tint).frame(width: 5, height: 5)

--- a/apps/omlx-mac/Sources/AppView/Utils/ModelActivityViews.swift
+++ b/apps/omlx-mac/Sources/AppView/Utils/ModelActivityViews.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+
+struct ModelActivityBadge: View {
+    let snapshot: ModelActivitySnapshot
+    @Environment(\.omlxTheme) private var theme
+
+    var body: some View {
+        StatusPill(status: .custom(color: tint, label: snapshot.badge, fillBg: true))
+    }
+
+    private var tint: Color {
+        switch snapshot.badgePhase {
+        case .prefill:              return theme.blueDot
+        case .generating, .working: return theme.greenDot
+        case .queued:               return theme.amberDot
+        }
+    }
+}
+
+struct ModelActivityList: View {
+    let snapshot: ModelActivitySnapshot
+    @Environment(\.omlxTheme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            ForEach(snapshot.requests) { ModelActivityRow(request: $0) }
+            if snapshot.queued > 0 {
+                HStack(spacing: 8) {
+                    Circle().fill(theme.amberDot).frame(width: 5, height: 5)
+                    Text(ActivityFormat.queuedDetail(count: snapshot.queued))
+                        .font(.omlxMono(10.5))
+                        .foregroundStyle(theme.textTertiary)
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+        // Keyed on the row set, not the snapshot: the numbers change every
+        // poll and cross-fading those would smear the text.
+        .animation(.easeInOut(duration: 0.18), value: rowIdentity)
+    }
+
+    private var rowIdentity: [String] {
+        snapshot.requests.map(\.id) + ["queued:\(snapshot.queued)"]
+    }
+}
+
+private struct ModelActivityRow: View {
+    let request: ModelRequestActivity
+    @Environment(\.omlxTheme) private var theme
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(request.shortID)
+                .font(.omlxMono(10.5))
+                .foregroundStyle(theme.textTertiary)
+                .frame(width: 60, alignment: .leading)
+
+            if let fraction = request.fraction, request.isLive {
+                ProgressBar(progress: fraction, tint: tint)
+                    .frame(width: 70)
+                Text(request.percentText ?? "")
+                    .font(.omlxMono(10.5))
+                    .foregroundStyle(tint)
+                    .frame(width: 32, alignment: .trailing)
+            } else {
+                HStack(spacing: 6) {
+                    Circle().fill(tint).frame(width: 5, height: 5)
+                    Text(label).font(.omlxMono(10.5)).lineLimit(1)
+                }
+                .foregroundStyle(tint)
+                // 70 + 8 + 32, so the detail column lines up with prefill rows.
+                .frame(width: 110, alignment: .leading)
+            }
+
+            Text(request.detail)
+                .font(.omlxMono(10.5))
+                .foregroundStyle(theme.textSecondary)
+                .lineLimit(1)
+            Spacer(minLength: 0)
+        }
+        .opacity(request.isLive ? 1 : 0.55)
+    }
+
+    private var label: String {
+        switch request.phase {
+        case .prefill:    return ActivityFormat.badge(for: .prefill)
+        case .generating: return ActivityFormat.badge(for: .generating)
+        case .working:    return ActivityFormat.badge(for: .working)
+        case .finished:   return ActivityFormat.doneBadge
+        }
+    }
+
+    private var tint: Color {
+        guard request.isLive else { return theme.textTertiary }
+        switch request.phase {
+        case .prefill:  return theme.blueDot
+        default:        return theme.greenDot
+        }
+    }
+}

--- a/apps/omlx-mac/Sources/AppView/ViewModels/ModelsScreenVM.swift
+++ b/apps/omlx-mac/Sources/AppView/ViewModels/ModelsScreenVM.swift
@@ -12,6 +12,7 @@ final class ModelsScreenVM {
     /// trash glyph and the whole row's button-stack is disabled to prevent
     /// double-tap deletes against a model the server is still unloading.
     private(set) var deletingID: String?
+    var activity = ModelActivityPoller()
 
     @ObservationIgnored
     private weak var client: OMLXClient?
@@ -25,6 +26,7 @@ final class ModelsScreenVM {
 
     func start(client: OMLXClient) async {
         self.client = client
+        activity.start(client: client)
         pollTask?.cancel()
         pollTask = Task { [weak self] in
             while !Task.isCancelled {
@@ -38,6 +40,7 @@ final class ModelsScreenVM {
     func stop() {
         pollTask?.cancel()
         pollTask = nil
+        activity.stop()
     }
 
     func load(id: String, client: OMLXClient) {

--- a/apps/omlx-mac/Sources/AppView/ViewModels/StatusScreenVM.swift
+++ b/apps/omlx-mac/Sources/AppView/ViewModels/StatusScreenVM.swift
@@ -11,6 +11,7 @@ final class StatusScreenVM {
     /// so the % column doesn't read 0/0 on first paint.
     var maxConcurrent: Int = 8
     var metrics = SystemMetricsPoller()
+    var activity = ModelActivityPoller()
 
     @ObservationIgnored
     private weak var client: OMLXClient?
@@ -67,6 +68,7 @@ final class StatusScreenVM {
     func start(client: OMLXClient) async {
         self.client = client
         metrics.start()
+        activity.start(client: client)
         // Load the scheduler cap once; failing silently is fine — the
         // default keeps the % column readable until the server responds.
         if let settings = try? await client.getGlobalSettings(),
@@ -87,6 +89,7 @@ final class StatusScreenVM {
         pollTask?.cancel()
         pollTask = nil
         metrics.stop()
+        activity.stop()
     }
 
     private func tick() async {

--- a/apps/omlx-mac/Sources/Menubar/MenubarController.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarController.swift
@@ -817,14 +817,13 @@ final class MenubarController: NSObject {
         let tickOK = statsPoller?.lastTickWasSuccess ?? false
         metricsStore.applyTick(
             live: tickOK
-                ? MenubarMetricsStore.liveRates(from: statsPoller?.liveStats)
+                ? MenubarMetricsStore.snapshot(for: .live, from: statsPoller?.liveStats)
                 : nil,
-            liveActivity: tickOK ? statsPoller?.liveStats?.liveActivity : nil,
             average: tickOK
-                ? MenubarMetricsStore.averageRates(from: statsPoller?.sessionStats)
+                ? MenubarMetricsStore.snapshot(for: .average, from: statsPoller?.sessionStats)
                 : nil,
             alltime: tickOK
-                ? MenubarMetricsStore.averageRates(from: statsPoller?.alltimeStats)
+                ? MenubarMetricsStore.snapshot(for: .alltime, from: statsPoller?.alltimeStats)
                 : nil,
             serverRunning: serverIsRunning && tickOK
         )

--- a/apps/omlx-mac/Sources/Menubar/MenubarController.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarController.swift
@@ -80,6 +80,8 @@ final class MenubarController: NSObject {
     private var modelsFetchTask: Task<Void, Never>?
     private var statsParentItem: NSMenuItem!
     private var statsSubmenu: NSMenu!
+    private var servingStatsSubmenuOpen = false
+    private var servingStatsPanelHost: NSHostingView<AnyView>?
     private var systemStatsParentItem: NSMenuItem!
     private var systemStatsSubmenu: NSMenu!
     private let systemStatsSampler = SystemStatsSampler()
@@ -304,9 +306,11 @@ final class MenubarController: NSObject {
                                action: nil,
                                symbol: "chart.bar")
         statsSubmenu = NSMenu()
+        statsSubmenu.autoenablesItems = false
+        statsSubmenu.delegate = self
         statsParentItem.submenu = statsSubmenu
         menu.addItem(statsParentItem)
-        rebuildStatsSubmenu()
+        buildServingStatsSubmenu()
         rebuildModelsSubmenu()
 
         menu.addItem(.separator())
@@ -619,80 +623,40 @@ final class MenubarController: NSObject {
         }
     }
 
-    private func rebuildStatsSubmenu() {
+    /// Serving Stats is one retained hosting view rather than a rebuilt list
+    /// of disabled menu rows. Replacing its value-driven root is safe while
+    /// AppKit tracks the menu and lets SwiftUI compute each fresh fitting size.
+    private func buildServingStatsSubmenu() {
         statsSubmenu.removeAllItems()
+        let hosting = NSHostingView(rootView: servingStatsPanelRoot())
+        servingStatsPanelHost = hosting
+        statsSubmenu.addItem(panelItem(hosting: hosting))
+    }
 
-        let isRunning: Bool
-        if case .running = server?.state { isRunning = true } else { isRunning = false }
+    private func servingStatsPanelRoot() -> AnyView {
+        AnyView(
+            ServingStatsMenuPanel(
+                live: metricsStore.snapshot(for: .live),
+                average: metricsStore.snapshot(for: .average),
+                alltime: metricsStore.snapshot(for: .alltime),
+                liveSeries: metricsStore.history[.live] ?? MenubarMetricsStore.Series(),
+                averageSeries: metricsStore.history[.average] ?? MenubarMetricsStore.Series(),
+                alltimeSeries: metricsStore.history[.alltime] ?? MenubarMetricsStore.Series(),
+                serverIsRunning: serverIsRunning
+            )
+            .omlxThemed()
+        )
+    }
 
-        if !isRunning {
-            statsSubmenu.addItem(disabled(String(localized: "menubar.stats.server_off",
-                                                 defaultValue: "Server is off",
-                                                 comment: "Disabled placeholder in the Serving Stats submenu when the server isn't running")))
+    private func updateServingStatsPanel() {
+        guard let servingStatsPanelHost else {
             return
         }
-        let session = statsPoller?.sessionStats
-        let liveActivity = statsPoller?.liveStats?.liveActivity
-        let alltime = statsPoller?.alltimeStats
-        if session == nil && alltime == nil {
-            statsSubmenu.addItem(disabled(statsPoller == nil
-                                          ? String(localized: "menubar.stats.no_api_key",
-                                                   defaultValue: "Set OMLX_API_KEY to enable stats",
-                                                   comment: "Disabled placeholder in the Serving Stats submenu when no API key is configured")
-                                          : String(localized: "menubar.stats.loading",
-                                                   defaultValue: "Loading stats…",
-                                                   comment: "Disabled placeholder shown while stats are loading")))
-            return
+        servingStatsPanelHost.rootView = servingStatsPanelRoot()
+        let fitting = servingStatsPanelHost.fittingSize
+        if servingStatsPanelHost.frame.size != fitting {
+            servingStatsPanelHost.frame.size = fitting
         }
-
-        appendCurrentRequests(liveActivity)
-        statsSubmenu.addItem(.separator())
-
-        statsSubmenu.addItem(disabled(String(localized: "menubar.stats.session_section",
-                                             defaultValue: "Session",
-                                             comment: "Section header inside the Serving Stats submenu for current-session metrics")))
-        appendStat(String(localized: "menubar.stats.total_tokens",
-                          defaultValue: "Total Tokens Processed",
-                          comment: "Stats row label for total tokens processed"),
-                   compact(session?.totalPromptTokens))
-        appendStat(String(localized: "menubar.stats.cached_tokens",
-                          defaultValue: "Cached Tokens",
-                          comment: "Stats row label for cached tokens count"),
-                   compact(session?.totalCachedTokens))
-        appendStat(String(localized: "menubar.stats.cache_efficiency",
-                          defaultValue: "Cache Efficiency",
-                          comment: "Stats row label for the cache efficiency percentage"),
-                   percent(session?.cacheEfficiency))
-        appendStat(String(localized: "menubar.stats.avg_pp_speed",
-                          defaultValue: "Avg PP Speed",
-                          comment: "Stats row label for the average prompt-processing (prefill) speed"),
-                   tps(session?.avgPrefillTps))
-        appendStat(String(localized: "menubar.stats.avg_tg_speed",
-                          defaultValue: "Avg TG Speed",
-                          comment: "Stats row label for the average token-generation speed"),
-                   tps(session?.avgGenerationTps))
-
-        statsSubmenu.addItem(.separator())
-
-        statsSubmenu.addItem(disabled(String(localized: "menubar.stats.alltime_section",
-                                             defaultValue: "All-Time",
-                                             comment: "Section header inside the Serving Stats submenu for all-time metrics")))
-        appendStat(String(localized: "menubar.stats.total_tokens",
-                          defaultValue: "Total Tokens Processed",
-                          comment: "Stats row label for total tokens processed"),
-                   compact(alltime?.totalPromptTokens))
-        appendStat(String(localized: "menubar.stats.cached_tokens",
-                          defaultValue: "Cached Tokens",
-                          comment: "Stats row label for cached tokens count"),
-                   compact(alltime?.totalCachedTokens))
-        appendStat(String(localized: "menubar.stats.cache_efficiency",
-                          defaultValue: "Cache Efficiency",
-                          comment: "Stats row label for the cache efficiency percentage"),
-                   percent(alltime?.cacheEfficiency))
-        appendStat(String(localized: "menubar.stats.total_requests",
-                          defaultValue: "Total Requests",
-                          comment: "Stats row label for total request count"),
-                   compact(alltime?.totalRequests))
     }
 
     // MARK: - Pollers
@@ -728,6 +692,7 @@ final class MenubarController: NSObject {
             object: p
         )
         p.setEnabledMetrics(MenubarMetricPrefs.enabledMetrics)
+        p.setServingStatsSubmenuOpen(servingStatsSubmenuOpen)
         p.start()
         self.statsPoller = p
         self.statsPollerBaseURL = baseURL
@@ -769,7 +734,6 @@ final class MenubarController: NSObject {
 
     @objc private func serverStateChanged(_ note: Notification) {
         refreshMenuState()
-        rebuildStatsSubmenu()
         rebuildModelsSubmenu()
         refreshStatsPollerEndpoint()
 
@@ -791,6 +755,9 @@ final class MenubarController: NSObject {
             break
         }
         metricItemsController.sync()
+        if servingStatsSubmenuOpen {
+            updateServingStatsPanel()
+        }
 
         if case .failed(let message) = server.state,
            MenubarController.shouldShowGenericFailureAlert(message: message) {
@@ -828,11 +795,10 @@ final class MenubarController: NSObject {
             serverRunning: serverIsRunning && tickOK
         )
         metricItemsController.sync()
-        // Stats only need to redraw if the submenu is open or about to open;
-        // menuWillOpen (NSMenuDelegate) handles the latter, so for now we
-        // rebuild eagerly — the next render will pick up fresh values.
         refreshMenuState()
-        rebuildStatsSubmenu()
+        if servingStatsSubmenuOpen {
+            updateServingStatsPanel()
+        }
     }
 
     @objc private func updateStateChanged(_ note: Notification) {
@@ -1320,75 +1286,6 @@ final class MenubarController: NSObject {
         return false
     }
 
-    private func appendStat(_ label: String, _ value: String) {
-        let it = NSMenuItem(title: "\(label):  \(value)", action: nil, keyEquivalent: "")
-        it.isEnabled = false
-        statsSubmenu.addItem(it)
-    }
-
-    private func appendCurrentRequests(_ activity: MenubarStatsPoller.Stats.LiveActivity?) {
-        statsSubmenu.addItem(disabled(String(
-            localized: "menubar.stats.current_requests",
-            defaultValue: "Current Requests",
-            comment: "Section header inside Serving Stats for active and queued requests"
-        )))
-
-        guard let activity else {
-            statsSubmenu.addItem(disabled(String(
-                localized: "menubar.stats.loading",
-                defaultValue: "Loading stats…",
-                comment: "Disabled placeholder shown while stats are loading"
-            )))
-            return
-        }
-        guard !activity.isIdle else {
-            statsSubmenu.addItem(disabled(String(
-                localized: "menubar.stats.no_current_requests",
-                defaultValue: "No active requests",
-                comment: "Disabled empty state in Serving Stats when no requests are active or queued"
-            )))
-            return
-        }
-
-        for group in activity.groups {
-            statsSubmenu.addItem(disabled(group.modelID))
-            for request in group.requests {
-                statsSubmenu.addItem(disabled("  \(request.title) · \(request.detail)"))
-            }
-        }
-        if activity.queuedRequestCount > 0 {
-            statsSubmenu.addItem(disabled(String(
-                localized: "menubar.stats.queued_requests",
-                defaultValue: "\(activity.queuedRequestCount) queued requests",
-                comment: "Current Requests row showing how many requests have not started; placeholder is the count"
-            )))
-        }
-        if activity.hiddenRequestCount > 0 {
-            statsSubmenu.addItem(disabled(String(
-                localized: "menubar.stats.more_requests",
-                defaultValue: "\(activity.hiddenRequestCount) more requests",
-                comment: "Current Requests row showing active requests omitted from the capped list; placeholder is the count"
-            )))
-        }
-    }
-
-    private func compact(_ value: Int?) -> String {
-        guard let n = value else { return "—" }
-        if n >= 1_000_000_000 { return String(format: "%.1fB", Double(n) / 1e9) }
-        if n >= 1_000_000     { return String(format: "%.1fM", Double(n) / 1e6) }
-        if n >= 1_000         { return String(format: "%.1fK", Double(n) / 1e3) }
-        return "\(n)"
-    }
-
-    private func percent(_ value: Double?) -> String {
-        guard let v = value else { return "—" }
-        return String(format: "%.1f%%", v)
-    }
-
-    private func tps(_ value: Double?) -> String {
-        guard let v = value else { return "—" }
-        return String(format: "%.1f tok/s", v)
-    }
 }
 
 // MARK: - Live endpoint resolution
@@ -1528,12 +1425,23 @@ extension MenubarController: NSMenuDelegate {
             systemSamplingTick()
             return
         }
+        if menu === statsSubmenu {
+            servingStatsSubmenuOpen = true
+            statsPoller?.setServingStatsSubmenuOpen(true)
+            updateServingStatsPanel()
+            if serverIsRunning {
+                Task { [weak self] in
+                    await self?.statsPoller?.refreshOnce()
+                }
+            }
+            return
+        }
         // One menubar dropdown at a time — the metric popovers don't dismiss
         // on a click that lands on our own main status item.
         metricItemsController.closeAllPopovers()
         systemItemsController.closeAllPopovers()
         refreshMenuState()
-        rebuildStatsSubmenu()
+        updateServingStatsPanel()
         rebuildModelsSubmenu()
         scheduleModelsRefresh()
     }
@@ -1541,6 +1449,10 @@ extension MenubarController: NSMenuDelegate {
     func menuDidClose(_ menu: NSMenu) {
         // The submenu posts its own close; the main-menu close is the
         // belt-and-suspenders for teardown paths that skip it.
+        if menu === statsSubmenu || menu === self.menu {
+            servingStatsSubmenuOpen = false
+            statsPoller?.setServingStatsSubmenuOpen(false)
+        }
         if menu === systemStatsSubmenu || menu === self.menu {
             systemStatsSubmenuOpen = false
             reconcileSystemSampling()

--- a/apps/omlx-mac/Sources/Menubar/MenubarController.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarController.swift
@@ -645,16 +645,8 @@ final class MenubarController: NSObject {
             return
         }
 
-        if let liveActivity {
-            statsSubmenu.addItem(disabled(String(
-                localized: "menubar.stats.live_activity",
-                defaultValue: "Live Activity",
-                comment: "Section header inside the Serving Stats submenu for the current active request"
-            )))
-            statsSubmenu.addItem(disabled(liveActivity.menuBarTitle))
-            statsSubmenu.addItem(disabled(liveActivity.detail))
-            statsSubmenu.addItem(.separator())
-        }
+        appendCurrentRequests(liveActivity)
+        statsSubmenu.addItem(.separator())
 
         statsSubmenu.addItem(disabled(String(localized: "menubar.stats.session_section",
                                              defaultValue: "Session",
@@ -827,6 +819,7 @@ final class MenubarController: NSObject {
             live: tickOK
                 ? MenubarMetricsStore.liveRates(from: statsPoller?.liveStats)
                 : nil,
+            liveActivity: tickOK ? statsPoller?.liveStats?.liveActivity : nil,
             average: tickOK
                 ? MenubarMetricsStore.averageRates(from: statsPoller?.sessionStats)
                 : nil,
@@ -1332,6 +1325,52 @@ final class MenubarController: NSObject {
         let it = NSMenuItem(title: "\(label):  \(value)", action: nil, keyEquivalent: "")
         it.isEnabled = false
         statsSubmenu.addItem(it)
+    }
+
+    private func appendCurrentRequests(_ activity: MenubarStatsPoller.Stats.LiveActivity?) {
+        statsSubmenu.addItem(disabled(String(
+            localized: "menubar.stats.current_requests",
+            defaultValue: "Current Requests",
+            comment: "Section header inside Serving Stats for active and queued requests"
+        )))
+
+        guard let activity else {
+            statsSubmenu.addItem(disabled(String(
+                localized: "menubar.stats.loading",
+                defaultValue: "Loading stats…",
+                comment: "Disabled placeholder shown while stats are loading"
+            )))
+            return
+        }
+        guard !activity.isIdle else {
+            statsSubmenu.addItem(disabled(String(
+                localized: "menubar.stats.no_current_requests",
+                defaultValue: "No active requests",
+                comment: "Disabled empty state in Serving Stats when no requests are active or queued"
+            )))
+            return
+        }
+
+        for group in activity.groups {
+            statsSubmenu.addItem(disabled(group.modelID))
+            for request in group.requests {
+                statsSubmenu.addItem(disabled("  \(request.title) · \(request.detail)"))
+            }
+        }
+        if activity.queuedRequestCount > 0 {
+            statsSubmenu.addItem(disabled(String(
+                localized: "menubar.stats.queued_requests",
+                defaultValue: "\(activity.queuedRequestCount) queued requests",
+                comment: "Current Requests row showing how many requests have not started; placeholder is the count"
+            )))
+        }
+        if activity.hiddenRequestCount > 0 {
+            statsSubmenu.addItem(disabled(String(
+                localized: "menubar.stats.more_requests",
+                defaultValue: "\(activity.hiddenRequestCount) more requests",
+                comment: "Current Requests row showing active requests omitted from the capped list; placeholder is the count"
+            )))
+        }
     }
 
     private func compact(_ value: Int?) -> String {

--- a/apps/omlx-mac/Sources/Menubar/MenubarMetricGlyph.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarMetricGlyph.swift
@@ -25,11 +25,7 @@ enum MenubarMetricGlyph {
         guard let value, value.isFinite else {
             return "–"
         }
-        let clamped = max(0, value)
-        if clamped >= 10_000 {
-            return String(format: "%.1fktk/s", clamped / 1_000)
-        }
-        return "\(Int(clamped.rounded()))tk/s"
+        return "\(ActivityFormat.rate(value))tk/s"
     }
 
     /// Cheap pixel-change detector: same signature ⇒ identical glyph, so the

--- a/apps/omlx-mac/Sources/Menubar/MenubarMetricItemsController.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarMetricItemsController.swift
@@ -75,9 +75,9 @@ final class MenubarMetricItemsController: NSObject, NSPopoverDelegate {
             // can be dark over a dark wallpaper while the app is light.
             let darkMenubar = button.effectiveAppearance
                 .bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
-            let rates = store.rates[spec.kind]
-            let promptValue = MenubarMetricGlyph.formatTps(rates?.promptTps)
-            let generationValue = MenubarMetricGlyph.formatTps(rates?.generationTps)
+            let snapshot = store.snapshot(for: spec.kind)
+            let promptValue = MenubarMetricGlyph.formatTps(snapshot.rates?.promptTps)
+            let generationValue = MenubarMetricGlyph.formatTps(snapshot.rates?.generationTps)
             let signature = MenubarMetricGlyph.signature(
                 tag: spec.tag,
                 promptValue: promptValue,

--- a/apps/omlx-mac/Sources/Menubar/MenubarMetricPopover.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarMetricPopover.swift
@@ -145,6 +145,83 @@ struct ServingStatsScopeView: View {
     }
 }
 
+/// The compact main-menu overview reuses the serving leaves without the
+/// standalone popovers' activity graphs or unavailable-state notes.
+struct ServingStatsMenuPanel: View {
+    let live: ServingStatsSnapshot
+    let average: ServingStatsSnapshot
+    let alltime: ServingStatsSnapshot
+    let liveSeries: MenubarMetricsStore.Series
+    let averageSeries: MenubarMetricsStore.Series
+    let alltimeSeries: MenubarMetricsStore.Series
+    let serverIsRunning: Bool
+
+    @Environment(\.omlxTheme) private var theme
+
+    var body: some View {
+        Group {
+            switch ServingStatsPresentation.menuComposition(serverIsRunning: serverIsRunning) {
+            case .serverOff:
+                Text(String(
+                    localized: "menubar.stats.server_off",
+                    defaultValue: "Server is off",
+                    comment: "Disabled placeholder in the Serving Stats submenu when the server isn't running"
+                ))
+                .font(.omlxText(11))
+                .foregroundStyle(theme.textTertiary)
+                .padding(.vertical, 14)
+            case .sections(let sections):
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(sections) { section in
+                        compactScope(section)
+                        if section.kind != .alltime {
+                            SectionRule()
+                        }
+                    }
+                }
+            }
+        }
+        .frame(width: MenubarStatsPanelLayout.contentWidth, alignment: .leading)
+        .padding(.horizontal, MenubarStatsPanelLayout.horizontalInset)
+        .padding(.vertical, MenubarStatsPanelLayout.verticalInset)
+        .frame(width: MenubarStatsPanelLayout.width)
+    }
+
+    private func compactScope(
+        _ section: ServingStatsPresentation.ScopeComposition
+    ) -> some View {
+        ServingStatsScopeView(
+            snapshot: snapshot(for: section.kind),
+            series: series(for: section.kind),
+            serverIsRunning: serverIsRunning,
+            composition: section,
+            showsStatusNote: false
+        )
+    }
+
+    private func snapshot(for kind: MenubarMetricsStore.Kind) -> ServingStatsSnapshot {
+        switch kind {
+        case .live:
+            return live
+        case .average:
+            return average
+        case .alltime:
+            return alltime
+        }
+    }
+
+    private func series(for kind: MenubarMetricsStore.Kind) -> MenubarMetricsStore.Series {
+        switch kind {
+        case .live:
+            return liveSeries
+        case .average:
+            return averageSeries
+        case .alltime:
+            return alltimeSeries
+        }
+    }
+}
+
 enum ServingStatsPresentation {
     enum TerminalDetail: Equatable {
         case currentRequests

--- a/apps/omlx-mac/Sources/Menubar/MenubarMetricPopover.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarMetricPopover.swift
@@ -12,49 +12,17 @@ struct MetricPopoverView: View {
     let openSettings: () -> Void
     let openDashboard: () -> Void
 
-    @Environment(\.omlxTheme) private var theme
-
     var body: some View {
-        let rates = store.rates[kind]
+        let snapshot = store.snapshot(for: kind)
         let series = store.history[kind] ?? MenubarMetricsStore.Series()
 
         VStack(alignment: .leading, spacing: 6) {
-            sectionHeader(kind.displayName)
-
-            valueRow(
-                label: "PP",
-                value: Self.popoverTps(rates?.promptTps),
-                tint: theme.blueDot
+            ServingStatsScopeView(
+                kind: kind,
+                snapshot: snapshot,
+                series: series,
+                serverIsRunning: store.serverIsRunning
             )
-            valueRow(
-                label: "TG",
-                value: Self.popoverTps(rates?.generationTps),
-                tint: theme.greenDot
-            )
-
-            if let note = statusNote {
-                Text(note)
-                    .font(.omlxText(11))
-                    .foregroundStyle(theme.textTertiary)
-            }
-
-            Divider().padding(.vertical, 2)
-
-            sectionHeader(String(
-                localized: "menubar.metric.activity",
-                defaultValue: "Activity",
-                comment: "Header above the throughput graphs in a menubar metric popover"
-            ))
-
-            graphCaption("PP tk/s")
-            MetricSparkline(values: series.promptTps, color: theme.blueDot)
-            graphCaption("TG tk/s")
-            MetricSparkline(values: series.generationTps, color: theme.greenDot)
-
-            if kind == .live {
-                Divider().padding(.vertical, 2)
-                CurrentRequestsView(activity: store.liveActivity)
-            }
 
             Divider().padding(.vertical, 2)
 
@@ -91,89 +59,349 @@ struct MetricPopoverView: View {
                 .disabled(!store.serverIsRunning)
             }
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
-        .frame(width: 260)
+        .padding(.horizontal, MenubarStatsPanelLayout.horizontalInset)
+        .padding(.vertical, MenubarStatsPanelLayout.verticalInset)
+        .frame(width: MenubarStatsPanelLayout.width)
+    }
+}
+
+/// Read-only, value-driven presentation for a detailed Serving Stats scope.
+/// It keeps the metrics, activity history, and terminal detail reusable while
+/// preserving the full popover composition for LIV, AVG, and ALL.
+struct ServingStatsScopeView: View {
+    let snapshot: ServingStatsSnapshot
+    let series: MenubarMetricsStore.Series
+    let serverIsRunning: Bool
+    let composition: ServingStatsPresentation.ScopeComposition
+    let showsStatusNote: Bool
+
+    @Environment(\.omlxTheme) private var theme
+
+    init(
+        kind: MenubarMetricsStore.Kind,
+        snapshot: ServingStatsSnapshot,
+        series: MenubarMetricsStore.Series,
+        serverIsRunning: Bool
+    ) {
+        self.init(
+            snapshot: snapshot,
+            series: series,
+            serverIsRunning: serverIsRunning,
+            composition: ServingStatsPresentation.popoverScope(for: kind),
+            showsStatusNote: true
+        )
     }
 
-    private var statusNote: String? {
-        if !store.serverIsRunning {
+    init(
+        snapshot: ServingStatsSnapshot,
+        series: MenubarMetricsStore.Series,
+        serverIsRunning: Bool,
+        composition: ServingStatsPresentation.ScopeComposition,
+        showsStatusNote: Bool = false
+    ) {
+        self.snapshot = snapshot
+        self.series = series
+        self.serverIsRunning = serverIsRunning
+        self.composition = composition
+        self.showsStatusNote = showsStatusNote
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            MenubarStatsPanelHeader(title: composition.kind.displayName)
+
+            if composition.showsThroughput {
+                ServingStatsThroughputValues(snapshot: snapshot)
+            }
+
+            if showsStatusNote, let note = ServingStatsPresentation.statusNote(
+                for: composition.kind,
+                snapshot: snapshot,
+                serverIsRunning: serverIsRunning
+            ) {
+                Text(note)
+                    .font(.omlxText(11))
+                    .foregroundStyle(theme.textTertiary)
+            }
+
+            if composition.activityGraphCount > 0 {
+                ServingStatsActivityGraphs(series: series)
+            }
+
+            Divider().padding(.vertical, 2)
+            switch composition.terminalDetail {
+            case .currentRequests:
+                CurrentRequestsView(
+                    activity: snapshot.liveActivity,
+                    showsHeader: composition.showsTerminalDetailHeader
+                )
+            case .scalarMetrics:
+                ScalarMetricsView(
+                    snapshot: snapshot,
+                    showsHeader: composition.showsTerminalDetailHeader
+                )
+            }
+        }
+    }
+}
+
+enum ServingStatsPresentation {
+    enum TerminalDetail: Equatable {
+        case currentRequests
+        case scalarMetrics
+    }
+
+    struct ScopeComposition: Equatable, Identifiable {
+        let kind: MenubarMetricsStore.Kind
+        let showsThroughput: Bool
+        let activityGraphCount: Int
+        let terminalDetail: TerminalDetail
+        let showsTerminalDetailHeader: Bool
+
+        init(
+            kind: MenubarMetricsStore.Kind,
+            showsThroughput: Bool,
+            activityGraphCount: Int,
+            terminalDetail: TerminalDetail,
+            showsTerminalDetailHeader: Bool = false
+        ) {
+            self.kind = kind
+            self.showsThroughput = showsThroughput
+            self.activityGraphCount = activityGraphCount
+            self.terminalDetail = terminalDetail
+            self.showsTerminalDetailHeader = showsTerminalDetailHeader
+        }
+
+        var id: MenubarMetricsStore.Kind { kind }
+    }
+
+    enum MenuComposition: Equatable {
+        case serverOff
+        case sections([ScopeComposition])
+    }
+
+    static func popoverScope(for kind: MenubarMetricsStore.Kind) -> ScopeComposition {
+        ScopeComposition(
+            kind: kind,
+            showsThroughput: true,
+            activityGraphCount: 2,
+            terminalDetail: kind == .live ? .currentRequests : .scalarMetrics,
+            showsTerminalDetailHeader: kind == .live
+        )
+    }
+
+    static func menuComposition(serverIsRunning: Bool) -> MenuComposition {
+        guard serverIsRunning else {
+            return .serverOff
+        }
+        return .sections([
+            ScopeComposition(
+                kind: .live,
+                showsThroughput: true,
+                activityGraphCount: 2,
+                terminalDetail: .currentRequests,
+                showsTerminalDetailHeader: true
+            ),
+            ScopeComposition(
+                kind: .average,
+                showsThroughput: true,
+                activityGraphCount: 0,
+                terminalDetail: .scalarMetrics
+            ),
+            ScopeComposition(
+                kind: .alltime,
+                showsThroughput: true,
+                activityGraphCount: 0,
+                terminalDetail: .scalarMetrics
+            )
+        ])
+    }
+
+    static func statusNote(
+        for kind: MenubarMetricsStore.Kind,
+        snapshot: ServingStatsSnapshot,
+        serverIsRunning: Bool
+    ) -> String? {
+        if !serverIsRunning {
             return String(
                 localized: "menubar.metric.server_off",
                 defaultValue: "Server is off",
                 comment: "Note in a menubar metric popover while the server is not running"
             )
         }
-        if kind == .live, store.rates[.live] == nil {
-            // The server answers but /admin/api/activity does not — the
-            // admin API key is missing or rejected.
+        if kind == .live, snapshot.isUnavailable {
             return String(
                 localized: "menubar.metric.live_unavailable",
                 defaultValue: "Set an API key to enable live activity",
                 comment: "Note in the LIV popover when live stats need admin authentication"
             )
         }
+        if kind != .live, snapshot.isUnavailable {
+            return String(
+                localized: "menubar.metric.unavailable",
+                defaultValue: "Serving stats are unavailable",
+                comment: "Note in an AVG or ALL popover when its scoped stats are unavailable"
+            )
+        }
         return nil
     }
 
-    private func sectionHeader(_ title: String) -> some View {
-        Text(title.uppercased())
-            .font(.omlxText(10, weight: .bold))
-            .kerning(1)
-            .foregroundStyle(theme.accent)
-            .frame(maxWidth: .infinity, alignment: .center)
-    }
-
-    private func valueRow(label: String, value: String, tint: Color) -> some View {
-        HStack {
-            Circle()
-                .fill(tint)
-                .frame(width: 6, height: 6)
-            Text(label)
-                .font(.omlxText(12, weight: .medium))
-                .foregroundStyle(theme.textSecondary)
-            Spacer()
-            Text(value)
-                .font(.omlxMono(12, weight: .medium))
-                .foregroundStyle(theme.text)
-        }
-    }
-
-    private func graphCaption(_ text: String) -> some View {
-        Text(text)
-            .font(.omlxMono(9))
-            .foregroundStyle(theme.textTertiary)
-    }
-
-    /// Popover readout: one decimal below 100 tk/s, whole numbers above,
-    /// "–" for unknown.
     static func popoverTps(_ value: Double?) -> String {
         guard let value, value.isFinite else {
             return "–"
         }
-        let clamped = max(0, value)
-        if clamped < 100 {
-            return String(format: "%.1f tk/s", clamped)
-        }
-        return "\(Int(clamped.rounded())) tk/s"
+        return "\(ActivityFormat.rate(value)) tk/s"
     }
 }
 
-private struct CurrentRequestsView: View {
-    let activity: MenubarStatsPoller.Stats.LiveActivity?
+struct ServingStatsActivityGraphs: View {
+    let series: MenubarMetricsStore.Series
+
     @Environment(\.omlxTheme) private var theme
 
     var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            MenubarStatsPanelCaption(text: "PP tk/s")
+            MetricSparkline(values: series.promptTps, color: theme.blueDot)
+            MenubarStatsPanelCaption(text: "TG tk/s")
+            MetricSparkline(values: series.generationTps, color: theme.greenDot)
+        }
+    }
+}
+
+struct ServingStatsThroughputValues: View {
+    let snapshot: ServingStatsSnapshot
+    @Environment(\.omlxTheme) private var theme
+
+    var body: some View {
+        HStack(spacing: 8) {
+            value(
+                label: "PP",
+                value: ServingStatsPresentation.popoverTps(snapshot.rates?.promptTps),
+                tint: theme.blueDot
+            )
+            value(
+                label: "TG",
+                value: ServingStatsPresentation.popoverTps(snapshot.rates?.generationTps),
+                tint: theme.greenDot
+            )
+        }
+    }
+
+    private func value(label: String, value: String, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 4) {
+                Circle()
+                    .fill(tint)
+                    .frame(width: 6, height: 6)
+                Text(label)
+                    .font(.omlxText(12))
+                    .foregroundStyle(theme.textSecondary)
+            }
+            Text(value)
+                .font(.omlxMono(12))
+                .foregroundStyle(theme.text)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct ScalarMetricsView: View {
+    let snapshot: ServingStatsSnapshot
+    let showsHeader: Bool
+
+    init(snapshot: ServingStatsSnapshot, showsHeader: Bool = true) {
+        self.snapshot = snapshot
+        self.showsHeader = showsHeader
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            if showsHeader {
+                MenubarStatsPanelHeader(title: String(
+                    localized: "menubar.metric.metrics",
+                    defaultValue: "Serving Stats",
+                    comment: "Header above scalar counters in an AVG or ALL serving metric popover"
+                ))
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                MenubarStatsValueRow(
+                    label: String(
+                        localized: "menubar.stats.total_tokens",
+                        defaultValue: "Total Tokens Processed",
+                        comment: "Stats row label for total tokens processed"
+                    ),
+                    value: Self.compact(snapshot.totalPromptTokens)
+                )
+                MenubarStatsValueRow(
+                    label: String(
+                        localized: "menubar.stats.cached_tokens",
+                        defaultValue: "Cached Tokens",
+                        comment: "Stats row label for cached tokens count"
+                    ),
+                    value: Self.compact(snapshot.totalCachedTokens)
+                )
+                MenubarStatsValueRow(
+                    label: String(
+                        localized: "menubar.stats.cache_efficiency",
+                        defaultValue: "Cache Efficiency",
+                        comment: "Stats row label for the cache efficiency percentage"
+                    ),
+                    value: Self.percent(snapshot.cacheEfficiency)
+                )
+                MenubarStatsValueRow(
+                    label: String(
+                        localized: "menubar.stats.total_requests",
+                        defaultValue: "Total Requests",
+                        comment: "Stats row label for total request count"
+                    ),
+                    value: Self.compact(snapshot.totalRequests)
+                )
+            }
+        }
+    }
+
+    private static func compact(_ value: Int?) -> String {
+        guard let value else { return "–" }
+        let clamped = max(0, value)
+        if clamped >= 1_000_000 {
+            return String(format: clamped >= 10_000_000 ? "%.0fM" : "%.1fM", Double(clamped) / 1_000_000)
+        }
+        if clamped >= 1_000 {
+            return String(format: clamped >= 10_000 ? "%.0fk" : "%.1fk", Double(clamped) / 1_000)
+        }
+        return "\(clamped)"
+    }
+
+    private static func percent(_ value: Double?) -> String {
+        guard let value, value.isFinite else { return "–" }
+        return String(format: "%.1f%%", max(0, value))
+    }
+}
+
+struct CurrentRequestsView: View {
+    let activity: MenubarStatsPoller.Stats.LiveActivity?
+    let showsHeader: Bool
+    @Environment(\.omlxTheme) private var theme
+
+    init(
+        activity: MenubarStatsPoller.Stats.LiveActivity?,
+        showsHeader: Bool = true
+    ) {
+        self.activity = activity
+        self.showsHeader = showsHeader
+    }
+
+    var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(String(
-                localized: "menubar.stats.current_requests",
-                defaultValue: "Current Requests",
-                comment: "Section header inside Serving Stats for active and queued requests"
-            ).uppercased())
-            .font(.omlxText(10, weight: .bold))
-            .kerning(1)
-            .foregroundStyle(theme.accent)
-            .frame(maxWidth: .infinity, alignment: .center)
+            if showsHeader {
+                MenubarStatsPanelHeader(title: String(
+                    localized: "menubar.stats.current_requests",
+                    defaultValue: "Current Requests",
+                    comment: "Section header inside Serving Stats for active and queued requests"
+                ))
+            }
 
             if let activity {
                 if activity.isIdle {
@@ -181,7 +409,7 @@ private struct CurrentRequestsView: View {
                 } else {
                     ForEach(activity.groups) { group in
                         Text(group.modelID)
-                            .font(.omlxMono(10, weight: .medium))
+                            .font(.omlxMono(11.5, weight: .medium))
                             .foregroundStyle(theme.textSecondary)
                             .lineLimit(1)
                         ForEach(group.requests) { request in
@@ -227,14 +455,22 @@ private struct CurrentRequestsView: View {
 
     private func requestRow(_ request: MenubarStatsPoller.Stats.LiveActivity.Request) -> some View {
         HStack(spacing: 6) {
+            if let marker = CurrentRequestMarker.marker(for: request.kind) {
+                Circle()
+                    .fill(marker.color(in: theme))
+                    .frame(width: 6, height: 6)
+                Text(marker.abbreviation)
+                    .font(.omlxMono(10))
+                    .foregroundStyle(marker.color(in: theme))
+            }
             Text(request.title)
-                .font(.omlxMono(10))
+                .font(.omlxMono(12))
                 .foregroundStyle(theme.text)
                 .lineLimit(1)
             Spacer(minLength: 4)
             Text(request.detail)
-                .font(.omlxMono(10))
-                .foregroundStyle(theme.textTertiary)
+                .font(.omlxMono(12))
+                .foregroundStyle(theme.textSecondary)
                 .lineLimit(1)
         }
     }
@@ -243,6 +479,42 @@ private struct CurrentRequestsView: View {
         Text(text)
             .font(.omlxText(11))
             .foregroundStyle(theme.textTertiary)
+    }
+}
+
+enum CurrentRequestMarker: Equatable {
+    case prefill
+    case generating
+
+    static func marker(
+        for kind: MenubarStatsPoller.Stats.LiveActivity.Request.Kind
+    ) -> CurrentRequestMarker? {
+        switch kind {
+        case .prefill:
+            return .prefill
+        case .generating:
+            return .generating
+        case .nonStreaming:
+            return nil
+        }
+    }
+
+    var abbreviation: String {
+        switch self {
+        case .prefill:
+            return "PP"
+        case .generating:
+            return "TG"
+        }
+    }
+
+    func color(in theme: OMLXTheme) -> Color {
+        switch self {
+        case .prefill:
+            return theme.blueDot
+        case .generating:
+            return theme.greenDot
+        }
     }
 }
 

--- a/apps/omlx-mac/Sources/Menubar/MenubarMetricPopover.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarMetricPopover.swift
@@ -51,6 +51,11 @@ struct MetricPopoverView: View {
             graphCaption("TG tk/s")
             MetricSparkline(values: series.generationTps, color: theme.greenDot)
 
+            if kind == .live {
+                Divider().padding(.vertical, 2)
+                CurrentRequestsView(activity: store.liveActivity)
+            }
+
             Divider().padding(.vertical, 2)
 
             HStack(spacing: 8) {
@@ -151,6 +156,93 @@ struct MetricPopoverView: View {
             return String(format: "%.1f tk/s", clamped)
         }
         return "\(Int(clamped.rounded())) tk/s"
+    }
+}
+
+private struct CurrentRequestsView: View {
+    let activity: MenubarStatsPoller.Stats.LiveActivity?
+    @Environment(\.omlxTheme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(String(
+                localized: "menubar.stats.current_requests",
+                defaultValue: "Current Requests",
+                comment: "Section header inside Serving Stats for active and queued requests"
+            ).uppercased())
+            .font(.omlxText(10, weight: .bold))
+            .kerning(1)
+            .foregroundStyle(theme.accent)
+            .frame(maxWidth: .infinity, alignment: .center)
+
+            if let activity {
+                if activity.isIdle {
+                    emptyState
+                } else {
+                    ForEach(activity.groups) { group in
+                        Text(group.modelID)
+                            .font(.omlxMono(10, weight: .medium))
+                            .foregroundStyle(theme.textSecondary)
+                            .lineLimit(1)
+                        ForEach(group.requests) { request in
+                            requestRow(request)
+                        }
+                    }
+                    if activity.queuedRequestCount > 0 {
+                        statusRow(String(
+                            localized: "menubar.stats.queued_requests",
+                            defaultValue: "\(activity.queuedRequestCount) queued requests",
+                            comment: "Current Requests row showing how many requests have not started; placeholder is the count"
+                        ))
+                    }
+                    if activity.hiddenRequestCount > 0 {
+                        statusRow(String(
+                            localized: "menubar.stats.more_requests",
+                            defaultValue: "\(activity.hiddenRequestCount) more requests",
+                            comment: "Current Requests row showing active requests omitted from the capped list; placeholder is the count"
+                        ))
+                    }
+                }
+            } else {
+                Text(String(
+                    localized: "menubar.stats.loading",
+                    defaultValue: "Loading stats…",
+                    comment: "Disabled placeholder shown while stats are loading"
+                ))
+                .font(.omlxText(11))
+                .foregroundStyle(theme.textTertiary)
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        Text(String(
+            localized: "menubar.stats.no_current_requests",
+            defaultValue: "No active requests",
+            comment: "Disabled empty state in Serving Stats when no requests are active or queued"
+        ))
+        .font(.omlxText(11))
+        .foregroundStyle(theme.textTertiary)
+    }
+
+    private func requestRow(_ request: MenubarStatsPoller.Stats.LiveActivity.Request) -> some View {
+        HStack(spacing: 6) {
+            Text(request.title)
+                .font(.omlxMono(10))
+                .foregroundStyle(theme.text)
+                .lineLimit(1)
+            Spacer(minLength: 4)
+            Text(request.detail)
+                .font(.omlxMono(10))
+                .foregroundStyle(theme.textTertiary)
+                .lineLimit(1)
+        }
+    }
+
+    private func statusRow(_ text: String) -> some View {
+        Text(text)
+            .font(.omlxText(11))
+            .foregroundStyle(theme.textTertiary)
     }
 }
 

--- a/apps/omlx-mac/Sources/Menubar/MenubarMetricPopover.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarMetricPopover.swift
@@ -486,7 +486,7 @@ struct CurrentRequestsView: View {
                 } else {
                     ForEach(activity.groups) { group in
                         Text(group.modelID)
-                            .font(.omlxMono(11.5, weight: .medium))
+                            .font(.omlxMono(12, weight: .medium))
                             .foregroundStyle(theme.textSecondary)
                             .lineLimit(1)
                         ForEach(group.requests) { request in
@@ -537,7 +537,7 @@ struct CurrentRequestsView: View {
                     .fill(marker.color(in: theme))
                     .frame(width: 6, height: 6)
                 Text(marker.abbreviation)
-                    .font(.omlxMono(10))
+                    .font(.omlxMono(12, weight: .medium))
                     .foregroundStyle(marker.color(in: theme))
             }
             Text(request.title)

--- a/apps/omlx-mac/Sources/Menubar/MenubarMetricsStore.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarMetricsStore.swift
@@ -36,17 +36,20 @@ final class MenubarMetricsStore {
     private(set) var rates: [Kind: MetricRates] = [:]
     private(set) var history: [Kind: Series] = [:]
     private(set) var serverIsRunning = false
+    private(set) var liveActivity: MenubarStatsPoller.Stats.LiveActivity?
 
     /// One call per poller tick. Unknown readings surface as nil rates (the
     /// glyph shows "–") but roll a 0 into the history so the graph timeline
     /// stays contiguous.
     func applyTick(
         live: MetricRates?,
+        liveActivity: MenubarStatsPoller.Stats.LiveActivity?,
         average: MetricRates?,
         alltime: MetricRates?,
         serverRunning: Bool
     ) {
         serverIsRunning = serverRunning
+        self.liveActivity = liveActivity
         record(.live, live)
         record(.average, average)
         record(.alltime, alltime)
@@ -57,6 +60,7 @@ final class MenubarMetricsStore {
     func markServerStopped() {
         serverIsRunning = false
         rates = [:]
+        liveActivity = nil
     }
 
     private func record(_ kind: Kind, _ reading: MetricRates?) {

--- a/apps/omlx-mac/Sources/Menubar/MenubarMetricsStore.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarMetricsStore.swift
@@ -15,6 +15,36 @@ struct MetricRates: Equatable, Sendable {
     var generationTps: Double?
 }
 
+/// Presentation-ready serving data for one menubar metric scope. This keeps
+/// popovers independent of the poller's transport DTOs.
+struct ServingStatsSnapshot: Equatable, Sendable {
+    let rates: MetricRates?
+    let totalPromptTokens: Int?
+    let totalCachedTokens: Int?
+    let cacheEfficiency: Double?
+    let totalRequests: Int?
+    let liveActivity: MenubarStatsPoller.Stats.LiveActivity?
+
+    static let unavailable = ServingStatsSnapshot(
+        rates: nil,
+        totalPromptTokens: nil,
+        totalCachedTokens: nil,
+        cacheEfficiency: nil,
+        totalRequests: nil,
+        liveActivity: nil
+    )
+
+    var isUnavailable: Bool {
+        rates?.promptTps == nil
+            && rates?.generationTps == nil
+            && totalPromptTokens == nil
+            && totalCachedTokens == nil
+            && cacheEfficiency == nil
+            && totalRequests == nil
+            && liveActivity == nil
+    }
+}
+
 @MainActor
 @Observable
 final class MenubarMetricsStore {
@@ -33,23 +63,20 @@ final class MenubarMetricsStore {
     /// graphs cover the last minute.
     nonisolated static let historyCapacity = 60
 
-    private(set) var rates: [Kind: MetricRates] = [:]
+    private(set) var snapshots: [Kind: ServingStatsSnapshot] = [:]
     private(set) var history: [Kind: Series] = [:]
     private(set) var serverIsRunning = false
-    private(set) var liveActivity: MenubarStatsPoller.Stats.LiveActivity?
 
     /// One call per poller tick. Unknown readings surface as nil rates (the
     /// glyph shows "–") but roll a 0 into the history so the graph timeline
     /// stays contiguous.
     func applyTick(
-        live: MetricRates?,
-        liveActivity: MenubarStatsPoller.Stats.LiveActivity?,
-        average: MetricRates?,
-        alltime: MetricRates?,
+        live: ServingStatsSnapshot?,
+        average: ServingStatsSnapshot?,
+        alltime: ServingStatsSnapshot?,
         serverRunning: Bool
     ) {
         serverIsRunning = serverRunning
-        self.liveActivity = liveActivity
         record(.live, live)
         record(.average, average)
         record(.alltime, alltime)
@@ -59,15 +86,18 @@ final class MenubarMetricsStore {
     /// the history where it was.
     func markServerStopped() {
         serverIsRunning = false
-        rates = [:]
-        liveActivity = nil
+        snapshots = [:]
     }
 
-    private func record(_ kind: Kind, _ reading: MetricRates?) {
-        rates[kind] = reading
+    func snapshot(for kind: Kind) -> ServingStatsSnapshot {
+        snapshots[kind] ?? .unavailable
+    }
+
+    private func record(_ kind: Kind, _ snapshot: ServingStatsSnapshot?) {
+        snapshots[kind] = snapshot ?? .unavailable
         var series = history[kind] ?? Series()
-        Self.append(&series.promptTps, reading?.promptTps ?? 0)
-        Self.append(&series.generationTps, reading?.generationTps ?? 0)
+        Self.append(&series.promptTps, snapshot?.rates?.promptTps ?? 0)
+        Self.append(&series.generationTps, snapshot?.rates?.generationTps ?? 0)
         history[kind] = series
     }
 
@@ -83,6 +113,42 @@ final class MenubarMetricsStore {
 // MARK: - Rate aggregation (pure, unit-testable)
 
 extension MenubarMetricsStore {
+    /// Maps each polling source into one shared popover model. LIV is
+    /// intentionally limited to instantaneous rates and current requests;
+    /// AVG and ALL retain the scalar counters from their respective scopes.
+    nonisolated static func snapshot(
+        for kind: Kind,
+        from stats: MenubarStatsPoller.Stats?
+    ) -> ServingStatsSnapshot? {
+        guard let stats else {
+            return nil
+        }
+
+        switch kind {
+        case .live:
+            guard let rates = liveRates(from: stats) else {
+                return nil
+            }
+            return ServingStatsSnapshot(
+                rates: rates,
+                totalPromptTokens: nil,
+                totalCachedTokens: nil,
+                cacheEfficiency: nil,
+                totalRequests: nil,
+                liveActivity: stats.liveActivity
+            )
+        case .average, .alltime:
+            return ServingStatsSnapshot(
+                rates: averageRates(from: stats),
+                totalPromptTokens: stats.totalPromptTokens,
+                totalCachedTokens: stats.totalCachedTokens,
+                cacheEfficiency: stats.cacheEfficiency,
+                totalRequests: stats.totalRequests,
+                liveActivity: nil
+            )
+        }
+    }
+
     /// Instantaneous rates summed across every in-flight request of every
     /// model. A decoded-but-idle activity payload yields 0/0; a missing
     /// payload (fetch disabled or failed) yields nil.

--- a/apps/omlx-mac/Sources/Menubar/MenubarStatsPoller.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarStatsPoller.swift
@@ -176,10 +176,16 @@ final class MenubarStatsPoller {
 
                 return Request(
                     id: "prefill-\(index)",
-                    title: "\(percentage)% · \(ActivityFormat.tokens(processedTokens)) / \(ActivityFormat.tokens(totalTokens)) tk",
+                    title: "\(percentage)% · \(formatPrefillProgressTokenCount(processedTokens)) / \(formatPrefillProgressTokenCount(totalTokens)) tk",
                     detail: "\(ActivityFormat.rate(max(0, progress.speed ?? 0))) tk/s",
                     kind: .prefill
                 )
+            }
+
+            private static func formatPrefillProgressTokenCount(_ count: Int) -> String {
+                guard count >= 1_000 else { return "\(count)" }
+                guard count < 10_000 else { return ActivityFormat.tokens(count) }
+                return String(format: "%.1fk", Double(count) / 1_000)
             }
 
             private static func generation(index: Int, progress: GenerationProgress) -> Request {

--- a/apps/omlx-mac/Sources/Menubar/MenubarStatsPoller.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarStatsPoller.swift
@@ -87,12 +87,47 @@ final class MenubarStatsPoller {
         }
 
         struct LiveActivity: Equatable, Sendable {
-            let menuBarTitle: String
-            let detail: String
+            /// A hard cap keeps the LIV popover useful without allowing a busy
+            /// server to grow an unbounded menubar panel.
+            static let maximumVisibleRequests = 6
 
-            private init(menuBarTitle: String, detail: String) {
-                self.menuBarTitle = menuBarTitle
-                self.detail = detail
+            struct Request: Equatable, Sendable, Identifiable {
+                enum Kind: Equatable, Sendable {
+                    case prefill
+                    case generating
+                    case nonStreaming
+                }
+
+                let id: String
+                let title: String
+                let detail: String
+                let kind: Kind
+            }
+
+            struct ModelGroup: Equatable, Sendable, Identifiable {
+                let modelID: String
+                let requests: [Request]
+
+                var id: String { modelID }
+            }
+
+            let groups: [ModelGroup]
+            let queuedRequestCount: Int
+            let hiddenRequestCount: Int
+
+            var isIdle: Bool {
+                groups.isEmpty && queuedRequestCount == 0
+            }
+
+            var detail: String {
+                if let group = groups.first, let request = group.requests.first {
+                    return [group.modelID, request.detail]
+                        .filter { !$0.isEmpty }
+                        .joined(separator: " · ")
+                }
+                return queuedRequestCount > 0
+                    ? "\(queuedRequestCount) queued request\(queuedRequestCount == 1 ? "" : "s")"
+                    : ""
             }
 
             init?(activeModels: ActiveModels?) {
@@ -100,111 +135,79 @@ final class MenubarStatsPoller {
                     return nil
                 }
 
+                var visibleCount = 0
+                var hiddenRequestCount = 0
+                var groups: [ModelGroup] = []
                 for activeModel in activeModels.models {
-                    if let prefill = activeModel.prefilling?.first {
-                        self = Self.prefill(modelID: activeModel.id, progress: prefill)
-                        return
+                    let requests = Self.requests(for: activeModel)
+                    let available = max(0, Self.maximumVisibleRequests - visibleCount)
+                    let shown = Array(requests.prefix(available))
+                    hiddenRequestCount += requests.count - shown.count
+                    visibleCount += shown.count
+                    if !shown.isEmpty {
+                        groups.append(ModelGroup(modelID: activeModel.id, requests: shown))
                     }
                 }
 
-                for activeModel in activeModels.models {
-                    if let generation = activeModel.generating?.first {
-                        self = Self.generation(modelID: activeModel.id, progress: generation)
-                        return
-                    }
-                }
-
-                for activeModel in activeModels.models {
-                    if let activity = activeModel.activities?.first {
-                        self = Self.nonStreaming(modelID: activeModel.id, activity: activity)
-                        return
-                    }
-                }
-
-                if let waitingRequestCount = activeModels.totalWaitingRequests,
-                   waitingRequestCount > 0 {
-                    self = Self.waiting(requestCount: waitingRequestCount)
-                    return
-                }
-
-                return nil
+                self.groups = groups
+                self.queuedRequestCount = max(0, activeModels.totalWaitingRequests ?? 0)
+                self.hiddenRequestCount = hiddenRequestCount
             }
 
-            private static func prefill(
-                modelID: String,
-                progress: PrefillProgress
-            ) -> LiveActivity {
+            private static func requests(for model: ActiveModel) -> [Request] {
+                let prefill = (model.prefilling ?? []).enumerated().map { index, progress in
+                    Self.prefill(index: index, progress: progress)
+                }
+                let generation = (model.generating ?? []).enumerated().map { index, progress in
+                    Self.generation(index: index, progress: progress)
+                }
+                let activity = (model.activities ?? []).enumerated().map { index, item in
+                    Self.nonStreaming(index: index, activity: item)
+                }
+                return prefill + generation + activity
+            }
+
+            private static func prefill(index: Int, progress: PrefillProgress) -> Request {
                 let processedTokens = max(0, progress.processed ?? 0)
                 let totalTokens = max(0, progress.total ?? 0)
                 let percentage = totalTokens > 0
                     ? Int((Double(processedTokens) / Double(totalTokens) * 100).rounded())
                     : 0
 
-                var detailParts = [modelID]
-                if let tokensPerSecond = progress.speed, tokensPerSecond > 0 {
-                    detailParts.append("\(Int(tokensPerSecond.rounded())) tok/s")
-                }
-                if let etaSeconds = progress.eta, etaSeconds >= 0 {
-                    detailParts.append("\(formatDuration(etaSeconds)) left")
-                }
-
-                return LiveActivity(
-                    menuBarTitle: "PP \(percentage)% · \(formatTokenCount(processedTokens))/\(formatTokenCount(totalTokens))",
-                    detail: detailParts.joined(separator: " · ")
+                return Request(
+                    id: "prefill-\(index)",
+                    title: "\(percentage)% · \(ActivityFormat.tokens(processedTokens)) / \(ActivityFormat.tokens(totalTokens)) tk",
+                    detail: "\(ActivityFormat.rate(max(0, progress.speed ?? 0))) tk/s",
+                    kind: .prefill
                 )
             }
 
-            private static func generation(
-                modelID: String,
-                progress: GenerationProgress
-            ) -> LiveActivity {
+            private static func generation(index: Int, progress: GenerationProgress) -> Request {
                 let tokensPerSecond = max(0, progress.tokensPerSecond ?? 0)
                 let generatedTokens = max(0, progress.generatedTokens ?? 0)
 
-                var detailParts = [modelID, "\(generatedTokens) tok"]
-                if let elapsedSeconds = progress.elapsedSeconds {
-                    detailParts.append(formatDuration(elapsedSeconds))
-                }
-
-                return LiveActivity(
-                    menuBarTitle: "GEN \(String(format: "%.1f", tokensPerSecond)) tok/s",
-                    detail: detailParts.joined(separator: " · ")
+                return Request(
+                    id: "generation-\(index)",
+                    title: "\(ActivityFormat.tokens(generatedTokens)) tk",
+                    detail: "\(ActivityFormat.rate(tokensPerSecond)) tk/s",
+                    kind: .generating
                 )
             }
 
-            private static func waiting(requestCount: Int) -> LiveActivity {
-                LiveActivity(
-                    menuBarTitle: "WAIT \(requestCount)",
-                    detail: "\(requestCount) queued request\(requestCount == 1 ? "" : "s")"
-                )
-            }
-
-            private static func nonStreaming(
-                modelID: String,
-                activity: NonStreamingActivity
-            ) -> LiveActivity {
+            private static func nonStreaming(index: Int, activity: NonStreamingActivity) -> Request {
                 let elapsed = activity.elapsedSeconds.map(formatDuration)
                 let activityDetail = activity.detail ?? activity.kind ?? "Active request"
-                var detailParts = [modelID, activityDetail]
+                var detailParts = [activityDetail]
                 if let elapsed {
                     detailParts.append(elapsed)
                 }
 
-                return LiveActivity(
-                    menuBarTitle: elapsed.map { "RUN \($0)" } ?? "RUN",
-                    detail: detailParts.joined(separator: " · ")
+                return Request(
+                    id: "working-\(index)",
+                    title: elapsed.map { "RUN \($0)" } ?? "RUN",
+                    detail: detailParts.joined(separator: " · "),
+                    kind: .nonStreaming
                 )
-            }
-
-            private static func formatTokenCount(_ tokenCount: Int) -> String {
-                if tokenCount >= 1_000_000 {
-                    let millions = Double(tokenCount) / 1_000_000
-                    return String(format: millions >= 10 ? "%.0fM" : "%.1fM", millions)
-                }
-                if tokenCount >= 1_000 {
-                    return "\(Int((Double(tokenCount) / 1_000).rounded()))k"
-                }
-                return "\(tokenCount)"
             }
 
             private static func formatDuration(_ seconds: Double) -> String {
@@ -292,12 +295,8 @@ final class MenubarStatsPoller {
             return
         }
 
-        let liveTurnedOff = enabledMetrics.live && !metrics.live
         let alltimeTurnedOn = !enabledMetrics.alltime && metrics.alltime
         enabledMetrics = metrics
-        if liveTurnedOff {
-            clearLiveStats()
-        }
         if alltimeTurnedOn {
             // Force an all-time fetch on the next tick so a freshly enabled
             // ALL item doesn't sit on "–" for up to a full cadence period.
@@ -331,17 +330,12 @@ final class MenubarStatsPoller {
             let s = try await fetchPublicStatus()
             self.sessionStats = s
             self.lastStatusSuccessAt = Date()
-            if enabledMetrics.live {
-                do {
-                    let live = try await fetchAdminActivity()
-                    if enabledMetrics.live {
-                        self.liveStats = live
-                    }
-                } catch {
-                    if enabledMetrics.live {
-                        clearLiveStats(shouldPostUpdate: false)
-                    }
-                }
+            do {
+                // Current Requests remains available in Serving Stats even
+                // when the optional LIV glyph is disabled.
+                self.liveStats = try await fetchAdminActivity()
+            } catch {
+                clearLiveStats(shouldPostUpdate: false)
             }
             if fetchAlltime, hasAPIKey,
                let alltime = try? await fetchAdminStats(scope: "alltime") {

--- a/apps/omlx-mac/Sources/Menubar/MenubarStatsPoller.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarStatsPoller.swift
@@ -1,6 +1,6 @@
 // Menubar poller: use lightweight /api/status for liveness, authenticated
 // /admin/api/activity reads for current request activity, and occasional
-// all-time stats reads for the Serving Stats submenu. Emits
+// all-time stats reads only while a consumer needs them. Emits
 // NotificationCenter posts so the menubar refreshes without polling state
 // itself.
 //
@@ -229,6 +229,7 @@ final class MenubarStatsPoller {
     private let idleInterval: TimeInterval
     private let session: URLSession
     private var task: Task<Void, Never>?
+    private var refreshInProgress = false
     /// Seconds between all-time fetches. All-time averages only change when a
     /// request completes and the endpoint is heavyweight (it also builds
     /// active_models/engines/runtime_cache), so it is never polled at the
@@ -238,6 +239,7 @@ final class MenubarStatsPoller {
         enabledMetrics.alltime ? 5 : 30
     }
     private var tickCount = 0
+    private(set) var servingStatsSubmenuOpen = false
     private(set) var enabledMetrics = EnabledMetrics(
         live: false, average: false, alltime: false
     )
@@ -295,7 +297,7 @@ final class MenubarStatsPoller {
             return
         }
 
-        let alltimeTurnedOn = !enabledMetrics.alltime && metrics.alltime
+        let alltimeTurnedOn = !needsAlltimeStats && (metrics.alltime || servingStatsSubmenuOpen)
         enabledMetrics = metrics
         if alltimeTurnedOn {
             // Force an all-time fetch on the next tick so a freshly enabled
@@ -304,12 +306,36 @@ final class MenubarStatsPoller {
         }
     }
 
+    /// The hosted Serving Stats menu is a consumer independent of the optional
+    /// LIV / AVG / ALL status items. Opening it starts the admin-backed scopes;
+    /// closing it leaves only explicitly enabled metric items polling them.
+    func setServingStatsSubmenuOpen(_ isOpen: Bool) {
+        guard servingStatsSubmenuOpen != isOpen else {
+            return
+        }
+
+        servingStatsSubmenuOpen = isOpen
+        if isOpen {
+            // The next pass fetches all-time data immediately instead of waiting
+            // for the submenu's lower-frequency cadence.
+            tickCount = 0
+        }
+    }
+
     /// Any enabled menubar metric item polls at the user-configured refresh
     /// interval (read live from UserDefaults so setting changes apply on the
-    /// next loop pass); otherwise the idle 2 s cadence keeps the Serving
-    /// Stats submenu fresh at minimal cost.
+    /// next loop pass); otherwise the idle 2 s cadence keeps public session
+    /// data fresh without background admin traffic.
     var currentPollingInterval: TimeInterval {
         enabledMetrics.any ? MenubarMetricPrefs.refreshInterval : idleInterval
+    }
+
+    var needsLiveActivity: Bool {
+        enabledMetrics.live || servingStatsSubmenuOpen
+    }
+
+    var needsAlltimeStats: Bool {
+        enabledMetrics.alltime || servingStatsSubmenuOpen
     }
 
     deinit {
@@ -320,6 +346,15 @@ final class MenubarStatsPoller {
     // MARK: - Polling
 
     func refreshOnce() async {
+        // Opening the hosted submenu requests a prompt refresh. If it lands
+        // during the timer's fetch, that fetch completes with the current
+        // demand and the next timer pass picks up any newly enabled scope.
+        guard !refreshInProgress else {
+            return
+        }
+        refreshInProgress = true
+        defer { refreshInProgress = false }
+
         let alltimeEveryNTicks = max(
             1,
             Int((alltimeRefreshInterval / currentPollingInterval).rounded())
@@ -331,13 +366,13 @@ final class MenubarStatsPoller {
             self.sessionStats = s
             self.lastStatusSuccessAt = Date()
             do {
-                // Current Requests remains available in Serving Stats even
-                // when the optional LIV glyph is disabled.
-                self.liveStats = try await fetchAdminActivity()
+                if needsLiveActivity {
+                    self.liveStats = try await fetchAdminActivity()
+                }
             } catch {
                 clearLiveStats(shouldPostUpdate: false)
             }
-            if fetchAlltime, hasAPIKey,
+            if fetchAlltime, needsAlltimeStats, hasAPIKey,
                let alltime = try? await fetchAdminStats(scope: "alltime") {
                 self.alltimeStats = alltime
             }

--- a/apps/omlx-mac/Sources/Menubar/SystemStatsPanels.swift
+++ b/apps/omlx-mac/Sources/Menubar/SystemStatsPanels.swift
@@ -6,7 +6,12 @@
 
 import SwiftUI
 
-private let panelWidth: CGFloat = 270
+enum MenubarStatsPanelLayout {
+    static let width: CGFloat = 270
+    static let horizontalInset: CGFloat = 14
+    static let verticalInset: CGFloat = 8
+    static let contentWidth = width - (horizontalInset * 2)
+}
 
 // MARK: - CPU
 
@@ -21,7 +26,7 @@ struct CPUStatsPanel: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            StatsPanelHeader(title: "CPU")
+            MenubarStatsPanelHeader(title: "CPU")
             UsageBarRow(
                 label: String(localized: "menubar.system.e_cores",
                               defaultValue: "E-cores",
@@ -38,7 +43,7 @@ struct CPUStatsPanel: View {
                 fraction: snapshot.pCoreUsage ?? 0,
                 color: pColor
             )
-            StatsPanelCaption(
+            MenubarStatsPanelCaption(
                 text: String(localized: "menubar.system.cpu_caption",
                              defaultValue: "E (amber) / P (blue) usage",
                              comment: "CPU panel caption under the usage bars"),
@@ -52,7 +57,7 @@ struct CPUStatsPanel: View {
                                 height: 26, domain: 0...1)
             }
             Divider()
-            StatsValueRow(
+            MenubarStatsValueRow(
                 label: String(localized: "menubar.system.thermal",
                               defaultValue: "Thermal",
                               comment: "CPU panel row label for the system thermal state"),
@@ -60,22 +65,22 @@ struct CPUStatsPanel: View {
                     for: SystemMetricsPoller.severity(for: snapshot.thermalState)
                 )
             )
-            StatsValueRow(
+            MenubarStatsValueRow(
                 label: String(localized: "menubar.system.load_avg",
                               defaultValue: "Load avg",
                               comment: "CPU panel row label for the 1/5/15-minute load averages"),
                 value: SystemStatsSampler.formatLoadAverages(snapshot.loadAverages)
             )
-            StatsValueRow(
+            MenubarStatsValueRow(
                 label: String(localized: "menubar.system.uptime",
                               defaultValue: "Uptime",
                               comment: "CPU panel row label for system uptime"),
                 value: SystemStatsSampler.formatUptime(snapshot.uptimeSeconds)
             )
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 8)
-        .frame(width: panelWidth)
+        .padding(.horizontal, MenubarStatsPanelLayout.horizontalInset)
+        .padding(.vertical, MenubarStatsPanelLayout.verticalInset)
+        .frame(width: MenubarStatsPanelLayout.width)
     }
 }
 
@@ -92,7 +97,7 @@ struct GPUStatsPanel: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            StatsPanelHeader(title: "GPU")
+            MenubarStatsPanelHeader(title: "GPU")
             UsageBarRow(
                 label: "GPU",
                 value: StatsFormat.percent(snapshot.gpuUsage),
@@ -111,7 +116,7 @@ struct GPUStatsPanel: View {
                 fraction: gpuMemoryFraction,
                 color: gpuMemColor
             )
-            StatsPanelCaption(
+            MenubarStatsPanelCaption(
                 text: String(localized: "menubar.system.gpu_caption",
                              defaultValue: "GPU (green) / GPU mem (cyan)",
                              comment: "GPU panel caption under the usage bars"),
@@ -121,9 +126,9 @@ struct GPUStatsPanel: View {
             MetricSparkline(values: snapshot.gpuHistory, color: gpuColor,
                             height: 26, domain: 0...1)
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 8)
-        .frame(width: panelWidth)
+        .padding(.horizontal, MenubarStatsPanelLayout.horizontalInset)
+        .padding(.vertical, MenubarStatsPanelLayout.verticalInset)
+        .frame(width: MenubarStatsPanelLayout.width)
     }
 
     private var gpuMemoryFraction: Double {
@@ -150,7 +155,7 @@ struct MemoryStatsPanel: View {
     var body: some View {
         let memory = snapshot.memory
         VStack(alignment: .leading, spacing: 6) {
-            StatsPanelHeader(title: String(
+            MenubarStatsPanelHeader(title: String(
                 localized: "menubar.system.memory_title",
                 defaultValue: "Memory",
                 comment: "Title of the Memory panel in the System Stats submenu"
@@ -193,9 +198,9 @@ struct MemoryStatsPanel: View {
                                     comment: "Memory panel legend row for free memory"),
                       bytes: memory.freeBytes)
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 8)
-        .frame(width: panelWidth)
+        .padding(.horizontal, MenubarStatsPanelLayout.horizontalInset)
+        .padding(.vertical, MenubarStatsPanelLayout.verticalInset)
+        .frame(width: MenubarStatsPanelLayout.width)
     }
 
     private func legendRow(color: Color, label: String, bytes: UInt64) -> some View {
@@ -237,7 +242,7 @@ struct SystemStatsPanelStack: View {
         // echo whatever the popover proposed — and a popover proposes its
         // default ~320 pt frame on first open, which then sticks, leaving a
         // dead right margin whenever two or more panels are stacked.
-        .frame(width: panelWidth)
+        .frame(width: MenubarStatsPanelLayout.width)
     }
 
     @ViewBuilder
@@ -260,20 +265,20 @@ struct SystemStatsPanelStack: View {
 /// stack level would let the hosting controller's fitting width track the
 /// popover's proposed frame instead of the panel width.
 struct SectionRule: View {
-    var containerWidth: CGFloat = panelWidth
+    var containerWidth: CGFloat = MenubarStatsPanelLayout.width
     @Environment(\.omlxTheme) private var theme
 
     var body: some View {
         Rectangle()
             .fill(theme.rowSep)
-            .frame(width: containerWidth - 28, height: 1)
+            .frame(width: containerWidth - (MenubarStatsPanelLayout.horizontalInset * 2), height: 1)
             .frame(width: containerWidth)
             .padding(.vertical, 4)
             .accessibilityHidden(true)
     }
 }
 
-private struct StatsPanelHeader: View {
+struct MenubarStatsPanelHeader: View {
     let title: String
     @Environment(\.omlxTheme) private var theme
 
@@ -286,10 +291,15 @@ private struct StatsPanelHeader: View {
     }
 }
 
-private struct StatsPanelCaption: View {
+struct MenubarStatsPanelCaption: View {
     let text: String
     let window: String
     @Environment(\.omlxTheme) private var theme
+
+    init(text: String, window: String? = nil) {
+        self.text = text
+        self.window = window ?? ""
+    }
 
     var body: some View {
         Text(window.isEmpty ? text : "\(text) · \(window)")
@@ -333,7 +343,7 @@ private struct UsageBarRow: View {
     }
 }
 
-private struct StatsValueRow: View {
+struct MenubarStatsValueRow: View {
     let label: String
     let value: String
     @Environment(\.omlxTheme) private var theme

--- a/apps/omlx-mac/Sources/Net/DTO/StatsDTO.swift
+++ b/apps/omlx-mac/Sources/Net/DTO/StatsDTO.swift
@@ -47,6 +47,35 @@ struct StatsDTO: Codable, Equatable, Sendable {
         let isLoading: Bool?
         let activeRequests: Int?
         let waitingRequests: Int?
+        /// Per-request live progress from `_build_active_models_data`.
+        /// `nil` on servers predating the fields.
+        let prefilling: [PrefillProgressDTO]?
+        let generating: [GenerationProgressDTO]?
+        let activities: [NonStreamingActivityDTO]?
+    }
+
+    struct PrefillProgressDTO: Codable, Equatable, Sendable {
+        let requestId: String?
+        let processed: Int?
+        let total: Int?
+        let speed: Double?
+        let eta: Double?
+        let elapsed: Double?
+        let detail: String?
+    }
+
+    struct GenerationProgressDTO: Codable, Equatable, Sendable {
+        let requestId: String?
+        let generatedTokens: Int?
+        let tokensPerSecond: Double?
+        let elapsedSeconds: Double?
+    }
+
+    struct NonStreamingActivityDTO: Codable, Equatable, Sendable {
+        let requestId: String?
+        let kind: String?
+        let detail: String?
+        let elapsedSeconds: Double?
     }
 
     /// Mirrors `_build_runtime_cache_observability` in `omlx/admin/routes.py`.
@@ -80,4 +109,10 @@ struct ClearSsdCacheResponse: Codable, Sendable {
 struct ClearHotCacheResponse: Codable, Sendable {
     let status: String?
     let totalCleared: Int?
+}
+
+/// `GET /admin/api/activity` — the `active_models` slice of `/admin/api/stats`
+/// without the counters, cheap enough to poll once a second.
+struct ActivityDTO: Codable, Equatable, Sendable {
+    let activeModels: StatsDTO.ActiveModelsDTO
 }

--- a/apps/omlx-mac/Sources/Net/Endpoints.swift
+++ b/apps/omlx-mac/Sources/Net/Endpoints.swift
@@ -15,6 +15,7 @@ enum AdminAPI {
     static let globalSettings  = "\(prefix)/global-settings"
     static let serverInfo      = "\(prefix)/server-info"
     static let stats           = "\(prefix)/stats"
+    static let activity        = "\(prefix)/activity"
     static let statsClear      = "\(prefix)/stats/clear"
     static let statsClearAlltime = "\(prefix)/stats/clear-alltime"
     static let ssdCacheClear   = "\(prefix)/ssd-cache/clear"

--- a/apps/omlx-mac/Sources/Net/OMLXClient.swift
+++ b/apps/omlx-mac/Sources/Net/OMLXClient.swift
@@ -94,6 +94,10 @@ final class OMLXClient: ObservableObject {
         ])
     }
 
+    func getActivity() async throws -> ActivityDTO {
+        try await get(AdminAPI.activity)
+    }
+
     @discardableResult
     func clearStats() async throws -> SimpleStatusResponse {
         try await postEmpty(AdminAPI.statsClear)

--- a/apps/omlx-mac/Tests/oMLXTests/MenubarControllerPortTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/MenubarControllerPortTests.swift
@@ -246,9 +246,66 @@ final class MenubarControllerPortTests: XCTestCase {
 
         let stats = try JSONDecoder().decode(MenubarStatsPoller.Stats.self, from: data)
         let activity = try XCTUnwrap(stats.liveActivity)
+        let request = try XCTUnwrap(activity.groups.first?.requests.first)
 
-        XCTAssertEqual(activity.menuBarTitle, "PP 38% · 12k/32k")
-        XCTAssertEqual(activity.detail, "Laguna XS.2 · 321 tok/s · 47s left")
+        XCTAssertEqual(request.title, "38% · 12k / 32k tk")
+        XCTAssertFalse(request.title.contains("PP"))
+        XCTAssertEqual(activity.detail, "Laguna XS.2 · 321 tk/s")
+        XCTAssertEqual(request.kind, .prefill)
+    }
+
+    func testLiveActivityGroupsRequestsAndCapsTheVisibleRows() throws {
+        let data = try XCTUnwrap(
+            """
+            {
+              "active_models": {
+                "models": [
+                  {
+                    "id": "model-a",
+                    "generating": [
+                      {"generated_tokens": 1, "tokens_per_second": 1},
+                      {"generated_tokens": 2, "tokens_per_second": 2},
+                      {"generated_tokens": 3, "tokens_per_second": 3},
+                      {"generated_tokens": 4, "tokens_per_second": 4}
+                    ]
+                  },
+                  {
+                    "id": "model-b",
+                    "generating": [
+                      {"generated_tokens": 5, "tokens_per_second": 5},
+                      {"generated_tokens": 6, "tokens_per_second": 6},
+                      {"generated_tokens": 7, "tokens_per_second": 7},
+                      {"generated_tokens": 8, "tokens_per_second": 8}
+                    ]
+                  }
+                ],
+                "total_waiting_requests": 3
+              }
+            }
+            """.data(using: .utf8)
+        )
+
+        let stats = try JSONDecoder().decode(MenubarStatsPoller.Stats.self, from: data)
+        let activity = try XCTUnwrap(stats.liveActivity)
+
+        XCTAssertEqual(activity.groups.map(\.modelID), ["model-a", "model-b"])
+        XCTAssertEqual(activity.groups.map { $0.requests.count }, [4, 2])
+        XCTAssertEqual(activity.hiddenRequestCount, 2)
+        XCTAssertEqual(activity.queuedRequestCount, 3)
+        XCTAssertFalse(activity.isIdle)
+    }
+
+    func testLiveActivityRepresentsAnIdleActivityPayload() throws {
+        let data = try XCTUnwrap(
+            #"{"active_models": {"models": [], "total_waiting_requests": 0}}"#
+                .data(using: .utf8)
+        )
+
+        let stats = try JSONDecoder().decode(MenubarStatsPoller.Stats.self, from: data)
+        let activity = try XCTUnwrap(stats.liveActivity)
+
+        XCTAssertTrue(activity.isIdle)
+        XCTAssertEqual(activity.groups, [])
     }
 
     func testLiveActivityShowsGenerationWhenNoPrefillIsActive() throws {
@@ -276,9 +333,97 @@ final class MenubarControllerPortTests: XCTestCase {
 
         let stats = try JSONDecoder().decode(MenubarStatsPoller.Stats.self, from: data)
         let activity = try XCTUnwrap(stats.liveActivity)
+        let request = try XCTUnwrap(activity.groups.first?.requests.first)
 
-        XCTAssertEqual(activity.menuBarTitle, "GEN 42.1 tok/s")
-        XCTAssertEqual(activity.detail, "Laguna XS.2 · 128 tok · 3s")
+        XCTAssertEqual(request.title, "128 tk")
+        XCTAssertFalse(request.title.contains("TG"))
+        XCTAssertEqual(activity.detail, "Laguna XS.2 · 42.1 tk/s")
+        XCTAssertEqual(request.kind, .generating)
+    }
+
+    func testLiveActivityUsesZeroRateWhenProgressRateIsMissing() throws {
+        let data = try XCTUnwrap(
+            """
+            {
+              "active_models": {
+                "models": [
+                  {
+                    "id": "Laguna XS.2",
+                    "prefilling": [{"processed": 66000, "total": 128000}],
+                    "generating": [{"generated_tokens": 1200}]
+                  }
+                ]
+              }
+            }
+            """.data(using: .utf8)
+        )
+
+        let stats = try JSONDecoder().decode(MenubarStatsPoller.Stats.self, from: data)
+        let requests = try XCTUnwrap(stats.liveActivity?.groups.first?.requests)
+
+        XCTAssertEqual(
+            requests.map(\.title),
+            [
+                "52% · \(ActivityFormat.tokens(66_000)) / \(ActivityFormat.tokens(128_000)) tk",
+                "\(ActivityFormat.tokens(1_200)) tk"
+            ]
+        )
+        XCTAssertEqual(requests.map(\.detail), ["0.0 tk/s", "0.0 tk/s"])
+    }
+
+    func testLiveActivityUsesSharedTokenFormattingForPrefillAndGeneration() throws {
+        let data = try XCTUnwrap(
+            """
+            {
+              "active_models": {
+                "models": [
+                  {
+                    "id": "Laguna XS.2",
+                    "prefilling": [{"processed": 1100, "total": 9999}],
+                    "generating": [{"generated_tokens": 10000}]
+                  }
+                ]
+              }
+            }
+            """.data(using: .utf8)
+        )
+
+        let stats = try JSONDecoder().decode(MenubarStatsPoller.Stats.self, from: data)
+        let requests = try XCTUnwrap(stats.liveActivity?.groups.first?.requests)
+
+        XCTAssertEqual(
+            requests.map(\.title),
+            [
+                "11% · \(ActivityFormat.tokens(1_100)) / \(ActivityFormat.tokens(9_999)) tk",
+                "\(ActivityFormat.tokens(10_000)) tk"
+            ]
+        )
+    }
+
+    func testLiveActivityUsesSharedRateFormattingForPrefillAndGeneration() throws {
+        let data = try XCTUnwrap(
+            """
+            {
+              "active_models": {
+                "models": [
+                  {
+                    "id": "Laguna XS.2",
+                    "prefilling": [{"processed": 1, "total": 2, "speed": 1200.0}],
+                    "generating": [{"generated_tokens": 1, "tokens_per_second": 321.4}]
+                  }
+                ]
+              }
+            }
+            """.data(using: .utf8)
+        )
+
+        let stats = try JSONDecoder().decode(MenubarStatsPoller.Stats.self, from: data)
+        let requests = try XCTUnwrap(stats.liveActivity?.groups.first?.requests)
+
+        XCTAssertEqual(
+            requests.map(\.detail),
+            ["\(ActivityFormat.rate(1200)) tk/s", "\(ActivityFormat.rate(321.4)) tk/s"]
+        )
     }
 
     func testLiveActivityShowsQueuedRequestsWhenNoRequestIsRunning() throws {
@@ -296,7 +441,6 @@ final class MenubarControllerPortTests: XCTestCase {
         let stats = try JSONDecoder().decode(MenubarStatsPoller.Stats.self, from: data)
         let activity = try XCTUnwrap(stats.liveActivity)
 
-        XCTAssertEqual(activity.menuBarTitle, "WAIT 2")
         XCTAssertEqual(activity.detail, "2 queued requests")
     }
 
@@ -324,9 +468,11 @@ final class MenubarControllerPortTests: XCTestCase {
 
         let stats = try JSONDecoder().decode(MenubarStatsPoller.Stats.self, from: data)
         let activity = try XCTUnwrap(stats.liveActivity)
+        let request = try XCTUnwrap(activity.groups.first?.requests.first)
 
-        XCTAssertEqual(activity.menuBarTitle, "RUN 12s")
+        XCTAssertEqual(request.title, "RUN 12s")
         XCTAssertEqual(activity.detail, "embed-model · Embedding · 12s")
+        XCTAssertEqual(request.kind, .nonStreaming)
     }
 
     func testRefreshOnceLoadsLiveActivityFromActivityEndpoint() async {
@@ -342,7 +488,7 @@ final class MenubarControllerPortTests: XCTestCase {
         await poller.refreshOnce()
 
         XCTAssertEqual(poller.sessionStats?.totalPromptTokens, 99)
-        XCTAssertEqual(poller.liveStats?.liveActivity?.menuBarTitle, "GEN 42.1 tok/s")
+        XCTAssertEqual(poller.liveStats?.liveActivity?.groups.first?.requests.first?.title, "128 tk")
         XCTAssertEqual(poller.alltimeStats?.totalRequests, 3)
         XCTAssertEqual(MenubarStatsURLProtocol.recordedActivityRequestCount(), 1)
     }
@@ -391,7 +537,7 @@ final class MenubarControllerPortTests: XCTestCase {
 
         await poller.refreshOnce()
 
-        XCTAssertEqual(poller.liveStats?.liveActivity?.menuBarTitle, "GEN 42.1 tok/s")
+        XCTAssertEqual(poller.liveStats?.liveActivity?.groups.first?.requests.first?.title, "128 tk")
         XCTAssertEqual(MenubarStatsURLProtocol.recordedActivityRequestCount(), 1)
     }
 
@@ -418,7 +564,7 @@ final class MenubarControllerPortTests: XCTestCase {
         XCTAssertEqual(MenubarStatsURLProtocol.recordedUpdateNotificationCount(), 1)
     }
 
-    func testRefreshOnceSkipsLiveAdminStatsWhenActivityDisplayIsDisabled() async {
+    func testRefreshOnceLoadsCurrentRequestsWhenLiveGlyphIsDisabled() async {
         let sessionConfiguration = URLSessionConfiguration.ephemeral
         sessionConfiguration.protocolClasses = [MenubarStatsURLProtocol.self]
         let poller = MenubarStatsPoller(
@@ -431,8 +577,8 @@ final class MenubarControllerPortTests: XCTestCase {
         await poller.refreshOnce()
 
         XCTAssertEqual(poller.sessionStats?.totalPromptTokens, 99)
-        XCTAssertNil(poller.liveStats)
-        XCTAssertEqual(MenubarStatsURLProtocol.recordedActivityRequestCount(), 0)
+        XCTAssertNotNil(poller.liveStats?.liveActivity)
+        XCTAssertEqual(MenubarStatsURLProtocol.recordedActivityRequestCount(), 1)
     }
 
     func testRefreshOnceClearsLiveActivityAfterActivityFailure() async {

--- a/apps/omlx-mac/Tests/oMLXTests/MenubarControllerPortTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/MenubarControllerPortTests.swift
@@ -27,6 +27,7 @@ import XCTest
 private final class MenubarStatsRequestRecorder: @unchecked Sendable {
     private let lock = NSLock()
     private var activityRequestCount = 0
+    private var alltimeStatsRequestCount = 0
     private var activityResponseStatusCode = 200
     private var publicStatusResponseStatusCode = 200
     private var updateNotificationCount = 0
@@ -35,6 +36,7 @@ private final class MenubarStatsRequestRecorder: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         activityRequestCount = 0
+        alltimeStatsRequestCount = 0
         activityResponseStatusCode = 200
         publicStatusResponseStatusCode = 200
         updateNotificationCount = 0
@@ -50,6 +52,18 @@ private final class MenubarStatsRequestRecorder: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return activityRequestCount
+    }
+
+    func recordAlltimeStatsRequest() {
+        lock.lock()
+        defer { lock.unlock() }
+        alltimeStatsRequestCount += 1
+    }
+
+    func recordedAlltimeStatsRequestCount() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return alltimeStatsRequestCount
     }
 
     func setActivityResponseStatusCode(_ statusCode: Int) {
@@ -100,6 +114,10 @@ private final class MenubarStatsURLProtocol: URLProtocol, @unchecked Sendable {
         requestRecorder.recordedActivityRequestCount()
     }
 
+    static func recordedAlltimeStatsRequestCount() -> Int {
+        requestRecorder.recordedAlltimeStatsRequestCount()
+    }
+
     static func setActivityResponseStatusCode(_ statusCode: Int) {
         requestRecorder.setActivityResponseStatusCode(statusCode)
     }
@@ -138,6 +156,9 @@ private final class MenubarStatsURLProtocol: URLProtocol, @unchecked Sendable {
         } else if url.path == "/admin/api/activity" {
             Self.requestRecorder.recordActivityRequest()
             statusCode = Self.requestRecorder.currentActivityResponseStatusCode()
+        } else if url.path == "/admin/api/stats", scope == "alltime" {
+            Self.requestRecorder.recordAlltimeStatsRequest()
+            statusCode = 200
         } else {
             statusCode = 200
         }
@@ -489,8 +510,9 @@ final class MenubarControllerPortTests: XCTestCase {
 
         XCTAssertEqual(poller.sessionStats?.totalPromptTokens, 99)
         XCTAssertEqual(poller.liveStats?.liveActivity?.groups.first?.requests.first?.title, "128 tk")
-        XCTAssertEqual(poller.alltimeStats?.totalRequests, 3)
+        XCTAssertNil(poller.alltimeStats)
         XCTAssertEqual(MenubarStatsURLProtocol.recordedActivityRequestCount(), 1)
+        XCTAssertEqual(MenubarStatsURLProtocol.recordedAlltimeStatsRequestCount(), 0)
     }
 
     func testPollingFollowsRefreshIntervalOnlyWhileAMetricItemIsEnabled() {
@@ -564,7 +586,7 @@ final class MenubarControllerPortTests: XCTestCase {
         XCTAssertEqual(MenubarStatsURLProtocol.recordedUpdateNotificationCount(), 1)
     }
 
-    func testRefreshOnceLoadsCurrentRequestsWhenLiveGlyphIsDisabled() async {
+    func testClosedServingStatsSubmenuDoesNotPollAdminEndpoints() async {
         let sessionConfiguration = URLSessionConfiguration.ephemeral
         sessionConfiguration.protocolClasses = [MenubarStatsURLProtocol.self]
         let poller = MenubarStatsPoller(
@@ -577,8 +599,39 @@ final class MenubarControllerPortTests: XCTestCase {
         await poller.refreshOnce()
 
         XCTAssertEqual(poller.sessionStats?.totalPromptTokens, 99)
+        XCTAssertNil(poller.liveStats)
+        XCTAssertNil(poller.alltimeStats)
+        XCTAssertEqual(MenubarStatsURLProtocol.recordedActivityRequestCount(), 0)
+        XCTAssertEqual(MenubarStatsURLProtocol.recordedAlltimeStatsRequestCount(), 0)
+    }
+
+    func testServingStatsSubmenuActivatesLiveAndAlltimePollingWithoutGlyphs() async {
+        let sessionConfiguration = URLSessionConfiguration.ephemeral
+        sessionConfiguration.protocolClasses = [MenubarStatsURLProtocol.self]
+        let poller = MenubarStatsPoller(
+            baseURL: URL(string: "http://omlx.test")!,
+            apiKey: "test-key",
+            sessionConfiguration: sessionConfiguration
+        )
+        poller.setEnabledMetrics(EnabledMetrics(live: false, average: false, alltime: false))
+
+        poller.setServingStatsSubmenuOpen(true)
+        XCTAssertTrue(poller.servingStatsSubmenuOpen)
+        XCTAssertTrue(poller.needsLiveActivity)
+        XCTAssertTrue(poller.needsAlltimeStats)
+
+        await poller.refreshOnce()
+
+        XCTAssertEqual(poller.sessionStats?.totalPromptTokens, 99)
         XCTAssertNotNil(poller.liveStats?.liveActivity)
+        XCTAssertEqual(poller.alltimeStats?.totalRequests, 3)
         XCTAssertEqual(MenubarStatsURLProtocol.recordedActivityRequestCount(), 1)
+        XCTAssertEqual(MenubarStatsURLProtocol.recordedAlltimeStatsRequestCount(), 1)
+
+        poller.setServingStatsSubmenuOpen(false)
+        XCTAssertFalse(poller.servingStatsSubmenuOpen)
+        XCTAssertFalse(poller.needsLiveActivity)
+        XCTAssertFalse(poller.needsAlltimeStats)
     }
 
     func testRefreshOnceClearsLiveActivityAfterActivityFailure() async {

--- a/apps/omlx-mac/Tests/oMLXTests/MenubarMetricTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/MenubarMetricTests.swift
@@ -94,6 +94,7 @@ final class MenubarMetricTests: XCTestCase {
         let store = MenubarMetricsStore()
         store.applyTick(
             live: MetricRates(promptTps: 100, generationTps: 10),
+            liveActivity: nil,
             average: MetricRates(promptTps: 200, generationTps: 20),
             alltime: nil,
             serverRunning: true
@@ -113,6 +114,7 @@ final class MenubarMetricTests: XCTestCase {
         let store = MenubarMetricsStore()
         store.applyTick(
             live: MetricRates(promptTps: 100, generationTps: 10),
+            liveActivity: nil,
             average: MetricRates(promptTps: 200, generationTps: 20),
             alltime: MetricRates(promptTps: 300, generationTps: 30),
             serverRunning: true

--- a/apps/omlx-mac/Tests/oMLXTests/MenubarMetricTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/MenubarMetricTests.swift
@@ -241,6 +241,34 @@ final class MenubarMetricTests: XCTestCase {
         XCTAssertEqual(live.liveActivity?.queuedRequestCount, 2)
     }
 
+    func testPrefillTitlesCompactOnlyProgressCounts() throws {
+        let stats = try decodeStats(
+            """
+            {
+              "active_models": {
+                "models": [{
+                  "id": "model-a",
+                  "prefilling": [
+                    {"processed": 999, "total": 1000, "speed": 0},
+                    {"processed": 1024, "total": 1700, "speed": 0},
+                    {"processed": 10000, "total": 12400, "speed": 0}
+                  ],
+                  "generating": [{"generated_tokens": 9999, "tokens_per_second": 0}]
+                }]
+              }
+            }
+            """
+        )
+        let requests = try XCTUnwrap(
+            MenubarMetricsStore.snapshot(for: .live, from: stats)?.liveActivity?.groups.first?.requests
+        )
+
+        XCTAssertEqual(requests[0].title, "100% · 999 / 1.0k tk")
+        XCTAssertEqual(requests[1].title, "60% · 1.0k / 1.7k tk")
+        XCTAssertEqual(requests[2].title, "81% · 10k / 12.4k tk")
+        XCTAssertEqual(requests[3].title, "9,999 tk")
+    }
+
     func testDetailedServingStatsPopoversKeepOneActivityBlockAndScopeSpecificTerminalDetail() {
         let live = ServingStatsPresentation.popoverScope(for: .live)
         let average = ServingStatsPresentation.popoverScope(for: .average)

--- a/apps/omlx-mac/Tests/oMLXTests/MenubarMetricTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/MenubarMetricTests.swift
@@ -77,6 +77,58 @@ final class MenubarMetricTests: XCTestCase {
         XCTAssertEqual(rates.generationTps, 48.7)
     }
 
+    func testScopedSnapshotsMapLiveAndAggregateData() throws {
+        let stats = try decodeStats(
+            """
+            {
+              "total_prompt_tokens": 12000,
+              "total_cached_tokens": 3000,
+              "cache_efficiency": 25.0,
+              "avg_prefill_tps": 512.3,
+              "avg_generation_tps": 48.7,
+              "total_requests": 9,
+              "active_models": {
+                "models": [{
+                  "id": "model-a",
+                  "prefilling": [{"processed": 3, "total": 10, "speed": 300.0}],
+                  "generating": [{"generated_tokens": 5, "tokens_per_second": 40.0}]
+                }]
+              }
+            }
+            """
+        )
+
+        let live = try XCTUnwrap(MenubarMetricsStore.snapshot(for: .live, from: stats))
+        XCTAssertEqual(live.rates, MetricRates(promptTps: 300, generationTps: 40))
+        XCTAssertNil(live.totalPromptTokens)
+        XCTAssertNotNil(live.liveActivity)
+
+        for kind in [MenubarMetricsStore.Kind.average, .alltime] {
+            let aggregate = try XCTUnwrap(MenubarMetricsStore.snapshot(for: kind, from: stats))
+            XCTAssertEqual(aggregate.rates, MetricRates(promptTps: 512.3, generationTps: 48.7))
+            XCTAssertEqual(aggregate.totalPromptTokens, 12000)
+            XCTAssertEqual(aggregate.totalCachedTokens, 3000)
+            XCTAssertEqual(aggregate.cacheEfficiency, 25.0)
+            XCTAssertEqual(aggregate.totalRequests, 9)
+            XCTAssertNil(aggregate.liveActivity)
+        }
+    }
+
+    func testUnavailableSnapshotKeepsUnknownValuesDistinctFromIdle() {
+        XCTAssertNil(MenubarMetricsStore.snapshot(for: .live, from: nil))
+        XCTAssertTrue(ServingStatsSnapshot.unavailable.isUnavailable)
+
+        let idle = ServingStatsSnapshot(
+            rates: MetricRates(promptTps: 0, generationTps: 0),
+            totalPromptTokens: nil,
+            totalCachedTokens: nil,
+            cacheEfficiency: nil,
+            totalRequests: nil,
+            liveActivity: nil
+        )
+        XCTAssertFalse(idle.isUnavailable)
+    }
+
     // MARK: - History ring buffer
 
     func testHistoryAppendCapsAtCapacityDroppingOldest() {
@@ -93,17 +145,31 @@ final class MenubarMetricTests: XCTestCase {
     func testApplyTickRecordsRatesAndRollsHistory() {
         let store = MenubarMetricsStore()
         store.applyTick(
-            live: MetricRates(promptTps: 100, generationTps: 10),
-            liveActivity: nil,
-            average: MetricRates(promptTps: 200, generationTps: 20),
+            live: ServingStatsSnapshot(
+                rates: MetricRates(promptTps: 100, generationTps: 10),
+                totalPromptTokens: nil,
+                totalCachedTokens: nil,
+                cacheEfficiency: nil,
+                totalRequests: nil,
+                liveActivity: nil
+            ),
+            average: ServingStatsSnapshot(
+                rates: MetricRates(promptTps: 200, generationTps: 20),
+                totalPromptTokens: 300,
+                totalCachedTokens: 40,
+                cacheEfficiency: 13.3,
+                totalRequests: 2,
+                liveActivity: nil
+            ),
             alltime: nil,
             serverRunning: true
         )
 
         XCTAssertTrue(store.serverIsRunning)
-        XCTAssertEqual(store.rates[.live]?.promptTps, 100)
-        XCTAssertEqual(store.rates[.average]?.generationTps, 20)
-        XCTAssertNil(store.rates[.alltime])
+        XCTAssertEqual(store.snapshot(for: .live).rates?.promptTps, 100)
+        XCTAssertEqual(store.snapshot(for: .average).rates?.generationTps, 20)
+        XCTAssertEqual(store.snapshot(for: .average).totalRequests, 2)
+        XCTAssertTrue(store.snapshot(for: .alltime).isUnavailable)
         // Unknown readings still roll a 0 so the graph timeline stays contiguous.
         XCTAssertEqual(store.history[.alltime]?.promptTps, [0])
         XCTAssertEqual(store.history[.live]?.promptTps, [100])
@@ -113,21 +179,124 @@ final class MenubarMetricTests: XCTestCase {
     func testMarkServerStoppedBlanksRatesButFreezesHistory() {
         let store = MenubarMetricsStore()
         store.applyTick(
-            live: MetricRates(promptTps: 100, generationTps: 10),
-            liveActivity: nil,
-            average: MetricRates(promptTps: 200, generationTps: 20),
-            alltime: MetricRates(promptTps: 300, generationTps: 30),
+            live: ServingStatsSnapshot(
+                rates: MetricRates(promptTps: 100, generationTps: 10),
+                totalPromptTokens: nil,
+                totalCachedTokens: nil,
+                cacheEfficiency: nil,
+                totalRequests: nil,
+                liveActivity: nil
+            ),
+            average: ServingStatsSnapshot(
+                rates: MetricRates(promptTps: 200, generationTps: 20),
+                totalPromptTokens: nil,
+                totalCachedTokens: nil,
+                cacheEfficiency: nil,
+                totalRequests: nil,
+                liveActivity: nil
+            ),
+            alltime: ServingStatsSnapshot(
+                rates: MetricRates(promptTps: 300, generationTps: 30),
+                totalPromptTokens: nil,
+                totalCachedTokens: nil,
+                cacheEfficiency: nil,
+                totalRequests: nil,
+                liveActivity: nil
+            ),
             serverRunning: true
         )
 
         store.markServerStopped()
 
         XCTAssertFalse(store.serverIsRunning)
-        XCTAssertNil(store.rates[.live])
-        XCTAssertNil(store.rates[.average])
-        XCTAssertNil(store.rates[.alltime])
+        XCTAssertTrue(store.snapshot(for: .live).isUnavailable)
+        XCTAssertTrue(store.snapshot(for: .average).isUnavailable)
+        XCTAssertTrue(store.snapshot(for: .alltime).isUnavailable)
         XCTAssertEqual(store.history[.live]?.promptTps, [100])
         XCTAssertEqual(store.history[.alltime]?.generationTps, [30])
+    }
+
+    func testLiveSnapshotRetainsRequestActivity() throws {
+        let stats = try decodeStats(
+            """
+            {
+              "active_models": {
+                "models": [{
+                  "id": "model-a",
+                  "generating": [{
+                    "generated_tokens": 128,
+                    "tokens_per_second": 42.1,
+                    "elapsed_seconds": 3
+                  }]
+                }],
+                "total_waiting_requests": 2
+              }
+            }
+            """
+        )
+
+        let live = try XCTUnwrap(MenubarMetricsStore.snapshot(for: .live, from: stats))
+        XCTAssertEqual(live.rates, MetricRates(promptTps: 0, generationTps: 42.1))
+        XCTAssertEqual(live.liveActivity?.groups.first?.requests.first?.title, "GEN 42.1 tok/s")
+        XCTAssertEqual(live.liveActivity?.queuedRequestCount, 2)
+    }
+
+    func testDetailedServingStatsPopoversKeepOneActivityBlockAndScopeSpecificTerminalDetail() {
+        let live = ServingStatsPresentation.popoverScope(for: .live)
+        let average = ServingStatsPresentation.popoverScope(for: .average)
+        let alltime = ServingStatsPresentation.popoverScope(for: .alltime)
+
+        XCTAssertEqual([live.kind, average.kind, alltime.kind], [.live, .average, .alltime])
+        XCTAssertEqual(
+            [live.activityGraphCount, average.activityGraphCount, alltime.activityGraphCount],
+            [2, 2, 2]
+        )
+        XCTAssertTrue(live.showsThroughput)
+        XCTAssertTrue(average.showsThroughput)
+        XCTAssertTrue(alltime.showsThroughput)
+        XCTAssertEqual(live.terminalDetail, .currentRequests)
+        XCTAssertEqual(average.terminalDetail, .scalarMetrics)
+        XCTAssertEqual(alltime.terminalDetail, .scalarMetrics)
+        XCTAssertTrue(live.showsTerminalDetailHeader)
+        XCTAssertFalse(average.showsTerminalDetailHeader)
+        XCTAssertFalse(alltime.showsTerminalDetailHeader)
+    }
+
+    func testServingStatsMenuCompositionKeepsLiveDetailAndHeaderlessScalarSummaries() {
+        XCTAssertEqual(
+            ServingStatsPresentation.menuComposition(serverIsRunning: false),
+            .serverOff
+        )
+
+        guard case .sections(let sections) = ServingStatsPresentation.menuComposition(
+            serverIsRunning: true
+        ) else {
+            return XCTFail("running server must compose the serving stats menu")
+        }
+
+        XCTAssertEqual(sections.map(\.kind), [.live, .average, .alltime])
+        XCTAssertEqual(sections.map(\.showsThroughput), [true, true, true])
+        XCTAssertEqual(sections.map(\.activityGraphCount), [2, 0, 0])
+        XCTAssertEqual(
+            sections.map(\.terminalDetail),
+            [.currentRequests, .scalarMetrics, .scalarMetrics]
+        )
+        XCTAssertEqual(sections.map(\.showsTerminalDetailHeader), [true, false, false])
+    }
+
+    func testMenubarStatsPanelLayoutKeepsServingAndSystemContentAligned() {
+        XCTAssertEqual(MenubarStatsPanelLayout.width, 270)
+        XCTAssertEqual(MenubarStatsPanelLayout.horizontalInset, 14)
+        XCTAssertEqual(MenubarStatsPanelLayout.verticalInset, 8)
+        XCTAssertEqual(MenubarStatsPanelLayout.contentWidth, 242)
+    }
+
+    func testCurrentRequestMarkersFollowRequestKind() {
+        XCTAssertEqual(CurrentRequestMarker.marker(for: .prefill), .prefill)
+        XCTAssertEqual(CurrentRequestMarker.marker(for: .generating), .generating)
+        XCTAssertNil(CurrentRequestMarker.marker(for: .nonStreaming))
+        XCTAssertEqual(CurrentRequestMarker.prefill.abbreviation, "PP")
+        XCTAssertEqual(CurrentRequestMarker.generating.abbreviation, "TG")
     }
 
     // MARK: - Model library scope pref
@@ -151,14 +320,17 @@ final class MenubarMetricTests: XCTestCase {
 
     // MARK: - Glyph formatting
 
-    func testFormatTpsCoversUnknownWholeAndCompactRanges() {
+    func testRateReadoutsUseSharedFormattingAndSurfaceSpecificUnitSpacing() {
         XCTAssertEqual(MenubarMetricGlyph.formatTps(nil), "–")
         XCTAssertEqual(MenubarMetricGlyph.formatTps(.infinity), "–")
-        XCTAssertEqual(MenubarMetricGlyph.formatTps(-3), "0tk/s")
-        XCTAssertEqual(MenubarMetricGlyph.formatTps(0), "0tk/s")
-        XCTAssertEqual(MenubarMetricGlyph.formatTps(24.4), "24tk/s")
-        XCTAssertEqual(MenubarMetricGlyph.formatTps(999.6), "1000tk/s")
-        XCTAssertEqual(MenubarMetricGlyph.formatTps(12_345), "12.3ktk/s")
+        XCTAssertEqual(ServingStatsPresentation.popoverTps(nil), "–")
+        XCTAssertEqual(ServingStatsPresentation.popoverTps(.infinity), "–")
+
+        for value in [1.0, 100, 9_999, 10_000] {
+            let expected = ActivityFormat.rate(value)
+            XCTAssertEqual(MenubarMetricGlyph.formatTps(value), "\(expected)tk/s")
+            XCTAssertEqual(ServingStatsPresentation.popoverTps(value), "\(expected) tk/s")
+        }
     }
 
     func testSignatureIsStableForIdenticalReadingsAndTracksEveryInput() {

--- a/apps/omlx-mac/Tests/oMLXTests/ModelActivityTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/ModelActivityTests.swift
@@ -1,0 +1,229 @@
+import XCTest
+@testable import oMLX
+
+final class ModelActivityTests: XCTestCase {
+
+    private static let activityJSON = """
+    {
+      "active_models": {
+        "models": [
+          {
+            "id": "model-a",
+            "is_loading": false,
+            "active_requests": 2,
+            "waiting_requests": 0,
+            "activities": [],
+            "generating": [],
+            "prefilling": [
+              {"request_id": "cmpl-abc123", "processed": 12400, "total": 20000,
+               "speed": 1820.0, "eta": 4.2, "elapsed": 6.8, "detail": null},
+              {"request_id": "cmpl-xyz999", "processed": 7100, "total": 40000,
+               "speed": 1390.0, "eta": 23.7, "elapsed": 5.1, "detail": null}
+            ]
+          },
+          {
+            "id": "model-b",
+            "is_loading": false,
+            "active_requests": 1,
+            "waiting_requests": 1,
+            "activities": [],
+            "prefilling": [],
+            "generating": [
+              {"request_id": "cmpl-def456", "elapsed_seconds": 5.7,
+               "generated_tokens": 184, "tokens_per_second": 32.5}
+            ]
+          }
+        ],
+        "total_active_requests": 3,
+        "total_waiting_requests": 1
+      }
+    }
+    """
+
+    private func decodedModel(_ id: String) throws -> StatsDTO.ActiveModelDTO {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let activity = try decoder.decode(ActivityDTO.self, from: Data(Self.activityJSON.utf8))
+        return try XCTUnwrap(activity.activeModels.models.first { $0.id == id })
+    }
+
+    private func makeModel(
+        waitingRequests: Int = 0,
+        prefilling: [StatsDTO.PrefillProgressDTO] = [],
+        generating: [StatsDTO.GenerationProgressDTO] = [],
+        activities: [StatsDTO.NonStreamingActivityDTO] = []
+    ) -> StatsDTO.ActiveModelDTO {
+        StatsDTO.ActiveModelDTO(
+            id: "model-a", estimatedSize: nil, estimatedSizeFormatted: nil,
+            pinned: nil, isLoading: false,
+            activeRequests: prefilling.count + generating.count + activities.count,
+            waitingRequests: waitingRequests, prefilling: prefilling,
+            generating: generating, activities: activities
+        )
+    }
+
+    private func row(_ id: String, detail: String = "12 tok") -> ModelRequestActivity {
+        ModelRequestActivity(id: id, phase: .generating, fraction: nil,
+                             percentText: nil, detail: detail)
+    }
+
+    // MARK: - Wire contract
+
+    func testActivityPayloadDecodes() throws {
+        let model = try decodedModel("model-a")
+
+        XCTAssertEqual(model.prefilling?.count, 2)
+        XCTAssertEqual(model.prefilling?.first?.processed, 12_400)
+        XCTAssertEqual(model.prefilling?.first?.speed, 1_820.0)
+        XCTAssertEqual(try decodedModel("model-b").generating?.first?.tokensPerSecond, 32.5)
+    }
+
+    // MARK: - Rows
+
+    func testConcurrentPrefillsGetIndependentRows() throws {
+        let snapshot = try XCTUnwrap(ModelActivitySnapshot(model: decodedModel("model-a")))
+
+        XCTAssertEqual(snapshot.requests.count, 2)
+        XCTAssertEqual(snapshot.badgePhase, .prefill)
+        XCTAssertEqual(try XCTUnwrap(snapshot.requests[0].fraction), 0.62, accuracy: 0.001)
+        XCTAssertEqual(snapshot.requests[0].percentText, "62%")
+        XCTAssertEqual(snapshot.requests[1].percentText, "18%")
+        XCTAssertTrue(snapshot.requests[0].detail.contains("12k / 20k tok"),
+                      snapshot.requests[0].detail)
+        XCTAssertTrue(snapshot.requests[0].detail.contains("1.8k tok/s"),
+                      snapshot.requests[0].detail)
+        XCTAssertNotEqual(snapshot.requests[0].shortID, snapshot.requests[1].shortID)
+    }
+
+    func testGeneratingRowsHaveNoProgressBar() throws {
+        let snapshot = try XCTUnwrap(ModelActivitySnapshot(model: decodedModel("model-b")))
+
+        XCTAssertEqual(snapshot.badgePhase, .generating)
+        XCTAssertNil(snapshot.requests[0].fraction)
+        XCTAssertEqual(snapshot.queued, 1)
+        XCTAssertTrue(snapshot.requests[0].detail.contains("184 tok"), snapshot.requests[0].detail)
+        XCTAssertTrue(snapshot.requests[0].detail.contains("32.5 tok/s"),
+                      snapshot.requests[0].detail)
+    }
+
+    func testPrefillWithoutTotalHasNoFraction() {
+        let snapshot = ModelActivitySnapshot(model: makeModel(
+            prefilling: [.init(requestId: "a", processed: 0, total: 0, speed: nil,
+                               eta: nil, elapsed: nil, detail: nil)]
+        ))
+
+        XCTAssertNil(snapshot?.requests.first?.fraction)
+    }
+
+    func testIdleModelHasNoSnapshot() {
+        XCTAssertNil(ModelActivitySnapshot(model: makeModel()))
+    }
+
+    func testQueuedOnlyModelIsBusyWithoutRows() {
+        let snapshot = ModelActivitySnapshot(model: makeModel(waitingRequests: 3))
+
+        XCTAssertEqual(snapshot?.requests.isEmpty, true)
+        XCTAssertEqual(snapshot?.queued, 3)
+        XCTAssertEqual(snapshot?.badgePhase, .queued)
+    }
+
+    // MARK: - Linger
+
+    func testFinishedRowIsHeldThenRetired() {
+        var linger = ActivityLinger(duration: 2.5)
+        XCTAssertEqual(linger.merge(live: [row("a")], for: "m", now: 100).map(\.phase),
+                       [.generating])
+
+        let held = linger.merge(live: [], for: "m", now: 101)
+        XCTAssertEqual(held.map(\.id), ["a"])
+        XCTAssertEqual(held.first?.phase, .finished)
+        XCTAssertEqual(held.first?.detail, "12 tok")
+
+        XCTAssertEqual(linger.merge(live: [], for: "m", now: 103.4).count, 1)
+        XCTAssertTrue(linger.merge(live: [], for: "m", now: 103.6).isEmpty)
+    }
+
+    func testPhaseChangeDoesNotLinger() {
+        var linger = ActivityLinger(duration: 2.5)
+        let prefill = ModelRequestActivity(id: "a", phase: .prefill, fraction: 0.5,
+                                           percentText: "50%", detail: "10 / 20 tok")
+        _ = linger.merge(live: [prefill], for: "m", now: 100)
+
+        let after = linger.merge(live: [row("a")], for: "m", now: 101)
+        XCTAssertEqual(after.map(\.id), ["a"])
+        XCTAssertEqual(after.first?.phase, .generating)
+    }
+
+    func testLingeringRowSortsBelowLiveOnes() {
+        var linger = ActivityLinger(duration: 2.5)
+        _ = linger.merge(live: [row("a"), row("b")], for: "m", now: 100)
+
+        let merged = linger.merge(live: [row("b")], for: "m", now: 101)
+        XCTAssertEqual(merged.map(\.id), ["b", "a"])
+        XCTAssertEqual(merged.map(\.phase), [.generating, .finished])
+    }
+
+    func testUnloadedModelDropsHeldRows() {
+        var linger = ActivityLinger(duration: 2.5)
+        _ = linger.merge(live: [row("a")], for: "m", now: 100)
+        linger.retain(models: [])
+
+        XCTAssertTrue(linger.merge(live: [], for: "m", now: 101).isEmpty)
+    }
+
+    func testLingeringRowDoesNotCountAsBusy() throws {
+        let snapshot = try XCTUnwrap(
+            ModelActivitySnapshot(requests: [row("a").finished], queued: 0)
+        )
+
+        XCTAssertFalse(snapshot.isBusy)
+        XCTAssertEqual(snapshot.badgePhase, .queued)
+    }
+
+    // MARK: - Speed smoothing
+
+    func testSmoothedSpeedDampensSwingsAndDrivesEta() throws {
+        var smoother = PrefillSpeedSmoother(alpha: 0.35)
+        func entry(speed: Double) -> StatsDTO.PrefillProgressDTO {
+            .init(requestId: "a", processed: 5_000, total: 20_000,
+                  speed: speed, eta: 999, elapsed: 1, detail: nil)
+        }
+
+        XCTAssertEqual(smoother.smoothed([entry(speed: 2_000)]).first?.speed, 2_000)
+
+        let dipped = try XCTUnwrap(smoother.smoothed([entry(speed: 1_000)]).first)
+        let speed = try XCTUnwrap(dipped.speed)
+        XCTAssertLessThan(speed, 2_000)
+        XCTAssertGreaterThan(speed, 1_000)
+        XCTAssertEqual(try XCTUnwrap(dipped.eta), 15_000 / speed, accuracy: 0.001)
+    }
+
+    func testSmootherRetainsOtherModelsAverages() throws {
+        var smoother = PrefillSpeedSmoother(alpha: 0.35)
+        func entry(_ id: String, speed: Double) -> StatsDTO.PrefillProgressDTO {
+            .init(requestId: id, processed: 10_000, total: 20_000,
+                  speed: speed, eta: nil, elapsed: 1, detail: nil)
+        }
+        _ = smoother.smoothed([entry("a", speed: 2_000)])
+        _ = smoother.smoothed([entry("b", speed: 400)])
+        smoother.retain(ids: ["a", "b"])
+
+        XCTAssertGreaterThan(
+            try XCTUnwrap(smoother.smoothed([entry("a", speed: 1_000)]).first?.speed), 1_000
+        )
+    }
+
+    func testSmootherForgetsFinishedRequests() throws {
+        var smoother = PrefillSpeedSmoother(alpha: 0.35)
+        let finished = StatsDTO.PrefillProgressDTO(
+            requestId: "a", processed: 10, total: 100, speed: 5_000,
+            eta: nil, elapsed: 1, detail: nil)
+        _ = smoother.smoothed([finished])
+        smoother.retain(ids: [])
+
+        let fresh = StatsDTO.PrefillProgressDTO(
+            requestId: "a", processed: 10, total: 100, speed: 50,
+            eta: nil, elapsed: 1, detail: nil)
+        XCTAssertEqual(try XCTUnwrap(smoother.smoothed([fresh]).first?.speed), 50)
+    }
+}

--- a/apps/omlx-mac/Tests/oMLXTests/ModelActivityTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/ModelActivityTests.swift
@@ -139,6 +139,16 @@ final class ModelActivityTests: XCTestCase {
         XCTAssertEqual(ActivityFormat.tokens(1_200_000, locale: locale), "1.2M")
     }
 
+    func testLocalizedActivityDetailsFormatArguments() {
+        let eta = ActivityFormat.left(4.2)
+        let queued = ActivityFormat.queuedDetail(count: 3)
+
+        XCTAssertTrue(eta.contains(ActivityFormat.duration(4.2)), eta)
+        XCTAssertFalse(eta.contains("%@"), eta)
+        XCTAssertTrue(queued.contains("3"), queued)
+        XCTAssertFalse(queued.contains("%lld"), queued)
+    }
+
     // MARK: - Linger
 
     func testFinishedRowIsHeldThenRetired() {

--- a/apps/omlx-mac/Tests/oMLXTests/ModelActivityTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/ModelActivityTests.swift
@@ -85,6 +85,7 @@ final class ModelActivityTests: XCTestCase {
 
         XCTAssertEqual(snapshot.requests.count, 2)
         XCTAssertEqual(snapshot.badgePhase, .prefill)
+        XCTAssertEqual(snapshot.badge, ActivityFormat.badge(for: .prefill))
         XCTAssertEqual(try XCTUnwrap(snapshot.requests[0].fraction), 0.62, accuracy: 0.001)
         XCTAssertEqual(snapshot.requests[0].percentText, "62%")
         XCTAssertEqual(snapshot.requests[1].percentText, "18%")
@@ -115,6 +116,33 @@ final class ModelActivityTests: XCTestCase {
         XCTAssertNil(snapshot?.requests.first?.fraction)
     }
 
+    func testPrefillUsesPayloadRawSpeedAndETA() throws {
+        let snapshot = try XCTUnwrap(ModelActivitySnapshot(model: makeModel(
+            prefilling: [.init(requestId: "a", processed: 5_000, total: 20_000,
+                               speed: 1_100, eta: 17.4, elapsed: 1, detail: nil)]
+        )))
+        let detail = try XCTUnwrap(snapshot.requests.first?.detail)
+
+        XCTAssertTrue(detail.contains("1100 tok/s"), detail)
+        XCTAssertTrue(detail.contains(ActivityFormat.left(17.4)), detail)
+    }
+
+    func testGeneratingUsesNumericAndCompactRateBoundaries() throws {
+        let snapshot = try XCTUnwrap(ModelActivitySnapshot(model: makeModel(
+            generating: [
+                .init(requestId: "a", generatedTokens: 1, tokensPerSecond: 9_999,
+                      elapsedSeconds: nil),
+                .init(requestId: "b", generatedTokens: 1, tokensPerSecond: 10_000,
+                      elapsedSeconds: nil),
+            ]
+        )))
+
+        XCTAssertTrue(snapshot.requests[0].detail.contains("9999 tok/s"),
+                      snapshot.requests[0].detail)
+        XCTAssertTrue(snapshot.requests[1].detail.contains("10.0k tok/s"),
+                      snapshot.requests[1].detail)
+    }
+
     func testIdleModelHasNoSnapshot() {
         XCTAssertNil(ModelActivitySnapshot(model: makeModel()))
     }
@@ -137,6 +165,13 @@ final class ModelActivityTests: XCTestCase {
         XCTAssertEqual(ActivityFormat.tokens(12_400, locale: locale), "12.4k")
         XCTAssertEqual(ActivityFormat.tokens(124_000, locale: locale), "124k")
         XCTAssertEqual(ActivityFormat.tokens(1_200_000, locale: locale), "1.2M")
+    }
+
+    func testRatesStayNumericUntilTenThousand() {
+        XCTAssertEqual(ActivityFormat.rate(999.6), "1000")
+        XCTAssertEqual(ActivityFormat.rate(1_100), "1100")
+        XCTAssertEqual(ActivityFormat.rate(9_999), "9999")
+        XCTAssertEqual(ActivityFormat.rate(10_000), "10.0k")
     }
 
     func testLocalizedActivityDetailsFormatArguments() {
@@ -202,50 +237,4 @@ final class ModelActivityTests: XCTestCase {
         XCTAssertEqual(snapshot.badgePhase, .queued)
     }
 
-    // MARK: - Speed smoothing
-
-    func testSmoothedSpeedDampensSwingsAndDrivesEta() throws {
-        var smoother = PrefillSpeedSmoother(alpha: 0.35)
-        func entry(speed: Double) -> StatsDTO.PrefillProgressDTO {
-            .init(requestId: "a", processed: 5_000, total: 20_000,
-                  speed: speed, eta: 999, elapsed: 1, detail: nil)
-        }
-
-        XCTAssertEqual(smoother.smoothed([entry(speed: 2_000)]).first?.speed, 2_000)
-
-        let dipped = try XCTUnwrap(smoother.smoothed([entry(speed: 1_000)]).first)
-        let speed = try XCTUnwrap(dipped.speed)
-        XCTAssertLessThan(speed, 2_000)
-        XCTAssertGreaterThan(speed, 1_000)
-        XCTAssertEqual(try XCTUnwrap(dipped.eta), 15_000 / speed, accuracy: 0.001)
-    }
-
-    func testSmootherRetainsOtherModelsAverages() throws {
-        var smoother = PrefillSpeedSmoother(alpha: 0.35)
-        func entry(_ id: String, speed: Double) -> StatsDTO.PrefillProgressDTO {
-            .init(requestId: id, processed: 10_000, total: 20_000,
-                  speed: speed, eta: nil, elapsed: 1, detail: nil)
-        }
-        _ = smoother.smoothed([entry("a", speed: 2_000)])
-        _ = smoother.smoothed([entry("b", speed: 400)])
-        smoother.retain(ids: ["a", "b"])
-
-        XCTAssertGreaterThan(
-            try XCTUnwrap(smoother.smoothed([entry("a", speed: 1_000)]).first?.speed), 1_000
-        )
-    }
-
-    func testSmootherForgetsFinishedRequests() throws {
-        var smoother = PrefillSpeedSmoother(alpha: 0.35)
-        let finished = StatsDTO.PrefillProgressDTO(
-            requestId: "a", processed: 10, total: 100, speed: 5_000,
-            eta: nil, elapsed: 1, detail: nil)
-        _ = smoother.smoothed([finished])
-        smoother.retain(ids: [])
-
-        let fresh = StatsDTO.PrefillProgressDTO(
-            requestId: "a", processed: 10, total: 100, speed: 50,
-            eta: nil, elapsed: 1, detail: nil)
-        XCTAssertEqual(try XCTUnwrap(smoother.smoothed([fresh]).first?.speed), 50)
-    }
 }

--- a/apps/omlx-mac/Tests/oMLXTests/ModelActivityTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/ModelActivityTests.swift
@@ -88,7 +88,7 @@ final class ModelActivityTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(snapshot.requests[0].fraction), 0.62, accuracy: 0.001)
         XCTAssertEqual(snapshot.requests[0].percentText, "62%")
         XCTAssertEqual(snapshot.requests[1].percentText, "18%")
-        XCTAssertTrue(snapshot.requests[0].detail.contains("12k / 20k tok"),
+        XCTAssertTrue(snapshot.requests[0].detail.contains("12.4k / 20k tok"),
                       snapshot.requests[0].detail)
         XCTAssertTrue(snapshot.requests[0].detail.contains("1.8k tok/s"),
                       snapshot.requests[0].detail)
@@ -125,6 +125,18 @@ final class ModelActivityTests: XCTestCase {
         XCTAssertEqual(snapshot?.requests.isEmpty, true)
         XCTAssertEqual(snapshot?.queued, 3)
         XCTAssertEqual(snapshot?.badgePhase, .queued)
+    }
+
+    func testTokenCountsStayExactUntilTenThousand() {
+        let locale = Locale(identifier: "en_US")
+
+        XCTAssertEqual(ActivityFormat.tokens(999, locale: locale), "999")
+        XCTAssertEqual(ActivityFormat.tokens(1_000, locale: locale), "1,000")
+        XCTAssertEqual(ActivityFormat.tokens(9_999, locale: locale), "9,999")
+        XCTAssertEqual(ActivityFormat.tokens(10_000, locale: locale), "10k")
+        XCTAssertEqual(ActivityFormat.tokens(12_400, locale: locale), "12.4k")
+        XCTAssertEqual(ActivityFormat.tokens(124_000, locale: locale), "124k")
+        XCTAssertEqual(ActivityFormat.tokens(1_200_000, locale: locale), "1.2M")
     }
 
     // MARK: - Linger

--- a/apps/omlx-mac/oMLX.xcodeproj/project.pbxproj
+++ b/apps/omlx-mac/oMLX.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		8BB000000000000000000005 /* ChatTemplateKwargs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC000000000000000000005 /* ChatTemplateKwargs.swift */; };
 		8BB000000000000000000006 /* DflashByteSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC000000000000000000006 /* DflashByteSize.swift */; };
 		8BB000000000000000000007 /* SystemMetricsPoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC000000000000000000007 /* SystemMetricsPoller.swift */; };
+		ABB000000000000000000201 /* ModelActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACC000000000000000000201 /* ModelActivity.swift */; };
 		8BB000000000000000000008 /* ProfileViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC000000000000000000008 /* ProfileViews.swift */; };
 		8BB000000000000000000009 /* ProfileWorkingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC000000000000000000009 /* ProfileWorkingState.swift */; };
 		8BB00000000000000000000A /* MSTaskDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC00000000000000000000A /* MSTaskDTO.swift */; };
@@ -114,6 +115,7 @@
 		DBB000000000000000000009 /* GlobalSettingsSamplingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000009 /* GlobalSettingsSamplingTests.swift */; };
 		DBB00000000000000000000A /* ProfileScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC00000000000000000000A /* ProfileScopeTests.swift */; };
 		DBB00000000000000000000B /* SystemMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC00000000000000000000B /* SystemMetricsTests.swift */; };
+		DBB000000000000000000201 /* ModelActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000201 /* ModelActivityTests.swift */; };
 		DBB00000000000000000000C /* WelcomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC00000000000000000000C /* WelcomeViewModelTests.swift */; };
 		DBB00000000000000000000D /* DTOFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC00000000000000000000D /* DTOFixtureTests.swift */; };
 		DBB00000000000000000000E /* ServerProcessIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC00000000000000000000E /* ServerProcessIntegrationTests.swift */; };
@@ -217,6 +219,7 @@
 		8CC000000000000000000005 /* ChatTemplateKwargs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTemplateKwargs.swift; sourceTree = "<group>"; };
 		8CC000000000000000000006 /* DflashByteSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DflashByteSize.swift; sourceTree = "<group>"; };
 		8CC000000000000000000007 /* SystemMetricsPoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMetricsPoller.swift; sourceTree = "<group>"; };
+		ACC000000000000000000201 /* ModelActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelActivity.swift; sourceTree = "<group>"; };
 		8CC000000000000000000008 /* ProfileViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViews.swift; sourceTree = "<group>"; };
 		8CC000000000000000000009 /* ProfileWorkingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileWorkingState.swift; sourceTree = "<group>"; };
 		8CC00000000000000000000A /* MSTaskDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSTaskDTO.swift; sourceTree = "<group>"; };
@@ -258,6 +261,7 @@
 		DCC000000000000000000009 /* GlobalSettingsSamplingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSettingsSamplingTests.swift; sourceTree = "<group>"; };
 		DCC00000000000000000000A /* ProfileScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileScopeTests.swift; sourceTree = "<group>"; };
 		DCC00000000000000000000B /* SystemMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMetricsTests.swift; sourceTree = "<group>"; };
+		DCC000000000000000000201 /* ModelActivityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelActivityTests.swift; sourceTree = "<group>"; };
 		DCC00000000000000000000C /* WelcomeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeViewModelTests.swift; sourceTree = "<group>"; };
 		DCC00000000000000000000D /* DTOFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DTOFixtureTests.swift; sourceTree = "<group>"; };
 		DCC00000000000000000000E /* ServerProcessIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerProcessIntegrationTests.swift; sourceTree = "<group>"; };
@@ -332,6 +336,7 @@
 				DCC000000000000000000009 /* GlobalSettingsSamplingTests.swift */,
 				DCC00000000000000000000A /* ProfileScopeTests.swift */,
 				DCC00000000000000000000B /* SystemMetricsTests.swift */,
+				DCC000000000000000000201 /* ModelActivityTests.swift */,
 				DCC00000000000000000000C /* WelcomeViewModelTests.swift */,
 				DCC00000000000000000000D /* DTOFixtureTests.swift */,
 				DCC00000000000000000000E /* ServerProcessIntegrationTests.swift */,
@@ -556,6 +561,7 @@
 				8CC000000000000000000009 /* ProfileWorkingState.swift */,
 				9CC000000000000000000006 /* PresetBundleStore.swift */,
 				8CC000000000000000000007 /* SystemMetricsPoller.swift */,
+				ACC000000000000000000201 /* ModelActivity.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -773,6 +779,7 @@
 				8BB000000000000000000005 /* ChatTemplateKwargs.swift in Sources */,
 				8BB000000000000000000006 /* DflashByteSize.swift in Sources */,
 				8BB000000000000000000007 /* SystemMetricsPoller.swift in Sources */,
+				ABB000000000000000000201 /* ModelActivity.swift in Sources */,
 				8BB000000000000000000008 /* ProfileViews.swift in Sources */,
 				8BB000000000000000000009 /* ProfileWorkingState.swift in Sources */,
 				9BB000000000000000000001 /* SubKeyDTO.swift in Sources */,
@@ -801,6 +808,7 @@
 				DBB000000000000000000009 /* GlobalSettingsSamplingTests.swift in Sources */,
 				DBB00000000000000000000A /* ProfileScopeTests.swift in Sources */,
 				DBB00000000000000000000B /* SystemMetricsTests.swift in Sources */,
+				DBB000000000000000000201 /* ModelActivityTests.swift in Sources */,
 				DBB00000000000000000000C /* WelcomeViewModelTests.swift in Sources */,
 				DBB00000000000000000000D /* DTOFixtureTests.swift in Sources */,
 				DBB00000000000000000000E /* ServerProcessIntegrationTests.swift in Sources */,

--- a/apps/omlx-mac/oMLX.xcodeproj/project.pbxproj
+++ b/apps/omlx-mac/oMLX.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		8BB000000000000000000006 /* DflashByteSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC000000000000000000006 /* DflashByteSize.swift */; };
 		8BB000000000000000000007 /* SystemMetricsPoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC000000000000000000007 /* SystemMetricsPoller.swift */; };
 		ABB000000000000000000201 /* ModelActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACC000000000000000000201 /* ModelActivity.swift */; };
+		ABB000000000000000000202 /* ModelActivityViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACC000000000000000000202 /* ModelActivityViews.swift */; };
 		8BB000000000000000000008 /* ProfileViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC000000000000000000008 /* ProfileViews.swift */; };
 		8BB000000000000000000009 /* ProfileWorkingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC000000000000000000009 /* ProfileWorkingState.swift */; };
 		8BB00000000000000000000A /* MSTaskDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC00000000000000000000A /* MSTaskDTO.swift */; };
@@ -220,6 +221,7 @@
 		8CC000000000000000000006 /* DflashByteSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DflashByteSize.swift; sourceTree = "<group>"; };
 		8CC000000000000000000007 /* SystemMetricsPoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMetricsPoller.swift; sourceTree = "<group>"; };
 		ACC000000000000000000201 /* ModelActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelActivity.swift; sourceTree = "<group>"; };
+		ACC000000000000000000202 /* ModelActivityViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelActivityViews.swift; sourceTree = "<group>"; };
 		8CC000000000000000000008 /* ProfileViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViews.swift; sourceTree = "<group>"; };
 		8CC000000000000000000009 /* ProfileWorkingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileWorkingState.swift; sourceTree = "<group>"; };
 		8CC00000000000000000000A /* MSTaskDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSTaskDTO.swift; sourceTree = "<group>"; };
@@ -562,6 +564,7 @@
 				9CC000000000000000000006 /* PresetBundleStore.swift */,
 				8CC000000000000000000007 /* SystemMetricsPoller.swift */,
 				ACC000000000000000000201 /* ModelActivity.swift */,
+				ACC000000000000000000202 /* ModelActivityViews.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -780,6 +783,7 @@
 				8BB000000000000000000006 /* DflashByteSize.swift in Sources */,
 				8BB000000000000000000007 /* SystemMetricsPoller.swift in Sources */,
 				ABB000000000000000000201 /* ModelActivity.swift in Sources */,
+				ABB000000000000000000202 /* ModelActivityViews.swift in Sources */,
 				8BB000000000000000000008 /* ProfileViews.swift in Sources */,
 				8BB000000000000000000009 /* ProfileWorkingState.swift in Sources */,
 				9BB000000000000000000001 /* SubKeyDTO.swift in Sources */,

--- a/omlx/prefill_progress.py
+++ b/omlx/prefill_progress.py
@@ -25,6 +25,8 @@ class PrefillProgressTracker:
     Called once per prefill chunk (default 2048 tokens).
     """
 
+    _SPEED_EMA_ALPHA = 0.35
+
     def __init__(self) -> None:
         self._progress: Dict[str, Dict[str, Any]] = {}
         self._lock = threading.Lock()
@@ -60,10 +62,19 @@ class PrefillProgressTracker:
                     dtok = processed - prev["processed"]
                     if dt > 0 and dtok > 0:
                         speed = dtok / dt
+                        previous_ema = prev.get("smoothed_speed")
+                        smoothed_speed = (
+                            speed
+                            if previous_ema is None
+                            else previous_ema
+                            + self._SPEED_EMA_ALPHA * (speed - previous_ema)
+                        )
                     else:
                         speed = prev.get("speed", 0.0)
+                        smoothed_speed = prev.get("smoothed_speed")
                 else:
                     speed = 0.0
+                    smoothed_speed = None
 
                 entry = dict(extra or {})
                 entry.update(
@@ -74,6 +85,7 @@ class PrefillProgressTracker:
                         "start_time": start_time,
                         "last_time": now,
                         "speed": speed,
+                        "smoothed_speed": smoothed_speed,
                         "phase": phase,
                         "detail": detail,
                     }
@@ -109,7 +121,8 @@ class PrefillProgressTracker:
                 elapsed = time.monotonic() - entry["start_time"]
                 speed = entry.get("speed", 0.0)
                 remaining = entry["total"] - entry["processed"]
-                eta = remaining / speed if speed > 0 else None
+                smoothed_speed = entry.get("smoothed_speed")
+                eta = remaining / smoothed_speed if smoothed_speed else None
                 result = {
                     "request_id": rid,
                     "processed": entry["processed"],

--- a/tests/test_prefill_progress.py
+++ b/tests/test_prefill_progress.py
@@ -76,7 +76,7 @@ class TestPrefillProgressTracker:
         assert result[0]["speed"] == 0.0
         assert result[0]["eta"] is None
 
-    def test_speed_and_eta_calculation(self):
+    def test_first_positive_rate_is_returned_raw_and_seeds_eta(self):
         t = 100.0
         with patch("omlx.prefill_progress.time") as mock_time:
             mock_time.monotonic.return_value = t
@@ -86,10 +86,56 @@ class TestPrefillProgressTracker:
             mock_time.monotonic.return_value = t + 1.0
             self.tracker.update("req-1", 2048, 8192, "llama-3b")
 
-        result = self.tracker.get_model_progress("llama-3b")
-        assert result[0]["speed"] == 2048.0
-        # eta = (8192 - 2048) / 2048 = 3.0 seconds
-        assert result[0]["eta"] == 3.0
+            result = self.tracker.get_model_progress("llama-3b")
+            assert result[0]["speed"] == 2048.0
+            assert result[0]["eta"] == 3.0
+
+    def test_eta_uses_ema_while_speed_stays_raw(self):
+        with patch("omlx.prefill_progress.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            self.tracker.update("req-1", 0, 1000, "llama-3b")
+            mock_time.monotonic.return_value = 101.0
+            self.tracker.update("req-1", 100, 1000, "llama-3b")
+            mock_time.monotonic.return_value = 102.0
+            self.tracker.update("req-1", 300, 1000, "llama-3b")
+
+            result = self.tracker.get_model_progress("llama-3b")[0]
+
+        assert result["speed"] == 200.0
+        assert result["eta"] == 5.2
+
+    def test_no_progress_does_not_degrade_rate_or_eta(self):
+        with patch("omlx.prefill_progress.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            self.tracker.update("req-1", 0, 1000, "llama-3b")
+            mock_time.monotonic.return_value = 101.0
+            self.tracker.update("req-1", 100, 1000, "llama-3b")
+            mock_time.monotonic.return_value = 102.0
+            self.tracker.update("req-1", 100, 1000, "llama-3b")
+
+            result = self.tracker.get_model_progress("llama-3b")[0]
+
+        assert result["speed"] == 100.0
+        assert result["eta"] == 9.0
+
+    def test_phase_change_resets_rate_and_eta_ema(self):
+        with patch("omlx.prefill_progress.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            self.tracker.update("req-1", 0, 1000, "llama-3b")
+            mock_time.monotonic.return_value = 101.0
+            self.tracker.update("req-1", 100, 1000, "llama-3b")
+            mock_time.monotonic.return_value = 102.0
+            self.tracker.update("req-1", 300, 1000, "llama-3b", phase="spec-prefill")
+
+            after_phase_change = self.tracker.get_model_progress("llama-3b")[0]
+            mock_time.monotonic.return_value = 103.0
+            self.tracker.update("req-1", 400, 1000, "llama-3b", phase="spec-prefill")
+            after_first_new_sample = self.tracker.get_model_progress("llama-3b")[0]
+
+        assert after_phase_change["speed"] == 0.0
+        assert after_phase_change["eta"] is None
+        assert after_first_new_sample["speed"] == 100.0
+        assert after_first_new_sample["eta"] == 6.0
 
     def test_eta_none_when_speed_zero(self):
         self.tracker.update("req-1", 2048, 8192, "llama-3b")


### PR DESCRIPTION
Adds live serving observability to the native macOS app and menubar.

## What changed

- Show live per-request activity on Models and Status, including prefill progress, generation, non-streaming work, queue state, and short completion linger.
- Add LIV, AVG, and ALL menubar metric items with live PP/TG rates, activity graphs, and scoped details.
- Add a compact Serving Stats menu with Live Activity, Current Requests, Average Session, and All Time summaries.
- Keep Current Requests readable under load by grouping by model, capping visible requests, and using consistent PP/TG markers and rate/token formatting.
- Align serving-stat panels with the existing System Stats layout and reuse shared presentation components.

## Data and refresh behavior

- Decode `/admin/api/activity` through the existing macOS API client.
- Display raw prefill and generation rates consistently across the app and menubar; calculate prefill ETA server-side from a positive-sample EMA to avoid ETA jitter.
- Preserve idle versus unavailable state, retain short-lived completed app rows, and poll admin-backed activity only while a consumer needs it.

<img width="882" height="1059" alt="2026-09-02_14-25-19" src="https://github.com/user-attachments/assets/b4f3a9a5-5920-4520-9ddc-448dd6b88044" />
<img width="318" height="345" alt="image" src="https://github.com/user-attachments/assets/76bd1e66-4b3d-4616-929e-744325f0ad0e" />
<img width="295" height="557" alt="2026-09-02_14-12-05" src="https://github.com/user-attachments/assets/b9bd199d-6ed2-4c79-85bb-3241a810e11f" />


