### PR TITLE
fix(codex): generate local model metadata catalog

### DIFF
--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -446,48 +446,89 @@ def launch_command(args, extra_args: list[str] | None = None):
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
 
-    # Pre-fetch model status (context_window, max_tokens, model_type per model)
+    # Pre-fetch detailed model metadata. Codex also needs the authoritative
+    # visible model IDs from /v1/models to build its local model catalog.
     models_status_map: dict[str, dict] = {}
+    models_status_available = False
     try:
         resp = requests.get(f"{base_url}/v1/models/status", headers=headers, timeout=5)
         if resp.ok:
-            for m in resp.json().get("models", []):
-                if m_id := m.get("id"):
-                    models_status_map[m_id] = m
-                if model_alias := m.get("model_alias"):
-                    models_status_map[model_alias] = m
+            status_models = resp.json().get("models")
+            if not isinstance(status_models, list):
+                raise ValueError("invalid model status response")
+
+            parsed_status_map: dict[str, dict] = {}
+            for m in status_models:
+                if not isinstance(m, dict):
+                    raise ValueError("invalid model status entry")
+                m_id = m.get("id")
+                model_type = m.get("model_type")
+                if (
+                    not isinstance(m_id, str)
+                    or not m_id
+                    or not isinstance(model_type, str)
+                    or not model_type
+                ):
+                    raise ValueError("incomplete model status entry")
+                parsed_status_map[m_id] = m
+                # Exposed profiles inherit their source model's alias in the
+                # status payload. Only the physical model should own that alias.
+                if not m.get("source_model_id") and (
+                    model_alias := m.get("model_alias")
+                ):
+                    parsed_status_map[model_alias] = m
+            models_status_map = parsed_status_map
+            models_status_available = True
     except Exception:
         pass
+
+    def _fetch_visible_models() -> list[str]:
+        try:
+            response = requests.get(f"{base_url}/v1/models", headers=headers, timeout=5)
+            response.raise_for_status()
+            visible_ids = [m["id"] for m in response.json().get("data", [])]
+            if not models_status_available:
+                return visible_ids
+            return [
+                model_id
+                for model_id in visible_ids
+                if models_status_map.get(model_id, {}).get("model_type")
+                in ("llm", "vlm")
+            ]
+        except Exception:
+            return []
+
+    visible_models: list[str] | None = None
+    if tool_name in ("codex", "codex_app"):
+        visible_models = _fetch_visible_models()
 
     # Determine model. Explicit CLI tier flags bypass the picker; otherwise always
     # prompt interactively so the user's selection is honoured.
     model = args.model
-    if not model and (cli_opus_model or cli_sonnet_model or cli_haiku_model):
+    if tool_name == "claude" and not model and (
+        cli_opus_model or cli_sonnet_model or cli_haiku_model
+    ):
         model = cli_sonnet_model or cli_opus_model or cli_haiku_model or ""
     elif not model:
-        # Fetch available models from server
-        try:
-            resp = requests.get(f"{base_url}/v1/models", headers=headers, timeout=5)
-            resp.raise_for_status()
-            data = resp.json()
-            models = [
-                m["id"]
-                for m in data.get("data", [])
-                if m.get("model_type") in ("llm", "vlm", None)
-            ]
-        except Exception:
-            models = []
+        if tool_name in ("codex", "codex_app") and not models_status_available:
+            print("Could not load model metadata for Codex.")
+            print("Specify a chat model explicitly with --model.")
+            sys.exit(1)
 
-        if not models:
+        if visible_models is None:
+            visible_models = _fetch_visible_models()
+
+        if not visible_models:
             print("No models available. Load a model first.")
             sys.exit(1)
 
-        if len(models) == 1:
-            model = models[0]
+        if len(visible_models) == 1:
+            model = visible_models[0]
             print(f"Using model: {model}")
         else:
             models_info_list = [
-                {"id": m_id, **models_status_map.get(m_id, {})} for m_id in models
+                {**models_status_map.get(m_id, {}), "id": m_id}
+                for m_id in visible_models
             ]
             model = integration.select_model(models_info_list, integration.display_name)
 
@@ -542,6 +583,16 @@ def launch_command(args, extra_args: list[str] | None = None):
 
     # Resolve model limits from pre-fetched status
     model_info = models_status_map.get(model, {})
+    catalog_model_ids = visible_models or []
+    if tool_name in ("codex", "codex_app") and not models_status_available:
+        # /v1/models has no model type, so it cannot safely distinguish chat
+        # models from embeddings and other visible API helpers. In degraded
+        # mode, catalog only the model the user actually selected.
+        catalog_model_ids = [model] if model else []
+    available_models = tuple(
+        {**models_status_map.get(model_id, {}), "id": model_id}
+        for model_id in catalog_model_ids
+    )
     ctx = IntegrationContext(
         host=connect_host,
         port=port,
@@ -554,6 +605,7 @@ def launch_command(args, extra_args: list[str] | None = None):
         max_tokens=model_info.get("max_tokens"),
         model_type=model_info.get("model_type"),
         reasoning=model_info.get("enable_thinking"),
+        available_models=available_models,
         tools_profile=getattr(args, "tools_profile", "coding"),
         extra_args=tuple(extra_args or ()),
         cross_session=getattr(args, "cross_session", False),

--- a/omlx/integrations/base.py
+++ b/omlx/integrations/base.py
@@ -26,6 +26,7 @@ class IntegrationContext:
     max_tokens: int | None = None
     model_type: str | None = None
     reasoning: bool | None = None
+    available_models: tuple[dict, ...] = ()
     tools_profile: str = "coding"
     extra_args: tuple[str, ...] = ()
     cross_session: bool = False

--- a/omlx/integrations/codex.py
+++ b/omlx/integrations/codex.py
@@ -13,10 +13,118 @@ from pathlib import Path
 from omlx.integrations.base import Integration, IntegrationContext
 from omlx.utils.install import get_cli_command_prefix
 
-CODEX_CONFIG_PATH = Path.home() / ".codex" / "config.toml"
+CODEX_PROFILE_NAME = "omlx"
+CODEX_PROFILE_CONFIG_NAME = f"{CODEX_PROFILE_NAME}.config.toml"
+CODEX_MODEL_CATALOG_NAME = "omlx-models.json"
+
+_CODEX_BASE_INSTRUCTIONS = (
+    "You are Codex, a coding agent. Follow the user's instructions carefully. "
+    "Inspect relevant files before editing, make focused changes, preserve "
+    "unrelated work, and verify changes with relevant tests."
+)
 
 
-def write_codex_config(config_path: Path, ctx: IntegrationContext) -> None:
+def codex_home_path() -> Path:
+    """Return the active Codex configuration directory."""
+    codex_home = os.environ.get("CODEX_HOME")
+    if codex_home:
+        return Path(codex_home)
+    return Path.home() / ".codex"
+
+
+def codex_model_catalog_path() -> Path:
+    """Return the dedicated oMLX catalog path in the active Codex home."""
+    return codex_home_path() / CODEX_MODEL_CATALOG_NAME
+
+
+def codex_profile_path() -> Path:
+    """Return the standalone oMLX profile path in the active Codex home."""
+    return codex_home_path() / CODEX_PROFILE_CONFIG_NAME
+
+
+def _positive_int(*values: object, default: int) -> int:
+    for value in values:
+        if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+            return value
+    return default
+
+
+def _codex_catalog_model(model: dict, priority: int, ctx: IntegrationContext) -> dict:
+    model_id = str(model.get("id") or ctx.model)
+    context_window = _positive_int(
+        model.get("max_context_window"),
+        model.get("model_context_length"),
+        ctx.context_window if model_id == ctx.model else None,
+        default=32_768,
+    )
+    modalities = ["text", "image"] if model.get("model_type") == "vlm" else ["text"]
+    return {
+        "slug": model_id,
+        "display_name": model_id,
+        "description": "Local model served by oMLX",
+        "default_reasoning_level": None,
+        "supported_reasoning_levels": [],
+        "shell_type": "unified_exec",
+        "visibility": "list",
+        "supported_in_api": True,
+        "priority": priority,
+        "availability_nux": None,
+        "upgrade": None,
+        "base_instructions": _CODEX_BASE_INSTRUCTIONS,
+        "model_messages": None,
+        # Keep both legacy and current names so catalogs work across recent
+        # Codex releases. Unknown fields are ignored by a given release.
+        "supports_reasoning_summaries": False,
+        "supports_reasoning_summary_parameter": False,
+        "default_reasoning_summary": "auto",
+        "support_verbosity": False,
+        "default_verbosity": None,
+        "apply_patch_tool_type": None,
+        "truncation_policy": {"mode": "bytes", "limit": 10_000},
+        "supports_parallel_tool_calls": False,
+        "supports_image_detail_original": False,
+        "context_window": context_window,
+        "max_context_window": context_window,
+        "auto_compact_token_limit": None,
+        "effective_context_window_percent": 95,
+        "experimental_supported_tools": [],
+        "input_modalities": modalities,
+    }
+
+
+def write_codex_model_catalog(catalog_path: Path, ctx: IntegrationContext) -> Path:
+    """Write Codex metadata for every model exposed by the oMLX server."""
+    models = list(ctx.available_models)
+    if ctx.model and not any(model.get("id") == ctx.model for model in models):
+        models.append(
+            {
+                "id": ctx.model,
+                "model_type": ctx.model_type,
+                "max_context_window": ctx.context_window,
+            }
+        )
+    if not models:
+        models.append({"id": ctx.model or "select-a-model"})
+
+    catalog = {
+        "models": [
+            _codex_catalog_model(model, priority, ctx)
+            for priority, model in enumerate(models)
+        ]
+    }
+    catalog_path.parent.mkdir(parents=True, exist_ok=True)
+    catalog_path.write_text(
+        json.dumps(catalog, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return catalog_path
+
+
+def write_codex_config(
+    config_path: Path,
+    ctx: IntegrationContext,
+    catalog_path: Path | None = None,
+) -> None:
     config_path.parent.mkdir(parents=True, exist_ok=True)
 
     existing_content = ""
@@ -42,6 +150,8 @@ def write_codex_config(config_path: Path, ctx: IntegrationContext) -> None:
         "model": f'"{ctx.model or "select-a-model"}"',
         "model_provider": '"omlx"',
     }
+    if catalog_path is not None:
+        top_level_overrides["model_catalog_json"] = json.dumps(str(catalog_path))
 
     # If it is a reasoning model, add reasoning effort
     is_reasoning = (
@@ -53,7 +163,9 @@ def write_codex_config(config_path: Path, ctx: IntegrationContext) -> None:
         top_level_overrides["model_reasoning_effort"] = '"high"'
 
     # Keys managed by oMLX that should be removed when not applicable
-    managed_keys = {"model_reasoning_effort"} - set(top_level_overrides.keys())
+    managed_keys = {"model_reasoning_effort", "model_catalog_json"} - set(
+        top_level_overrides.keys()
+    )
 
     seen_keys = set()
 
@@ -94,7 +206,9 @@ def write_codex_config(config_path: Path, ctx: IntegrationContext) -> None:
     print(f"Config updated: {config_path}")
 
 
-def codex_config_args(ctx: IntegrationContext) -> list[str]:
+def codex_config_args(
+    ctx: IntegrationContext, catalog_path: Path | None = None
+) -> list[str]:
     """Build process-scoped Codex config overrides for an oMLX launch."""
     overrides: list[tuple[str, str]] = [
         ("model_provider", json.dumps("omlx")),
@@ -102,6 +216,8 @@ def codex_config_args(ctx: IntegrationContext) -> list[str]:
         ("model_providers.omlx.base_url", json.dumps(ctx.openai_base_url)),
         ("model_providers.omlx.env_key", json.dumps("OMLX_API_KEY")),
     ]
+    if catalog_path is not None:
+        overrides.append(("model_catalog_json", json.dumps(str(catalog_path))))
     if ctx.context_window is not None and ctx.context_window > 0:
         overrides.append(("model_context_window", str(ctx.context_window)))
 
@@ -135,9 +251,9 @@ class CodexIntegration(Integration):
         )
 
     def configure(self, ctx: IntegrationContext) -> None:
-        # Launch-time arguments carry the oMLX settings. Keeping this a no-op
-        # ensures normal Codex sessions continue to use the user's config.
-        return None
+        # The dedicated catalog does not alter the user's normal Codex config;
+        # launch-time arguments scope it to this oMLX process.
+        write_codex_model_catalog(codex_model_catalog_path(), ctx)
 
     def launch(self, ctx: IntegrationContext) -> None:
         self.configure(ctx)
@@ -145,7 +261,7 @@ class CodexIntegration(Integration):
         env = self._scrubbed_env()
         env["OMLX_API_KEY"] = ctx.auth_token
 
-        args = ["codex", *codex_config_args(ctx)]
+        args = ["codex", *codex_config_args(ctx, codex_model_catalog_path())]
         if ctx.model:
             args.extend(["-m", ctx.model])
         args.extend(ctx.extra_args)

--- a/omlx/integrations/codex_app.py
+++ b/omlx/integrations/codex_app.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Codex App (OpenAI Codex App Desktop) integration.
 
-This integration launches the Codex App Desktop GUI/TUI via the
-``codex app`` subcommand, while sharing the same config file as
-the CLI variant (``~/.codex/config.toml``).
+This integration launches the Codex App Desktop GUI/TUI via a standalone
+``omlx`` profile, leaving the user's base Codex configuration unchanged.
 
 OpenAI renamed the desktop app from Codex to ChatGPT. In-place
 upgrades keep the old ``/Applications/Codex.app`` folder name while
@@ -17,10 +16,11 @@ Usage:
     omlx launch codex_app --model qwen3.5
 
 Which launches:
-    codex app
+    codex --profile omlx app
 
-Both CLI and App use the same config file:
-    ~/.codex/config.toml
+The generated profile and model catalog live in the active Codex home:
+    ~/.codex/omlx.config.toml
+    ~/.codex/omlx-models.json
 """
 
 from __future__ import annotations
@@ -31,7 +31,13 @@ import shutil
 from pathlib import Path
 
 from omlx.integrations.base import Integration, IntegrationContext
-from omlx.integrations.codex import CODEX_CONFIG_PATH, write_codex_config
+from omlx.integrations.codex import (
+    CODEX_PROFILE_NAME,
+    codex_model_catalog_path,
+    codex_profile_path,
+    write_codex_config,
+    write_codex_model_catalog,
+)
 from omlx.utils.install import get_cli_command_prefix
 
 CODEX_APP_BUNDLE_ID = "com.openai.codex"
@@ -77,9 +83,7 @@ def resolve_codex_binary() -> str | None:
 
 
 class CodexAppIntegration(Integration):
-    """Codex App Desktop integration that configures ~/.codex/config.toml for oMLX."""
-
-    CONFIG_PATH = CODEX_CONFIG_PATH
+    """Codex App Desktop integration using a standalone oMLX profile."""
 
     def __init__(self):
         super().__init__(
@@ -105,7 +109,8 @@ class CodexAppIntegration(Integration):
         )
 
     def configure(self, ctx: IntegrationContext) -> None:
-        write_codex_config(self.CONFIG_PATH, ctx)
+        catalog_path = write_codex_model_catalog(codex_model_catalog_path(), ctx)
+        write_codex_config(codex_profile_path(), ctx, catalog_path)
 
     def launch(self, ctx: IntegrationContext) -> None:
         self.configure(ctx)
@@ -113,10 +118,10 @@ class CodexAppIntegration(Integration):
         env = self._scrubbed_env()
         env["OMLX_API_KEY"] = ctx.auth_token
 
-        # Launch codex app (desktop GUI/TUI) instead of codex CLI
-        # Note: codex app doesn't accept -m flag, model is set in config
+        # Launch Codex App with the standalone oMLX profile. The base user
+        # config remains untouched, so normal OpenAI sessions are unaffected.
         codex_bin = resolve_codex_binary() or "codex"
-        args = [codex_bin, "app"]
+        args = [codex_bin, "--profile", CODEX_PROFILE_NAME, "app"]
         args.extend(ctx.extra_args)
 
         os.execvpe(codex_bin, args, env)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -436,6 +436,7 @@ class TestLaunchCommandFunction:
         assert ctx.max_tokens == 8192
         assert ctx.cross_session is False
         assert ctx.model_type == "vlm"
+        assert ctx.available_models == ()
         assert ctx.extra_args == ()
 
     def test_launch_command_passes_cross_session_flag_to_integration(self):
@@ -532,6 +533,228 @@ class TestLaunchCommandFunction:
         assert ctx.max_tokens == 8192
         assert ctx.model_type == "vlm"
         assert ctx.reasoning is False
+
+    def test_launch_codex_catalog_uses_visible_model_ids(self):
+        """Codex catalog excludes hidden status entries and preserves profiles."""
+        from omlx.cli import launch_command
+
+        integration = MagicMock()
+        integration.display_name = "Codex"
+        integration.is_installed.return_value = True
+
+        health_response = MagicMock()
+        health_response.raise_for_status.return_value = None
+
+        status_response = MagicMock()
+        status_response.ok = True
+        status_response.json.return_value = {
+            "models": [
+                {
+                    "id": "qwen-raw",
+                    "model_alias": "gpt-4o",
+                    "model_type": "vlm",
+                    "max_context_window": 65536,
+                },
+                {
+                    "id": "hidden-helper",
+                    "model_type": "llm",
+                    "is_hidden": True,
+                },
+                {
+                    "id": "coding-profile",
+                    "source_model_id": "qwen-raw",
+                    "model_alias": "gpt-4o",
+                    "model_type": "vlm",
+                    "max_context_window": 32768,
+                },
+                {
+                    "id": "embedding-model",
+                    "model_type": "embedding",
+                    "max_context_window": 512,
+                },
+            ]
+        }
+
+        models_response = MagicMock()
+        models_response.raise_for_status.return_value = None
+        models_response.json.return_value = {
+            "data": [
+                {"id": "gpt-4o"},
+                {"id": "coding-profile"},
+                {"id": "embedding-model"},
+            ]
+        }
+
+        settings = MagicMock()
+        settings.server.host = "127.0.0.1"
+        settings.server.port = 8000
+
+        args = argparse.Namespace(
+            tool="codex",
+            host=None,
+            port=None,
+            api_key="test-key",
+            model="gpt-4o",
+            tools_profile="coding",
+        )
+
+        with (
+            patch(
+                "requests.get",
+                side_effect=[health_response, status_response, models_response],
+            ),
+            patch("omlx.integrations.get_integration", return_value=integration),
+            patch("omlx.settings.GlobalSettings.load", return_value=settings),
+        ):
+            launch_command(args)
+
+        launch_ctx = integration.launch.call_args.args[0]
+        assert [model["id"] for model in launch_ctx.available_models] == [
+            "gpt-4o",
+            "coding-profile",
+        ]
+        assert launch_ctx.available_models[0]["max_context_window"] == 65536
+        assert launch_ctx.available_models[1]["source_model_id"] == "qwen-raw"
+
+    @pytest.mark.parametrize("tool_name", ["codex", "codex_app"])
+    @pytest.mark.parametrize(
+        "failure_mode",
+        [
+            "request_error",
+            "malformed_collection",
+            "missing_type",
+            "invalid_after_valid",
+            "models_request_error",
+        ],
+    )
+    def test_launch_codex_catalog_status_failure_uses_selected_model_only(
+        self, failure_mode, tool_name
+    ):
+        """Missing type metadata must not admit every visible API model."""
+        from omlx.cli import launch_command
+
+        integration = MagicMock()
+        integration.display_name = "Codex"
+        integration.is_installed.return_value = True
+
+        health_response = MagicMock()
+        health_response.raise_for_status.return_value = None
+
+        status_response = MagicMock()
+        status_response.ok = True
+        status_payloads = {
+            "malformed_collection": {"models": "not-a-list"},
+            "missing_type": {"models": [{"id": "gpt-4o"}]},
+            "invalid_after_valid": {
+                "models": [
+                    {"id": "gpt-4o", "model_type": "llm"},
+                    {"id": "broken-entry"},
+                ]
+            },
+        }
+        status_response.json.return_value = status_payloads.get(
+            failure_mode, {"models": []}
+        )
+
+        models_response = MagicMock()
+        models_response.raise_for_status.return_value = None
+        models_response.json.return_value = {
+            "data": [{"id": "gpt-4o"}, {"id": "embedding-model"}]
+        }
+
+        status_result = (
+            RuntimeError("status unavailable")
+            if failure_mode in ("request_error", "models_request_error")
+            else status_response
+        )
+        models_result = (
+            RuntimeError("models unavailable")
+            if failure_mode == "models_request_error"
+            else models_response
+        )
+
+        settings = MagicMock()
+        settings.server.host = "127.0.0.1"
+        settings.server.port = 8000
+
+        args = argparse.Namespace(
+            tool=tool_name,
+            host=None,
+            port=None,
+            api_key="test-key",
+            model="gpt-4o",
+            tools_profile="coding",
+        )
+
+        with (
+            patch(
+                "requests.get",
+                side_effect=[health_response, status_result, models_result],
+            ),
+            patch("omlx.integrations.get_integration", return_value=integration),
+            patch("omlx.settings.GlobalSettings.load", return_value=settings),
+        ):
+            launch_command(args)
+
+        launch_ctx = integration.launch.call_args.args[0]
+        assert launch_ctx.available_models == ({"id": "gpt-4o"},)
+
+    @pytest.mark.parametrize("tool_name", ["codex", "codex_app"])
+    @pytest.mark.parametrize("tier_model", [None, "embedding-model"])
+    def test_launch_codex_status_failure_requires_explicit_model(
+        self, tool_name, tier_model, capsys
+    ):
+        """Untyped inventory and Claude tier flags must not bypass --model."""
+        from omlx.cli import launch_command
+
+        integration = MagicMock()
+        integration.display_name = "Codex"
+
+        health_response = MagicMock()
+        health_response.raise_for_status.return_value = None
+
+        settings = MagicMock()
+        settings.server.host = "127.0.0.1"
+        settings.server.port = 8000
+
+        args = argparse.Namespace(
+            tool=tool_name,
+            host=None,
+            port=None,
+            api_key="test-key",
+            model=None,
+            tools_profile="coding",
+            opus_model=None,
+            sonnet_model=tier_model,
+            haiku_model=None,
+        )
+
+        models_response = MagicMock()
+        models_response.raise_for_status.return_value = None
+        models_response.json.return_value = {
+            "data": [{"id": "gpt-4o"}, {"id": "embedding-model"}]
+        }
+
+        with (
+            patch(
+                "requests.get",
+                side_effect=[
+                    health_response,
+                    RuntimeError("status unavailable"),
+                    models_response,
+                ],
+            ),
+            patch("omlx.integrations.get_integration", return_value=integration),
+            patch("omlx.settings.GlobalSettings.load", return_value=settings),
+            pytest.raises(SystemExit) as exc,
+        ):
+            launch_command(args)
+
+        assert exc.value.code == 1
+        integration.select_model.assert_not_called()
+        integration.launch.assert_not_called()
+        output = capsys.readouterr().out
+        assert "Specify a chat model explicitly with --model." in output
 
     def test_launch_command_forwards_extra_args(self):
         """Unknown CLI tokens (e.g. --resume <id>) should reach integration.launch."""
@@ -649,9 +872,21 @@ class TestLaunchCommandFunction:
         status_response.ok = True
         status_response.json.return_value = {
             "models": [
-                {"id": "opus-32k", "max_context_window": 32768},
-                {"id": "sonnet-64k", "max_context_window": 65536},
-                {"id": "haiku-64k", "max_context_window": 65536},
+                {
+                    "id": "opus-32k",
+                    "model_type": "llm",
+                    "max_context_window": 32768,
+                },
+                {
+                    "id": "sonnet-64k",
+                    "model_type": "llm",
+                    "max_context_window": 65536,
+                },
+                {
+                    "id": "haiku-64k",
+                    "model_type": "llm",
+                    "max_context_window": 65536,
+                },
             ]
         }
 
@@ -705,7 +940,13 @@ class TestLaunchCommandFunction:
         status_response = MagicMock()
         status_response.ok = True
         status_response.json.return_value = {
-            "models": [{"id": "only-32k", "max_context_window": 32768}]
+            "models": [
+                {
+                    "id": "only-32k",
+                    "model_type": "llm",
+                    "max_context_window": 32768,
+                }
+            ]
         }
 
         models_response = MagicMock()
@@ -767,7 +1008,12 @@ class TestLaunchCommandFunction:
 
         status_map_response = MagicMock()
         status_map_response.ok = True
-        status_map_response.json.return_value = {"models": []}
+        status_map_response.json.return_value = {
+            "models": [
+                {"id": "sonnet-local", "model_type": "llm"},
+                {"id": "opus-local", "model_type": "llm"},
+            ]
+        }
 
         models_response = MagicMock()
         models_response.raise_for_status.return_value = None

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -14,7 +14,10 @@ from omlx.integrations.claude import ClaudeCodeIntegration
 from omlx.integrations.codex import (
     CodexIntegration,
     codex_config_args,
+    codex_model_catalog_path,
+    codex_profile_path,
     write_codex_config,
+    write_codex_model_catalog,
 )
 from omlx.integrations.codex_app import CodexAppIntegration, find_codex_app_bundle
 from omlx.integrations.copilot import CopilotIntegration
@@ -117,11 +120,20 @@ class TestCodexIntegration:
         assert 'model_reasoning_effort="high"' in reasoning_args
         assert not any("model_reasoning_effort" in arg for arg in non_reasoning_args)
 
-    def test_configure_does_not_write_codex_config(self):
-        with patch("omlx.integrations.codex.write_codex_config") as writer:
-            CodexIntegration().configure(ctx(port=8000, model="new-model"))
+    def test_configure_writes_dedicated_model_catalog(self, tmp_path):
+        catalog_path = tmp_path / "omlx-models.json"
+        with patch(
+            "omlx.integrations.codex.codex_model_catalog_path",
+            return_value=catalog_path,
+        ):
+            result = CodexIntegration().configure(
+                ctx(port=8000, model="new-model", context_window=65_536)
+            )
 
-        writer.assert_not_called()
+        assert result is None
+        catalog = json.loads(catalog_path.read_text())
+        assert catalog["models"][0]["slug"] == "new-model"
+        assert catalog["models"][0]["context_window"] == 65_536
 
     def test_type(self):
         codex = CodexIntegration()
@@ -143,7 +155,14 @@ class TestCodexIntegration:
             "PYTHONDONTWRITEBYTECODE": "1",
         }
         with (
-            patch("omlx.integrations.codex.write_codex_config") as writer,
+            patch(
+                "omlx.integrations.codex.codex_model_catalog_path",
+                return_value=Path("/tmp/omlx-models.json"),
+            ),
+            patch(
+                "omlx.integrations.codex.write_codex_model_catalog",
+                return_value=Path("/tmp/omlx-models.json"),
+            ) as writer,
             patch("omlx.integrations.codex.os.environ", base_env),
             patch("omlx.integrations.codex.os.execvpe", side_effect=fake_execvpe),
         ):
@@ -158,12 +177,54 @@ class TestCodexIntegration:
 
         assert captured["argv"][-3:] == ["-m", "qwen3.5", "--yolo"]
         assert 'model_provider="omlx"' in captured["argv"]
+        assert 'model_catalog_json="/tmp/omlx-models.json"' in captured["argv"]
         assert "model_context_window=240000" not in captured["argv"]
         assert captured["env"]["OMLX_API_KEY"] == "key"
         assert "PYTHONHOME" not in captured["env"]
         assert "PYTHONPATH" not in captured["env"]
         assert "PYTHONDONTWRITEBYTECODE" not in captured["env"]
-        writer.assert_not_called()
+        writer.assert_called_once()
+
+
+class TestCodexModelCatalogWriter:
+    def test_paths_respect_codex_home(self, tmp_path):
+        with patch.dict(
+            "omlx.integrations.codex.os.environ",
+            {"CODEX_HOME": str(tmp_path)},
+            clear=True,
+        ):
+            assert codex_model_catalog_path() == tmp_path / "omlx-models.json"
+            assert codex_profile_path() == tmp_path / "omlx.config.toml"
+
+    def test_writes_all_available_models_with_metadata(self, tmp_path):
+        catalog_path = tmp_path / "omlx-models.json"
+        write_codex_model_catalog(
+            catalog_path,
+            ctx(
+                model="qwen-text",
+                context_window=65_536,
+                available_models=(
+                    {
+                        "id": "qwen-text",
+                        "model_type": "llm",
+                        "max_context_window": 65_536,
+                    },
+                    {
+                        "id": "qwen-vl",
+                        "model_type": "vlm",
+                        "model_context_length": 131_072,
+                    },
+                ),
+            ),
+        )
+
+        models = json.loads(catalog_path.read_text())["models"]
+        assert [model["slug"] for model in models] == ["qwen-text", "qwen-vl"]
+        assert models[0]["context_window"] == 65_536
+        assert models[0]["input_modalities"] == ["text"]
+        assert models[1]["context_window"] == 131_072
+        assert models[1]["input_modalities"] == ["text", "image"]
+        assert models[1]["base_instructions"]
 
 
 class TestCodexConfigWriter:
@@ -180,6 +241,7 @@ class TestCodexConfigWriter:
                 api_key="test-key",
                 model="qwen3.5",
             ),
+            tmp_path / "omlx-models.json",
         )
 
         content = config_path.read_text()
@@ -187,6 +249,7 @@ class TestCodexConfigWriter:
         assert 'model_provider = "omlx"' in content
         assert 'base_url = "http://192.168.1.100:9000/v1"' in content
         assert 'env_key = "OMLX_API_KEY"' in content
+        assert 'model_catalog_json = "' in content
 
     def test_creates_backup(self, tmp_path):
         config_path = tmp_path / "config.toml"
@@ -238,6 +301,18 @@ class TestCodexConfigWriter:
         assert 'model = "llama-3.1-8b"' in content
         assert "model_reasoning_effort" not in content
 
+    def test_clears_stale_model_catalog_when_not_managed(self, tmp_path):
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            'model = "old-model"\n'
+            'model_provider = "omlx"\n'
+            'model_catalog_json = "/old/omlx-models.json"\n'
+        )
+
+        write_codex_config(config_path, ctx(port=8000, model="new-model"))
+
+        assert "model_catalog_json" not in config_path.read_text()
+
 
 def make_app_bundle(
     root: Path, name: str, bundle_id: str, with_cli: bool = True
@@ -265,20 +340,39 @@ class TestCodexAppIntegration:
 
     def test_configure(self, tmp_path):
         codex_app = CodexAppIntegration()
-        config_path = tmp_path / "codex" / "config.toml"
-        with patch.object(CodexAppIntegration, "CONFIG_PATH", config_path):
+        codex_home = tmp_path / "codex"
+        base_config_path = codex_home / "config.toml"
+        profile_path = codex_home / "omlx.config.toml"
+        catalog_path = codex_home / "omlx-models.json"
+        codex_home.mkdir()
+        base_config_path.write_text('model = "gpt-5.5"\n')
+        with (
+            patch(
+                "omlx.integrations.codex_app.codex_profile_path",
+                return_value=profile_path,
+            ),
+            patch(
+                "omlx.integrations.codex_app.codex_model_catalog_path",
+                return_value=catalog_path,
+            ),
+        ):
             codex_app.configure(ctx(port=8000, api_key="test-key", model="qwen3.5"))
 
-        assert config_path.exists()
-        content = config_path.read_text()
+        assert base_config_path.read_text() == 'model = "gpt-5.5"\n'
+        assert profile_path.exists()
+        content = profile_path.read_text()
         assert 'model = "qwen3.5"' in content
         assert 'model_provider = "omlx"' in content
         assert 'base_url = "http://127.0.0.1:8000/v1"' in content
         assert 'env_key = "OMLX_API_KEY"' in content
+        assert 'model_catalog_json = "' in content
+        catalog = json.loads(catalog_path.read_text())
+        assert catalog["models"][0]["slug"] == "qwen3.5"
 
     def test_launch_app(self, tmp_path):
         codex_app = CodexAppIntegration()
-        config_path = tmp_path / "codex" / "config.toml"
+        profile_path = tmp_path / "codex" / "omlx.config.toml"
+        catalog_path = tmp_path / "codex" / "omlx-models.json"
         captured = {}
 
         def fake_execvpe(binary, argv, env):
@@ -292,7 +386,14 @@ class TestCodexAppIntegration:
             "PYTHONDONTWRITEBYTECODE": "1",
         }
         with (
-            patch.object(CodexAppIntegration, "CONFIG_PATH", config_path),
+            patch(
+                "omlx.integrations.codex_app.codex_profile_path",
+                return_value=profile_path,
+            ),
+            patch(
+                "omlx.integrations.codex_app.codex_model_catalog_path",
+                return_value=catalog_path,
+            ),
             patch("omlx.integrations.codex_app.os.environ", base_env),
             patch("omlx.integrations.codex_app.os.execvpe", side_effect=fake_execvpe),
             patch(
@@ -309,8 +410,12 @@ class TestCodexAppIntegration:
                 )
             )
 
-        # Codex App should launch with "app" subcommand, not "-m <model>"
-        assert captured["argv"] == ["/opt/homebrew/bin/codex", "app"]
+        assert captured["argv"] == [
+            "/opt/homebrew/bin/codex",
+            "--profile",
+            "omlx",
+            "app",
+        ]
         assert captured["env"]["OMLX_API_KEY"] == "key"
         assert "PYTHONHOME" not in captured["env"]
         assert "PYTHONPATH" not in captured["env"]
@@ -354,7 +459,8 @@ class TestCodexAppIntegration:
 
     def test_launch_falls_back_to_bundled_cli(self, tmp_path):
         bundle = make_app_bundle(tmp_path, "Codex.app", "com.openai.codex")
-        config_path = tmp_path / "codex" / "config.toml"
+        profile_path = tmp_path / "codex" / "omlx.config.toml"
+        catalog_path = tmp_path / "codex" / "omlx-models.json"
         captured = {}
 
         def fake_execvpe(binary, argv, env):
@@ -362,7 +468,14 @@ class TestCodexAppIntegration:
             captured["argv"] = argv
 
         with (
-            patch.object(CodexAppIntegration, "CONFIG_PATH", config_path),
+            patch(
+                "omlx.integrations.codex_app.codex_profile_path",
+                return_value=profile_path,
+            ),
+            patch(
+                "omlx.integrations.codex_app.codex_model_catalog_path",
+                return_value=catalog_path,
+            ),
             patch("omlx.integrations.codex_app.shutil.which", return_value=None),
             patch("omlx.integrations.codex_app._APP_BUNDLE_ROOTS", (tmp_path,)),
             patch("omlx.integrations.codex_app.os.execvpe", side_effect=fake_execvpe),
@@ -371,7 +484,7 @@ class TestCodexAppIntegration:
 
         bundled = str(bundle / "Contents" / "Resources" / "codex")
         assert captured["binary"] == bundled
-        assert captured["argv"] == [bundled, "app"]
+        assert captured["argv"] == [bundled, "--profile", "omlx", "app"]
 
     def test_type(self):
         codex_app = CodexAppIntegration()


### PR DESCRIPTION
## Summary

Generate a local Codex model metadata catalog from models exposed by oMLX. This prevents Codex from falling back to unknown-model defaults that can disable tools or apply incorrect context-window behavior.

- Generate `omlx-models.json` with Codex-compatible model metadata.
- Join visible `/v1/models` IDs with detailed `/v1/models/status` metadata.
- Preserve model aliases and exposed profiles.
- Exclude hidden helpers and non-chat models such as embeddings.
- Configure Codex CLI with process-scoped arguments, without modifying the user's normal Codex configuration.
- Configure Codex App through a standalone `omlx.config.toml` profile and launch it with `--profile omlx`.
- Respect `CODEX_HOME` for the generated profile and catalog.
- Leave the user's base `config.toml` unchanged.
- Require an explicit `--model` when model-type metadata is unavailable, preventing unsafe fallback selection.
- Ensure Claude-only tier flags do not affect Codex model selection.

## Validation

- `python -m pytest tests/test_integrations.py tests/test_cli.py -q` — 212 passed on Python 3.13.
- `git diff --check`
- Verified Codex CLI against a locally served oMLX model:
  - loaded the generated catalog without the unknown-model metadata warning;
  - invoked the shell tool successfully.
- Verified that Codex can load the generated standalone `omlx` profile and complete a request.
- Unit tests verify that Codex App launches with `--profile omlx`, respects `CODEX_HOME`, and preserves the base Codex configuration.

Fixes #2050
