### PR TITLE
perf(qwen4): flatten exact long-context MTP decode

### DIFF
--- a/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.cpp
@@ -307,10 +307,16 @@ class Qwen4QSAIndexerScoresPrimitive : public Primitive {
 
     out.set_data(allocator::malloc(out.nbytes()));
 
-    constexpr int bm = 64;
+    // Lightning-MTP verifies at most eight rows.  The prefill BM64 kernel
+    // otherwise executes eight 8-row MMA fragments for a six-row window and
+    // makes that wasted work grow with the full QSA index.  BK and the MMA
+    // fragment reduction order stay identical; only the unused M tiles are
+    // removed, so retained FP32 scores are bit-for-bit equal.
+    const bool verify_tile = q.shape(2) <= 8;
+    const int bm = verify_tile ? 8 : 64;
     constexpr int bn = 64;
     constexpr int bk = 16;
-    constexpr int wm = 2;
+    const int wm = verify_tile ? 1 : 2;
     constexpr int wn = 2;
     const int B = q.shape(0);
     const int H = q.shape(1);

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.metal
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.metal
@@ -54,6 +54,11 @@ instantiate_dsa_indexer_score(bfloat16, bfloat16_t, 64, 64, 16, 2, 2);
 // Qwen4 QSA scores use the same validated M3 Steel tile, but write fp32 after
 // reducing the fixed four heads. Keeping this in the existing metallib also
 // lets stale extension builds fail closed at the missing ABI symbol.
+// MTP verify has at most eight rows.  BM8 retains the identical BK16 MMA
+// sequence for those rows while avoiding the 56 unused rows in the prefill
+// tile; BM64 remains the production prefill route.
+instantiate_qwen4_qsa_indexer_score(float16, half, 8, 64, 16, 1, 2);
+instantiate_qwen4_qsa_indexer_score(bfloat16, bfloat16_t, 8, 64, 16, 1, 2);
 instantiate_qwen4_qsa_indexer_score(float16, half, 64, 64, 16, 2, 2);
 instantiate_qwen4_qsa_indexer_score(bfloat16, bfloat16_t, 64, 64, 16, 2, 2);
 

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -37,6 +37,7 @@ from .qsa_fast import (
 _PLE_RUNTIME_MODEL_PATH: Path | None = None
 _PLE_RUNTIME_MODE = "resident"
 _HYPER_SPLIT_INDICES: dict[tuple[int, int], tuple[mx.array, mx.array]] = {}
+_QSA_DIRECT_VERIFY_MIN_TOKENS = 65_536
 
 
 @dataclass(frozen=True)
@@ -1220,10 +1221,12 @@ class Qwen4ExpAttention(Qwen3_5Attention):
             ):
                 return False
 
-        prospective_blocks = (
-            cache.offset + x.shape[1]
-        ) // self.indexer.compress_ratio
-        return prospective_blocks > self.indexer.block_topk
+        prospective_tokens = cache.offset + x.shape[1]
+        prospective_blocks = prospective_tokens // self.indexer.compress_ratio
+        return bool(
+            prospective_tokens >= _QSA_DIRECT_VERIFY_MIN_TOKENS
+            and prospective_blocks > self.indexer.block_topk
+        )
 
     def _gathered_text_prefill(
         self,

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -355,7 +355,23 @@ class _QSAIndexerCache:
 
     def _trim_indexer(self, length: int):
         self._index_offset = min(self._index_offset, max(0, int(length)))
-        self._invalidate_pooled_indexer()
+        # Speculative rollback changes only a suffix of the raw index state.
+        # Completed blocks strictly before the new logical end are immutable,
+        # so retain their normalized/RoPE-rotated rows.  Rewind to the last
+        # complete block: a partially retained block may contain rejected
+        # verify tokens and must be recomputed on the next append.
+        if (
+            self._pooled_index_keys is None
+            or self._pooled_index_ratio is None
+            or self._pooled_index_ratio <= 0
+        ):
+            self._invalidate_pooled_indexer()
+            return
+        complete_blocks = self._index_offset // self._pooled_index_ratio
+        self._pooled_index_offset = min(
+            self._pooled_index_offset,
+            complete_blocks,
+        )
 
     @property
     def indexer_nbytes(self):

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -1108,19 +1108,75 @@ class Qwen4ExpAttention(Qwen3_5Attention):
         prospective_blocks = (cache.offset + 1) // self.indexer.compress_ratio
         return prospective_blocks > self.indexer.block_topk
 
+    def _gathered_text_verify_eligible(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array],
+        cache: Optional[Any],
+        position_ids: Optional[mx.array],
+        position_embeddings: Optional[tuple[mx.array, mx.array]],
+        target_verify: bool,
+    ) -> bool:
+        """Admit only the exact batch-one Lightning-MTP verify geometry.
+
+        The general target-verify implementation evaluates each row against
+        the full K/V cache.  QSA selection is still exact, but the boolean mask
+        does not make dense SDPA sparse.  This route preserves each verify
+        position's selector and causal boundary while sending the whole window
+        through the same direct selected-block implementation as prefill.
+        """
+
+        causal_mask = mask is None or (isinstance(mask, str) and mask == "causal")
+        if not (
+            target_verify
+            and x.ndim == 3
+            and x.shape[0] == 1
+            and 2 <= x.shape[1] <= 9
+            and causal_mask
+            and type(cache) is QSAKVCache
+            and isinstance(cache.offset, int)
+            and position_embeddings is None
+            and self._batch_one_text_position_ids(position_ids, x.shape[1])
+        ):
+            return False
+
+        # A speculative rollback must restore all four QSA cache components.
+        # Never enter the direct route if a restored/foreign cache omitted or
+        # misaligned the auxiliary indexer state.
+        if cache.offset:
+            if cache.index_keys is None or cache.index_position_ids is None:
+                return False
+            if (
+                cache.index_keys.shape[1] != cache.offset
+                or cache.index_position_ids.shape[-1] != cache.offset
+            ):
+                return False
+
+        prospective_blocks = (
+            cache.offset + x.shape[1]
+        ) // self.indexer.compress_ratio
+        return prospective_blocks > self.indexer.block_topk
+
     def _gathered_text_prefill(
         self,
         x: mx.array,
         cache: QSAKVCache,
         position_ids: Optional[mx.array] = None,
+        *,
+        target_verify: bool = False,
     ) -> mx.array:
-        """Project once, append both caches, and attend only to selected K/V."""
+        """Project once, append both caches, and attend only to selected K/V.
+
+        ``target_verify`` retains the canonical verify-shaped projection
+        routing while the direct QSA kernel evaluates every verify row's own
+        exact selected block set and causal tail.
+        """
 
         batch, length, _ = x.shape
         q_proj_output, keys, values = _target_verify_linears(
             (self.q_proj, self.k_proj, self.v_proj),
             x,
-            False,
+            target_verify,
         )
         queries, gate = mx.split(
             q_proj_output.reshape(batch, length, self.num_attention_heads, -1),
@@ -1156,7 +1212,11 @@ class Qwen4ExpAttention(Qwen3_5Attention):
         )
         keys, values = cache.update_and_fetch(keys, values)
 
-        projected = self.indexer.index_qk_proj(x).reshape(
+        projected = _target_verify_linear(
+            self.indexer.index_qk_proj,
+            x,
+            target_verify,
+        ).reshape(
             batch,
             length,
             self.indexer.n_heads + self.indexer.kv_heads,
@@ -1199,7 +1259,11 @@ class Qwen4ExpAttention(Qwen3_5Attention):
             pooled_index_keys=pooled_index_keys,
         )
         output = output.reshape(batch, length, -1)
-        return self.o_proj(output * mx.sigmoid(gate))
+        return _target_verify_linear(
+            self.o_proj,
+            output * mx.sigmoid(gate),
+            target_verify,
+        )
 
     def _gathered_text_decode(
         self,
@@ -1306,6 +1370,21 @@ class Qwen4ExpAttention(Qwen3_5Attention):
         position_embeddings: Optional[tuple[mx.array, mx.array]] = None,
         target_verify: bool = False,
     ) -> mx.array:
+        if self._gathered_text_verify_eligible(
+            x,
+            mask,
+            cache,
+            position_ids,
+            position_embeddings,
+            target_verify,
+        ):
+            return self._gathered_text_prefill(
+                x,
+                cache,
+                position_ids,
+                target_verify=True,
+            )
+
         if self._gathered_text_decode_eligible(
             x,
             mask,

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -160,6 +160,7 @@ class _QSAIndexerCache:
         self._index_position_ids = None
         self._index_offset = 0
         self._index_capacity_managed = True
+        self._omlx_text_position_ids_qualified = False
         self._invalidate_pooled_indexer()
 
     @property
@@ -199,6 +200,7 @@ class _QSAIndexerCache:
         self._index_position_ids = position_ids
         self._index_offset = 0 if keys is None else int(keys.shape[1])
         self._index_capacity_managed = False
+        self._omlx_text_position_ids_qualified = False
         self._invalidate_pooled_indexer()
 
     @staticmethod
@@ -254,6 +256,11 @@ class _QSAIndexerCache:
         length = int(keys.shape[1])
         if position_ids.shape[-1] != length:
             raise ValueError("QSA index update keys and positions are misaligned")
+        # A general 3-D update may carry genuine image/video MRoPE.  Revoke a
+        # prior text qualification; the target-verify route deliberately
+        # collapses its already-qualified equal planes to 2-D before append.
+        if position_ids.ndim == 3:
+            self._omlx_text_position_ids_qualified = False
 
         if self._index_position_ids is not None:
             if self._index_position_ids.ndim == 3 and position_ids.ndim == 2:
@@ -518,6 +525,51 @@ class QSAKVCache(_QSAIndexerCache, KVCache):
     @property
     def nbytes(self):
         return super().nbytes + self.indexer_nbytes
+
+
+def _qualified_text_verify_position_ids(
+    position_ids: Optional[mx.array],
+    cache: Optional[Any],
+) -> Optional[mx.array]:
+    """Collapse equal 3-plane text MRoPE only after exact history proof.
+
+    mlx-vlm can carry ordinary text positions in the VLM-shaped
+    ``[3, 1, L]`` container.  Qwen4's direct verify path is text-only, so a
+    rank check alone rejects that valid case.  Qualify the current positions
+    and the complete cached QSA position history once; genuine multimodal
+    planes remain divergent and fail closed.  The cache marker survives normal
+    verify appends and is revoked by any later general 3-D index update.
+    """
+
+    if not (
+        isinstance(position_ids, mx.array)
+        and position_ids.ndim == 3
+        and position_ids.shape[0] == 3
+        and position_ids.shape[1] == 1
+        and type(cache) is QSAKVCache
+    ):
+        return position_ids
+    if getattr(cache, "_omlx_text_position_ids_qualified", False):
+        return position_ids[0]
+
+    cached = cache.index_position_ids
+    if cached is None:
+        return position_ids
+    current_equal = mx.all(position_ids[0] == position_ids[1]) & mx.all(
+        position_ids[0] == position_ids[2]
+    )
+    if cached.ndim == 2:
+        history_equal = mx.array(True)
+    elif cached.ndim == 3 and cached.shape[0] == 3 and cached.shape[1] == 1:
+        history_equal = mx.all(cached[0] == cached[1]) & mx.all(
+            cached[0] == cached[2]
+        )
+    else:
+        return position_ids
+    if not bool((current_equal & history_equal).item()):
+        return position_ids
+    cache._omlx_text_position_ids_qualified = True
+    return position_ids[0]
 
 
 class BatchQSAKVCache:
@@ -2469,6 +2521,12 @@ class Qwen4ExpModel(nn.Module):
         hidden_states = mx.tile(hidden_states, (1, 1, self.args.hc_count))
         if cache is None:
             cache = [None] * len(self.layers)
+
+        if gdn_sink is not None and cache:
+            position_ids = _qualified_text_verify_position_ids(
+                position_ids,
+                cache[self.fa_idx],
+            )
 
         fa_mask = _create_qwen3_5_attention_mask(hidden_states, cache[self.fa_idx])
         ssm_mask = _create_qwen3_5_ssm_mask(hidden_states, cache[self.ssm_idx])

--- a/tests/test_qwen4_qsa_decode_gather.py
+++ b/tests/test_qwen4_qsa_decode_gather.py
@@ -110,6 +110,100 @@ def test_qwen4_decode_gathers_budget_and_tail_and_matches_official(monkeypatch):
         assert mx.array_equal(fast_value, reference_value).item()
 
 
+def test_qwen4_verify_window_uses_direct_qsa_and_matches_official(monkeypatch):
+    config = _tiny_text_config()
+    import mlx_vlm.models.qwen4_exp.language as language
+
+    attention = language.Qwen4ExpAttention(config)
+    mx.eval(attention.parameters())
+    fast_cache = language.QSAKVCache()
+    reference_cache = language.QSAKVCache()
+
+    mx.random.seed(29)
+    prefix = mx.random.normal((1, 10, config.hidden_size))
+    verify = mx.random.normal((1, 4, config.hidden_size))
+    mx.eval(
+        attention(prefix, mask="causal", cache=fast_cache),
+        attention(prefix, mask="causal", cache=reference_cache),
+    )
+
+    calls = []
+    original = language.contiguous_causal_gathered_qsa
+
+    def tracked(*args, **kwargs):
+        calls.append((args[0].shape[2], args[1].shape[2]))
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(language, "contiguous_causal_gathered_qsa", tracked)
+    actual = attention(
+        verify,
+        mask="causal",
+        cache=fast_cache,
+        target_verify=True,
+    )
+
+    monkeypatch.setattr(
+        language.Qwen4ExpAttention,
+        "_gathered_text_verify_eligible",
+        lambda *args, **kwargs: False,
+    )
+    expected = attention(
+        verify,
+        mask="causal",
+        cache=reference_cache,
+        target_verify=True,
+    )
+    mx.eval(actual, expected)
+
+    assert calls == [(4, 14)]
+    assert mx.allclose(actual, expected, rtol=2e-5, atol=2e-5).item()
+    assert mx.array_equal(
+        mx.argmax(actual, axis=-1),
+        mx.argmax(expected, axis=-1),
+    ).item()
+    assert fast_cache.offset == reference_cache.offset == 14
+    for fast_value, reference_value in zip(
+        fast_cache.state,
+        reference_cache.state,
+    ):
+        assert mx.array_equal(fast_value, reference_value).item()
+
+
+def test_qwen4_verify_window_eligibility_fails_closed():
+    config = _tiny_text_config()
+    import mlx_vlm.models.qwen4_exp.language as language
+
+    attention = language.Qwen4ExpAttention(config)
+    cache = language.QSAKVCache()
+    prefix = mx.random.normal((1, 10, config.hidden_size))
+    mx.eval(attention(prefix, mask="causal", cache=cache))
+    window = mx.random.normal((1, 6, config.hidden_size))
+
+    assert attention._gathered_text_verify_eligible(
+        window, None, cache, None, None, True
+    )
+    assert not attention._gathered_text_verify_eligible(
+        window, None, cache, None, None, False
+    )
+    assert not attention._gathered_text_verify_eligible(
+        window, None, cache, mx.zeros((3, 1, 6), dtype=mx.int32), None, True
+    )
+    assert not attention._gathered_text_verify_eligible(
+        mx.broadcast_to(window, (2, 6, config.hidden_size)),
+        None,
+        cache,
+        None,
+        None,
+        True,
+    )
+
+    incomplete = language.QSAKVCache()
+    incomplete.offset = cache.offset
+    assert not attention._gathered_text_verify_eligible(
+        window, None, incomplete, None, None, True
+    )
+
+
 def test_qwen4_language_wrapper_routes_2d_text_positions_to_gather(monkeypatch):
     config = _tiny_text_config()
     import mlx_vlm.models.qwen4_exp.language as language

--- a/tests/test_qwen4_qsa_decode_gather.py
+++ b/tests/test_qwen4_qsa_decode_gather.py
@@ -115,6 +115,7 @@ def test_qwen4_verify_window_uses_direct_qsa_and_matches_official(monkeypatch):
     import mlx_vlm.models.qwen4_exp.language as language
 
     attention = language.Qwen4ExpAttention(config)
+    monkeypatch.setattr(language, "_QSA_DIRECT_VERIFY_MIN_TOKENS", 0)
     mx.eval(attention.parameters())
     fast_cache = language.QSAKVCache()
     reference_cache = language.QSAKVCache()
@@ -169,11 +170,12 @@ def test_qwen4_verify_window_uses_direct_qsa_and_matches_official(monkeypatch):
         assert mx.array_equal(fast_value, reference_value).item()
 
 
-def test_qwen4_verify_window_eligibility_fails_closed():
+def test_qwen4_verify_window_eligibility_fails_closed(monkeypatch):
     config = _tiny_text_config()
     import mlx_vlm.models.qwen4_exp.language as language
 
     attention = language.Qwen4ExpAttention(config)
+    monkeypatch.setattr(language, "_QSA_DIRECT_VERIFY_MIN_TOKENS", 0)
     cache = language.QSAKVCache()
     prefix = mx.random.normal((1, 10, config.hidden_size))
     mx.eval(attention(prefix, mask="causal", cache=cache))

--- a/tests/test_qwen4_qsa_incremental_cache.py
+++ b/tests/test_qwen4_qsa_incremental_cache.py
@@ -226,6 +226,62 @@ def test_qsa_ephemeral_pool_rebuilds_after_restore_extract_and_rewinds_trim():
     assert mx.array_equal(rebuilt, expected).item()
 
 
+def test_qsa_equal_mrope_text_planes_qualify_once_and_3d_update_revokes():
+    cache = language.QSAKVCache()
+    raw = mx.random.normal((1, 12, 8))
+    text_positions = mx.broadcast_to(
+        mx.arange(12, dtype=mx.int32)[None, None],
+        (3, 1, 12),
+    )
+    cache.update_indexer(raw, text_positions)
+    assert cache._omlx_text_position_ids_qualified is False
+
+    current = mx.broadcast_to(
+        mx.arange(12, 18, dtype=mx.int32)[None, None],
+        (3, 1, 6),
+    )
+    qualified = language._qualified_text_verify_position_ids(current, cache)
+    assert qualified.shape == (1, 6)
+    assert mx.array_equal(qualified, current[0]).item()
+    assert cache._omlx_text_position_ids_qualified is True
+
+    # The direct verify path appends the collapsed 2-D text view and keeps the
+    # one-time qualification live for the next speculative cycle.
+    cache.update_indexer(mx.random.normal((1, 6, 8)), qualified)
+    assert cache._omlx_text_position_ids_qualified is True
+
+    multimodal = mx.stack(
+        [
+            mx.arange(18, 20, dtype=mx.int32)[None],
+            mx.arange(28, 30, dtype=mx.int32)[None],
+            mx.arange(38, 40, dtype=mx.int32)[None],
+        ]
+    )
+    cache.update_indexer(mx.random.normal((1, 2, 8)), multimodal)
+    assert cache._omlx_text_position_ids_qualified is False
+
+
+def test_qsa_divergent_mrope_history_fails_closed_as_multimodal():
+    cache = language.QSAKVCache()
+    raw = mx.random.normal((1, 8, 8))
+    positions = mx.stack(
+        [
+            mx.arange(8, dtype=mx.int32)[None],
+            mx.arange(10, 18, dtype=mx.int32)[None],
+            mx.arange(20, 28, dtype=mx.int32)[None],
+        ]
+    )
+    cache.update_indexer(raw, positions)
+    current = mx.broadcast_to(
+        mx.arange(28, 34, dtype=mx.int32)[None, None],
+        (3, 1, 6),
+    )
+
+    actual = language._qualified_text_verify_position_ids(current, cache)
+    assert actual is current
+    assert cache._omlx_text_position_ids_qualified is False
+
+
 @pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
 def test_portable_qsa_flattened_gemm_is_exactly_the_broadcast_reference(dtype):
     mx.random.seed(909)

--- a/tests/test_qwen4_qsa_incremental_cache.py
+++ b/tests/test_qwen4_qsa_incremental_cache.py
@@ -171,7 +171,7 @@ def test_gathered_qsa_one_shot_and_incremental_appends_are_exact(chunks, monkeyp
     assert mx.array_equal(actual, expected).item()
 
 
-def test_qsa_ephemeral_pool_rebuilds_after_restore_extract_and_trim():
+def test_qsa_ephemeral_pool_rebuilds_after_restore_extract_and_rewinds_trim():
     cache = language.QSAKVCache()
     raw = mx.sin(mx.arange(13 * 8, dtype=mx.float32)).reshape(1, 13, 8)
     _append(cache, raw, 0, 13)
@@ -199,11 +199,19 @@ def test_qsa_ephemeral_pool_rebuilds_after_restore_extract_and_trim():
     assert mx.array_equal(extracted_pool, pooled).item()
 
     assert cache.trim(3) == 3
-    assert cache._pooled_index_keys is None
+    pooled_backing = cache._pooled_index_keys
+    assert pooled_backing is not None
+    assert cache._pooled_index_offset == 2
     replacement = mx.cos(mx.arange(3 * 8, dtype=mx.float32)).reshape(1, 3, 8)
     _append(cache, mx.concatenate([raw[:, :10], replacement], axis=1), 10, 13)
+    block_calls = []
+
+    def tracked_norm(x):
+        block_calls.append(int(x.shape[1]))
+        return x
+
     rebuilt = cache.pooled_indexer_keys(
-        4, lambda x: x, _identity_rope, cache_tag=cache
+        4, tracked_norm, _identity_rope, cache_tag=cache
     )
     expected = qsa_fast.pool_completed_index_keys(
         cache.index_keys,
@@ -213,6 +221,8 @@ def test_qsa_ephemeral_pool_rebuilds_after_restore_extract_and_trim():
         apply_index_rope=_identity_rope,
     )
     mx.eval(rebuilt, expected)
+    assert cache._pooled_index_keys is pooled_backing
+    assert block_calls == [1]
     assert mx.array_equal(rebuilt, expected).item()
 
 

--- a/tests/test_qwen4_qsa_native_indexer.py
+++ b/tests/test_qwen4_qsa_native_indexer.py
@@ -190,6 +190,39 @@ def test_qwen4_qsa_native_scores_and_topk_match_fp32_reference(dtype):
     assert mx.array_equal(_topk_sets(actual, 64), _topk_sets(expected, 64)).item()
 
 
+@pytest.mark.parametrize("rows", [1, 6, 8])
+@pytest.mark.skipif(
+    not _native_available(),
+    reason="native Qwen4 QSA indexer-score ABI is unavailable",
+)
+def test_qwen4_qsa_native_verify_tile_is_bit_exact(rows):
+    mx.random.seed(1731 + rows)
+    q = (mx.random.normal((1, 4, rows, 128)) * 0.25).astype(mx.bfloat16)
+    k = (mx.random.normal((1, 1, 521, 128)) * 0.25).astype(mx.bfloat16)
+    mask_q_offset = 2048
+
+    actual = fast.qwen4_qsa_indexer_scores(
+        q,
+        k,
+        mask_ratio=4,
+        mask_q_offset=mask_q_offset,
+    )
+    expected = _reference_scores(
+        q,
+        k,
+        mask_ratio=4,
+        mask_q_offset=mask_q_offset,
+    )
+    mx.eval(actual, expected)
+
+    assert actual.shape == (1, rows, 521)
+    assert mx.array_equal(actual, expected).item()
+    assert mx.array_equal(
+        _topk_sets(actual, 64),
+        _topk_sets(expected, 64),
+    ).item()
+
+
 @pytest.mark.skipif(
     not _native_available(),
     reason="native Qwen4 QSA indexer-score ABI is unavailable",


### PR DESCRIPTION
## Current review status

This PR remains draft for a technical requalification gate, not for owner approval. A later low-margin workload exposed a parity failure in the prior fast wide-verifier evidence. That unqualified experimental path is not being promoted. Before this PR becomes ready, its claimed performance table must be refreshed against current main and the exact 10K-220K output-hash, cache-state, selector, prefill, and decode gates must pass.

## Why this matters

Qwen3.8-Flash-Next ordinary batch-one decode already uses the bounded direct-QSA path, but Lightning MTP target verification did not. A depth-5 cycle therefore evaluated up to six rows through the general QSA mask path. Its target-backbone cost grew from about 60 ms/cycle at 10K context to about 90 ms/cycle at 150K, reducing high-acceptance decode from roughly 83 tok/s to 59 tok/s.

This PR adds an exact, fail-closed direct-QSA verification window for native qwen4_exp. It keeps the faster reference route below the measured crossover and switches only at 65,536 tokens, so short-context performance is preserved while long-context verification remains bounded.

## What changed

- Route batch-one Qwen4 Lightning-MTP verify windows (2-9 rows) through the existing direct selected-block QSA implementation.
- Preserve target-verify projection routing for Q/K/V, indexer, and output projections.
- Qualify VLM-shaped [3,1,L] text positions once by proving all three MRoPE planes are equal over both the full cached history and current window. Genuine multimodal divergence stays on the official path.
- Retain immutable completed pooled-index blocks across speculative rollback and recompute only the affected partial suffix block.
- Add an exact BM8 QSA score tile for verify widths up to eight rows. The existing BM64 prefill tile is unchanged.
- Gate direct verification at 65,536 tokens. Below that point the current reference path is faster; above it the bounded path wins.
- Preserve aligned QSA K/V, raw index keys, index positions, and pooled state across full and partial acceptance.

## Performance

Hardware/runtime:

- Apple M3 Ultra, 256 GB unified memory, 819 GB/s
- Qwen3.8-Flash-Next-oQ4e-mtp, resident PLE
- MLX 0.32.0, mlx-vlm 0.6.3
- Batch 1, temperature 0, 500 generated tokens
- Lightning MTP fixed depth 5 for a stable geometry comparison
- Predictable code continuation, 98.3-98.8% draft acceptance
- Decode figures below exclude prefix-cache restore and suffix-prefill time and come from the MTP stage timers

| Context | Route | Decode-only |
|---:|---|---:|
| 10K | reference | 85.6 tok/s |
| 50K | reference | 74.4 tok/s |
| 100K | direct QSA verify | 71.8 tok/s |
| 150K | direct QSA verify | 70.9 tok/s |

Before this change, the same fixed-depth high-acceptance 150K path measured about 59.4 tok/s. The final 150K result is a 19.3% improvement. The bounded direct path itself measured about 72.9 / 71.3 / 71.9 / 71.1 tok/s at 20K / 50K / 100K / 150K, a roughly 2.5% spread.

A salted zero-cache 150K cold-prefill regression run on the final build completed at about 830 tok/s overall. Full 4,096-token chunks ranged from about 876 tok/s at the start to about 819 tok/s at the end. The new route does not enter during prefill, and BM64 prefill dispatch is unchanged.

## Extended B1 validation

The fixed-depth table above is the controlled geometry A/B that isolates this PR. I also ran the exact PR head end-to-end through the normal adaptive controller with deterministic code continuation, thinking disabled, temperature 0, 500 generated tokens, and unique zero-cache prompts:

| Context | Cold prefill | Adaptive decode | Draft acceptance |
|---:|---:|---:|---:|
| 10K | 758.75 tok/s | 77.78 tok/s | 99.0% |
| 50K | 817.10 tok/s | 64.76 tok/s | 98.8% |
| 100K | 808.58 tok/s | 60.58 tok/s | 99.0% |
| 150K | 804.31 tok/s | 57.26 tok/s | 99.0% |
| 200K | 827.48 tok/s | 54.48 tok/s | 99.5% |
| 220K | 818.38 tok/s | 53.15 tok/s | 99.0% |

This production-style table deliberately includes the existing controller's depth warmup and probe cycles; it is not substituted for the fixed-depth route comparison. It exposed two independent follow-ups that are intentionally outside this narrow QSA PR: censored deep-tail learning in the generic adaptive controller, and the Qwen4 MTP head's exact full-history selector scan.

The before/after story is therefore reported at two scopes:

- **Same-path PR A/B:** 150K fixed-depth high-acceptance decode improves from about 59.4 to 70.9 tok/s (+19.3%).
- **Historical capability ladder (not a single-change A/B):** the earlier sustained native baseline was 22.84 tok/s before direct QSA/HC/PLE work; native MTP-off reached 34.72 tok/s; fixed-depth Lightning MTP then reached 85.6 tok/s at 10K and 70.9 tok/s at 150K.

A deterministic MTP on/off parity check produced byte-identical output hashes at both 10K and 220K. MTP-off measured 33.88 / 26.37 tok/s; adaptive MTP measured 77.78 / 53.15 tok/s. The 220K parity run restored 217,088 prompt tokens (98.69% cache hit).

## Correctness and lossless gates

- FP32 QSA score math is unchanged.
- Deterministic top-512 membership and cutoff-tie behavior are unchanged.
- Selected blocks remain chronological; each verify row retains its own exact causal tail.
- Tiny-model direct/reference tests match attention output within the existing exact-path tolerance, retain identical argmax tokens, and leave all four QSA cache components array-equal.
- The BM8 native score tile is bit-exact to the FP32 reference for verify widths 1, 6, and 8.
- Full/partial speculative rollback retains only immutable complete pooled blocks; the affected suffix is recomputed and matches a one-shot rebuild.
- Genuine 3-D multimodal MRoPE, misaligned/restored auxiliary cache state, batches, unsupported geometry/dtype/layout, and missing native symbols fail closed to the existing implementation.
- MTP remains lossless speculation: the target backbone verifies every proposed token.

## Validation

Clean branch based on current upstream main:

- 445 passed, 22 skipped across Qwen4, MTP chain/controller/priming, prefix cache, loader, and QSA suites. The skips are native-extension-only in a fresh worktree.
- Fresh native extension build against MLX 0.32.0 succeeded.
- 51 passed across native QSA score/top-k/sparse-GQA, verify-window, and incremental-cache parity suites.
- Five SSH-signed commits.
- Scope: six Qwen4/QSA source/test files; no GLM, DS4, cluster, scheduler, updater, release, or branding changes.

## Attribution

This follow-up builds on the direct sparse-QSA foundation merged in #3244. That source retains David Dalcu MIT attribution for the K/V staging pattern. This work was inspired by that staging idea, but it is not the same mechanism or implementation: the MRoPE qualification, verify routing, rollback lifecycle, and BM8 score-tile changes are oMLX-specific, and no additional third-party code was copied.