### PR TITLE
fix(grammar): bound JSON schema whitespace

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -4277,6 +4277,9 @@ def _compile_with_structural_tag(
     return compiler.compile_structural_tag(tag_dict)
 
 
+_JSON_SCHEMA_MAX_WHITESPACE_CNT = 32
+
+
 def _compile_bare_grammar(compiler, fmt: dict):
     """Compile a grammar without any structural tag wrapping."""
     if fmt["type"] == "json_schema":
@@ -4286,7 +4289,15 @@ def _compile_bare_grammar(compiler, fmt: dict):
         if not schema:
             return compiler.compile_builtin_json_grammar()
         schema_str = _json.dumps(schema) if isinstance(schema, dict) else schema
-        return compiler.compile_json_schema(schema_str)
+        # An unlimited whitespace run can trap a grammar-constrained decoder
+        # after an early string termination: whitespace remains valid while
+        # every useful token is masked.  Keep the bound local to the compiler
+        # call so ordinary JSON and user-supplied EBNF/regex grammars retain
+        # their existing behavior.
+        return compiler.compile_json_schema(
+            schema_str,
+            max_whitespace_cnt=_JSON_SCHEMA_MAX_WHITESPACE_CNT,
+        )
     elif fmt["type"] == "grammar":
         return compiler.compile_grammar(fmt["grammar"])
     elif fmt["type"] == "regex":

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -418,7 +418,9 @@ class TestCompileBareGrammar:
         schema = {"type": "object"}
         result = self._call(compiler, {"type": "json_schema", "json_schema": schema})
         assert result == "compiled_json"
-        compiler.compile_json_schema.assert_called_once()
+        compiler.compile_json_schema.assert_called_once_with(
+            json.dumps(schema), max_whitespace_cnt=32
+        )
 
     def test_empty_json_schema(self):
         compiler = MagicMock()
@@ -482,7 +484,12 @@ class TestCompileGrammarForRequest:
             "json": {"type": "object", "properties": {"x": {"type": "integer"}}},
         })
         assert result == "compiled_json"
-        compiler.compile_json_schema.assert_called_once()
+        compiler.compile_json_schema.assert_called_once_with(
+            json.dumps(
+                {"type": "object", "properties": {"x": {"type": "integer"}}}
+            ),
+            max_whitespace_cnt=32,
+        )
 
     def test_bare_regex(self):
         compiler = MagicMock()
@@ -573,7 +580,9 @@ class TestCompileGrammarForRequest:
             reasoning_parser=None,
         )
         assert result == "compiled_bare"
-        compiler.compile_json_schema.assert_called_once()
+        compiler.compile_json_schema.assert_called_once_with(
+            json.dumps({"type": "object"}), max_whitespace_cnt=32
+        )
         compiler.compile_structural_tag.assert_not_called()
 
     def test_compilation_error_raises_for_structured_outputs(self):


### PR DESCRIPTION
Fixes #2990

JSON-schema constrained decoding currently compiles with xgrammar's unlimited whitespace. If a model closes a string early, whitespace remains valid while useful tokens are masked, so generation can spin until `max_tokens` and return a truncated response.

This passes `max_whitespace_cnt=32` for JSON-schema grammars only. EBNF, regex, and existing built-in JSON grammar paths are unchanged. The focused grammar tests now assert the compiler option.

Verification:
- `python3 -m py_compile omlx/server.py tests/test_grammar.py`
- AST-level regression check confirmed the compiled schema receives `max_whitespace_cnt=32`
- `git diff --check` clean

The repository pytest process was unable to complete in this Apple Silicon environment because importing the optional native xgrammar stack stalled; CI should exercise the full test matrix.