### PR TITLE
perf(qwen4): prime verified MTP drafter from cached suffix

### DIFF
--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -740,6 +740,11 @@ class _MtpState:
     # from verify-forward hidden rows so the head sees a dense, committed-only
     # timeline.
     hist_offset: int = 0
+    # Qwen4 suffix-local priming keeps the draft head on a local zero-based
+    # suffix timeline while the verified target cache remains absolute. Never
+    # use target_expected_offset to trim the head cache.
+    target_expected_offset: Optional[int] = None
+    suffix_local_priming: bool = False
     # Sampler for draft tokens (lazily resolved). For stochastic target
     # samplers this is a *sharper* distribution than the target (temp 0.6 /
     # top_p 0.95 / top_k 20) — the Leviathan/Chen acceptance ratio uses the
@@ -1220,11 +1225,21 @@ def _prepare_mtp_state_for_next(gen_batch: Any) -> Optional[_MtpState]:
             park_state.cooldown_tokens,
         )
 
-    logger.info(
-        "MTP path activated for uid=%s (model has mtp_forward, batch=1, primed=%d)",
-        state.uid,
-        max(0, int(getattr(state, "hist_offset", 0)) - 1),
-    )
+    if state.suffix_local_priming:
+        logger.info(
+            "MTP path activated for uid=%s (model has mtp_forward, batch=1, "
+            "primed=%d local suffix tokens, target_offset=%d)",
+            state.uid,
+            max(0, int(state.hist_offset) - 1),
+            int(state.target_expected_offset or 0),
+        )
+    else:
+        logger.info(
+            "MTP path activated for uid=%s "
+            "(model has mtp_forward, batch=1, primed=%d)",
+            state.uid,
+            max(0, int(getattr(state, "hist_offset", 0)) - 1),
+        )
     return state
 
 
@@ -1676,6 +1691,77 @@ def _mtp_head_trim_to(mtp_cache: List[Any], offset: int) -> None:
         extra = current - offset
         if extra > 0:
             c.trim(extra)
+
+
+def _adopt_primed_head_state(
+    state: _MtpState,
+    primed: Any,
+    target_cache: Optional[List[Any]],
+) -> bool:
+    """Install generic or Qwen4 suffix-local priming, failing closed."""
+
+    if isinstance(primed, _prompt_priming.SuffixLocalPrimedState):
+        head_offset = _prompt_priming.mtp_cache_offset(primed.mtp_cache)
+        target_offset = _prompt_priming.target_cache_offset(target_cache)
+        if (
+            head_offset != primed.head_hist_offset
+            or target_offset != primed.target_expected_offset
+        ):
+            logger.debug(
+                "Qwen4 suffix-local priming rejected at activation: "
+                "head=%s/%s target=%s/%s",
+                head_offset,
+                primed.head_hist_offset,
+                target_offset,
+                primed.target_expected_offset,
+            )
+            return False
+        state.mtp_cache = primed.mtp_cache
+        state.hist_offset = primed.head_hist_offset
+        state.target_expected_offset = primed.target_expected_offset
+        state.suffix_local_priming = True
+        return True
+    try:
+        mtp_cache, hist_offset = primed
+    except (TypeError, ValueError):
+        return False
+    state.mtp_cache = mtp_cache
+    state.hist_offset = int(hist_offset)
+    return True
+
+
+def _trim_committed_mtp_head(state: _MtpState) -> None:
+    """Trim against the local head timeline and prove suffix isolation."""
+
+    _mtp_head_trim_to(state.mtp_cache, state.hist_offset)
+    if state.suffix_local_priming:
+        observed = _prompt_priming.mtp_cache_offset(state.mtp_cache)
+        if observed != state.hist_offset:
+            raise _MtpStepFallback(
+                "Qwen4 suffix-local MTP head escaped its local trim boundary "
+                f"(expected={state.hist_offset}, observed={observed})"
+            )
+
+
+def _advance_suffix_local_target(
+    state: _MtpState,
+    target_cache: Optional[List[Any]],
+    retained_tokens: int,
+) -> None:
+    """Advance and verify the separate absolute target-cache timeline."""
+
+    if not state.suffix_local_priming:
+        return
+    if state.target_expected_offset is None or retained_tokens <= 0:
+        raise _MtpStepFallback("Qwen4 suffix-local target seam is incomplete")
+    expected = state.target_expected_offset + int(retained_tokens)
+    observed = _prompt_priming.target_cache_offset(target_cache)
+    if observed != expected:
+        raise _MtpStepFallback(
+            "Qwen4 suffix-local target cache left its absolute seam "
+            f"(expected={expected}, observed={observed})"
+        )
+    state.target_expected_offset = expected
 
 
 # Loop-tax measurement (feeds _DepthController.EXIT_MARGIN): right after a
@@ -2493,9 +2579,11 @@ def _post_init_mtp(gen_batch: Any) -> None:
         primed = _prompt_priming.take_primed(
             gen_batch.model, gen_batch.prompt_cache, main_tok
         )
-        if primed is not None:
-            state.mtp_cache, state.hist_offset = primed
-        else:
+        if primed is None or not _adopt_primed_head_state(
+            state,
+            primed,
+            gen_batch.prompt_cache,
+        ):
             state.mtp_cache = gen_batch.model.make_mtp_cache()
         state.next_main = _ensure_uint32(next_main_tok)
         state.queue.append((int(main_tok.tolist()[0]), main_lp, "init"))
@@ -3091,11 +3179,15 @@ def _run_verify_cycle_chain(gen_batch: Any, state: _MtpState) -> None:
         if procs is not None:
             _trim_token_buffer(gen_batch, k - m)
     state.stats.cache_ops_ms += (time.perf_counter() - t0) * 1000
+    # Target verification committed exactly m accepted drafts plus the
+    # correction/bonus token. Keep its absolute timeline independent from the
+    # suffix-local draft-head offset.
+    _advance_suffix_local_target(state, gen_batch.prompt_cache, m + 1)
 
     # --- MTP-head history + next draft chain (async-dispatched) ---
     t0 = time.perf_counter()
     if not state.head_clone:
-        _mtp_head_trim_to(state.mtp_cache, state.hist_offset)
+        _trim_committed_mtp_head(state)
     committed = mx.array(
         [int(d) for d in draft_ids[:m]] + [int(emit_last_id)], dtype=mx.uint32
     )
@@ -3157,6 +3249,7 @@ def _materialize_mtp_boundary_emit(gen_batch: Any, state: _MtpState) -> None:
         gen_batch.prompt_cache,
     )
     _clear_rollback(gen_batch.prompt_cache)
+    _advance_suffix_local_target(state, gen_batch.prompt_cache, 1)
     next_logits = _apply_processors(procs, prev_buf, logits[:, -1, :])
     next_lp_2d = _logprobs(next_logits)
     next_tok = _ensure_uint32(_resolve_sampler(gen_batch)(next_lp_2d))
@@ -3164,6 +3257,12 @@ def _materialize_mtp_boundary_emit(gen_batch: Any, state: _MtpState) -> None:
     state.stats.backbone_ms += (time.perf_counter() - t0) * 1000
 
     t0 = time.perf_counter()
+    if not state.head_clone:
+        # The first next-draft chain may have appended speculative local-head
+        # rows past hist_offset. Boundary materialization commits another target
+        # token before rebuilding that chain, so rewind to the local committed
+        # seam first (head-clone families already keep the persistent cache clean).
+        _trim_committed_mtp_head(state)
     _chain_next_drafts(
         gen_batch,
         state,

--- a/omlx/patches/mlx_lm_mtp/prompt_priming.py
+++ b/omlx/patches/mlx_lm_mtp/prompt_priming.py
@@ -25,7 +25,7 @@ first forward starts at offset 0), so it invalidates or restarts the slot,
 and the activating request is always the slot's last writer.
 
 Fail-safe invariant: every capture verifies the anchor offset advanced
-contiguously since the previous capture (``expected_offset``). Any rewind,
+contiguously since the previous capture (``target_expected_offset``). Any rewind,
 trim, request switch, or unknown cache path breaks the equality and
 invalidates the context, degrading to the current unprimed behaviour —
 never to a wrong history. A batched (B>1) forward advances the anchor
@@ -72,6 +72,7 @@ HEAD_HIDDEN_POST_NORM = True
 
 _CTX_ATTR = "_omlx_mtp_prime_ctx"
 _PLAN_ATTR = "_omlx_mtp_prime_plan"
+_QWEN4_SUFFIX_LOCAL_CAPABILITY = "qwen4-verified-text-v1"
 
 _SUPPRESS = threading.local()
 
@@ -123,11 +124,18 @@ class _PrimeCtx:
     # Head-input hidden of the newest seen token, (1, 1, ..., H) — pairs
     # with the first token of the next chunk (or main_tok at activation).
     pending_hidden: Optional[Any] = None
-    # Folded (hidden, next_token) pairs == head-cache offset.
-    folded: int = 0
+    # Folded (hidden, next_token) pairs == the LOCAL head-cache offset.  For
+    # ordinary/full-history priming this also equals the absolute history.  A
+    # Qwen4 suffix-local context deliberately starts this counter at zero even
+    # when the target backbone was restored at a large absolute offset.
+    head_hist_offset: int = 0
     # Anchor cache offset observed after the last captured forward. The next
-    # capture requires offset_now - S == expected_offset (contiguity).
-    expected_offset: int = 0
+    # capture requires offset_now - S == target_expected_offset (contiguity).
+    # This is always the ABSOLUTE target/backbone timeline.
+    target_expected_offset: int = 0
+    # Qwen4-only verified-drafter mode: the head contains only the uncached
+    # text suffix. The target still owns/validates the absolute full history.
+    suffix_local: bool = False
     valid: bool = True
     # The current contiguous timeline exceeded OMLX_MTP_PRIME_WINDOW. Keep a
     # lightweight marker so later small chunks cannot restart priming.
@@ -156,6 +164,7 @@ class _PrimePlan:
 
     request_id: str
     prompt_tokens: tuple[int, ...]
+    cached_tokens: int
     block_size: int
     prefix_cache: Any
     extra_keys: Optional[tuple[Any, ...]] = None
@@ -178,6 +187,15 @@ class _MtpBoundaryCandidate:
 
     boundary_tokens: int
     pending_hidden: Any
+
+
+@dataclass(frozen=True)
+class SuffixLocalPrimedState:
+    """Qwen4 head state whose offsets are local to the uncached text suffix."""
+
+    mtp_cache: List[Any]
+    head_hist_offset: int
+    target_expected_offset: int
 
 
 def _read_offset(entry: Any) -> Optional[int]:
@@ -331,6 +349,56 @@ def _eligible_host(model: Any) -> Any | None:
     return None
 
 
+def _qwen4_suffix_local_host(host: Any) -> bool:
+    """Return whether ``host`` opts into verified suffix-only priming."""
+
+    return bool(
+        getattr(host, "_omlx_mtp_suffix_local_capability", None)
+        == _QWEN4_SUFFIX_LOCAL_CAPABILITY
+    )
+
+
+def _text_only_suffix_plan(host: Any, plan: Optional[_PrimePlan]) -> bool:
+    """Narrow capability gate for Qwen4 verified-drafter local history."""
+
+    return bool(
+        _qwen4_suffix_local_host(host)
+        and isinstance(plan, _PrimePlan)
+        and plan.cached_tokens > 0
+        and not plan.extra_keys
+        and plan.extra_key_token_start is None
+        and not plan.extra_key_ranges
+    )
+
+
+def _inputs_match_plan(
+    inputs: Any,
+    plan: _PrimePlan,
+    *,
+    start: int,
+    stop: int,
+) -> bool:
+    """Prove a suffix chunk is the exact scheduler-owned text-token slice.
+
+    This intentionally materializes ``inputs`` on the host as the fail-closed
+    cross-request identity proof. BatchGenerator's usual size-one array anchor
+    already synchronizes just above, but a scalar-offset cache need not; these
+    figures are therefore only the incremental, already-materialized cost, not
+    a bound on a pending graph. M3 Ultra microbenchmark (2026-08-30, 300 warm
+    samples, materialized int32): median 25.0/25.5/32.3/60.8/88.6 us for
+    1/64/512/2048/4096 tokens; p95 33.5/32.8/57.7/84.8/107.0 us. Real-model
+    synchronization/throughput impact remains explicitly deferred.
+    """
+
+    if start < plan.cached_tokens or stop > len(plan.prompt_tokens) or stop <= start:
+        return False
+    try:
+        actual = tuple(int(token) for token in inputs.reshape(-1).tolist())
+    except Exception:
+        return False
+    return actual == plan.prompt_tokens[start:stop]
+
+
 def _clone_mtp_cache(cache: List[Any]) -> List[Any]:
     """Detach an MTP cache so later decode writes cannot mutate a snapshot."""
     import copy
@@ -361,6 +429,42 @@ def _flat_cache_entries(cache: List[Any]):
             yield entry
         else:
             yield from subs
+
+
+def mtp_cache_offset(cache: Optional[List[Any]]) -> Optional[int]:
+    """Uniform local offset across every readable MTP-head cache entry."""
+
+    if not cache:
+        return None
+    offsets: list[int] = []
+    for entry in _flat_cache_entries(cache):
+        offset = _read_offset(entry)
+        if offset is not None:
+            offsets.append(offset)
+    if not offsets or any(offset != offsets[0] for offset in offsets[1:]):
+        return None
+    return offsets[0]
+
+
+def target_cache_offset(cache: Optional[List[Any]]) -> Optional[int]:
+    """Uniform absolute offset across every readable target cache layer.
+
+    A first-layer answer is insufficient for suffix-local priming: a partial
+    rollback can leave one later QSA layer misaligned while the leading layer
+    still looks valid.  Unreadable recurrent caches are ignored, but every
+    readable leaf must agree or the verified-drafter seam fails closed.
+    """
+
+    if not cache:
+        return None
+    offsets: list[int] = []
+    for entry in _flat_cache_entries(cache):
+        offset = _read_offset(entry)
+        if offset is not None:
+            offsets.append(offset)
+    if not offsets or any(offset != offsets[0] for offset in offsets[1:]):
+        return None
+    return offsets[0]
 
 
 def _cache_at_offset(cache: List[Any], target: int) -> Optional[List[Any]]:
@@ -409,12 +513,23 @@ def capture_eligible(host: Any, cache: Optional[List[Any]]) -> bool:
     :func:`maybe_capture`; this exists purely to keep the ineligible path
     identical to stock.
     """
-    return (
+    eligible = (
         not _suppressed()
         and priming_enabled()
         and cache is not None
         and _host_eligible(host)
     )
+    if not eligible:
+        return False
+    # Qwen4's capability is deliberately suffix-local: a cold request has no
+    # missing-prefix seam to bridge, and folding its complete prompt adds one
+    # draft-head forward to every prefill chunk.  Require the immutable
+    # scheduler plan to prove a real text-only cache hit before the model even
+    # enters the capture hook.  Generic/DS4 families retain full-history cold
+    # priming and its existing sidecar publication behavior.
+    if _qwen4_suffix_local_host(host):
+        return _text_only_suffix_plan(host, _find_plan(host))
+    return True
 
 
 def prepare_prefix_context(
@@ -447,22 +562,37 @@ def prepare_prefix_context(
 
     tokens = tuple(int(token) for token in prompt_tokens)
     cached_tokens = max(0, int(cached_tokens))
+    if _qwen4_suffix_local_host(host) and cached_tokens <= 0:
+        # Do not retain even a plan marker for cold Qwen4.  This keeps its
+        # model-call shape and hidden-state lifetime identical to priming OFF;
+        # only a scheduler-proven cached suffix may opt into the feature.
+        drop_ctx(model)
+        return False
     existing = _find_ctx(model)
     plan = _find_plan(model)
     if (
-        (existing is not None and existing.request_id == request_id)
+        (
+            existing is not None
+            and existing.request_id == request_id
+            and existing.prompt_tokens == tokens
+        )
         or (
             plan is not None
             and plan.request_id == request_id
             and plan.prompt_tokens == tokens
+            and plan.cached_tokens == cached_tokens
         )
     ):
-        return existing is not None and existing.expected_offset >= cached_tokens
+        return (
+            existing is not None
+            and existing.target_expected_offset >= cached_tokens
+        )
 
     drop_ctx(model)
     plan = _PrimePlan(
         request_id=request_id,
         prompt_tokens=tokens,
+        cached_tokens=cached_tokens,
         block_size=max(0, int(getattr(prefix_cache, "block_size", 0) or 0)),
         prefix_cache=prefix_cache,
         extra_keys=extra_keys,
@@ -509,8 +639,8 @@ def prepare_prefix_context(
     ctx = _PrimeCtx(
         mtp_cache=restored_cache,
         pending_hidden=pending_hidden,
-        folded=target_offset,
-        expected_offset=cached_tokens,
+        head_hist_offset=target_offset,
+        target_expected_offset=cached_tokens,
         request_id=request_id,
         prompt_tokens=tokens,
         block_size=plan.block_size,
@@ -544,6 +674,10 @@ def _capture_boundary_candidate(
     seq_end: int,
 ) -> None:
     """Detach the newest full-block MTP boundary crossed by this chunk."""
+    # A suffix-local cache cannot represent the missing durable prefix. Never
+    # publish it under an absolute full-history block hash.
+    if ctx.suffix_local:
+        return
     block = int(ctx.block_size or 0)
     if (
         block <= 0
@@ -565,7 +699,7 @@ def _capture_boundary_candidate(
     # A backbone boundary at C tokens needs MTP pairs through C-1 and keeps
     # hidden(token[C-1]) pending for the next token.  ``normed`` spans
     # [seq_start, seq_end), so the boundary row is available without replay.
-    if boundary <= 1 or ctx.folded < boundary - 1:
+    if boundary <= 1 or ctx.head_hist_offset < boundary - 1:
         return
     row = boundary - seq_start - 1
     if row < 0 or row >= int(normed.shape[1]):
@@ -585,6 +719,8 @@ def _capture_boundary_candidate(
 
 
 def _publish_boundary_candidate(ctx: _PrimeCtx) -> None:
+    if ctx.suffix_local:
+        return
     candidate = ctx.snapshot_candidate
     store = getattr(ctx.prefix_cache, "store_mtp_prefix_snapshot", None)
     if not isinstance(candidate, _MtpBoundaryCandidate) or not callable(store):
@@ -632,8 +768,10 @@ def maybe_capture(
     ``host`` is the patched language model (mlx-lm ``TextModel`` or mlx-vlm
     ``LanguageModel``) exposing ``mtp`` / ``model.embed_tokens`` /
     ``make_mtp_cache``. ``normed`` is the trunk-normed hidden for all
-    positions of ``inputs`` (1, S, H). Host-side bookkeeping only — the head
-    forward is dispatched lazily and no GPU sync happens here.
+    positions of ``inputs`` (1, S, H). The head forward is dispatched lazily.
+    Offset contiguity performs the existing anchor sync; Qwen4 suffix-local
+    capture additionally materializes the small token chunk for exact
+    scheduler-plan identity (cost documented in :func:`_inputs_match_plan`).
 
     Call sites guard the cheap negatives (return_hidden / n_confirmed /
     inputs_embeds) before calling; everything here re-checks what is
@@ -642,6 +780,14 @@ def maybe_capture(
     if _suppressed() or not priming_enabled():
         return
     if cache is None or not _host_eligible(host):
+        return
+    plan = _find_plan(host)
+    qwen4_suffix_capable = _qwen4_suffix_local_host(host)
+    if qwen4_suffix_capable and not _text_only_suffix_plan(host, plan):
+        # Re-check the scheduler-owned warm-prefix contract even when a caller
+        # bypasses capture_eligible().  A stale/missing/cold plan can never
+        # fall through into generic full-history Qwen4 priming.
+        drop_ctx(host)
         return
     if inputs is None or getattr(inputs, "ndim", 0) != 2:
         return
@@ -663,16 +809,29 @@ def maybe_capture(
     if offset_after is None:
         return
 
+    seq_start = offset_after - seq_len
     ctx = getattr(host, _CTX_ATTR, None)
     if ctx is not None and (
-        not ctx.valid or ctx.expected_offset != offset_after - seq_len
+        not ctx.valid or ctx.target_expected_offset != seq_start
     ):
         # Rewind / trim / request switch / unknown path: never guess.
         drop_ctx(host)
         ctx = None
     if ctx is not None and ctx.window_exceeded:
-        ctx.expected_offset = offset_after
+        ctx.target_expected_offset = offset_after
         return
+    if ctx is not None and ctx.suffix_local:
+        if not (
+            _text_only_suffix_plan(host, plan)
+            and _inputs_match_plan(
+                inputs,
+                plan,
+                start=seq_start,
+                stop=offset_after,
+            )
+        ):
+            drop_ctx(host)
+            return
     window = prime_window()
     if window:
         # Cap by the primed span (the head-KV the window exists to bound),
@@ -685,29 +844,63 @@ def maybe_capture(
                 host,
                 _CTX_ATTR,
                 _PrimeCtx(
-                    expected_offset=offset_after,
+                    target_expected_offset=offset_after,
                     window_exceeded=True,
                 ),
             )
             return
     if ctx is None:
-        if seq_len <= 1:
+        # Generic/DS4 priming still requires a zero-offset full history.
+        # Qwen4 alone may opt into a clearly tagged local head timeline for an
+        # exact scheduler-owned text suffix: the target keeps the absolute
+        # durable history and verifies every draft.
+        suffix_local = qwen4_suffix_capable
+        if suffix_local:
+            if not (
+                _text_only_suffix_plan(host, plan)
+                and seq_start == plan.cached_tokens
+                and _inputs_match_plan(
+                    inputs,
+                    plan,
+                    start=seq_start,
+                    stop=offset_after,
+                )
+            ):
+                return
+        if not suffix_local and seq_len <= 1:
             # A lone decode step cannot start a prompt timeline.
             return
-        plan = _find_plan(host)
         ctx = _PrimeCtx(
             mtp_cache=host.make_mtp_cache(),
+            target_expected_offset=seq_start,
+            suffix_local=suffix_local,
             request_id=plan.request_id if plan is not None else None,
             prompt_tokens=plan.prompt_tokens if plan is not None else None,
-            block_size=plan.block_size if plan is not None else 0,
-            prefix_cache=plan.prefix_cache if plan is not None else None,
-            extra_keys=plan.extra_keys if plan is not None else None,
-            extra_key_token_start=(
-                plan.extra_key_token_start if plan is not None else None
+            # A suffix-local cache is intentionally never publishable as an
+            # absolute full-history sidecar.
+            block_size=(
+                plan.block_size if plan is not None and not suffix_local else 0
             ),
-            extra_key_ranges=(plan.extra_key_ranges if plan is not None else None),
+            prefix_cache=(
+                plan.prefix_cache if plan is not None and not suffix_local else None
+            ),
+            extra_keys=(
+                plan.extra_keys if plan is not None and not suffix_local else None
+            ),
+            extra_key_token_start=(
+                plan.extra_key_token_start
+                if plan is not None and not suffix_local
+                else None
+            ),
+            extra_key_ranges=(
+                plan.extra_key_ranges
+                if plan is not None and not suffix_local
+                else None
+            ),
         )
         if not ctx.mtp_cache:
+            return
+        if suffix_local and mtp_cache_offset(ctx.mtp_cache) != 0:
             return
         setattr(host, _CTX_ATTR, ctx)
 
@@ -720,7 +913,7 @@ def maybe_capture(
     else:
         if seq_len <= 1:
             ctx.pending_hidden = normed[:, -1:]
-            ctx.expected_offset = offset_after
+            ctx.target_expected_offset = offset_after
             return
         pairs_hidden = normed[:, :-1]
         pairs_tokens = inputs[:, 1:]
@@ -730,10 +923,10 @@ def maybe_capture(
     # model patch. The returned logits are never evaluated — nothing pulls
     # on them, so the lm_head tail costs nothing.
     host.mtp_forward(pairs_hidden, pairs_tokens, ctx.mtp_cache, logits_keep=1)
-    ctx.folded += int(pairs_tokens.shape[1])
+    ctx.head_hist_offset += int(pairs_tokens.shape[1])
     ctx.folded_this_request += int(pairs_tokens.shape[1])
     ctx.pending_hidden = normed[:, -1:]
-    ctx.expected_offset = offset_after
+    ctx.target_expected_offset = offset_after
     _capture_boundary_candidate(
         ctx,
         normed,
@@ -795,13 +988,21 @@ def take_primed(
         # hook declined without popping it — not ours to consume.
         return None
     drop_ctx(model)
-    if not (ctx.valid and ctx.folded > 0 and ctx.pending_hidden is not None):
+    if not (
+        ctx.valid
+        and (ctx.head_hist_offset > 0 or ctx.suffix_local)
+        and ctx.pending_hidden is not None
+    ):
         return None
-    offset = _activation_offset(cache)
-    if offset is None or ctx.expected_offset != offset - 1:
+    offset = (
+        target_cache_offset(cache)
+        if ctx.suffix_local
+        else _activation_offset(cache)
+    )
+    if offset is None or ctx.target_expected_offset != offset - 1:
         logger.debug(
             "MTP priming discarded: seam offset mismatch (ctx=%s cache=%s)",
-            ctx.expected_offset,
+            ctx.target_expected_offset,
             offset,
         )
         return None
@@ -815,14 +1016,35 @@ def take_primed(
     except Exception as exc:
         logger.debug("MTP priming discarded: seam fold failed: %s", exc)
         return None
+    local_offset = ctx.head_hist_offset + 1
+    if ctx.suffix_local:
+        observed = mtp_cache_offset(ctx.mtp_cache)
+        if observed != local_offset:
+            logger.debug(
+                "Qwen4 suffix-local MTP priming discarded: head offset "
+                "mismatch (expected=%s observed=%s target=%s)",
+                local_offset,
+                observed,
+                offset,
+            )
+            return None
+        return SuffixLocalPrimedState(
+            mtp_cache=ctx.mtp_cache,
+            head_hist_offset=local_offset,
+            target_expected_offset=offset,
+        )
     _publish_boundary_candidate(ctx)
-    return ctx.mtp_cache, ctx.folded + 1
+    return ctx.mtp_cache, local_offset
 
 
 def prime_ctx_stats(model: Any) -> Optional[int]:
     """Folded pair count of a live context (introspection / tests)."""
     ctx = _find_ctx(model)
-    return ctx.folded if ctx is not None and not ctx.window_exceeded else None
+    return (
+        ctx.head_hist_offset
+        if ctx is not None and not ctx.window_exceeded
+        else None
+    )
 
 
 __all__ = [
@@ -835,4 +1057,7 @@ __all__ = [
     "take_primed",
     "drop_ctx",
     "prime_ctx_stats",
+    "SuffixLocalPrimedState",
+    "mtp_cache_offset",
+    "target_cache_offset",
 ]

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -2548,6 +2548,11 @@ class LanguageModel(Qwen3_5LanguageModel):
         self._omlx_mtp_chain = True
         self._omlx_mtp_depth = get_mtp_depth()
         self._omlx_mtp_head_prenorm = True
+        # The target backbone verifies every draft, so a restart may prime the
+        # drafter from only the exact uncached TEXT suffix when the durable
+        # backbone prefix has no matching in-memory MTP sidecar. Generic/DS4
+        # hosts never receive this narrow capability marker.
+        self._omlx_mtp_suffix_local_capability = "qwen4-verified-text-v1"
 
     def get_mtp_module(self):
         module = getattr(self, "mtp", None)

--- a/tests/test_mtp_prompt_priming.py
+++ b/tests/test_mtp_prompt_priming.py
@@ -327,8 +327,8 @@ class TestCaptureFold:
         )
         warm_ctx = prompt_priming._find_ctx(model)
         assert warm_ctx is not None
-        assert warm_ctx.folded == 7
-        assert warm_ctx.expected_offset == 8
+        assert warm_ctx.head_hist_offset == 7
+        assert warm_ctx.target_expected_offset == 8
         assert mx.array_equal(warm_ctx.pending_hidden, boundary_pending).item()
 
         # The scheduler's prepared-set normally prevents this second call;
@@ -504,7 +504,7 @@ class TestCaptureSkips:
         assert prompt_priming.prime_ctx_stats(model) is None
         ctx = prompt_priming._find_ctx(model)
         assert ctx is not None and ctx.window_exceeded
-        assert ctx.expected_offset == 17
+        assert ctx.target_expected_offset == 17
 
     def test_take_primed_requires_seam_offset(self, model):
         """No activation forward ran: seam mismatch must discard the ctx."""

--- a/tests/test_qwen4_suffix_local_priming.py
+++ b/tests/test_qwen4_suffix_local_priming.py
@@ -1,0 +1,759 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qwen4-only verified-drafter suffix-local prompt-priming contracts."""
+
+from __future__ import annotations
+
+from collections import deque
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+
+from omlx.patches import mlx_vlm_qwen4_exp_compat as compat
+from omlx.patches.mlx_lm_mtp import prompt_priming
+
+
+def _tiny_config():
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models import qwen4_exp
+
+    text = qwen4_exp.TextConfig(
+        model_type="qwen4_exp_text",
+        hidden_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        linear_num_value_heads=4,
+        linear_num_key_heads=2,
+        linear_key_head_dim=8,
+        linear_value_head_dim=8,
+        linear_conv_kernel_dim=3,
+        num_experts=4,
+        num_experts_per_tok=2,
+        shared_expert_intermediate_size=16,
+        moe_intermediate_size=16,
+        rms_norm_eps=1e-6,
+        vocab_size=64,
+        num_key_value_heads=2,
+        max_position_embeddings=128,
+        hc_count=2,
+        hc_lowrank=8,
+        head_dim=8,
+        layer_types=["linear_attention", "full_attention"],
+        ple_layer_ids=[1],
+        ple_embed_dim=32,
+        ple_conv_kernel_size=3,
+        ngram_size=3,
+        heads_per_ngram=2,
+        ngram_vocab_size_base=17,
+        make_ngram_vocab_size_divisible_by=4,
+        split_ngram_parts=4,
+        indexer_n_heads=2,
+        indexer_kv_heads=1,
+        indexer_head_dim=8,
+        indexer_budget=8,
+        indexer_compress_ratio=2,
+        eos_token_id=1,
+        rope_parameters={
+            "rope_type": "default",
+            "mrope_section": [2, 1, 1],
+            "rope_theta": 10_000,
+            "partial_rotary_factor": 1.0,
+        },
+    )
+    vision = qwen4_exp.VisionConfig(
+        model_type="qwen4_exp",
+        depth=1,
+        hidden_size=32,
+        intermediate_size=64,
+        out_hidden_size=32,
+        num_heads=4,
+        patch_size=14,
+        in_channels=3,
+        spatial_merge_size=2,
+        temporal_patch_size=2,
+        num_position_embeddings=16,
+        deepstack_visual_indexes=[],
+    )
+    return qwen4_exp.ModelConfig(
+        text_config=text,
+        vision_config=vision,
+        model_type="qwen4_exp",
+        image_token_id=60,
+        video_token_id=61,
+        vision_start_token_id=58,
+        vision_end_token_id=59,
+        vocab_size=64,
+    )
+
+
+def _model():
+    config = _tiny_config()
+    from mlx_vlm.models.qwen4_exp.language import (
+        LanguageModel,
+        Qwen4ExpMTPModule,
+    )
+
+    model = LanguageModel(config.text_config, config)
+    model.mtp = Qwen4ExpMTPModule(config.text_config)
+    model._enable_mtp_decode_markers()
+    mx.eval(model.parameters())
+    return model
+
+
+class _NoSidecarPrefixCache:
+    block_size = 4
+
+    def __init__(self):
+        self.store_calls = []
+
+    def restore_mtp_prefix_snapshot(self, *args, **kwargs):
+        return None
+
+    def store_mtp_prefix_snapshot(self, *args, **kwargs):
+        self.store_calls.append((args, kwargs))
+        return True
+
+
+def _arrays(value):
+    if isinstance(value, mx.array):
+        yield value
+        return
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            yield from _arrays(item)
+
+
+def _assert_target_cache_equal(left, right):
+    assert [type(cache) for cache in left] == [type(cache) for cache in right]
+    for left_cache, right_cache in zip(left, right):
+        left_arrays = list(_arrays(left_cache.state))
+        right_arrays = list(_arrays(right_cache.state))
+        assert len(left_arrays) == len(right_arrays)
+        mx.eval(*left_arrays, *right_arrays)
+        for left_value, right_value in zip(left_arrays, right_arrays):
+            assert left_value.shape == right_value.shape
+            assert left_value.dtype == right_value.dtype
+            assert mx.array_equal(left_value, right_value).item()
+
+
+def _assert_qsa_ple_cache_parity(left, right):
+    """Compare every persisted PLE/QSA array after different forward shapes."""
+
+    assert [type(cache) for cache in left] == [type(cache) for cache in right]
+    compared = {"ple": 0, "qsa": 0}
+    for left_cache, right_cache in zip(left, right):
+        family = "qsa" if type(left_cache).__name__.startswith("QSA") else "ple"
+        left_state = left_cache.state
+        right_state = right_cache.state
+        if family == "ple":
+            # Qwen4's linear layer shares one ArraysCache: slots 0/1 are GDN;
+            # slots 2/3 are exactly PLE short-conv and n-gram history.
+            left_state = left_state[2:]
+            right_state = right_state[2:]
+        left_arrays = list(_arrays(left_state))
+        right_arrays = list(_arrays(right_state))
+        assert len(left_arrays) == len(right_arrays)
+        mx.eval(*left_arrays, *right_arrays)
+        for left_value, right_value in zip(left_arrays, right_arrays):
+            compared[family] += 1
+            assert left_value.shape == right_value.shape
+            assert left_value.dtype == right_value.dtype
+            if mx.issubdtype(left_value.dtype, mx.integer):
+                assert mx.array_equal(left_value, right_value).item()
+            else:
+                assert mx.allclose(
+                    left_value,
+                    right_value,
+                    rtol=1e-3,
+                    atol=1e-3,
+                ).item()
+    assert compared["ple"] > 0
+    assert compared["qsa"] >= 4
+
+
+def _restore_target_prefix(model, cache, prefix):
+    with prompt_priming.suppress_capture():
+        output = model(prefix[None], cache=cache)
+        mx.eval(output.logits)
+
+
+def _greedy(logprobs):
+    return mx.argmax(logprobs, axis=-1).astype(mx.uint32)
+
+
+def _target_continuation(model, history, count):
+    """Unprimed target oracle: next token and subsequent greedy tokens."""
+
+    cache = model.make_cache()
+    with prompt_priming.suppress_capture():
+        output = model(history[None], cache=cache)
+        mx.eval(output.logits)
+        token = mx.argmax(output.logits[:, -1], axis=-1).astype(mx.uint32)
+        next_main = int(token.item())
+        tokens = []
+        for _ in range(count):
+            current = token
+            output = model(current[:, None], cache=cache)
+            token = mx.argmax(output.logits[:, -1], axis=-1).astype(mx.uint32)
+            mx.eval(token)
+            tokens.append(int(token.item()))
+    # tokens[0] is the prediction after feeding the first next_main token.
+    return next_main, tokens
+
+
+def _suffix_cycle_fixture(model):
+    """Build the real target and local Qwen4 head through activation."""
+
+    from omlx.patches.mlx_lm_mtp import batch_generator as bg
+
+    prefix = mx.array([2, 3, 4, 5, 6], dtype=mx.int32)
+    suffix = mx.array([7, 8, 9], dtype=mx.int32)
+    prompt = mx.concatenate([prefix, suffix])
+    target_cache = model.make_cache()
+    _restore_target_prefix(model, target_cache, prefix)
+    prompt_priming.prepare_prefix_context(
+        model,
+        request_id="qwen4-real-cycle",
+        prompt_tokens=prompt.tolist(),
+        cached_tokens=len(prefix),
+        prefix_cache=_NoSidecarPrefixCache(),
+    )
+    suffix_output = model(suffix[None], cache=target_cache)
+    main_tok = mx.argmax(suffix_output.logits[:, -1], axis=-1).astype(mx.uint32)
+    activation = model(main_tok[:, None], cache=target_cache, return_hidden=True)
+    primed = prompt_priming.take_primed(model, target_cache, main_tok)
+    assert isinstance(primed, prompt_priming.SuffixLocalPrimedState)
+
+    state = bg._MtpState(uid=1, chain=True, depth=2, head_clone=False)
+    assert bg._adopt_primed_head_state(state, primed, target_cache)
+    next_main = mx.argmax(activation.logits[:, -1], axis=-1).astype(mx.uint32)
+    state.next_main = next_main
+    bg._chain_next_drafts(
+        SimpleNamespace(
+            model=model,
+            logits_processors=[],
+            samplers=[None],
+            fallback_sampler=_greedy,
+        ),
+        state,
+        activation.hidden_states[0][:, -1:],
+        next_main,
+        None,
+    )
+    mx.eval(state.drafts)
+    history = mx.concatenate([prompt, main_tok.astype(mx.int32)])
+    return target_cache, state, history, int(next_main.item())
+
+
+@pytest.mark.parametrize("accepted", [0, 1, 2], ids=["reject", "partial", "full"])
+def test_real_qwen4_suffix_local_verify_cycle_matches_unprimed_target(
+    accepted,
+    monkeypatch,
+):
+    """Real target verify/rollback/bonus stays identical for every accept case."""
+
+    from omlx.patches.mlx_lm_mtp import batch_generator as bg
+
+    model = _model()
+    target_cache, state, history, next_main = _suffix_cycle_fixture(model)
+
+    # Derive target tokens from an independent, unprimed target replay.
+    model._position_ids = None
+    model._rope_deltas = None
+    oracle_next_main, target_tokens = _target_continuation(model, history, 4)
+    assert oracle_next_main == next_main
+
+    drafts = target_tokens[:2]
+    if accepted < 2:
+        drafts = list(drafts)
+        drafts[accepted] = (drafts[accepted] + 1) % model.args.vocab_size
+        assert drafts[accepted] != target_tokens[accepted]
+    state.drafts = mx.array(drafts, dtype=mx.uint32)
+    state.draft_lps = [
+        mx.zeros((model.args.vocab_size,), dtype=mx.float32) for _ in drafts
+    ]
+    state.draft_accept_lps = list(state.draft_lps)
+
+    # Put the correction/bonus exactly on a cache boundary so the real cycle
+    # must execute _materialize_mtp_boundary_emit after rollback/full accept.
+    model._omlx_mtp_commit_align = 8
+    emitted = 8 - (accepted + 1)
+    batch = SimpleNamespace(
+        model=model,
+        prompt_cache=target_cache,
+        tokens=[[0] * emitted],
+        samplers=[None],
+        fallback_sampler=_greedy,
+        logits_processors=[],
+        _token_context=[],
+    )
+
+    rollback_calls = []
+    original_rollback = model.rollback_speculative_cache
+
+    def tracked_rollback(*args, **kwargs):
+        rollback_calls.append((args[2], args[3]))
+        return original_rollback(*args, **kwargs)
+
+    model.rollback_speculative_cache = tracked_rollback
+    boundary_calls = []
+    original_boundary = bg._materialize_mtp_boundary_emit
+
+    def tracked_boundary(gen_batch, mtp_state):
+        boundary_calls.append(True)
+        return original_boundary(gen_batch, mtp_state)
+
+    monkeypatch.setattr(bg, "_materialize_mtp_boundary_emit", tracked_boundary)
+    bg._run_verify_cycle_chain(batch, state)
+    mx.eval(*[row[1] for row in state.queue])
+
+    emitted_tokens = [token for token, _lp, _source in state.queue]
+    assert emitted_tokens == target_tokens[: accepted + 2]
+    assert boundary_calls == [True]
+    if accepted < 2:
+        assert rollback_calls == [(accepted, 3)]
+    else:
+        assert rollback_calls == []
+
+    # Verify kept next_main + accepted drafts, then boundary materialization
+    # committed the target correction/bonus. The final queued token remains one
+    # position ahead, matching the standard decoder pipeline.
+    retained_inputs = mx.array(
+        [next_main, *target_tokens[: accepted + 1]],
+        dtype=mx.int32,
+    )
+    expected_history = mx.concatenate([history, retained_inputs])
+    reference_cache = model.make_cache()
+    model._position_ids = None
+    model._rope_deltas = None
+    with prompt_priming.suppress_capture():
+        reference = model(expected_history[None], cache=reference_cache)
+        mx.eval(reference.logits)
+    _assert_qsa_ple_cache_parity(target_cache, reference_cache)
+    assert state.target_expected_offset == len(expected_history)
+    assert prompt_priming.target_cache_offset(target_cache) == len(expected_history)
+    # Local head history advances by next_main, the verify commit, and boundary
+    # materialization; it never jumps to the absolute target offset.
+    assert state.hist_offset == 3 + accepted + 3
+    assert state.hist_offset < state.target_expected_offset
+    assert state.drafts is not None  # boundary path rebuilt the next draft chain
+
+
+def test_qwen4_suffix_local_priming_preserves_target_output_and_cache():
+    """The target is byte-identical; only the verified drafter gains a suffix."""
+
+    model = _model()
+    assert (
+        model._omlx_mtp_suffix_local_capability
+        == "qwen4-verified-text-v1"
+    )
+    prefix = mx.array([2, 3, 4, 5, 6, 7], dtype=mx.int32)
+    suffix = mx.array([8, 9, 10], dtype=mx.int32)
+    prompt = mx.concatenate([prefix, suffix])
+    control_cache = model.make_cache()
+    primed_cache = model.make_cache()
+    _restore_target_prefix(model, control_cache, prefix)
+    _restore_target_prefix(model, primed_cache, prefix)
+
+    with prompt_priming.suppress_capture():
+        control_suffix = model(suffix[None], cache=control_cache)
+    prefix_cache = _NoSidecarPrefixCache()
+    assert not prompt_priming.prepare_prefix_context(
+        model,
+        request_id="qwen4-suffix",
+        prompt_tokens=prompt.tolist(),
+        cached_tokens=len(prefix),
+        prefix_cache=prefix_cache,
+    )
+    plan = prompt_priming._find_plan(model)
+    assert plan is not None and plan.cached_tokens == len(prefix)
+    assert prompt_priming.capture_eligible(model, primed_cache)
+    primed_suffix = model(suffix[None], cache=primed_cache)
+    ctx = prompt_priming._find_ctx(model)
+    assert ctx is not None and ctx.suffix_local
+    assert ctx.head_hist_offset == len(suffix) - 1
+    assert ctx.target_expected_offset == len(prompt)
+    assert prompt_priming.mtp_cache_offset(ctx.mtp_cache) == len(suffix) - 1
+    assert ctx.snapshot_candidate is None
+    assert prefix_cache.store_calls == []
+
+    mx.eval(control_suffix.logits, primed_suffix.logits)
+    assert mx.array_equal(control_suffix.logits, primed_suffix.logits).item()
+    _assert_target_cache_equal(control_cache, primed_cache)
+
+    main_tok = mx.argmax(primed_suffix.logits[:, -1], axis=-1).astype(mx.int32)
+    with prompt_priming.suppress_capture():
+        control_activation = model(
+            main_tok[:, None], cache=control_cache, return_hidden=True
+        )
+    primed_activation = model(
+        main_tok[:, None], cache=primed_cache, return_hidden=True
+    )
+    mx.eval(control_activation.logits, primed_activation.logits)
+    assert mx.array_equal(
+        control_activation.logits, primed_activation.logits
+    ).item()
+    _assert_target_cache_equal(control_cache, primed_cache)
+
+    primed = prompt_priming.take_primed(model, primed_cache, main_tok)
+    assert isinstance(primed, prompt_priming.SuffixLocalPrimedState)
+    assert primed.head_hist_offset == len(suffix)
+    assert primed.target_expected_offset == len(prompt) + 1
+    assert prompt_priming.mtp_cache_offset(primed.mtp_cache) == len(suffix)
+    assert prefix_cache.store_calls == []
+    # The seam fold touched only the drafter; target output/cache stay exact.
+    _assert_target_cache_equal(control_cache, primed_cache)
+
+
+def test_qwen4_cold_plan_never_captures_or_changes_forward(monkeypatch):
+    """Cold Qwen4 stays on the exact priming-OFF model-forward path."""
+
+    model = _model()
+    prompt = mx.array([2, 3, 4, 5, 6, 7, 8], dtype=mx.int32)
+    control_cache = model.make_cache()
+    candidate_cache = model.make_cache()
+
+    with prompt_priming.suppress_capture():
+        control = model(prompt[None], cache=control_cache)
+
+    assert not prompt_priming.prepare_prefix_context(
+        model,
+        request_id="qwen4-cold-no-capture",
+        prompt_tokens=prompt.tolist(),
+        cached_tokens=0,
+        prefix_cache=_NoSidecarPrefixCache(),
+    )
+    assert prompt_priming._find_plan(model) is None
+    assert prompt_priming._find_ctx(model) is None
+    assert not prompt_priming.capture_eligible(model, candidate_cache)
+
+    def unexpected_capture(*_args, **_kwargs):
+        raise AssertionError("cold Qwen4 entered prompt capture")
+
+    monkeypatch.setattr(prompt_priming, "maybe_capture", unexpected_capture)
+    candidate = model(prompt[None], cache=candidate_cache)
+
+    mx.eval(control.logits, candidate.logits)
+    assert candidate.logits.shape == control.logits.shape
+    assert mx.array_equal(candidate.logits, control.logits).item()
+    assert not getattr(control, "hidden_states", None)
+    assert not getattr(candidate, "hidden_states", None)
+    _assert_target_cache_equal(control_cache, candidate_cache)
+    assert prompt_priming._find_ctx(model) is None
+
+
+@pytest.mark.parametrize(
+    ("extra_keys", "extra_start", "extra_ranges"),
+    [
+        (("image-hash",), 2, None),
+        (None, None, [(2, ("video-hash",))]),
+    ],
+)
+def test_qwen4_suffix_local_multimodal_plan_fails_closed(
+    extra_keys,
+    extra_start,
+    extra_ranges,
+):
+    model = _model()
+    cache = model.make_cache()
+    prefix = mx.array([2, 3, 4, 5], dtype=mx.int32)
+    suffix = mx.array([6, 7], dtype=mx.int32)
+    prompt = mx.concatenate([prefix, suffix])
+    _restore_target_prefix(model, cache, prefix)
+    prompt_priming.prepare_prefix_context(
+        model,
+        request_id="qwen4-media",
+        prompt_tokens=prompt.tolist(),
+        cached_tokens=len(prefix),
+        prefix_cache=_NoSidecarPrefixCache(),
+        extra_keys=extra_keys,
+        extra_key_token_start=extra_start,
+        extra_key_ranges=extra_ranges,
+    )
+    output = model(suffix[None], cache=cache)
+    mx.eval(output.logits)
+    assert prompt_priming._find_ctx(model) is None
+
+
+@pytest.mark.parametrize("fault", ["offset", "tokens"])
+def test_qwen4_suffix_local_malformed_plan_fails_closed(fault):
+    model = _model()
+    cache = model.make_cache()
+    prefix = mx.array([2, 3, 4, 5], dtype=mx.int32)
+    suffix = mx.array([6, 7], dtype=mx.int32)
+    _restore_target_prefix(model, cache, prefix)
+    planned = mx.concatenate([prefix, suffix]).tolist()
+    cached_tokens = len(prefix)
+    if fault == "offset":
+        cached_tokens += 1
+    else:
+        planned[-1] = 11
+    prompt_priming.prepare_prefix_context(
+        model,
+        request_id=f"qwen4-malformed-{fault}",
+        prompt_tokens=planned,
+        cached_tokens=cached_tokens,
+        prefix_cache=_NoSidecarPrefixCache(),
+    )
+    output = model(suffix[None], cache=cache)
+    mx.eval(output.logits)
+    assert prompt_priming._find_ctx(model) is None
+
+
+def test_qwen4_suffix_local_activation_rejects_malformed_head_offset():
+    model = _model()
+    cache = model.make_cache()
+    prefix = mx.array([2, 3, 4, 5], dtype=mx.int32)
+    suffix = mx.array([6, 7, 8], dtype=mx.int32)
+    prompt = mx.concatenate([prefix, suffix])
+    _restore_target_prefix(model, cache, prefix)
+    prompt_priming.prepare_prefix_context(
+        model,
+        request_id="qwen4-head-offset",
+        prompt_tokens=prompt.tolist(),
+        cached_tokens=len(prefix),
+        prefix_cache=_NoSidecarPrefixCache(),
+    )
+    output = model(suffix[None], cache=cache)
+    ctx = prompt_priming._find_ctx(model)
+    assert ctx is not None and ctx.suffix_local
+    assert ctx.mtp_cache[0].trim(1) == 1
+    main_tok = mx.argmax(output.logits[:, -1], axis=-1).astype(mx.int32)
+    model(main_tok[:, None], cache=cache, return_hidden=True)
+    assert prompt_priming.take_primed(model, cache, main_tok) is None
+
+
+def test_qwen4_suffix_local_single_token_suffix_primes_activation_seam():
+    """An exact N-1 backbone hit still contributes its one uncached token."""
+
+    model = _model()
+    cache = model.make_cache()
+    prefix = mx.array([2, 3, 4, 5], dtype=mx.int32)
+    suffix = mx.array([6], dtype=mx.int32)
+    prompt = mx.concatenate([prefix, suffix])
+    _restore_target_prefix(model, cache, prefix)
+    prompt_priming.prepare_prefix_context(
+        model,
+        request_id="qwen4-one-token-suffix",
+        prompt_tokens=prompt.tolist(),
+        cached_tokens=len(prefix),
+        prefix_cache=_NoSidecarPrefixCache(),
+    )
+    output = model(suffix[None], cache=cache)
+    ctx = prompt_priming._find_ctx(model)
+    assert ctx is not None and ctx.suffix_local
+    assert ctx.head_hist_offset == 0
+    assert prompt_priming.mtp_cache_offset(ctx.mtp_cache) == 0
+
+    main_tok = mx.argmax(output.logits[:, -1], axis=-1).astype(mx.int32)
+    model(main_tok[:, None], cache=cache, return_hidden=True)
+    primed = prompt_priming.take_primed(model, cache, main_tok)
+    assert isinstance(primed, prompt_priming.SuffixLocalPrimedState)
+    assert primed.head_hist_offset == 1
+    assert primed.target_expected_offset == len(prompt) + 1
+
+
+class _OffsetCache:
+    def __init__(self, offset):
+        self.offset = offset
+
+    def trim(self, amount):
+        amount = min(self.offset, int(amount))
+        self.offset -= amount
+        return amount
+
+
+def test_suffix_local_state_keeps_head_trim_local_and_target_absolute():
+    from omlx.patches.mlx_lm_mtp import batch_generator as bg
+
+    state = bg._MtpState(
+        mtp_cache=[_OffsetCache(7)],
+        hist_offset=3,
+        target_expected_offset=100,
+        suffix_local_priming=True,
+    )
+    bg._trim_committed_mtp_head(state)
+    assert state.mtp_cache[0].offset == 3
+    assert state.hist_offset == 3
+    assert state.target_expected_offset == 100
+
+    target = [_OffsetCache(102)]
+    bg._advance_suffix_local_target(state, target, 2)
+    assert state.target_expected_offset == 102
+    assert state.hist_offset == 3
+
+    bad = SimpleNamespace(offset=104)
+    with pytest.raises(bg._MtpStepFallback, match="absolute seam"):
+        bg._advance_suffix_local_target(state, [bad], 1)
+
+
+def test_batch_activation_adopts_only_aligned_suffix_local_state():
+    from omlx.patches.mlx_lm_mtp import batch_generator as bg
+
+    primed = prompt_priming.SuffixLocalPrimedState(
+        mtp_cache=[_OffsetCache(3)],
+        head_hist_offset=3,
+        target_expected_offset=101,
+    )
+    state = bg._MtpState()
+    assert bg._adopt_primed_head_state(state, primed, [_OffsetCache(101)])
+    assert state.mtp_cache is primed.mtp_cache
+    assert state.hist_offset == 3
+    assert state.target_expected_offset == 101
+    assert state.suffix_local_priming
+
+    malformed = bg._MtpState()
+    assert not bg._adopt_primed_head_state(
+        malformed,
+        primed,
+        [_OffsetCache(100)],
+    )
+    assert malformed.mtp_cache is None
+    assert not malformed.suffix_local_priming
+
+
+def test_target_cache_offset_requires_every_readable_layer_aligned():
+    aligned = [
+        _OffsetCache(12),
+        SimpleNamespace(caches=[_OffsetCache(12), object()]),
+        _OffsetCache(12),
+    ]
+    assert prompt_priming.target_cache_offset(aligned) == 12
+    aligned[2].offset = 11
+    assert prompt_priming.target_cache_offset(aligned) is None
+
+
+def test_batch_activation_rejects_misaligned_multilayer_target():
+    from omlx.patches.mlx_lm_mtp import batch_generator as bg
+
+    primed = prompt_priming.SuffixLocalPrimedState(
+        mtp_cache=[_OffsetCache(3)],
+        head_hist_offset=3,
+        target_expected_offset=101,
+    )
+    state = bg._MtpState()
+    assert not bg._adopt_primed_head_state(
+        state,
+        primed,
+        [_OffsetCache(101), _OffsetCache(100)],
+    )
+    assert state.mtp_cache is None
+
+
+def test_suffix_plan_new_request_replaces_stale_owner():
+    model = _model()
+    cache = model.make_cache()
+    prefix = mx.array([2, 3, 4, 5], dtype=mx.int32)
+    suffix_a = mx.array([6, 7], dtype=mx.int32)
+    suffix_b = mx.array([8, 9], dtype=mx.int32)
+    _restore_target_prefix(model, cache, prefix)
+    prompt_priming.prepare_prefix_context(
+        model,
+        request_id="stale-a",
+        prompt_tokens=mx.concatenate([prefix, suffix_a]).tolist(),
+        cached_tokens=len(prefix),
+        prefix_cache=_NoSidecarPrefixCache(),
+    )
+    prompt_priming.prepare_prefix_context(
+        model,
+        request_id="fresh-b",
+        prompt_tokens=mx.concatenate([prefix, suffix_b]).tolist(),
+        cached_tokens=len(prefix),
+        prefix_cache=_NoSidecarPrefixCache(),
+    )
+    output = model(suffix_b[None], cache=cache)
+    mx.eval(output.logits)
+    ctx = prompt_priming._find_ctx(model)
+    assert ctx is not None
+    assert ctx.request_id == "fresh-b"
+    assert ctx.suffix_local
+
+
+def test_suffix_plan_interleaving_cannot_steal_the_new_request_plan():
+    model = _model()
+    cache_a = model.make_cache()
+    cache_b = model.make_cache()
+    prefix = mx.array([2, 3, 4, 5], dtype=mx.int32)
+    suffix_a = mx.array([6, 7], dtype=mx.int32)
+    suffix_b = mx.array([8, 9], dtype=mx.int32)
+    _restore_target_prefix(model, cache_a, prefix)
+    _restore_target_prefix(model, cache_b, prefix)
+    prompt_priming.prepare_prefix_context(
+        model,
+        request_id="interleave-a",
+        prompt_tokens=mx.concatenate([prefix, suffix_a]).tolist(),
+        cached_tokens=len(prefix),
+        prefix_cache=_NoSidecarPrefixCache(),
+    )
+    # B becomes the scheduler-owned plan before A's stale chunk reaches capture.
+    prompt_priming.prepare_prefix_context(
+        model,
+        request_id="interleave-b",
+        prompt_tokens=mx.concatenate([prefix, suffix_b]).tolist(),
+        cached_tokens=len(prefix),
+        prefix_cache=_NoSidecarPrefixCache(),
+    )
+    stale = model(suffix_a[None], cache=cache_a)
+    mx.eval(stale.logits)
+    assert prompt_priming._find_ctx(model) is None
+    plan = prompt_priming._find_plan(model)
+    assert plan is not None and plan.request_id == "interleave-b"
+    # A's mismatched chunk cannot consume or mutate B's immutable plan. B may
+    # still start only from its own matching target cache and token suffix.
+    current = model(suffix_b[None], cache=cache_b)
+    mx.eval(current.logits)
+    ctx = prompt_priming._find_ctx(model)
+    assert ctx is not None and ctx.request_id == "interleave-b"
+
+
+def test_suffix_local_b1_to_batch_reconcile_uses_absolute_stream_only(
+    monkeypatch,
+):
+    from omlx.patches.mlx_lm_mtp import batch_generator as bg
+
+    class _TargetCache:
+        def __init__(self):
+            self.offset = 0
+            self._mtp_undo = None
+
+    def fake_backbone(_model, inputs, cache, n_confirmed=0):
+        del n_confirmed
+        cache[0].offset = int(inputs.shape[1])
+        cache[0]._mtp_undo = object()
+        logits = mx.full((1, inputs.shape[1], 64), -10.0)
+        logits[:, -1, 5] = 10.0
+        return logits, None, None
+
+    monkeypatch.setattr(bg, "_rebuild_singleton_cache", lambda _model: [_TargetCache()])
+    monkeypatch.setattr(bg, "_call_backbone", fake_backbone)
+    queued_lp = mx.zeros((64,))
+    state = bg._MtpState(
+        uid=7,
+        queue=deque([(42, queued_lp, "draft")]),
+        mtp_cache=[_OffsetCache(3)],
+        hist_offset=3,
+        target_expected_offset=100,
+        suffix_local_priming=True,
+    )
+    batch = SimpleNamespace(
+        model=object(),
+        uids=[7],
+        tokens=[[10, 11, 12, 13]],
+        _num_tokens=[4],
+        samplers=[None],
+        fallback_sampler=_greedy,
+        logits_processors=[],
+        _next_tokens=mx.array([999], dtype=mx.uint32),
+        _next_logprobs=[],
+        _token_context=[],
+        prompt_cache=[object()],
+        _omlx_mtp_state=state,
+    )
+    assert bg._reconcile_mtp_to_standard(batch, state)
+    assert batch._next_tokens.tolist() == [42]
+    assert batch.prompt_cache[0].offset == len(batch.tokens[0])
+    assert batch.prompt_cache[0]._mtp_undo is None
+    # The rebuilt standard target is derived only from the absolute emitted
+    # stream; neither local head offset nor stale absolute seam is copied.
+    assert not hasattr(batch.prompt_cache[0], "hist_offset")
+    assert not hasattr(batch.prompt_cache[0], "target_expected_offset")


### PR DESCRIPTION
## Summary

This PR is the separately reviewable cached-drafter follow-up to #3320. A backbone prefix-cache/SSD restore can recover the target cache while the memory-only Lightning-MTP head history is absent. Previously Qwen4 entered decode with `primed=0`, paying lower early acceptance and avoidable agent-turn latency.

This is a capability-scoped **text-token suffix optimization**, not a text-only Qwen implementation. Native Qwen3.8-Flash-Next text, image, and video serving was merged in #3169 and remains unchanged. Image/video requests continue through that official multimodal path; this optimization detects media state and fails closed instead of folding vision/video embeddings into the text MTP head.

## What changed

- Adds verified suffix-local MTP priming for eligible Qwen4 B1 text-token cache restores.
- Proves each incoming suffix chunk is the exact scheduler-owned token slice before folding it into the drafter.
- Keeps local head-history offsets separate from absolute target-cache offsets.
- Requires every readable target cache layer to agree on the same absolute offset.
- Exercises ordinary reject, partial accept, full accept, rollback, boundary materialization, request replacement/interleaving, and B1-to-batch reconciliation.
- Explicitly tests that image/video media plans skip suffix-local priming and retain the existing multimodal serving path.
- Never publishes suffix-local state as a full-history MTP sidecar; media, batched, misaligned, and otherwise unsupported cases fail closed to existing behavior.

## Relationship to #3330

#3330 is the generic Metal/ExactResident/prompt-tail engine. This PR provides one Qwen-specific prerequisite that #3330 can consume: reconstructing verified MTP head history from an exact cached suffix.

The PRs are deliberately independently mergeable and independently reviewable:

- **#3328** changes only Qwen4 cached-suffix drafter reconstruction.
- **#3330** changes the generic local engine/cache/idle-materialization framework and fails closed for unsupported speculative models.

Full speculative-Qwen ExactResident/prompt-tail reuse also requires the separate exact target-terminal transaction proven in Fusion. That transaction is intentionally not hidden inside either PR; until its own review unit lands, #3330 remains fail closed for speculative Qwen. This is an explicit composition relationship, not an assertion that #3328 alone unlocks the full 6.7× Fusion TTFT result.

## Physical validation

Apple M3 Ultra, Qwen3.8-Flash-Next-oQ4e-MTP, deterministic 100K restart restore:

- 98,304 prompt tokens restored from the target prefix cache.
- 1,689 exact local suffix tokens primed into the drafter.
- 98.3% draft acceptance, 5.38 tokens/target cycle.
- 65.25 tok/s decode for 500 generated tokens.
- Exact output hash matched the unmodified target result.
- Cold 99,993-token control skipped priming (`primed=0`) and held 867.11 tok/s prefill, proving the cached optimization does not tax cold prompts.

## Tests

- Exact targeted Qwen terminal/rollback/interleaving suite: 48 passed.
- Broad Qwen/MTP/cache suite: 743 passed, 19 skipped.
- Full Python 3.13 CI-equivalent run: 10,613 passed, 150 skipped, 77 deselected.
- Signed commit; independent review found no correctness blocker.
- Rebased onto current upstream `main`; exact-head Python 3.11–3.13 CI is green at `170e38dd`.

## Relationship to #3320 and multimodal Qwen

This branch is independently based on current `main`; it composes conflict-free with #3320 and the combined relevant suite passes (747 passed, 22 skipped). It remains separate because #3320 explicitly excludes cached-drafter priming and folding this test-heavy change into it would nearly triple that PR.

The complete native `qwen4_exp` architecture—including text, image, video, tools, QSA state, PLE residency, and deterministic unload—is already upstream through merged #3169. This PR changes only how an eligible cached **text suffix** reconstructs the speculative MTP head; it does not remove or narrow multimodal model support.
