### PR TITLE
fix: scope SDPA headroom providers to engine workers

### DIFF
--- a/omlx/patches/sdpa256_attention.py
+++ b/omlx/patches/sdpa256_attention.py
@@ -25,6 +25,7 @@ everything else passes through to the original SDPA unchanged.
 
 import logging
 import os
+import threading
 import weakref
 
 import mlx.core as mx
@@ -51,12 +52,12 @@ _KV_TILE = 1024
 _NEG_INF = -1e30
 
 # Live guard-headroom provider for memory-aware routing (issue #2204).
-# Registered by Scheduler.__init__ as a bound method returning the bytes left
-# under the adaptive-prefill-throttle target (hard ceiling x headroom safety,
-# clamped by the abort cap), or a negative value when no ceiling is active.
-# Held as a WeakMethod so a torn-down Scheduler auto-unregisters and the route
-# falls back to the memory-bounded native fused default.
-_HEADROOM_PROVIDER: "weakref.WeakMethod | None" = None
+# Scheduler.step registers the active Scheduler on its execution thread. Each
+# engine uses its own worker, so thread-local storage keeps concurrent engines
+# from replacing one another's provider. The bound method is weakly held so a
+# torn-down Scheduler leaves that worker on the memory-bounded native fused
+# default.
+_HEADROOM_PROVIDER_LOCAL = threading.local()
 # Backward-compatible override: True = always force fused, False = never force,
 # None = memory-aware auto.
 _FORCE_TILED: bool | None = None
@@ -79,11 +80,21 @@ def _note_tiled_route(reason: str, detail: str) -> None:
 
 
 def set_unfused_headroom_provider(method) -> None:
-    """Register a bound method returning the prefill guard's live headroom in
-    bytes (negative when no ceiling is active). Lets ``_should_route`` prefer
-    the faster unfused fallback whenever its O(L^2) transient fits."""
-    global _HEADROOM_PROVIDER
-    _HEADROOM_PROVIDER = weakref.WeakMethod(method)
+    """Bind the active Scheduler's headroom provider to this worker thread."""
+    ref = getattr(_HEADROOM_PROVIDER_LOCAL, "ref", None)
+    current = ref() if ref is not None else None
+    if (
+        current is not None
+        and current.__self__ is method.__self__
+        and current.__func__ is method.__func__
+    ):
+        return
+    _HEADROOM_PROVIDER_LOCAL.ref = weakref.WeakMethod(method)
+
+
+def _get_unfused_headroom_provider():
+    ref = getattr(_HEADROOM_PROVIDER_LOCAL, "ref", None)
+    return ref() if ref is not None else None
 
 
 def _parse_force_tiled_env() -> bool | None:
@@ -107,7 +118,7 @@ def _tiled_route_required(queries, keys) -> bool:
             _note_tiled_route("forced", "forced by OMLX_SDPA256_TILED=1")
         return _FORCE_TILED
     try:
-        provider = _HEADROOM_PROVIDER() if _HEADROOM_PROVIDER is not None else None
+        provider = _get_unfused_headroom_provider()
         if provider is None:
             _note_tiled_route(
                 "no-provider",

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -51,13 +51,13 @@ from .cache.observability import BoundarySnapshotDiagnostics, CacheRateTracker
 from .cache.paged_cache import PagedCacheManager
 from .cache.pooling_delta import compact_pooling_cache_snapshot
 from .cache.prefix_cache import BlockAwarePrefixCache, cachelist_pm_member_plan
+from .decode_activity import get_decode_activity
 from .exceptions import (
     PrefillMemoryExceededError,
     describe_ceiling_binding,
     is_cache_corruption_error,
 )
 from .patches.sdpa256_attention import set_unfused_headroom_provider
-from .decode_activity import get_decode_activity
 from .prefill_progress import get_prefill_tracker
 from .prefill_transient_tracker import PrefillTransientTracker
 from .request import Request, RequestOutput, RequestStatus, SamplingParams
@@ -1984,12 +1984,6 @@ class Scheduler:
         # and taken after the first prefill chunk's eval.
         self._fixed_state_measure_armed: bool = False
         self._fixed_state_recorded: bool = False
-        # Let the sdpa256 head_dim-256 prefill route ask for live guard
-        # headroom so it only forces bounded native SDPA when the faster
-        # unfused default would not fit (issue #2204). Weakly held; harmless
-        # when the patch is never applied.
-        set_unfused_headroom_provider(self._sdpa256_unfused_headroom)
-
         # SpecPrefill: draft model for attention-based sparse prefill
         self._specprefill_draft_model: Any | None = None
         self._draft_paged_ssd_cache_manager: Any | None = None
@@ -11883,6 +11877,11 @@ class Scheduler:
         Returns:
             SchedulerOutput with results of this step
         """
+        # Bind on the thread that runs model forwards. Scheduler construction
+        # can happen on a shared event-loop thread, while every engine executes
+        # steps on its own worker. The setter is idempotent for repeated steps.
+        set_unfused_headroom_provider(self._sdpa256_unfused_headroom)
+
         output = SchedulerOutput()
 
         # Publish decode activity for cross-engine prefill fairness (a

--- a/tests/test_qwen4_qsa_prefill_memory.py
+++ b/tests/test_qwen4_qsa_prefill_memory.py
@@ -50,9 +50,11 @@ def test_qsa_cache_is_not_retained_in_boundary_snapshots(cache_cls):
 
 
 def test_bool_mask_uses_tiled_sdpa_and_matches_dense(monkeypatch):
+    import threading
+
     from omlx.patches import sdpa256_attention as sdpa256
 
-    monkeypatch.setattr(sdpa256, "_HEADROOM_PROVIDER", None)
+    monkeypatch.setattr(sdpa256, "_HEADROOM_PROVIDER_LOCAL", threading.local())
     monkeypatch.setattr(sdpa256, "_FORCE_TILED", None)
     monkeypatch.setattr(sdpa256, "_SDPA256_MIN_KV_LEN", 64)
     monkeypatch.setattr(sdpa256, "_Q_TILE", 16)

--- a/tests/test_sdpa256_attention.py
+++ b/tests/test_sdpa256_attention.py
@@ -368,10 +368,14 @@ class _HeadroomOwner:
 
 @pytest.fixture
 def _sdpa256_provider_reset(monkeypatch):
-    """Isolate the module-level provider/override state and restore it."""
+    """Isolate the thread-local provider/override state and restore it."""
+    import threading
+
     from omlx.patches import sdpa256_attention as sdpa256
 
-    monkeypatch.setattr(sdpa256, "_HEADROOM_PROVIDER", None, raising=False)
+    monkeypatch.setattr(
+        sdpa256, "_HEADROOM_PROVIDER_LOCAL", threading.local(), raising=False
+    )
     monkeypatch.setattr(sdpa256, "_FORCE_TILED", None, raising=False)
     monkeypatch.setattr(sdpa256, "_TILED_ROUTE_LOGGED", set(), raising=False)
     return sdpa256
@@ -412,6 +416,60 @@ def test_route_defaults_to_tiled_when_provider_owner_dies(_sdpa256_provider_rese
     assert sdpa256._should_route(q, k, None, "causal", None) is True
 
 
+def test_provider_binding_is_idempotent_and_replaceable(_sdpa256_provider_reset):
+    sdpa256 = _sdpa256_provider_reset
+    first = _HeadroomOwner(1)
+    second = _HeadroomOwner(2)
+
+    sdpa256.set_unfused_headroom_provider(first.headroom)
+    first_ref = sdpa256._HEADROOM_PROVIDER_LOCAL.ref
+    sdpa256.set_unfused_headroom_provider(first.headroom)
+    assert sdpa256._HEADROOM_PROVIDER_LOCAL.ref is first_ref
+
+    sdpa256.set_unfused_headroom_provider(second.headroom)
+    provider = sdpa256._get_unfused_headroom_provider()
+    assert provider is not None
+    assert provider.__self__ is second
+
+
+def test_worker_provider_survives_other_scheduler_teardown(
+    _sdpa256_provider_reset,
+):
+    """A later engine must not replace or clear a surviving engine's provider."""
+    import concurrent.futures
+    import gc
+
+    sdpa256 = _sdpa256_provider_reset
+    q, k, _ = _qkv(2048, 16384)
+    surviving = _HeadroomOwner(1 << 40)
+    later = _HeadroomOwner(1)
+
+    def route(worker):
+        return worker.submit(
+            sdpa256._should_route, q, k, None, "causal", None
+        ).result()
+
+    with (
+        concurrent.futures.ThreadPoolExecutor(max_workers=1) as first_worker,
+        concurrent.futures.ThreadPoolExecutor(max_workers=1) as second_worker,
+    ):
+        first_worker.submit(
+            sdpa256.set_unfused_headroom_provider, surviving.headroom
+        ).result()
+        second_worker.submit(
+            sdpa256.set_unfused_headroom_provider, later.headroom
+        ).result()
+
+        assert route(first_worker) is False
+        assert route(second_worker) is True
+
+        del later
+        gc.collect()
+
+        assert route(first_worker) is False
+        assert route(second_worker) is True
+
+
 def test_route_defaults_to_tiled_when_provider_raises(_sdpa256_provider_reset):
     sdpa256 = _sdpa256_provider_reset
 
@@ -426,6 +484,8 @@ def test_route_defaults_to_tiled_when_provider_raises(_sdpa256_provider_reset):
 
 
 def test_force_tiled_override(_sdpa256_provider_reset, monkeypatch):
+    import threading
+
     sdpa256 = _sdpa256_provider_reset
     q, k, _ = _qkv(2048, 16384)
     owner = _HeadroomOwner(1 << 40)
@@ -435,7 +495,9 @@ def test_force_tiled_override(_sdpa256_provider_reset, monkeypatch):
     assert sdpa256._should_route(q, k, None, "causal", None) is True
     # 0: never tiled even without headroom info.
     monkeypatch.setattr(sdpa256, "_FORCE_TILED", False, raising=False)
-    monkeypatch.setattr(sdpa256, "_HEADROOM_PROVIDER", None, raising=False)
+    monkeypatch.setattr(
+        sdpa256, "_HEADROOM_PROVIDER_LOCAL", threading.local(), raising=False
+    )
     assert sdpa256._should_route(q, k, None, "causal", None) is False
 
 
@@ -610,10 +672,8 @@ def test_unguarded_fast_path_logs_once(caplog):
     assert "OMLX_SDPA256_TILED=1" in msg
 
 
-def test_scheduler_init_registers_headroom_provider(_sdpa256_provider_reset):
-    """Constructing a Scheduler must wire the provider (the production seam:
-    a rename that silently skips registration would revert #2204 to an
-    unbounded default)."""
+def test_scheduler_step_registers_headroom_provider(_sdpa256_provider_reset):
+    """Scheduler.step must bind its provider on the model execution thread."""
     from unittest.mock import MagicMock
 
     from omlx.scheduler import Scheduler, SchedulerConfig
@@ -628,9 +688,9 @@ def test_scheduler_init_registers_headroom_provider(_sdpa256_provider_reset):
         tokenizer=tokenizer,
         config=SchedulerConfig(paged_cache_block_size=0),
     )
-    ref = sdpa256._HEADROOM_PROVIDER
-    assert ref is not None
-    bound = ref()
+    assert sdpa256._get_unfused_headroom_provider() is None
+    scheduler.step()
+    bound = sdpa256._get_unfused_headroom_provider()
     assert bound is not None
     assert bound.__self__ is scheduler
     # Ceiling not propagated yet -> negative sentinel keeps the bounded default.


### PR DESCRIPTION
## Summary

- Bind the live SDPA headroom provider on the worker executing `Scheduler.step()`.
- Keep each worker's provider in thread-local weak storage so concurrent engines cannot overwrite one another.
- Preserve the memory-bounded fallback when no live provider is available.

## Problem

The SDPA route previously stored one process-global `WeakMethod`, and every
`Scheduler` construction replaced it. In a multi-engine process, tearing down
the most recently created scheduler therefore left surviving engines with a
dead provider reference.

This remained safe for output correctness and memory use, but it could force a
surviving head-dim-256 model onto the bounded route even when its own live
headroom allowed the faster default route.

## Implementation

Provider registration now happens at the beginning of `Scheduler.step()`, on
the thread that performs model execution. Each engine worker resolves its own
weak provider, while a missing or destroyed scheduler continues to select the
memory-bounded fallback.

Repeated steps from the same scheduler reuse the existing weak reference, and
a worker can replace it when it begins executing a different scheduler.

## Validation

- `pytest -q tests/test_sdpa256_attention.py` (36 passed with MLX 0.32.2)
- `pytest -q tests/test_engine_core.py tests/test_scheduler_prefill_memory_guard.py tests/test_scheduler.py` (348 passed)
- `pytest -q tests/test_per_engine_threads.py tests/test_engine_pool.py` (154 passed)
- `test_worker_provider_survives_other_scheduler_teardown` verifies independent routing before and after the later scheduler is destroyed.
- Ruff checks and `git diff --cached --check` passed.
