### PR TITLE
fix(cache): skip decode-time boundary captures beyond the cacheable bound

### DIFF
--- a/omlx/cache/observability.py
+++ b/omlx/cache/observability.py
@@ -115,7 +115,7 @@ class BoundarySnapshotDiagnostics:
         source: str | None = None,
         storage: str | None = None,
         available_boundaries: int | None = None,
-    ) -> None:
+    ) -> dict[str, Any]:
         counter = {
             "capture_attempt": "capture_attempts",
             "capture_success": "captures",
@@ -157,6 +157,9 @@ class BoundarySnapshotDiagnostics:
                 if value is not None:
                     last_event[key] = value
             self._last_event = last_event
+            # Callers logging the event (e.g. the store-skip INFO line) need
+            # the derived cause, which only exists on this assembled record.
+            return dict(last_event)
 
     def snapshot(self) -> dict[str, Any]:
         with self._lock:

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -6723,6 +6723,22 @@ class Scheduler:
         if not self._detect_boundary_snapshot_need():
             return
 
+        # Reasoning-model requests cache prompt tokens only (the
+        # needs_think_prefix branch of the final-response store), so a
+        # snapshot keyed past the prompt can never pass
+        # _get_boundary_store_override's tc <= len(cacheable_sequence)
+        # filter. Skip before paying the extraction and the sidecar write.
+        if request.needs_think_prefix and total_tokens > request.num_prompt_tokens:
+            self._boundary_snapshot_diagnostics.record(
+                "capture_skipped",
+                reason="beyond_cacheable_bound",
+                request_id=request.request_id,
+                token_count=total_tokens,
+                block_size=block_size,
+                source="decode",
+            )
+            return
+
         self._boundary_snapshot_diagnostics.record(
             "capture_attempt",
             request_id=request.request_id,
@@ -11316,7 +11332,7 @@ class Scheduler:
                             available_boundaries = len(
                                 self._boundary_cache_snapshots.get(request_id, {})
                             )
-                            self._boundary_snapshot_diagnostics.record(
+                            skip_event = self._boundary_snapshot_diagnostics.record(
                                 "store_skip",
                                 reason="boundary_snapshot_unavailable",
                                 request_id=request_id,
@@ -11326,7 +11342,8 @@ class Scheduler:
                             )
                             logger.info(
                                 "Skipping cache store for %s: reason=%s "
-                                "tokens=%d block_size=%d available_boundaries=%d; "
+                                "tokens=%d block_size=%d available_boundaries=%d "
+                                "cause=%s; "
                                 "storing live non-sliceable state would corrupt "
                                 "later prefix hits",
                                 request_id,
@@ -11334,6 +11351,7 @@ class Scheduler:
                                 len(cacheable_sequence),
                                 self.config.paged_cache_block_size,
                                 available_boundaries,
+                                skip_event.get("cause", "unspecified"),
                             )
                             block_table = None
                             if self.paged_cache_manager:

--- a/tests/test_cache_observability.py
+++ b/tests/test_cache_observability.py
@@ -303,6 +303,34 @@ def test_boundary_snapshot_diagnostics_preserve_store_skip_cause():
     assert diagnostics.snapshot()["last_event"]["cause"] == "ssd_load_failed"
 
 
+def test_boundary_snapshot_diagnostics_record_returns_event_with_cause():
+    """record() hands back the assembled event so callers logging the skip
+    (the store-skip INFO line) can include the derived cause without a
+    second snapshot() round-trip."""
+    diagnostics = BoundarySnapshotDiagnostics()
+    miss = diagnostics.record(
+        "override_miss",
+        reason="no_aligned_snapshots",
+        request_id="req-a",
+        token_count=4096,
+        block_size=2048,
+        available_boundaries=1,
+    )
+    assert miss["event"] == "override_miss"
+    assert "cause" not in miss
+
+    skip = diagnostics.record(
+        "store_skip",
+        reason="boundary_snapshot_unavailable",
+        request_id="req-a",
+        token_count=4096,
+        block_size=2048,
+        available_boundaries=1,
+    )
+    assert skip["cause"] == "no_aligned_snapshots"
+    assert skip == diagnostics.snapshot()["last_event"]
+
+
 def test_boundary_snapshot_diagnostics_clear_resets_state():
     diagnostics = BoundarySnapshotDiagnostics()
     diagnostics.record(

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -2512,6 +2512,78 @@ class TestSchedulerBoundarySnapshots:
         assert diagnostics["captures"] == 0
         assert diagnostics["reasons"]["cache_offset_mismatch"] == 1
 
+    def test_decode_capture_skipped_beyond_cacheable_bound(
+        self, mock_model, mock_tokenizer
+    ):
+        """Reasoning-model requests (needs_think_prefix) cache prompt tokens
+        only, so a decode-time snapshot keyed past the prompt can never pass
+        the store's tc <= len(cacheable_sequence) filter — the capture must
+        be skipped BEFORE extraction and any sidecar write."""
+        config = SchedulerConfig(paged_cache_block_size=4)
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer, config=config)
+        scheduler.block_aware_cache = MagicMock()
+        scheduler._boundary_snapshot_required = True
+        scheduler.batch_generator = MagicMock()
+        scheduler._boundary_snapshot_store = MagicMock()
+
+        request = Request(
+            request_id="req-think",
+            prompt="hello",
+            sampling_params=SamplingParams(),
+        )
+        request.prompt_token_ids = [10, 11]
+        request.num_prompt_tokens = 2
+        request.output_token_ids = [12, 13]  # Total = 4 (boundary), past prompt
+        request.needs_think_prefix = True
+
+        scheduler._maybe_capture_boundary_snapshot(request, 123)
+
+        scheduler.batch_generator.extract_cache.assert_not_called()
+        scheduler._boundary_snapshot_store.save.assert_not_called()
+        assert "req-think" not in scheduler._boundary_cache_snapshots
+        diagnostics = scheduler._boundary_snapshot_diagnostics.snapshot()
+        assert diagnostics["capture_attempts"] == 0
+        assert diagnostics["captures"] == 0
+        assert diagnostics["reasons"]["beyond_cacheable_bound"] == 1
+
+    def test_decode_capture_at_prompt_boundary_with_think_prefix(
+        self, mock_model, mock_tokenizer
+    ):
+        """The suppression bound is strict: a reasoning-model capture whose
+        token count equals the prompt length (tc == cacheable bound) is still
+        storable and must proceed."""
+        config = SchedulerConfig(paged_cache_block_size=4)
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer, config=config)
+        scheduler.block_aware_cache = MagicMock()
+        scheduler._boundary_snapshot_required = True
+
+        mock_layer_cache = MagicMock()
+        type(mock_layer_cache).__name__ = "BatchArraysCache"
+        mock_layer_cache.offset = 4
+
+        scheduler.batch_generator = MagicMock()
+        scheduler.batch_generator.extract_cache.return_value = {
+            123: ([mock_layer_cache], [10, 11, 12, 13])
+        }
+
+        request = Request(
+            request_id="req-think-eq",
+            prompt="hello",
+            sampling_params=SamplingParams(),
+        )
+        request.prompt_token_ids = [10, 11, 12, 13]
+        request.num_prompt_tokens = 4
+        request.output_token_ids = []  # Total = 4 == prompt == boundary
+        request.needs_think_prefix = True
+
+        scheduler._maybe_capture_boundary_snapshot(request, 123)
+
+        assert 4 in scheduler._boundary_cache_snapshots["req-think-eq"]
+        diagnostics = scheduler._boundary_snapshot_diagnostics.snapshot()
+        assert diagnostics["capture_attempts"] == 1
+        assert diagnostics["captures"] == 1
+        assert "beyond_cacheable_bound" not in diagnostics["reasons"]
+
     @staticmethod
     def _cache_list_layer(leaf_offset: int):
         """CacheList-style wrapper: no own offset, sub-caches carry it."""
@@ -2630,6 +2702,7 @@ class TestSchedulerBoundarySnapshots:
         }
         assert diagnostics["last_event"]["cause"] == "no_snapshots"
         assert "reason=boundary_snapshot_unavailable" in caplog.text
+        assert "cause=no_snapshots" in caplog.text
 
     def test_prefix_lookup_observation_explains_reprefill_boundary(
         self, mock_model, mock_tokenizer


### PR DESCRIPTION
## Summary

On hybrid models that require boundary snapshots, decode-time capture (`Scheduler._maybe_capture_boundary_snapshot`) fires whenever the emitted token count lands exactly on a block boundary. For reasoning-model requests (`needs_think_prefix`), the final-response store deliberately caches prompt tokens only — `<think>` output is stripped by the API layer before the next turn, so generated tokens never prefix-match. A decode-time snapshot is keyed at an emitted position beyond the prompt, which means the store's alignment filter (`tc <= len(cacheable_sequence)`) can never select it. The capture still pays the full non-sliceable state extraction on the inference thread plus an fp32 GDN sidecar SSD write (~111 MiB per event on Qwen3.8-Flash-Next) before the store discards it.

This change skips the capture up front when the position is beyond the request's cacheable bound, and records the skip in the boundary diagnostics (`capture_skipped` / `beyond_cacheable_bound`) so the suppression stays observable. It also surfaces the store-skip `cause` in the existing INFO log line: today the log says only `reason=boundary_snapshot_unavailable available_boundaries=N`, while the decisive cause (`no_snapshots`, `no_aligned_snapshots`, …) is visible only through `/admin/api/stats` — the reporters in #3317 and #3314 spent days guessing at exactly this.

Measured on an M5 Max 128 GB with `Qwen3.8-Flash-Next-oQ4e-mtp` (MTP on, hot+SSD cache, block_size 2048): in a deterministic 9-turn agentic session shape (~32k→47k context, a few hundred tokens per turn, pinned transcripts, temperature 0), stock v0.6.4 produced 14 captures of which 7 were decode-time and all 7 were discarded at store — roughly 770 MiB of dead sidecar writes per session, with each wasted boundary re-captured by the next turn's prefill anyway. With this fix the same workload suppresses exactly those 7 (visible as `beyond_cacheable_bound: 7` in the diagnostics), keeps the 7 prefill captures and their stores byte-for-byte identical, and reproduces the identical per-turn `cached_tokens` sequence (30,720 → 43,008). No reuse behavior changes; only the wasted work goes away.

## Changes

- `omlx/scheduler.py`: `_maybe_capture_boundary_snapshot` returns early — before extraction and the sidecar save — when `request.needs_think_prefix` and the capture position exceeds `request.num_prompt_tokens` (the same bound the final store applies); records `capture_skipped` with reason `beyond_cacheable_bound`. The store-skip INFO line gains a `cause=` token.
- `omlx/cache/observability.py`: `BoundarySnapshotDiagnostics.record()` now returns the assembled event dict so the log site can include the derived cause without a second snapshot round-trip. Additive; no counter or schema changes.
- Tests: a regression test proving the skip (no extract call, no sidecar save, reason recorded — fails before the patch), a contrast test proving the bound is strict (a reasoning-model capture at exactly the prompt boundary still proceeds), a `record()`-return-value test, and a `cause=` assertion added to the existing store-skip caplog test. The existing block-boundary capture test covers the non-reasoning path unchanged.

## Test plan

- `uv run pytest tests/` — 10595 passed, 149 skipped, 0 failed (4m31s, Python 3.12, M5 Max). Five tests were deselected because they fail identically on stock v0.6.4 on this machine with zero local changes (fp-tolerance misses in `test_dflash_laguna`, `test_mlx_vlm_glm5_next_compat`, and three qwen4_exp gather-path tests; possibly M5-generation numerics — happy to file separately) and are unrelated to this change.
- New tests verified to fail before the patch and pass after.
- Live A/B on the workload above, both arms from a fresh scheduler: patched arm shows `capture_attempts` reduced exactly by the baseline's decode-time count, `beyond_cacheable_bound` equal to it, identical stores and identical per-turn `cached_tokens`.

Related to #3317, #3314 — this does not resolve the pinned-reuse regression reported there (which we could not reproduce at block_size 2048 with first-party checkpoints on either qwen3_5 or qwen4_exp), but it removes the wasted decode-capture work in the same path and makes the skip cause visible in the server log, which would have named the failure mode for those reports directly.

— Generated with Marshal · gate: READY · 5274c38 · tier: standard
verify bar: passed at 5274c38 — 1 check(s) + secrets scan, sha-keyed proof