### PR TITLE
fix(ane): clear the per-module state caches when releasing ANE banks

### DIFF
--- a/omlx/patches/qwen35_ane_prefill.py
+++ b/omlx/patches/qwen35_ane_prefill.py
@@ -3562,8 +3562,9 @@ def release_qwen35_ane_prefill(model: Any) -> tuple[int, int]:
     prefill needs back once the KV cache has grown into the guard's sizing
     target. Latches every sliced module through the existing per-module
     failure flags first (so the dispatch sites fall back to stock GPU compute
-    and never lazily recompile), then drops the state references; the native
-    models free their programs and mapped blobs when the last reference dies.
+    and never lazily recompile), then drops the state references and clears the
+    per-module state caches that hold the same objects; the native models free
+    their programs and mapped blobs when the last reference dies.
     Idempotent, and scoped to this engine instance: the next load of the
     model rebuilds the banks from its settings.
 
@@ -3587,6 +3588,17 @@ def release_qwen35_ane_prefill(model: Any) -> tuple[int, int]:
             setattr(module, failed_attr, True)
             setattr(module, state_attr, None)
             modules_released += 1
+        # _compile_pair and _compile_gdn cache their state per module, so
+        # dropping the attributes above frees nothing while those stay
+        # populated. Cleared unconditionally rather than alongside a live
+        # state: an entry left over from an earlier slice is exactly the
+        # mapped bank this call exists to hand back. No _COMPILE_LOCK needed
+        # -- compiles and this release both run on the engine's single-worker
+        # MLX executor, so they are already serialized.
+        for cache_attr in ("_omlx_ane_prefill_cache", "_omlx_ane_gdn_cache"):
+            cache = getattr(module, cache_attr, None)
+            if cache:
+                cache.clear()
     if modules_released:
         # Zero (not delete) the status counters and set the shed marker:
         # attempted=True/configured=False alone is indistinguishable from a

--- a/tests/test_qwen35_ane_prefill.py
+++ b/tests/test_qwen35_ane_prefill.py
@@ -3248,6 +3248,56 @@ def test_release_latches_modules_drops_states_and_zeroes_counters():
     assert status["resident_programs"] == 0
 
 
+def test_release_clears_the_state_cache_that_pins_the_same_states():
+    import gc
+    model = _ReleasableModel()
+    mlp_handle = _NativeHandle()
+    gdn_handle = _NativeHandle()
+    mlp_ref = weakref.ref(mlp_handle)
+    gdn_ref = weakref.ref(gdn_handle)
+    mlp_state = SimpleNamespace(model=mlp_handle)
+    gdn_state = SimpleNamespace(model=gdn_handle)
+    model.mlp._omlx_ane_prefill_state = mlp_state
+    # _compile_pair and _compile_gdn cache the state per module, so this is a
+    # second reference to everything the release drops.
+    model.mlp._omlx_ane_prefill_cache = {("mlp-key",): mlp_state}
+    model.gdn._omlx_ane_gdn_state = gdn_state
+    model.gdn._omlx_ane_gdn_cache = {("gdn-key",): gdn_state}
+
+    released, _ = ane_patch.release_qwen35_ane_prefill(model)
+    del mlp_state, gdn_state, mlp_handle, gdn_handle
+    gc.collect()
+
+    assert released == 2
+    # Asserted before the cache contents: left populated, the cache keeps the
+    # mapped bank alive and the release hands back nothing, and that is the
+    # failure worth reading when this regresses.
+    assert mlp_ref() is None
+    assert gdn_ref() is None
+    assert model.mlp._omlx_ane_prefill_cache == {}
+    assert model.gdn._omlx_ane_gdn_cache == {}
+
+
+def test_release_clears_a_stale_state_cache_entry():
+    import gc
+    model = _ReleasableModel()
+    handle = _NativeHandle()
+    ref = weakref.ref(handle)
+    # An entry can outlive its state attribute -- an earlier release, or a
+    # slice replaced at a different chunk width.
+    model.mlp._omlx_ane_prefill_cache = {("stale",): SimpleNamespace(model=handle)}
+
+    released, _ = ane_patch.release_qwen35_ane_prefill(model)
+    del handle
+    gc.collect()
+
+    # Nothing to latch, so nothing counts as released -- but the bank the entry
+    # pinned still has to be handed back.
+    assert released == 0
+    assert ref() is None
+    assert model.mlp._omlx_ane_prefill_cache == {}
+
+
 def test_release_is_idempotent_and_noop_without_slices():
     model = _ReleasableModel()
     assert ane_patch.release_qwen35_ane_prefill(model) == (0, 0)


### PR DESCRIPTION
`release_qwen35_ane_prefill` exists to hand back the compiled ANE procedure banks — the docstring puts them at roughly 13 GB for a 27B at mlp 0.35 / gdn 0.45 — once a long-context prefill needs that resident memory back for the KV cache. It latches every sliced module through the existing per-module failure flags, drops the state attributes, and relies on the native models freeing their programs and mapped blobs when the last reference dies.

`_compile_pair` and `_compile_gdn` also cache their state per module, in `_omlx_ane_prefill_cache` and `_omlx_ane_gdn_cache`. The release cleared neither, so a second reference always survived and nothing was freed. `engine_pool` brackets the call with `get_phys_footprint()` and a `gc.collect()` specifically to reclaim that memory, which made the release a no-op on the one path that exists to perform it.

The caches are cleared unconditionally rather than alongside a live state: an entry left over from an earlier slice is exactly the mapped bank the call is being asked to free, and a subsequent enable recompiles instead of reusing it. A module whose cache holds only such a leftover is not counted in `modules_released`, so the shed marker and counter reset stay tied to modules that were actually serving. No `_COMPILE_LOCK` is taken — compiles and this release both run on the engine's single-worker MLX executor (`engine_core.py`, `max_workers=1`), so a concurrent compile cannot observe the cache while it is being cleared.

Both new tests hold a weak reference to each native handle and assert it has been collected once the release returns. They fail without the change, on that assertion rather than on the cache contents:

```
>       assert mlp_ref() is None
E       AssertionError: assert <_NativeHandle object at 0x1086782f0> is None
```

Not addressed here: the caches are also unbounded, so an enable at a new chunk width or fraction leaves the previous entry behind. No current path reaches that, since those settings enter the engine runtime signature and changing one reloads the engine, taking the caches with it. Bounding the cache is a separate change.

## Validation

- Full fast suite on macOS 26.6.2 / Apple M1 Max, MLX 0.32.2, custom kernels built: 10,737 passed, 30 skipped, 6 failed. The six are pre-existing float-tolerance comparisons in `test_decode_fast_sdpa.py`, `test_glm_moe_dsa_patch.py` and `test_mlx_vlm_qwen4_exp_compat.py` — custom kernel comparisons in files this change does not touch, and a standing baseline on this machine rather than a regression.
- `ruff check` clean on both changed files under the project config.
