### PR TITLE
fix(vlm): claim mRoPE rope_deltas onto the request (#3345)

### DIFF
--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -45,7 +45,11 @@ from ..api.utils import (
 )
 from ..cache.vision_feature_cache import VisionFeatureSSDCache
 from ..exceptions import InvalidRequestError
-from ..models.vlm import VLMModelAdapter
+from ..models.vlm import (
+    VLMModelAdapter,
+    reset_lm_mrope_state,
+    rope_deltas_as_float,
+)
 from ..patches.mlx_vlm_pixtral_torch_free import apply_pixtral_torch_free_patch
 from ..reasoning_effort import apply_chat_template_with_reasoning_effort_fallback
 from ..utils.image import (
@@ -3236,6 +3240,10 @@ class VLMBatchedEngine(BaseEngine):
             # Run vision encoder + embedding merge.
             # Pass attention_mask as 'mask' — mlx-vlm models (e.g. Gemma 3)
             # expect it as a positional/keyword arg named 'mask'.
+            # Drop leftover MTP / prior-request mRoPE fields first so
+            # get_input_embeddings recomputes deltas for *this* prompt
+            # instead of tiling a stale (batch, 1) vector.
+            reset_lm_mrope_state(getattr(self._vlm_model, "language_model", None))
             try:
                 embed_features = self._vlm_model.get_input_embeddings(
                     input_ids, pixel_values, mask=attention_mask, **call_kwargs
@@ -3279,7 +3287,7 @@ class VLMBatchedEngine(BaseEngine):
                     extra_kwargs["position_ids"] = pid
                 rd = getattr(lm, "_rope_deltas", None)
                 if rd is not None:
-                    extra_kwargs["_captured_rope_deltas"] = rd
+                    extra_kwargs["_captured_rope_deltas"] = rope_deltas_as_float(rd)
 
             # Extract token IDs as list
             token_ids = (

--- a/omlx/models/vlm.py
+++ b/omlx/models/vlm.py
@@ -28,6 +28,53 @@ import mlx.nn as nn
 logger = logging.getLogger(__name__)
 
 
+def rope_deltas_as_float(rd: Any) -> float:
+    """Coerce language-model ``_rope_deltas`` to the per-request scalar.
+
+    ``Request.rope_deltas`` is a single float. Qwen mRoPE writes
+    ``(batch_size, 1)``, and Lightning MTP can leave that vector on the
+    shared language model. ``mx.array.item()`` only accepts size 1.
+    """
+    if rd is None:
+        return 0.0
+    if hasattr(rd, "reshape"):
+        flat = rd.reshape((-1,))
+        size = int(getattr(flat, "size", 0) or 0)
+        if size == 0:
+            return 0.0
+        first = flat[0]
+        return float(first.item()) if hasattr(first, "item") else float(first)
+    if hasattr(rd, "item"):
+        return float(rd.item())
+    return float(rd)
+
+
+def reset_lm_mrope_state(lm: Any) -> None:
+    """Drop leftover mRoPE fields so the next embed pass recomputes them."""
+    if lm is None:
+        return
+    lm._position_ids = None
+    lm._rope_deltas = None
+
+
+def claim_request_rope_deltas(request: Any) -> bool:
+    """Move ``_captured_rope_deltas`` onto ``request.rope_deltas``.
+
+    The snapshot used to live in ``vlm_extra_kwargs``, the same dict
+    prefill slices and the adapter forwards into the language model.
+    That bag is the wrong home for a per-request scalar: the key got
+    popped or seq-sliced, and the scheduler then re-read leftover
+    ``language_model._rope_deltas``. Lift the value once, as a float,
+    and take it out of the extras dict.
+    """
+    extra = getattr(request, "vlm_extra_kwargs", None)
+    if extra and "_captured_rope_deltas" in extra:
+        request.rope_deltas = rope_deltas_as_float(extra.pop("_captured_rope_deltas"))
+        request._rope_deltas_bound = True
+        return True
+    return bool(getattr(request, "_rope_deltas_bound", False))
+
+
 class VLMModelAdapter(nn.Module):
     """
     Adapter wrapping a VLM's language_model for BatchGenerator compatibility.
@@ -327,12 +374,7 @@ class VLMModelAdapter(nn.Module):
         Should be called after get_input_embeddings() which sets
         ``_rope_deltas`` on the language model.
         """
-        rd = getattr(self._language_model, "_rope_deltas", None)
-        if rd is None:
-            return 0.0
-        if hasattr(rd, "item"):
-            return float(rd.item())
-        return float(rd)
+        return rope_deltas_as_float(getattr(self._language_model, "_rope_deltas", None))
 
     @property
     def has_pending_embeddings(self) -> bool:
@@ -372,7 +414,10 @@ class VLMModelAdapter(nn.Module):
             if self.model_type == "qwen4_exp":
                 kwargs["skip_logits"] = True
         inputs_embeds = kwargs.pop("inputs_embeds", None)
-        vlm_extra = kwargs.pop("vlm_extra_kwargs", None) or {}
+        # Copy: the scheduler packs request.vlm_extra_kwargs into the
+        # forward. Popping the snapshot off that shared dict used to
+        # force the next schedule step to re-read leftover LM state.
+        vlm_extra = dict(kwargs.pop("vlm_extra_kwargs", None) or {})
         vlm_extra.pop("_captured_rope_deltas", None)
 
         if inputs_embeds is not None:

--- a/omlx/request.py
+++ b/omlx/request.py
@@ -174,7 +174,8 @@ class Request:
     vlm_cache_key_ranges: Optional[List[Tuple[int, str]]] = (
         None  # [(token_start, cumulative_image_hash)]
     )
-    rope_deltas: float = 0.0  # Per-request mRoPE position delta (set after VLM prefill)
+    rope_deltas: float = 0.0  # Per-request mRoPE position delta
+    _rope_deltas_bound: bool = False  # True once the embed snapshot is claimed
 
     @property
     def vlm_extra_keys_for_cache(self) -> Optional[Tuple[str, ...]]:

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -60,6 +60,7 @@ from .patches.sdpa256_attention import set_unfused_headroom_provider
 from .decode_activity import get_decode_activity
 from .prefill_progress import get_prefill_tracker
 from .prefill_transient_tracker import PrefillTransientTracker
+from .models.vlm import claim_request_rope_deltas
 from .request import Request, RequestOutput, RequestStatus, SamplingParams
 from .speculative.processing_sampler import (
     MTPProcessingSampler,
@@ -8324,6 +8325,10 @@ class Scheduler:
                 self._release_paged_cache_for_request(request.request_id)
                 raise
 
+        # Own the mRoPE scalar on the request before it enters the
+        # queue. Prefill must not see ``_captured_rope_deltas`` in extras.
+        claim_request_rope_deltas(request)
+
         # Add to tracking
         self.requests[request.request_id] = request
         self.waiting.append(request)
@@ -10090,6 +10095,7 @@ class Scheduler:
                 break
 
             request = self.waiting.popleft()
+            claim_request_rope_deltas(request)
             self._cache_freshness_waits.pop(request.request_id, None)
             self._clear_memory_admission_blocker(request.request_id)
             self._clear_store_cache_admission_blocker(request.request_id)
@@ -10616,20 +10622,17 @@ class Scheduler:
                 cache_to_use = prefilled_cache
                 tokens_to_process = last_token
 
-            # Capture per-request mRoPE rope_deltas for decode.
-            # Prefer _captured_rope_deltas from per-request extra_kwargs
-            # (set during get_input_embeddings), since the global
-            # _rope_deltas may be stale when explicit position_ids are used.
-            if request.vlm_inputs_embeds is not None:
-                extra = request.vlm_extra_kwargs or {}
-                captured = extra.get("_captured_rope_deltas")
-                if captured is not None:
-                    if hasattr(captured, "item"):
-                        request.rope_deltas = float(captured.item())
-                    else:
-                        request.rope_deltas = float(captured)
-                elif hasattr(self.model, "get_last_rope_deltas"):
-                    request.rope_deltas = self.model.get_last_rope_deltas()
+            # Decode uses request.rope_deltas, claimed at admit time.
+            # Only fall back to the live LM field when no embed snapshot
+            # was available. Never re-read extras here: prefill may have
+            # already mutated that dict.
+            if (
+                request.vlm_inputs_embeds is not None
+                and not request._rope_deltas_bound
+                and hasattr(self.model, "get_last_rope_deltas")
+            ):
+                request.rope_deltas = self.model.get_last_rope_deltas()
+                request._rope_deltas_bound = True
 
             # Build per-request state machine for stop tokens
             sm = self._build_state_machine(request)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -5887,6 +5887,41 @@ class TestVLMPositionStateClearing:
 
         model.clear_vlm_position_state.assert_not_called()
 
+    def test_schedule_waiting_coerces_multi_element_captured_rope_deltas(
+        self, mock_tokenizer
+    ):
+        """#3345: embed snapshot is claimed onto the request, not re-read later."""
+        model = self._make_vlm_model()
+        model.get_last_rope_deltas = MagicMock(return_value=99.0)
+        scheduler = Scheduler(model=model, tokenizer=mock_tokenizer)
+
+        mock_bg = MagicMock()
+        mock_bg.insert = MagicMock(return_value=[42])
+        scheduler.batch_generator = mock_bg
+
+        request = Request(
+            request_id="vlm-rope-3345",
+            prompt="describe this image",
+            sampling_params=SamplingParams(max_tokens=50),
+        )
+        request.prompt_token_ids = [1, 2, 3, 4, 5]
+        request.num_prompt_tokens = 5
+        request.vlm_inputs_embeds = mx.zeros((1, 5, 64))
+        request.vlm_extra_kwargs = {
+            "_captured_rope_deltas": mx.array([12.0, 24.0, 36.0]),
+        }
+
+        scheduler.add_request(request)
+
+        assert request.rope_deltas == 12.0
+        assert request._rope_deltas_bound is True
+        assert "_captured_rope_deltas" not in (request.vlm_extra_kwargs or {})
+
+        scheduler._schedule_waiting()
+
+        assert request.rope_deltas == 12.0
+        model.get_last_rope_deltas.assert_not_called()
+
     def test_schedule_waiting_clears_text_only_position_state(self, mock_tokenizer):
         """Text-only request in _schedule_waiting should clear position state.
 

--- a/tests/test_vlm_model_adapter.py
+++ b/tests/test_vlm_model_adapter.py
@@ -268,12 +268,17 @@ class TestVLMModelAdapter:
         embeds = MockMXArray(shape=(2, 10, 128))
         extra = {"position_ids": MockMXArray(shape=(2, 10))}
 
+        extra["_captured_rope_deltas"] = 12.0
         adapter(input_ids, cache=cache, inputs_embeds=embeds, vlm_extra_kwargs=extra)
 
         # Should call language_model with inputs_embeds and extra kwargs
         call_args = vlm.language_model.call_args
         assert call_args.kwargs.get("inputs_embeds") is embeds
         assert call_args.kwargs.get("position_ids") is extra["position_ids"]
+        assert "_captured_rope_deltas" not in call_args.kwargs
+        # Shared extras dict must keep the snapshot; popping it forced
+        # the scheduler to re-read leftover language-model state.
+        assert extra["_captured_rope_deltas"] == 12.0
         # _pending_embeds should NOT be set (batched path doesn't use it)
         assert adapter._pending_embeds is None
 
@@ -585,6 +590,52 @@ class TestPerRequestMRoPEDecode:
 
         vlm.language_model._rope_deltas = None
         assert adapter.get_last_rope_deltas() == 0.0
+
+    def test_get_last_rope_deltas_multi_element_array(self):
+        """Qwen MTP leaves (batch, 1) deltas; .item() used to kill the engine."""
+        import mlx.core as mx
+
+        from omlx.models.vlm import VLMModelAdapter, rope_deltas_as_float
+
+        vlm = self._make_mrope_vlm_model()
+        adapter = VLMModelAdapter(vlm)
+
+        vlm.language_model._rope_deltas = mx.array([10.0, 20.0])
+        assert adapter.get_last_rope_deltas() == 10.0
+
+        vlm.language_model._rope_deltas = mx.zeros((3, 1))
+        assert adapter.get_last_rope_deltas() == 0.0
+
+        vlm.language_model._rope_deltas = mx.array([[123]])
+        assert adapter.get_last_rope_deltas() == 123.0
+
+        assert rope_deltas_as_float(None) == 0.0
+        assert rope_deltas_as_float(-7.5) == -7.5
+        assert rope_deltas_as_float(mx.array(-42.0)) == -42.0
+
+    def test_claim_request_rope_deltas_leaves_extras_bag(self):
+        """The embed snapshot belongs on the request, not in vlm_extra_kwargs."""
+        import mlx.core as mx
+
+        from omlx.models.vlm import claim_request_rope_deltas
+        from omlx.request import Request, SamplingParams
+
+        request = Request(
+            request_id="claim-3345",
+            prompt="hi",
+            sampling_params=SamplingParams(max_tokens=8),
+        )
+        request.vlm_extra_kwargs = {
+            "position_ids": mx.zeros((1, 4)),
+            "_captured_rope_deltas": mx.array([12.0, 24.0]),
+        }
+
+        assert claim_request_rope_deltas(request) is True
+        assert request.rope_deltas == 12.0
+        assert request._rope_deltas_bound is True
+        assert "_captured_rope_deltas" not in request.vlm_extra_kwargs
+        assert "position_ids" in request.vlm_extra_kwargs
+        assert claim_request_rope_deltas(request) is True
 
     def test_mrope_scalar_offset_fallback_initializes_position_state(self):
         """Regression #2387: MiniCPM-o text-only prefill with scalar cache offsets.


### PR DESCRIPTION
## Summary

Fixes #3345. After a long Lightning MTP generate on Qwen3.8-Flash-Next, the next `/v1/chat/completions` turn killed the engine loop with `Only length-1 arrays can be converted to Python scalars`.

`_rope_deltas` lived on the shared language model. A copy also sat in `vlm_extra_kwargs`, the same dict prefill slices and the adapter forwards. That bag is the wrong home for a per-request scalar. The key got popped or seq-sliced, and the scheduler then called `.item()` on leftover LM state.

This PR owns a float on `Request.rope_deltas` at admit time, takes the snapshot out of extras, copies extras before the adapter pops, and resets leftover mRoPE fields before the next embed pass. Decode uses the request field. It only falls back to the live LM when no embed snapshot existed.

## Test plan

- [x] `rope_deltas_as_float` on scalar, `(3, 1)`, and `[10, 20]` (the old `.item()` throw)
- [x] `claim_request_rope_deltas` lifts the snapshot and leaves `position_ids` in extras
- [x] Adapter forward does not steal `_captured_rope_deltas` from the caller's dict
- [x] `Scheduler.add_request` + `_schedule_waiting` keep the claimed `12.0` and do not call `get_last_rope_deltas`
- [ ] Long Flash-Next MTP generate, then a one-word follow-up in the same process (the #3345 session)


Made with [Cursor](https://cursor.com)