### PR TITLE
fix(qwen4_exp): gather text mRoPE prefills and stop pricing them as dense SDPA (#3350)

### DIFF
--- a/omlx/admin/context_benchmark.py
+++ b/omlx/admin/context_benchmark.py
@@ -244,7 +244,7 @@ def _guard_ready(scheduler: Any) -> bool:
 def _make_fits(scheduler: Any) -> Callable[[int], bool]:
     def fits(n: int) -> bool:
         try:
-            scheduler.preflight_or_raise(num_prompt_tokens=n)
+            scheduler.preflight_or_raise(num_prompt_tokens=n, text_only=True)
         except PrefillMemoryExceededError:
             return False
         return True

--- a/omlx/engine/base.py
+++ b/omlx/engine/base.py
@@ -71,6 +71,7 @@ async def _run_scheduler_preflight_with_cleanup_retry(
     request_id: str | None,
     eviction_callback: Any | None,
     executor: Any | None = None,
+    text_only: bool = False,
 ) -> None:
     """Run route preflight after transient post-request cleanup settles.
 
@@ -91,11 +92,13 @@ async def _run_scheduler_preflight_with_cleanup_retry(
         eviction_request = scheduler.preflight_eviction_request(
             num_prompt_tokens=num_prompt_tokens,
             request_id=request_id,
+            text_only=text_only,
         )
         if eviction_request is None:
             scheduler.preflight_or_raise(
                 num_prompt_tokens=num_prompt_tokens,
                 request_id=request_id,
+                text_only=text_only,
             )
             return
 
@@ -150,6 +153,7 @@ async def _run_scheduler_preflight_with_cleanup_retry(
         scheduler.preflight_or_raise(
             num_prompt_tokens=num_prompt_tokens,
             request_id=request_id,
+            text_only=text_only,
         )
         return
 

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -97,6 +97,7 @@ class BatchedEngine(BaseEngine):
                 "_mlx_executor",
                 None,
             ),
+            text_only=True,
         )
 
     @property

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1454,6 +1454,7 @@ class VLMBatchedEngine(BaseEngine):
         *,
         num_prompt_tokens: int,
         request_id: str | None,
+        text_only: bool = False,
     ) -> None:
         await _run_scheduler_preflight_with_cleanup_retry(
             scheduler,
@@ -1465,6 +1466,7 @@ class VLMBatchedEngine(BaseEngine):
                 "_mlx_executor",
                 None,
             ),
+            text_only=text_only,
         )
 
     @property
@@ -3868,19 +3870,23 @@ class VLMBatchedEngine(BaseEngine):
             return
         # Count images from the ORIGINAL messages (the stripped
         # ``text_messages`` no longer has the image content-parts).
-        num_tokens += _count_image_tokens_real(
+        image_tokens = _count_image_tokens_real(
             messages,
             getattr(self, "_processor", None),
             upper_bound=_derive_image_token_upper_bound(
                 getattr(self, "_processor", None)
             ),
         )
+        num_tokens += image_tokens
         scheduler = getattr(getattr(self._engine, "engine", None), "scheduler", None)
         if scheduler is None:
             _warn_scheduler_unreachable_once(self, "preflight_chat")
             return
         await self._preflight_or_raise_with_eviction(
-            scheduler, num_prompt_tokens=num_tokens, request_id=request_id
+            scheduler,
+            num_prompt_tokens=num_tokens,
+            request_id=request_id,
+            text_only=image_tokens == 0,
         )
 
     async def preflight_completion(
@@ -3913,7 +3919,10 @@ class VLMBatchedEngine(BaseEngine):
             _warn_scheduler_unreachable_once(self, "preflight_completion")
             return
         await self._preflight_or_raise_with_eviction(
-            scheduler, num_prompt_tokens=num_tokens, request_id=request_id
+            scheduler,
+            num_prompt_tokens=num_tokens,
+            request_id=request_id,
+            text_only=True,
         )
 
     async def stream_chat(

--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -249,8 +249,8 @@ class MemoryMonitor:
         # Fixed per-sequence recurrent state (GDN/Mamba ArraysCache),
         # measured once from a live cache after the first prefill chunk.
         self._fixed_state_bytes: int = 0
-        # When True, Qwen4 QSA prefill is priced as gathered (token budget)
-        # rather than dense Q x kv_len. Set only for text-only prefills.
+        # Fallback for estimate_chunk_transient_bytes when the caller omits
+        # gathered_core=. Scheduler paths pass the argument explicitly.
         self.qwen4_charge_gathered_core: bool = False
 
         # PagedCacheManager for KV cache memory measurement
@@ -691,8 +691,11 @@ class MemoryMonitor:
         if num_tokens <= 0:
             return 0
         if self._prefill_memory_profile is not None:
-            return self._prefill_memory_profile.estimate_resident_kv_bytes(
-                num_tokens, chunk_tokens=chunk_tokens
+            return (
+                self._prefill_memory_profile.estimate_resident_kv_bytes(
+                    num_tokens, chunk_tokens=chunk_tokens
+                )
+                + self._fixed_state_bytes
             )
         total = self.estimate_prompt_kv_bytes(num_tokens)
 
@@ -840,7 +843,19 @@ class MemoryMonitor:
         kv = self.estimate_resident_kv_bytes(new_tokens, chunk_tokens=eff_chunk)
         return attn + kv + self._ane_prefill_transient_bytes
 
-    def estimate_chunk_transient_bytes(self, n_tokens: int, kv_len: int) -> int:
+    def is_qwen4_gathered_prefill_profile(self) -> bool:
+        """True when this monitor prices Qwen4 QSA gathered-core prefill."""
+        return isinstance(
+            self._prefill_memory_profile, _Qwen4ExpPrefillMemoryProfile
+        )
+
+    def estimate_chunk_transient_bytes(
+        self,
+        n_tokens: int,
+        kv_len: int,
+        *,
+        gathered_core: bool | None = None,
+    ) -> int:
         """Transient SDPA activation bytes for ONE prefill chunk.
 
         Isolates the per-chunk attention transient — the spike that drives
@@ -855,14 +870,20 @@ class MemoryMonitor:
         and scale with total ``kv_len``.
 
         Returns 0 when model info is unavailable.
+
+        ``gathered_core`` prices Qwen4 QSA as a gathered core instead of
+        dense Q×kv_len. Scheduler paths pass it explicitly. When omitted,
+        ``qwen4_charge_gathered_core`` is the fallback for older tests.
         """
+        if gathered_core is None:
+            gathered_core = bool(self.qwen4_charge_gathered_core)
         if self._prefill_memory_profile is not None:
             profile = self._prefill_memory_profile
             if isinstance(profile, _Qwen4ExpPrefillMemoryProfile):
                 return profile.estimate_prefill_transient_bytes(
                     n_tokens,
                     kv_len,
-                    gathered_core=self.qwen4_charge_gathered_core,
+                    gathered_core=bool(gathered_core),
                 )
             return profile.estimate_prefill_transient_bytes(n_tokens, kv_len)
         return self._estimate_sdpa_activation_bytes(n_tokens, kv_len)

--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -249,6 +249,9 @@ class MemoryMonitor:
         # Fixed per-sequence recurrent state (GDN/Mamba ArraysCache),
         # measured once from a live cache after the first prefill chunk.
         self._fixed_state_bytes: int = 0
+        # When True, Qwen4 QSA prefill is priced as gathered (token budget)
+        # rather than dense Q x kv_len. Set only for text-only prefills.
+        self.qwen4_charge_gathered_core: bool = False
 
         # PagedCacheManager for KV cache memory measurement
         self._paged_cache_manager: Optional["PagedCacheManager"] = None
@@ -854,9 +857,14 @@ class MemoryMonitor:
         Returns 0 when model info is unavailable.
         """
         if self._prefill_memory_profile is not None:
-            return self._prefill_memory_profile.estimate_prefill_transient_bytes(
-                n_tokens, kv_len
-            )
+            profile = self._prefill_memory_profile
+            if isinstance(profile, _Qwen4ExpPrefillMemoryProfile):
+                return profile.estimate_prefill_transient_bytes(
+                    n_tokens,
+                    kv_len,
+                    gathered_core=self.qwen4_charge_gathered_core,
+                )
+            return profile.estimate_prefill_transient_bytes(n_tokens, kv_len)
         return self._estimate_sdpa_activation_bytes(n_tokens, kv_len)
 
     def estimate_blocks_to_free(self, bytes_to_free: int, block_size: int) -> int:
@@ -1221,14 +1229,134 @@ class _DeepSeekV4PrefillMemoryProfile:
         return max(candidates, default=0)
 
 
+@dataclass(frozen=True)
+class _Qwen4ExpPrefillMemoryProfile:
+    """Prefill estimator for Qwen4 / Flash-Next hybrid GDN + QSA.
+
+    GDN layers keep a fixed recurrent state. QSA core attention, once the
+    gathered path is active, attends at most ``indexer_budget`` tokens.
+    The indexer still scores every compressed block (``kv_len / r``).
+    Dense ``Q x kv_len`` SDPA is the wrong price for that core.
+    """
+
+    qsa_layers: int
+    num_attention_heads: int
+    num_kv_heads: int
+    head_dim: int
+    indexer_n_heads: int
+    indexer_head_dim: int
+    indexer_budget: int
+    compress_ratio: int
+    dtype_size: float
+    score_dtype_size: float
+
+    def estimate_resident_kv_bytes(
+        self, num_tokens: int, *, chunk_tokens: int = 1
+    ) -> int:
+        if num_tokens <= 0 or self.qsa_layers <= 0:
+            return 0
+        per_layer = (
+            2 * self.num_kv_heads * self.head_dim * self.dtype_size
+            + self.indexer_head_dim * self.dtype_size
+            + 3 * 8
+        )
+        return int(self.qsa_layers * per_layer * int(num_tokens))
+
+    def estimate_prefill_transient_bytes(
+        self,
+        query_tokens: int,
+        kv_len: int,
+        *,
+        gathered_core: bool = False,
+    ) -> int:
+        if query_tokens <= 0 or kv_len <= 0:
+            return 0
+        query_tokens = int(query_tokens)
+        kv_len = int(kv_len)
+        pooled = max(kv_len // max(self.compress_ratio, 1), 1)
+        indexer = int(
+            self.indexer_n_heads * query_tokens * pooled * 4
+            + self.indexer_n_heads * query_tokens * self.indexer_head_dim * 4
+        )
+        core_kv = kv_len
+        if gathered_core and kv_len > self.indexer_budget:
+            core_kv = min(kv_len, self.indexer_budget + self.compress_ratio - 1)
+        core = estimate_unfused_sdpa_call_bytes(
+            self.num_attention_heads,
+            query_tokens,
+            core_kv,
+            self.head_dim,
+            self.score_dtype_size,
+        )
+        return indexer + core
+
+
+def _make_qwen4_exp_prefill_memory_profile(
+    config: Any,
+    *,
+    compute_dtype_size: float,
+) -> PrefillMemoryProfile | None:
+    num_layers = _cfg_get(config, "num_hidden_layers")
+    num_attention_heads = _cfg_get(config, "num_attention_heads")
+    num_kv_heads = _cfg_get(config, "num_key_value_heads")
+    head_dim = _cfg_get(config, "head_dim")
+    indexer_n_heads = _cfg_get(config, "indexer_n_heads")
+    indexer_head_dim = _cfg_get(config, "indexer_head_dim")
+    indexer_budget = _cfg_get(config, "indexer_budget")
+    compress_ratio = _cfg_get(config, "indexer_compress_ratio")
+    required = (
+        num_layers,
+        num_attention_heads,
+        num_kv_heads,
+        head_dim,
+        indexer_n_heads,
+        indexer_head_dim,
+        indexer_budget,
+        compress_ratio,
+    )
+    if not all(_pos_int(value) for value in required):
+        return None
+    if not isinstance(compute_dtype_size, (int, float)) or compute_dtype_size <= 0:
+        return None
+    layer_types = _cfg_get(config, "layer_types") or ()
+    qsa_layers = sum(
+        1
+        for kind in layer_types
+        if kind in {"qwen_sparse_attention", "full_attention"}
+    )
+    if qsa_layers <= 0:
+        interval = _cfg_get(config, "full_attention_interval") or 4
+        if not _pos_int(interval):
+            return None
+        qsa_layers = int(num_layers) // int(interval)
+    if qsa_layers <= 0:
+        return None
+    return _Qwen4ExpPrefillMemoryProfile(
+        qsa_layers=qsa_layers,
+        num_attention_heads=int(num_attention_heads),
+        num_kv_heads=int(num_kv_heads),
+        head_dim=int(head_dim),
+        indexer_n_heads=int(indexer_n_heads),
+        indexer_head_dim=int(indexer_head_dim),
+        indexer_budget=int(indexer_budget),
+        compress_ratio=int(compress_ratio),
+        dtype_size=float(compute_dtype_size),
+        score_dtype_size=float(compute_dtype_size),
+    )
+
+
 def make_prefill_memory_profile(
     config: Any,
     *,
     compute_dtype_size: float,
     wsdpa_dtype_supported: bool = False,
 ) -> PrefillMemoryProfile | None:
-    """Build the one model-specific prefill strategy currently required."""
+    """Build a model-specific prefill strategy when the uniform formulas fail."""
     model_type = str(_cfg_get(config, "model_type", "") or "")
+    if model_type.startswith("qwen4_exp"):
+        return _make_qwen4_exp_prefill_memory_profile(
+            config, compute_dtype_size=compute_dtype_size
+        )
     if not model_type.startswith("deepseek_v4"):
         return None
 

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -1210,7 +1210,12 @@ class Qwen4ExpAttention(Qwen3_5Attention):
         position_embeddings: Optional[tuple[mx.array, mx.array]],
         target_verify: bool,
     ) -> bool:
-        """Fail closed outside scalar-offset batch-one text decode."""
+        """Fail closed outside scalar-offset batch-one text decode.
+
+        Prefill may accept broadcast-identical 3-D text mRoPE. Decode keeps
+        the 2-D / absent predicate until that arm has its own numerical
+        parity coverage.
+        """
 
         causal_mask = mask is None or (isinstance(mask, str) and mask == "causal")
         if not (
@@ -1221,7 +1226,13 @@ class Qwen4ExpAttention(Qwen3_5Attention):
             and isinstance(cache.offset, int)
             and position_embeddings is None
             and not target_verify
-            and self._batch_one_text_position_ids(position_ids, 1)
+            and (
+                position_ids is None
+                or (
+                    position_ids.ndim == 2
+                    and tuple(position_ids.shape) == (1, 1)
+                )
+            )
         ):
             return False
 

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import math
 import mmap
 import os
@@ -37,6 +38,83 @@ from .qsa_fast import (
 _PLE_RUNTIME_MODEL_PATH: Path | None = None
 _PLE_RUNTIME_MODE = "resident"
 _HYPER_SPLIT_INDICES: dict[tuple[int, int], tuple[mx.array, mx.array]] = {}
+_TEXT_MROPE_EQUAL_PLANES: dict[int, tuple[int, bool]] = {}
+_LAST_QSA_PATH_LOG: tuple[Any, ...] | None = None
+logger = logging.getLogger("omlx.qwen4_qsa")
+
+
+def _broadcast_text_mrope_position_ids(
+    position_ids: Optional[mx.array],
+    length: int,
+) -> bool:
+    """True for missing/2-D text ids, or 3-D MRoPE that is a text broadcast.
+
+    Parent LanguageModel tiles identical ``(1, L)`` positions to ``(3, 1, L)``
+    for text-only mRoPE. Real image grids differ across the three planes and
+    must stay on the official mask+SDPA path.
+    """
+    if position_ids is None:
+        return True
+    if not isinstance(position_ids, mx.array):
+        return False
+    if position_ids.ndim == 2:
+        return tuple(position_ids.shape) == (1, length)
+    if position_ids.ndim != 3 or tuple(position_ids.shape) != (3, 1, length):
+        return False
+    cache_key = id(position_ids)
+    cached = _TEXT_MROPE_EQUAL_PLANES.get(cache_key)
+    if cached is not None and cached[0] == length:
+        return cached[1]
+    same = bool(
+        mx.array_equal(position_ids[0], position_ids[1]).item()
+        and mx.array_equal(position_ids[1], position_ids[2]).item()
+    )
+    if len(_TEXT_MROPE_EQUAL_PLANES) >= 8:
+        _TEXT_MROPE_EQUAL_PLANES.clear()
+    _TEXT_MROPE_EQUAL_PLANES[cache_key] = (length, same)
+    return same
+
+
+def _split_text_mrope_positions(
+    position_ids: Optional[mx.array],
+    batch: int,
+    length: int,
+    past_len: int,
+) -> tuple[mx.array, mx.array]:
+    """Indexer text ids vs rotary ids for the gathered QSA arms."""
+    if position_ids is None:
+        text_position_ids = mx.arange(
+            past_len, past_len + length, dtype=mx.int32
+        )[None]
+        rotary_position_ids = mx.broadcast_to(
+            text_position_ids,
+            (3, batch, length),
+        )
+        return text_position_ids, rotary_position_ids
+    if position_ids.ndim == 3:
+        return position_ids[0], position_ids
+    return position_ids, position_ids
+
+
+def _log_qsa_prefill_path(
+    path: str,
+    *,
+    kv_len: int,
+    query: int,
+    position_ndim: int | None,
+) -> None:
+    global _LAST_QSA_PATH_LOG
+    key = (path, kv_len, query, position_ndim)
+    if key == _LAST_QSA_PATH_LOG:
+        return
+    _LAST_QSA_PATH_LOG = key
+    logger.info(
+        "qwen4 QSA prefill path=%s query=%d kv_len=%d position_ids.ndim=%s",
+        path,
+        query,
+        kv_len,
+        position_ndim,
+    )
 
 
 @dataclass(frozen=True)
@@ -1030,13 +1108,9 @@ class Qwen4ExpAttention(Qwen3_5Attention):
         position_ids: Optional[mx.array],
         length: int,
     ) -> bool:
-        """Accept absent or shape-matched 2-D text positions, never MRoPE."""
+        """Accept absent, 2-D text, or broadcast-identical 3-D text mRoPE."""
 
-        return position_ids is None or bool(
-            isinstance(position_ids, mx.array)
-            and position_ids.ndim == 2
-            and position_ids.shape == (1, length)
-        )
+        return _broadcast_text_mrope_position_ids(position_ids, length)
 
     def _gathered_text_prefill_eligible(
         self,
@@ -1137,17 +1211,9 @@ class Qwen4ExpAttention(Qwen3_5Attention):
         ).transpose(0, 2, 1, 3)
 
         past_len = cache.offset
-        if position_ids is None:
-            text_position_ids = mx.arange(
-                past_len, past_len + length, dtype=mx.int32
-            )[None]
-            rotary_position_ids = mx.broadcast_to(
-                text_position_ids,
-                (3, batch, length),
-            )
-        else:
-            text_position_ids = position_ids
-            rotary_position_ids = position_ids
+        text_position_ids, rotary_position_ids = _split_text_mrope_positions(
+            position_ids, batch, length, past_len
+        )
         queries, keys = self.rotary_emb.apply_rotary(
             queries,
             keys,
@@ -1238,19 +1304,9 @@ class Qwen4ExpAttention(Qwen3_5Attention):
         ).transpose(0, 2, 1, 3)
 
         past_len = cache.offset
-        if position_ids is None:
-            text_position_ids = mx.arange(
-                past_len,
-                past_len + 1,
-                dtype=mx.int32,
-            )[None]
-            rotary_position_ids = mx.broadcast_to(
-                text_position_ids,
-                (3, batch, length),
-            )
-        else:
-            text_position_ids = position_ids
-            rotary_position_ids = position_ids
+        text_position_ids, rotary_position_ids = _split_text_mrope_positions(
+            position_ids, batch, length, past_len
+        )
         queries, new_keys = self.rotary_emb.apply_rotary(
             queries,
             new_keys,
@@ -1306,6 +1362,11 @@ class Qwen4ExpAttention(Qwen3_5Attention):
         position_embeddings: Optional[tuple[mx.array, mx.array]] = None,
         target_verify: bool = False,
     ) -> mx.array:
+        query = int(x.shape[1]) if x.ndim == 3 else 0
+        kv_len = int(getattr(cache, "offset", 0) or 0) + query
+        position_ndim = (
+            int(position_ids.ndim) if isinstance(position_ids, mx.array) else None
+        )
         if self._gathered_text_decode_eligible(
             x,
             mask,
@@ -1324,8 +1385,21 @@ class Qwen4ExpAttention(Qwen3_5Attention):
             position_embeddings,
             target_verify,
         ):
+            _log_qsa_prefill_path(
+                "gathered",
+                kv_len=kv_len,
+                query=query,
+                position_ndim=position_ndim,
+            )
             return self._gathered_text_prefill(x, cache, position_ids)
 
+        if query > 1:
+            _log_qsa_prefill_path(
+                "mask_dense",
+                kv_len=kv_len,
+                query=query,
+                position_ndim=position_ndim,
+            )
         qsa_mask = self.indexer(
             x,
             cache,

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -38,7 +38,8 @@ from .qsa_fast import (
 _PLE_RUNTIME_MODEL_PATH: Path | None = None
 _PLE_RUNTIME_MODE = "resident"
 _HYPER_SPLIT_INDICES: dict[tuple[int, int], tuple[mx.array, mx.array]] = {}
-_TEXT_MROPE_EQUAL_PLANES: dict[int, tuple[int, bool]] = {}
+# Identity cache: keep the array alive so CPython cannot recycle id().
+_TEXT_MROPE_EQUAL_PLANES: list[tuple[Any, int, bool]] = []
 _LAST_QSA_PATH_LOG: tuple[Any, ...] | None = None
 logger = logging.getLogger("omlx.qwen4_qsa")
 
@@ -61,17 +62,16 @@ def _broadcast_text_mrope_position_ids(
         return tuple(position_ids.shape) == (1, length)
     if position_ids.ndim != 3 or tuple(position_ids.shape) != (3, 1, length):
         return False
-    cache_key = id(position_ids)
-    cached = _TEXT_MROPE_EQUAL_PLANES.get(cache_key)
-    if cached is not None and cached[0] == length:
-        return cached[1]
+    for cached_ids, cached_len, cached_same in _TEXT_MROPE_EQUAL_PLANES:
+        if cached_ids is position_ids and cached_len == length:
+            return cached_same
     same = bool(
         mx.array_equal(position_ids[0], position_ids[1]).item()
         and mx.array_equal(position_ids[1], position_ids[2]).item()
     )
-    if len(_TEXT_MROPE_EQUAL_PLANES) >= 8:
-        _TEXT_MROPE_EQUAL_PLANES.clear()
-    _TEXT_MROPE_EQUAL_PLANES[cache_key] = (length, same)
+    _TEXT_MROPE_EQUAL_PLANES.append((position_ids, length, same))
+    if len(_TEXT_MROPE_EQUAL_PLANES) > 8:
+        del _TEXT_MROPE_EQUAL_PLANES[:-8]
     return same
 
 

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -117,6 +117,62 @@ def _log_qsa_prefill_path(
     )
 
 
+def _python_cache_offset(offset: Any) -> int:
+    """Scalar KV length for logging. Batched offsets use the longest row.
+
+    ``BatchQSAKVCache.offset`` is an ``mx.array`` of per-row lengths. ``int()``
+    on that array raises ``[convert] Only length-1 arrays...`` and used to
+    abort the engine before eligibility could fail closed onto the official
+    path. Logging still wants one number; the longest row is the conservative
+    choice for ``kv_len``.
+    """
+    if offset is None:
+        return 0
+    if isinstance(offset, (int, np.integer)):
+        return int(offset)
+    shape = getattr(offset, "shape", None)
+    if shape is None:
+        try:
+            return int(offset)
+        except (TypeError, ValueError):
+            return 0
+    size = 1
+    for dim in shape:
+        size *= int(dim)
+    if size <= 1:
+        value = offset.reshape(-1)[0] if size == 1 else offset
+        return int(value.item()) if hasattr(value, "item") else int(value)
+    return int(mx.max(offset).item())
+
+
+def _promote_index_positions_to_3d(positions: mx.array, planes: int) -> mx.array:
+    if positions.ndim == 3:
+        if int(positions.shape[0]) != planes:
+            raise ValueError(
+                "QSA indexer mRoPE plane count mismatch during cache extend: "
+                f"{tuple(int(d) for d in positions.shape)} vs planes={planes}"
+            )
+        return positions
+    return mx.broadcast_to(positions[None], (planes, *positions.shape))
+
+
+def _unify_index_position_list(
+    positions: list[mx.array],
+) -> list[mx.array]:
+    """Promote 2-D text indexer positions to 3-D mRoPE so batch concat matches.
+
+    Gathered QSA stores the text plane as ``(B, S)``. The official mask_dense
+    path stores full mRoPE as ``(3, B, S)``. MTP late-join ``extend`` used to
+    concatenate those ranks and raise ``[concatenate] ... dimensions 3 and 2``.
+    """
+    if len(positions) < 2:
+        return positions
+    if all(item.ndim == positions[0].ndim for item in positions):
+        return positions
+    planes = next((int(item.shape[0]) for item in positions if item.ndim == 3), 3)
+    return [_promote_index_positions_to_3d(item, planes) for item in positions]
+
+
 @dataclass(frozen=True)
 class Qwen4ExpMTPRuntime:
     """Lightning MTP construction decision for the next model load."""
@@ -700,10 +756,11 @@ class BatchQSAKVCache:
         target = max(self.index_offset, other.index_offset)
         left = self._pad_index(self, target, sample_keys, sample_positions)
         right = self._pad_index(other, target, sample_keys, sample_positions)
+        left_pos, right_pos = _unify_index_position_list([left[1], right[1]])
         self.index_keys = mx.concatenate([left[0], right[0]], axis=0)
-        position_axis = 1 if sample_positions.ndim == 3 else 0
+        position_axis = 1 if left_pos.ndim == 3 else 0
         self.index_position_ids = mx.concatenate(
-            [left[1], right[1]], axis=position_axis
+            [left_pos, right_pos], axis=position_axis
         )
         self.index_offset = target
 
@@ -754,9 +811,10 @@ class BatchQSAKVCache:
             for cache in caches
         ]
         out.index_keys = mx.concatenate([row[0] for row in rows], axis=0)
-        position_axis = 1 if sample.index_position_ids.ndim == 3 else 0
+        unified_positions = _unify_index_position_list([row[1] for row in rows])
+        position_axis = 1 if unified_positions[0].ndim == 3 else 0
         out.index_position_ids = mx.concatenate(
-            [row[1] for row in rows], axis=position_axis
+            unified_positions, axis=position_axis
         )
         out.index_offset = target
         return out
@@ -1363,7 +1421,7 @@ class Qwen4ExpAttention(Qwen3_5Attention):
         target_verify: bool = False,
     ) -> mx.array:
         query = int(x.shape[1]) if x.ndim == 3 else 0
-        kv_len = int(getattr(cache, "offset", 0) or 0) + query
+        kv_len = _python_cache_offset(getattr(cache, "offset", 0)) + query
         position_ndim = (
             int(position_ids.ndim) if isinstance(position_ids, mx.array) else None
         )

--- a/omlx/prefill_transient_tracker.py
+++ b/omlx/prefill_transient_tracker.py
@@ -61,6 +61,11 @@ class PrefillTransientTracker:
         # need to allocate that pool again on the next chunk, so the scheduler
         # prices it once until a positive measurement confirms reallocation.
         self._recent_reclaim_bytes: int = 0
+        # True if the last recorded chunk was priced as gathered QSA core.
+        # None means no tagged sample yet. Used so leftover *dense* history
+        # can be ignored on a gathered Qwen4 chunk without discarding a
+        # spike measured on this same gathered request.
+        self._last_sample_gathered: bool | None = None
 
     def record_reclaim(self, reclaimed_bytes: int) -> None:
         """Accumulate footprint released since the last positive sample."""
@@ -78,7 +83,12 @@ class PrefillTransientTracker:
         self._recent_reclaim_bytes = 0
 
     def update(
-        self, n_tokens: int, transient_bytes: int, *, floor_sample: bool = False
+        self,
+        n_tokens: int,
+        transient_bytes: int,
+        *,
+        floor_sample: bool = False,
+        gathered_core: bool | None = None,
     ) -> None:
         """Record one chunk observation.
 
@@ -150,6 +160,8 @@ class PrefillTransientTracker:
         self._samples += 1
         self._last_delta_bytes = transient_bytes
         self._last_n_tokens = n_tokens
+        if gathered_core is not None:
+            self._last_sample_gathered = bool(gathered_core)
 
     def predict(self, n_tokens: int, *, safety_factor: float = 1.2) -> int:
         """Predicted transient bytes for a chunk of `n_tokens`.
@@ -191,6 +203,11 @@ class PrefillTransientTracker:
         """Footprint released since the last positive chunk measurement."""
         return self._recent_reclaim_bytes
 
+    @property
+    def last_sample_gathered(self) -> bool | None:
+        """Whether the last tagged sample was a gathered QSA core charge."""
+        return self._last_sample_gathered
+
     def reset(self) -> None:
         """Drop all observations (e.g. on model reload or after a long idle)."""
         self._ewma_per_token = 0.0
@@ -199,3 +216,4 @@ class PrefillTransientTracker:
         self._last_n_tokens = 0
         self._observed_max_bytes = 0
         self._recent_reclaim_bytes = 0
+        self._last_sample_gathered = None

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -3399,7 +3399,33 @@ class Scheduler:
                 f"cache layers to {bits}-bit{skip_msg}"
             )
 
+    @contextmanager
+    def _qwen4_gathered_core_charge(self, enabled: bool):
+        """Price Qwen4 QSA core as gathered for text-only prefills only."""
+        monitor = self.memory_monitor
+        if monitor is None:
+            yield
+            return
+        previous = bool(getattr(monitor, "qwen4_charge_gathered_core", False))
+        monitor.qwen4_charge_gathered_core = bool(enabled)
+        try:
+            yield
+        finally:
+            monitor.qwen4_charge_gathered_core = previous
+
     def _do_external_prefill(
+        self,
+        request: "Request",
+        tokens: list[int],
+        existing_cache: list[Any] | None,
+        vlm_embeds: tuple[mx.array, dict[str, Any], int] | None = None,
+    ) -> tuple[list[Any], list[int]]:
+        with self._qwen4_gathered_core_charge(vlm_embeds is None):
+            return self._do_external_prefill_impl(
+                request, tokens, existing_cache, vlm_embeds
+            )
+
+    def _do_external_prefill_impl(
         self,
         request: "Request",
         tokens: list[int],
@@ -3872,21 +3898,43 @@ class Scheduler:
         static_per_token = 0.0
         recent_reclaim = 0
         tracker = self._prefill_transient_tracker
-        if tracker is not None:
-            if tracker.last_n_tokens > 0 and tracker.last_delta_bytes > 0:
-                per_token = max(
-                    per_token, tracker.last_delta_bytes / tracker.last_n_tokens
-                )
-            if tracker.bytes_per_token > 0:
-                per_token = max(per_token, tracker.bytes_per_token)
-            recent_reclaim = tracker.recent_reclaim_bytes
+        # Gathered QSA prices a ~2K core, not Q×kv_len. A leftover dense
+        # last_delta/EWMA would still refuse that cheap chunk. Only ignore
+        # history while that cheaper charge is active — other models must
+        # keep max(last_delta, EWMA, static) or a real dense spike undercharges.
+        # `is True` so a MagicMock monitor in tests cannot trip this gate.
+        ignore_dense_history = (
+            getattr(self.memory_monitor, "qwen4_charge_gathered_core", False)
+            is True
+        )
         if self.memory_monitor is not None:
             static = self.memory_monitor.estimate_chunk_transient_bytes(
                 n_tokens, kv_len + n_tokens
             )
             static += self.memory_monitor.estimate_prompt_kv_bytes(n_tokens)
             static_per_token = float(static) / n_tokens
-            per_token = max(per_token, static_per_token)
+            per_token = static_per_token
+        if tracker is not None:
+            ewma = float(tracker.bytes_per_token)
+            recent_reclaim = tracker.recent_reclaim_bytes
+            outlier_ratio = PrefillTransientTracker._EWMA_OUTLIER_RATIO
+            dense_history_is_stale = (
+                ignore_dense_history
+                and static_per_token > 0
+                and ewma > static_per_token * outlier_ratio
+            )
+            if ewma > 0 and not dense_history_is_stale:
+                per_token = max(per_token, ewma)
+            if tracker.last_n_tokens > 0 and tracker.last_delta_bytes > 0:
+                measured = tracker.last_delta_bytes / tracker.last_n_tokens
+                if (
+                    ignore_dense_history
+                    and static_per_token > 0
+                    and measured > static_per_token * outlier_ratio
+                ):
+                    measured = 0.0
+                if measured > 0:
+                    per_token = max(per_token, measured)
         base_prediction = per_token * n_tokens * self._PREFILL_TRANSIENT_SAFETY
         reallocation_prediction = (
             static_per_token * n_tokens * self._PREFILL_TRANSIENT_SAFETY

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -3399,19 +3399,18 @@ class Scheduler:
                 f"cache layers to {bits}-bit{skip_msg}"
             )
 
-    @contextmanager
-    def _qwen4_gathered_core_charge(self, enabled: bool):
-        """Price Qwen4 QSA core as gathered for text-only prefills only."""
-        monitor = self.memory_monitor
-        if monitor is None:
-            yield
-            return
-        previous = bool(getattr(monitor, "qwen4_charge_gathered_core", False))
-        monitor.qwen4_charge_gathered_core = bool(enabled)
-        try:
-            yield
-        finally:
-            monitor.qwen4_charge_gathered_core = previous
+    def _qwen4_text_gathered_pricing(self, text_only: bool) -> bool:
+        """True when this engine can price Qwen4 text prefill as gathered QSA.
+
+        Callers that do not know whether the request is text-only must pass
+        False. Preflight and prefill then share an argument instead of a
+        mutable flag on the shared monitor.
+        """
+        if text_only is not True:
+            return False
+        monitor = getattr(self, "memory_monitor", None)
+        checker = getattr(monitor, "is_qwen4_gathered_prefill_profile", None)
+        return callable(checker) and checker() is True
 
     def _do_external_prefill(
         self,
@@ -3420,10 +3419,9 @@ class Scheduler:
         existing_cache: list[Any] | None,
         vlm_embeds: tuple[mx.array, dict[str, Any], int] | None = None,
     ) -> tuple[list[Any], list[int]]:
-        with self._qwen4_gathered_core_charge(vlm_embeds is None):
-            return self._do_external_prefill_impl(
-                request, tokens, existing_cache, vlm_embeds
-            )
+        return self._do_external_prefill_impl(
+            request, tokens, existing_cache, vlm_embeds
+        )
 
     def _do_external_prefill_impl(
         self,
@@ -3454,6 +3452,7 @@ class Scheduler:
             RuntimeError: If memory limit exceeded during prefill.
         """
         n_tokens = len(tokens)
+        gathered_core = self._qwen4_text_gathered_pricing(vlm_embeds is None)
         if n_tokens <= 1:
             # Nothing to prefill, return cache + tokens as-is.
             cache = existing_cache or make_prompt_cache(self.model)
@@ -3591,6 +3590,7 @@ class Scheduler:
                 request_id=request.request_id,
                 loop_label="external",
                 kv_len=base_size + processed_tokens,
+                gathered_core=gathered_core,
             )
 
             # Pre-chunk safety guard: NEVER submit a chunk whose predicted peak
@@ -3605,6 +3605,7 @@ class Scheduler:
                 progress=processed_tokens,
                 loop_label="external",
                 request_id=request.request_id,
+                gathered_core=gathered_core,
             )
             if getattr(request, "benchmark_trace", False):
                 request.benchmark_prefill_chunks.append(int(n_to_process))
@@ -3653,6 +3654,7 @@ class Scheduler:
                 loop_label="external",
                 kv_len=base_size + processed_tokens,
                 requested_step=prefill_step_size,
+                gathered_core=gathered_core,
             )
             self._maybe_record_fixed_state_bytes(prompt_cache)
             # Enforcer-requested hard-pressure drain. The flag's normal
@@ -3877,7 +3879,24 @@ class Scheduler:
     _MEMORY_ADMISSION_STALL_TIMEOUT_S: float = 60.0
     _STORE_CACHE_ADMISSION_STALL_TIMEOUT_S: float = 60.0
 
-    def _predicted_chunk_transient(self, n_tokens: int, kv_len: int) -> float:
+    def _estimate_chunk_transient_bytes(
+        self, n_tokens: int, kv_len: int, *, gathered_core: bool
+    ) -> int:
+        """Call the monitor with an explicit gathered_core flag.
+
+        Test doubles often still take ``(n_tokens, kv_len)`` only.
+        """
+        estimate = self.memory_monitor.estimate_chunk_transient_bytes
+        try:
+            return int(
+                estimate(n_tokens, kv_len, gathered_core=gathered_core)
+            )
+        except TypeError:
+            return int(estimate(n_tokens, kv_len))
+
+    def _predicted_chunk_transient(
+        self, n_tokens: int, kv_len: int, *, gathered_core: bool = False
+    ) -> float:
         """Conservative predicted Metal peak growth for one prefill chunk.
 
         The per-chunk SDPA/MoE transient scales with ``query_len * kv_len``, so
@@ -3899,17 +3918,19 @@ class Scheduler:
         recent_reclaim = 0
         tracker = self._prefill_transient_tracker
         # Gathered QSA prices a ~2K core, not Q×kv_len. A leftover dense
-        # last_delta/EWMA would still refuse that cheap chunk. Only ignore
-        # history while that cheaper charge is active — other models must
-        # keep max(last_delta, EWMA, static) or a real dense spike undercharges.
-        # `is True` so a MagicMock monitor in tests cannot trip this gate.
+        # last_delta/EWMA would still refuse that cheap chunk. Ignore that
+        # leftover only when this chunk is priced gathered AND the last
+        # recorded sample was not itself gathered (a gathered spike on this
+        # request must still bind). `is True` so a MagicMock cannot trip it.
+        last_gathered = getattr(
+            self._prefill_transient_tracker, "last_sample_gathered", None
+        )
         ignore_dense_history = (
-            getattr(self.memory_monitor, "qwen4_charge_gathered_core", False)
-            is True
+            gathered_core is True and last_gathered is not True
         )
         if self.memory_monitor is not None:
-            static = self.memory_monitor.estimate_chunk_transient_bytes(
-                n_tokens, kv_len + n_tokens
+            static = self._estimate_chunk_transient_bytes(
+                n_tokens, kv_len + n_tokens, gathered_core=gathered_core
             )
             static += self.memory_monitor.estimate_prompt_kv_bytes(n_tokens)
             static_per_token = float(static) / n_tokens
@@ -3942,7 +3963,9 @@ class Scheduler:
         )
         return max(base_prediction, reallocation_prediction)
 
-    def _admission_transient_bound(self, n_tokens: int, kv_len: int) -> float:
+    def _admission_transient_bound(
+        self, n_tokens: int, kv_len: int, *, gathered_core: bool = False
+    ) -> float:
         """Transient charge for admission and the guard's pass/abort gates.
 
         The largest FLOOR-SIZE chunk transient observed this session is a
@@ -3962,7 +3985,9 @@ class Scheduler:
         shrink arithmetic stay on ``_predicted_chunk_transient``; a flat
         size-invariant bound would zero out their proportional response.
         """
-        bound = self._predicted_chunk_transient(n_tokens, kv_len)
+        bound = self._predicted_chunk_transient(
+            n_tokens, kv_len, gathered_core=gathered_core
+        )
         tracker = self._prefill_transient_tracker
         if tracker is not None:
             bound = max(bound, float(tracker.observed_max_bytes))
@@ -4102,6 +4127,7 @@ class Scheduler:
         progress: int,
         loop_label: str,
         request_id: str | None = None,
+        gathered_core: bool = False,
     ) -> int:
         """Clamp/abort a prefill chunk so its predicted peak can never reach
         the physical Metal cap (the uncatchable async OOM crash).
@@ -4124,12 +4150,16 @@ class Scheduler:
         else:
             min_chunk = max(1, self._prefill_min_chunk_tokens)
         current = self._current_usage_bytes()
-        if current + self._admission_transient_bound(n_tokens, kv_len) <= cap:
+        if current + self._admission_transient_bound(
+            n_tokens, kv_len, gathered_core=gathered_core
+        ) <= cap:
             return n_tokens
 
         # Predicted to breach — reclaim transients and re-measure once.
         current = self._reclaim_prefill_headroom()
-        min_transient = self._admission_transient_bound(min_chunk, kv_len)
+        min_transient = self._admission_transient_bound(
+            min_chunk, kv_len, gathered_core=gathered_core
+        )
         if current + min_transient > cap:
             maybe_raise_eviction = getattr(
                 self, "_raise_prefill_eviction_if_available", None
@@ -4210,7 +4240,9 @@ class Scheduler:
             )
 
         # The floor fits — pick the largest chunk that still fits under the cap.
-        per_token = self._predicted_chunk_transient(n_tokens, kv_len) / n_tokens
+        per_token = self._predicted_chunk_transient(
+            n_tokens, kv_len, gathered_core=gathered_core
+        ) / n_tokens
         safe_n = int((cap - current) / per_token) if per_token > 0 else n_tokens
         n_fit = max(min_chunk, min(n_tokens, safe_n))
         # Same quantization as the adaptive throttle: an off-grid size here
@@ -4265,6 +4297,7 @@ class Scheduler:
         request_id: str,
         loop_label: str,
         kv_len: int = 0,
+        gathered_core: bool = False,
     ) -> int:
         """Size the next prefill chunk so its predicted peak stays under a
         safety margin below the hard cap.
@@ -4321,7 +4354,9 @@ class Scheduler:
         # safety) — see _predicted_chunk_transient. Anchored on the most recent
         # measurement so it tracks growth with kv_len instead of lagging behind
         # a long-run average.
-        per_token = self._predicted_chunk_transient(requested, kv_len) / requested
+        per_token = self._predicted_chunk_transient(
+            requested, kv_len, gathered_core=gathered_core
+        ) / requested
         predictor = "measured" if per_token > 0 else "none"
 
         # Keep each chunk's predicted peak under the LOWER of the dynamic
@@ -4696,6 +4731,7 @@ class Scheduler:
         loop_label: str,
         kv_len: int = 0,
         requested_step: int | None = None,
+        gathered_core: bool = False,
     ) -> None:
         """Feed one chunk's measured transient into the EWMA tracker.
 
@@ -4770,7 +4806,10 @@ class Scheduler:
             )
             return
         self._prefill_transient_tracker.update(
-            n_tokens, delta, floor_sample=n_tokens <= min_chunk
+            n_tokens,
+            delta,
+            floor_sample=n_tokens <= min_chunk,
+            gathered_core=gathered_core,
         )
         logger.debug(
             "[throttle:%s] measure rid=%s n=%d kv_len=%d transient=%.2fMB per_token=%.1fKB ewma=%.1fKB observed_max=%.1fMB samples=%d",
@@ -5193,11 +5232,14 @@ class Scheduler:
         # if even prefill_min_chunk_tokens would exceed the cap; #1405
         # cleanup paths in _schedule_waiting / _advance_chunked_prefills
         # convert that into a finish_reason="error" output for the client.
+        # Chunked prefill is text-only (VLM never builds _PrefillState).
+        gathered_core = self._qwen4_text_gathered_pricing(True)
         n = self._adaptive_chunk_size(
             n,
             request_id=state.request.request_id,
             loop_label="chunked_step",
             kv_len=state.base_size + state.tokens_processed,
+            gathered_core=gathered_core,
         )
 
         # Pre-chunk safety guard (mirrors the external loop): never submit a
@@ -5208,6 +5250,7 @@ class Scheduler:
             progress=state.tokens_processed,
             loop_label="chunked_step",
             request_id=state.request.request_id,
+            gathered_core=gathered_core,
         )
         if getattr(state.request, "benchmark_trace", False):
             state.request.benchmark_prefill_chunks.append(int(n))
@@ -5237,6 +5280,7 @@ class Scheduler:
             loop_label="chunked_step",
             kv_len=state.base_size + state.tokens_processed,
             requested_step=prefill_step_size,
+            gathered_core=gathered_core,
         )
         self._maybe_record_fixed_state_bytes(state.cache)
         state.tokens_processed += n
@@ -8367,6 +8411,7 @@ class Scheduler:
                     num_prompt_tokens=request.num_prompt_tokens,
                     cached_tokens=request.cached_tokens or 0,
                     request_id=request.request_id,
+                    text_only=getattr(request, "vlm_inputs_embeds", None) is None,
                 )
             except Exception:
                 self._release_paged_cache_for_request(request.request_id)
@@ -9627,6 +9672,7 @@ class Scheduler:
             num_prompt_tokens=prompt_tokens,
             cached_tokens=cached_tokens,
             current=current,
+            text_only=getattr(request, "vlm_inputs_embeds", None) is None,
         )
         if est is None:
             return None  # can't estimate, skip
@@ -9685,6 +9731,7 @@ class Scheduler:
         num_prompt_tokens: int,
         cached_tokens: int,
         current: int,
+        text_only: bool = False,
     ) -> _AdmissionEstimate | None:
         """Deterministic admission estimate shared by every preflight path.
 
@@ -9737,7 +9784,12 @@ class Scheduler:
         kv_exact = int(
             monitor.estimate_resident_kv_bytes(new_tokens, chunk_tokens=floor_chunk)
         )
-        transient = int(self._admission_transient_bound(floor_chunk, kv_len))
+        gathered_core = self._qwen4_text_gathered_pricing(text_only)
+        transient = int(
+            self._admission_transient_bound(
+                floor_chunk, kv_len, gathered_core=gathered_core
+            )
+        )
         if kv_exact <= 0 and transient <= 0:
             return None
         return _AdmissionEstimate(
@@ -9796,6 +9848,7 @@ class Scheduler:
         num_prompt_tokens: int,
         cached_tokens: int = 0,
         request_id: str | None = None,
+        text_only: bool = False,
     ) -> None:
         """Pre-StreamingResponse prefill memory check.
 
@@ -9821,6 +9874,7 @@ class Scheduler:
             num_prompt_tokens=num_prompt_tokens,
             cached_tokens=cached_tokens,
             current=current,
+            text_only=text_only,
         )
         if est is None:
             return
@@ -9881,6 +9935,7 @@ class Scheduler:
         num_prompt_tokens: int,
         cached_tokens: int = 0,
         request_id: str | None = None,
+        text_only: bool = False,
     ) -> PrefillEvictionRequest | None:
         """Return an idle-model eviction request for route-level preflight.
 
@@ -9904,6 +9959,7 @@ class Scheduler:
             num_prompt_tokens=num_prompt_tokens,
             cached_tokens=cached_tokens,
             current=current,
+            text_only=text_only,
         )
         if est is None:
             return None

--- a/tests/test_context_benchmark.py
+++ b/tests/test_context_benchmark.py
@@ -162,7 +162,12 @@ class _FakeScheduler:
         self._prefill_transient_tracker = MagicMock()
 
     def preflight_or_raise(
-        self, *, num_prompt_tokens, cached_tokens=0, request_id=None
+        self,
+        *,
+        num_prompt_tokens,
+        cached_tokens=0,
+        request_id=None,
+        text_only=False,
     ):
         if num_prompt_tokens > self.boundary:
             raise PrefillMemoryExceededError(

--- a/tests/test_engine_preflight.py
+++ b/tests/test_engine_preflight.py
@@ -181,10 +181,12 @@ async def test_batched_engine_preflight_runs_eviction_before_final_check():
     scheduler.preflight_eviction_request.assert_called_once_with(
         num_prompt_tokens=123,
         request_id="req-evict",
+        text_only=True,
     )
     scheduler.preflight_or_raise.assert_called_once_with(
         num_prompt_tokens=123,
         request_id="req-evict",
+        text_only=True,
     )
     assert order == [("evict", "req-evict"), ("final", "checked")]
 
@@ -229,6 +231,7 @@ async def test_batched_engine_retries_transient_rejection_after_cleanup(monkeypa
     scheduler.preflight_or_raise.assert_called_once_with(
         num_prompt_tokens=60_000,
         request_id="req-next",
+        text_only=True,
     )
     evict.assert_not_awaited()
 

--- a/tests/test_memory_monitor.py
+++ b/tests/test_memory_monitor.py
@@ -700,6 +700,40 @@ class TestEstimateResidentKvBytes:
         assert m.fixed_state_bytes == 0
         assert m.estimate_resident_kv_bytes(100) == base
 
+    def test_fixed_state_added_on_qwen4_profile_path(self):
+        from omlx.memory_monitor import make_prefill_memory_profile
+
+        config = SimpleNamespace(
+            model_type="qwen4_exp",
+            num_hidden_layers=48,
+            num_attention_heads=24,
+            num_key_value_heads=2,
+            head_dim=256,
+            indexer_n_heads=4,
+            indexer_head_dim=128,
+            indexer_budget=2048,
+            indexer_compress_ratio=4,
+            full_attention_interval=4,
+            layer_types=None,
+        )
+        profile = make_prefill_memory_profile(config, compute_dtype_size=2)
+        m = MemoryMonitor(max_kv_cache_memory=2 * 1024**3)
+        m.set_model_info(
+            num_layers=48,
+            num_kv_heads=2,
+            head_dim=256,
+            dtype_size=2,
+            num_attention_heads=24,
+            compute_dtype_size=2,
+            prefill_memory_profile=profile,
+        )
+        assert m.is_qwen4_gathered_prefill_profile() is True
+        base = m.estimate_resident_kv_bytes(100)
+        prompt_kv = m.estimate_prompt_kv_bytes(100)
+        m.set_fixed_state_bytes(123_456_789)
+        assert m.estimate_resident_kv_bytes(100) == base + 123_456_789
+        assert m.estimate_prompt_kv_bytes(100) == prompt_kv
+
     def test_zero_tokens_returns_zero(self):
         m = self._make(num_kv_cache_layers=30)
         m.set_fixed_state_bytes(999)

--- a/tests/test_memory_monitor_vlm_config.py
+++ b/tests/test_memory_monitor_vlm_config.py
@@ -12,6 +12,7 @@ These tests pin the priority: prefer any sub-config that has the LM layer
 count, else fall back to the top-level config.
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import mlx.core as mx
@@ -132,6 +133,43 @@ def test_qwen4_qsa_memory_includes_indexer_and_mrope_state():
 
     assert (full_layers, rotating, arrays) == (12, [], 0)
     assert estimate == 12 * (2 * 2 * 128 * 2 + 128 * 2 + 3 * 8)
+
+
+def test_qwen4_prefill_profile_gathered_core_caps_score_matrix():
+    from omlx.memory_monitor import MemoryMonitor, make_prefill_memory_profile
+
+    config = SimpleNamespace(
+        model_type="qwen4_exp",
+        num_hidden_layers=48,
+        num_attention_heads=24,
+        num_key_value_heads=2,
+        head_dim=256,
+        indexer_n_heads=4,
+        indexer_head_dim=128,
+        indexer_budget=2048,
+        indexer_compress_ratio=4,
+        full_attention_interval=4,
+        layer_types=None,
+    )
+    profile = make_prefill_memory_profile(config, compute_dtype_size=2)
+    assert profile is not None
+    monitor = MemoryMonitor(max_kv_cache_memory=1024**3, eviction_enabled=False)
+    monitor.set_model_info(
+        num_layers=48,
+        num_kv_heads=2,
+        head_dim=256,
+        dtype_size=2,
+        num_attention_heads=24,
+        prefill_memory_profile=profile,
+    )
+    query, kv_len = 4096, 233_472
+    monitor.qwen4_charge_gathered_core = False
+    dense = monitor.estimate_chunk_transient_bytes(query, kv_len)
+    monitor.qwen4_charge_gathered_core = True
+    gathered = monitor.estimate_chunk_transient_bytes(query, kv_len)
+    assert gathered * 8 < dense
+    # 147GB resident + this gathered gulp stays under the 214GB safety cap.
+    assert gathered < 12 * 1024**3
 
 
 class TestSetModelInfoForMonitorVLMWalk:

--- a/tests/test_mlx_vlm_qwen4_exp_compat.py
+++ b/tests/test_mlx_vlm_qwen4_exp_compat.py
@@ -1404,6 +1404,54 @@ def test_qwen4_batch_qsa_trim_slices_indexer_arrays():
     assert batch.index_offset == 5
     assert batch.index_keys.shape[1] == 5
     assert batch.index_position_ids.shape[-1] == 5
+
+
+def test_qwen4_batch_extend_unifies_2d_and_3d_indexer_positions():
+    """MTP late-join mixed gathered 2-D text positions with mask_dense 3-D mRoPE.
+
+    That used to raise ``[concatenate] ... dimensions 3 and 2`` at
+    ``BatchQSAKVCache.extend``.
+    """
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models.qwen4_exp.language import BatchQSAKVCache
+
+    left = _warm_qsa_row(4, 0)
+    right = _warm_qsa_row(2, 40)
+    right.index_position_ids = mx.broadcast_to(
+        right.index_position_ids[None],
+        (3, *right.index_position_ids.shape),
+    )
+    left_batch = left.to_batch([0])
+    right_batch = right.to_batch([0])
+
+    left_batch.extend(right_batch)
+    mx.eval(left_batch.index_position_ids, left_batch.index_keys)
+
+    assert left_batch.index_position_ids.ndim == 3
+    assert left_batch.index_position_ids.shape[0] == 3
+    assert left_batch.index_keys.shape[0] == 2
+    extracted_right = left_batch.extract(1)
+    assert extracted_right.index_position_ids.ndim == 3
+    assert extracted_right.index_position_ids.shape[-1] == 2
+
+
+def test_qwen4_batch_merge_unifies_mixed_indexer_position_ranks():
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models.qwen4_exp.language import BatchQSAKVCache
+
+    text = _warm_qsa_row(3, 10)
+    mrope = _warm_qsa_row(1, 30)
+    mrope.index_position_ids = mx.broadcast_to(
+        mrope.index_position_ids[None],
+        (3, *mrope.index_position_ids.shape),
+    )
+    merged = BatchQSAKVCache.merge([text, mrope])
+    mx.eval(merged.index_position_ids)
+    assert merged.index_position_ids.ndim == 3
+    assert merged.index_position_ids.shape[0] == 3
+    assert merged.offset.tolist() == [3, 1]
+
+
 def _make_bound_qwen4_language_model(config):
     from mlx_vlm.models.qwen4_exp.language import LanguageModel, Qwen4ExpMTPModule
 

--- a/tests/test_mlx_vlm_qwen4_exp_compat.py
+++ b/tests/test_mlx_vlm_qwen4_exp_compat.py
@@ -684,7 +684,39 @@ def test_qwen4_gathered_qsa_fails_closed_for_multimodal_positions(monkeypatch):
     assert output.shape == hidden.shape
 
 
-def test_qwen4_gathered_qsa_fails_closed_for_batched_prefill(monkeypatch):
+def test_qwen4_gathered_qsa_routes_broadcast_text_mrope(monkeypatch):
+    """Parent LM tiles identical text positions to (3,1,L). That is still text."""
+    config = _tiny_config()
+    import mlx_vlm.models.qwen4_exp.language as language
+    from mlx_vlm.models.qwen4_exp.language import QSAKVCache, Qwen4ExpAttention
+
+    attention = Qwen4ExpAttention(config.text_config)
+    mx.eval(attention.parameters())
+    hidden = mx.random.normal((1, 20, config.text_config.hidden_size))
+    text_ids = mx.arange(20, dtype=mx.int32)[None]
+    position_ids = mx.broadcast_to(text_ids[None], (3, 1, 20))
+
+    calls = []
+    gathered = language.contiguous_causal_gathered_qsa
+
+    def tracked(*args, **kwargs):
+        calls.append((args[0].shape, args[1].shape))
+        return gathered(*args, **kwargs)
+
+    monkeypatch.setattr(language, "contiguous_causal_gathered_qsa", tracked)
+    actual = attention(
+        hidden,
+        mask="causal",
+        cache=QSAKVCache(),
+        position_ids=position_ids,
+    )
+    mx.eval(actual)
+
+    assert calls, "broadcast text mRoPE must take gathered QSA, not mask+dense SDPA"
+    assert actual.shape == hidden.shape
+
+
+def test_qwen4_gathered_qsa_fails_closed_for_batched_requests(monkeypatch):
     config = _tiny_config()
     import mlx_vlm.models.qwen4_exp.language as language
     from mlx_vlm.models.qwen4_exp.language import QSAKVCache, Qwen4ExpAttention

--- a/tests/test_mlx_vlm_qwen4_exp_compat.py
+++ b/tests/test_mlx_vlm_qwen4_exp_compat.py
@@ -716,6 +716,55 @@ def test_qwen4_gathered_qsa_routes_broadcast_text_mrope(monkeypatch):
     assert actual.shape == hidden.shape
 
 
+def test_qwen4_gathered_qsa_prefill_matches_official_broadcast_text_mrope(
+    monkeypatch,
+):
+    """Equal-plane 3-D text mRoPE gathered prefill matches the official path."""
+    config = _tiny_config()
+    import mlx_vlm.models.qwen4_exp.language as language
+    from mlx_vlm.models.qwen4_exp.language import QSAKVCache, Qwen4ExpAttention
+
+    attention = Qwen4ExpAttention(config.text_config)
+    mx.eval(attention.parameters())
+    hidden = mx.random.normal((1, 20, config.text_config.hidden_size))
+    plane = mx.arange(20, dtype=mx.int32)
+    position_ids = mx.stack([plane, plane, plane])[:, None, :]
+
+    calls = []
+    gathered = language.contiguous_causal_gathered_qsa
+
+    def tracked(*args, **kwargs):
+        calls.append((args[0].shape, args[1].shape))
+        return gathered(*args, **kwargs)
+
+    monkeypatch.setattr(language, "contiguous_causal_gathered_qsa", tracked)
+    fast_cache = QSAKVCache()
+    actual = attention(
+        hidden,
+        mask="causal",
+        cache=fast_cache,
+        position_ids=position_ids,
+    )
+
+    monkeypatch.setattr(
+        Qwen4ExpAttention,
+        "_gathered_text_prefill_eligible",
+        staticmethod(lambda *args, **kwargs: False),
+    )
+    reference_cache = QSAKVCache()
+    expected = attention(
+        hidden,
+        mask="causal",
+        cache=reference_cache,
+        position_ids=position_ids,
+    )
+    mx.eval(actual, expected)
+
+    assert calls, "materialized equal-plane 3-D text must take gathered QSA"
+    assert mx.allclose(actual, expected, rtol=2e-5, atol=2e-5).item()
+    assert fast_cache.offset == reference_cache.offset == 20
+
+
 def test_qwen4_gathered_qsa_fails_closed_for_batched_requests(monkeypatch):
     config = _tiny_config()
     import mlx_vlm.models.qwen4_exp.language as language

--- a/tests/test_prefill_oom_graceful.py
+++ b/tests/test_prefill_oom_graceful.py
@@ -134,6 +134,9 @@ def _throttle_ctx(
     ns._predicted_chunk_transient = Scheduler._predicted_chunk_transient.__get__(
         ns, Scheduler
     )
+    ns._estimate_chunk_transient_bytes = (
+        Scheduler._estimate_chunk_transient_bytes.__get__(ns, Scheduler)
+    )
     ns._admission_transient_bound = Scheduler._admission_transient_bound.__get__(
         ns, Scheduler
     )
@@ -532,19 +535,59 @@ def test_predicted_transient_drops_dense_ewma_when_qsa_static_is_cheaper():
         num_attention_heads=24,
         prefill_memory_profile=profile,
     )
-    monitor.qwen4_charge_gathered_core = True
     tracker = PrefillTransientTracker()
-    tracker.update(4096, int(69.58 * _GB))
+    tracker.update(4096, int(69.58 * _GB), gathered_core=False)
     ns = _throttle_ctx(current=0, hard=240 * _GB, samples_bpt=None, monitor=monitor)
     ns._prefill_transient_tracker = tracker
-    predicted = ns._predicted_chunk_transient(4096, 233_472)
+    predicted = ns._predicted_chunk_transient(
+        4096, 233_472, gathered_core=True
+    )
     dense_poison = 69.58 * _GB * Scheduler._PREFILL_TRANSIENT_SAFETY
     assert predicted < dense_poison / 8
     assert 147 * _GB + predicted < 214 * _GB
-    # Without the gathered flag, that same leftover gulp must still bind.
-    monitor.qwen4_charge_gathered_core = False
-    dense_predicted = ns._predicted_chunk_transient(4096, 233_472)
+    # Without gathered pricing, that same leftover gulp must still bind.
+    dense_predicted = ns._predicted_chunk_transient(
+        4096, 233_472, gathered_core=False
+    )
     assert dense_predicted == pytest.approx(dense_poison, rel=1e-3)
+
+
+def test_predicted_transient_keeps_gathered_spike_from_this_request():
+    """A gathered chunk's own measured spike must still bind the next chunk."""
+    from omlx.memory_monitor import make_prefill_memory_profile
+
+    config = SimpleNamespace(
+        model_type="qwen4_exp",
+        num_hidden_layers=48,
+        num_attention_heads=24,
+        num_key_value_heads=2,
+        head_dim=256,
+        indexer_n_heads=4,
+        indexer_head_dim=128,
+        indexer_budget=2048,
+        indexer_compress_ratio=4,
+        full_attention_interval=4,
+        layer_types=None,
+    )
+    profile = make_prefill_memory_profile(config, compute_dtype_size=2)
+    monitor = MemoryMonitor(max_kv_cache_memory=_GB, eviction_enabled=False)
+    monitor.set_model_info(
+        num_layers=48,
+        num_kv_heads=2,
+        head_dim=256,
+        dtype_size=2,
+        num_attention_heads=24,
+        prefill_memory_profile=profile,
+    )
+    tracker = PrefillTransientTracker()
+    tracker.update(4096, int(69.58 * _GB), gathered_core=True)
+    ns = _throttle_ctx(current=0, hard=240 * _GB, samples_bpt=None, monitor=monitor)
+    ns._prefill_transient_tracker = tracker
+    dense_poison = 69.58 * _GB * Scheduler._PREFILL_TRANSIENT_SAFETY
+    predicted = ns._predicted_chunk_transient(
+        4096, 233_472, gathered_core=True
+    )
+    assert predicted == pytest.approx(dense_poison, rel=1e-3)
 
 
 def test_adaptive_throttle_charges_recently_reclaimed_footprint():
@@ -910,6 +953,9 @@ def test_step_prefill_reclaims_before_first_guard():
     ):
         setattr(ns, _name, getattr(Scheduler, _name).__get__(ns, Scheduler))
     ns._step_prefill_chunk = Scheduler._step_prefill_chunk.__get__(ns, Scheduler)
+    ns._qwen4_text_gathered_pricing = Scheduler._qwen4_text_gathered_pricing.__get__(
+        ns, Scheduler
+    )
 
     with (
         patch.object(
@@ -933,6 +979,7 @@ def test_step_prefill_reclaims_before_first_guard():
         loop_label="chunked_step",
         kv_len=0,
         requested_step=2,
+        gathered_core=False,
     )
 
 

--- a/tests/test_prefill_oom_graceful.py
+++ b/tests/test_prefill_oom_graceful.py
@@ -505,6 +505,48 @@ def test_predicted_transient_zero_without_signals():
     assert ns._predicted_chunk_transient(4, 1000) == 0.0
 
 
+def test_predicted_transient_drops_dense_ewma_when_qsa_static_is_cheaper():
+    """A leftover dense last_delta must not refuse gathered QSA static."""
+    from omlx.memory_monitor import make_prefill_memory_profile
+
+    config = SimpleNamespace(
+        model_type="qwen4_exp",
+        num_hidden_layers=48,
+        num_attention_heads=24,
+        num_key_value_heads=2,
+        head_dim=256,
+        indexer_n_heads=4,
+        indexer_head_dim=128,
+        indexer_budget=2048,
+        indexer_compress_ratio=4,
+        full_attention_interval=4,
+        layer_types=None,
+    )
+    profile = make_prefill_memory_profile(config, compute_dtype_size=2)
+    monitor = MemoryMonitor(max_kv_cache_memory=_GB, eviction_enabled=False)
+    monitor.set_model_info(
+        num_layers=48,
+        num_kv_heads=2,
+        head_dim=256,
+        dtype_size=2,
+        num_attention_heads=24,
+        prefill_memory_profile=profile,
+    )
+    monitor.qwen4_charge_gathered_core = True
+    tracker = PrefillTransientTracker()
+    tracker.update(4096, int(69.58 * _GB))
+    ns = _throttle_ctx(current=0, hard=240 * _GB, samples_bpt=None, monitor=monitor)
+    ns._prefill_transient_tracker = tracker
+    predicted = ns._predicted_chunk_transient(4096, 233_472)
+    dense_poison = 69.58 * _GB * Scheduler._PREFILL_TRANSIENT_SAFETY
+    assert predicted < dense_poison / 8
+    assert 147 * _GB + predicted < 214 * _GB
+    # Without the gathered flag, that same leftover gulp must still bind.
+    monitor.qwen4_charge_gathered_core = False
+    dense_predicted = ns._predicted_chunk_transient(4096, 233_472)
+    assert dense_predicted == pytest.approx(dense_poison, rel=1e-3)
+
+
 def test_adaptive_throttle_charges_recently_reclaimed_footprint():
     """A pool drop must remain priced until the next chunk reallocates it."""
     static_prediction = 11.18 * _GB

--- a/tests/test_qwen4_qsa_decode_gather.py
+++ b/tests/test_qwen4_qsa_decode_gather.py
@@ -274,6 +274,26 @@ def test_qwen4_decode_gather_eligibility_fails_closed_for_general_paths():
     )
 
 
+def test_qwen4_text_mrope_equal_plane_cache_does_not_reuse_dead_ids():
+    """CPython can recycle id() once a temporary mx.array is collected."""
+
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    import mlx_vlm.models.qwen4_exp.language as language
+
+    equal = mx.array([[[10]], [[10]], [[10]]], dtype=mx.int32)
+    unequal = mx.array([[[10]], [[10]], [[9]]], dtype=mx.int32)
+    assert language._broadcast_text_mrope_position_ids(equal, 1)
+    assert not language._broadcast_text_mrope_position_ids(unequal, 1)
+
+    for _ in range(64):
+        assert language._broadcast_text_mrope_position_ids(
+            mx.array([[[4]], [[4]], [[4]]], dtype=mx.int32), 1
+        )
+        assert not language._broadcast_text_mrope_position_ids(
+            mx.array([[[4]], [[4]], [[3]]], dtype=mx.int32), 1
+        )
+
+
 @pytest.mark.parametrize("key_tokens", [4097, 32769])
 def test_qwen4_decode_gather_stays_budget_bounded_at_long_cache(
     monkeypatch,

--- a/tests/test_qwen4_qsa_decode_gather.py
+++ b/tests/test_qwen4_qsa_decode_gather.py
@@ -403,3 +403,16 @@ def test_qwen4_decode_sdpa_uses_native_only_after_capability_accepts(monkeypatch
         (256**-0.5, False, "native"),
     ]
     assert mx.array_equal(actual, expected).item()
+
+
+def test_python_cache_offset_accepts_batched_mx_array():
+    """Batched MTP decode used to crash the QSA path log on ``int(offset)``."""
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    import mlx_vlm.models.qwen4_exp.language as language
+
+    assert language._python_cache_offset(None) == 0
+    assert language._python_cache_offset(0) == 0
+    assert language._python_cache_offset(11) == 11
+    assert language._python_cache_offset(mx.array(7, dtype=mx.int32)) == 7
+    assert language._python_cache_offset(mx.array([7], dtype=mx.int32)) == 7
+    assert language._python_cache_offset(mx.array([10, 20], dtype=mx.int32)) == 20

--- a/tests/test_qwen4_qsa_decode_gather.py
+++ b/tests/test_qwen4_qsa_decode_gather.py
@@ -238,8 +238,8 @@ def test_qwen4_decode_gather_eligibility_fails_closed_for_general_paths():
     assert attention._gathered_text_decode_eligible(
         token, None, cache, mx.array([[10]], dtype=mx.int32), None, False
     )
-    # Parent LM tiles identical text positions to (3, 1, 1). That is still text.
-    assert attention._gathered_text_decode_eligible(
+    # 3-D equal planes are a decode-follow-up. Prefill still accepts them.
+    assert not attention._gathered_text_decode_eligible(
         token,
         None,
         cache,

--- a/tests/test_qwen4_qsa_decode_gather.py
+++ b/tests/test_qwen4_qsa_decode_gather.py
@@ -238,11 +238,20 @@ def test_qwen4_decode_gather_eligibility_fails_closed_for_general_paths():
     assert attention._gathered_text_decode_eligible(
         token, None, cache, mx.array([[10]], dtype=mx.int32), None, False
     )
-    assert not attention._gathered_text_decode_eligible(
+    # Parent LM tiles identical text positions to (3, 1, 1). That is still text.
+    assert attention._gathered_text_decode_eligible(
         token,
         None,
         cache,
         mx.array([[[10]], [[10]], [[10]]], dtype=mx.int32),
+        None,
+        False,
+    )
+    assert not attention._gathered_text_decode_eligible(
+        token,
+        None,
+        cache,
+        mx.array([[[10]], [[10]], [[9]]], dtype=mx.int32),
         None,
         False,
     )

--- a/tests/test_scheduler_prefill_memory_guard.py
+++ b/tests/test_scheduler_prefill_memory_guard.py
@@ -989,3 +989,134 @@ def test_admission_compares_against_hard_watermark():
     scheduler._memory_hard_watermark_bytes = int(est.estimated) + 1
     with patches[0], patches[1]:
         scheduler.preflight_or_raise(num_prompt_tokens=32768)
+
+
+def _qwen4_prefill_profile():
+    from omlx.memory_monitor import make_prefill_memory_profile
+
+    return make_prefill_memory_profile(
+        SimpleNamespace(
+            model_type="qwen4_exp",
+            num_hidden_layers=48,
+            num_attention_heads=24,
+            num_key_value_heads=2,
+            head_dim=256,
+            indexer_n_heads=4,
+            indexer_head_dim=128,
+            indexer_budget=2048,
+            indexer_compress_ratio=4,
+            full_attention_interval=4,
+            layer_types=None,
+        ),
+        compute_dtype_size=2,
+    )
+
+
+def _attach_qwen4_profile(scheduler: Scheduler) -> None:
+    profile = _qwen4_prefill_profile()
+    scheduler.memory_monitor.set_model_info(
+        num_layers=48,
+        num_kv_heads=2,
+        head_dim=256,
+        dtype_size=2,
+        num_attention_heads=24,
+        compute_dtype_size=2,
+        prefill_memory_profile=profile,
+    )
+
+
+def test_qwen4_text_admission_uses_gathered_transient():
+    scheduler = _make_scheduler()
+    _attach_qwen4_profile(scheduler)
+    current = 147 * 1024**3
+    dense = scheduler._admission_estimate(
+        num_prompt_tokens=233_472,
+        cached_tokens=0,
+        current=current,
+        text_only=False,
+    )
+    gathered = scheduler._admission_estimate(
+        num_prompt_tokens=233_472,
+        cached_tokens=0,
+        current=current,
+        text_only=True,
+    )
+    assert dense is not None and gathered is not None
+    assert gathered.kv_exact == dense.kv_exact
+    assert gathered.transient * 4 < dense.transient
+    assert scheduler._qwen4_text_gathered_pricing(True) is True
+    assert scheduler._qwen4_text_gathered_pricing(False) is False
+
+
+def test_qwen4_preflight_doors_use_gathered_for_text_only():
+    scheduler = _make_scheduler()
+    _attach_qwen4_profile(scheduler)
+    scheduler._prefill_memory_guard = True
+    current = 147 * 1024**3
+    dense = scheduler._admission_estimate(
+        num_prompt_tokens=233_472,
+        cached_tokens=0,
+        current=current,
+        text_only=False,
+    )
+    gathered = scheduler._admission_estimate(
+        num_prompt_tokens=233_472,
+        cached_tokens=0,
+        current=current,
+        text_only=True,
+    )
+    assert dense is not None and gathered is not None
+    cap = (dense.estimated + gathered.estimated) // 2
+    scheduler._memory_hard_limit_bytes = cap
+    scheduler._memory_abort_limit_bytes = 10**18
+    with (
+        patch("omlx.scheduler.mx.get_active_memory", return_value=current),
+        patch("omlx.scheduler.get_phys_footprint", return_value=current),
+    ):
+        with pytest.raises(PrefillMemoryExceededError):
+            scheduler.preflight_or_raise(
+                num_prompt_tokens=233_472, text_only=False
+            )
+        scheduler.preflight_or_raise(num_prompt_tokens=233_472, text_only=True)
+        assert (
+            scheduler.preflight_eviction_request(
+                num_prompt_tokens=233_472, text_only=True
+            )
+            is None
+        )
+        assert (
+            scheduler.preflight_eviction_request(
+                num_prompt_tokens=233_472, text_only=False
+            )
+            is not None
+        )
+
+
+def test_qwen4_image_request_preflight_stays_dense():
+    scheduler = _make_scheduler()
+    _attach_qwen4_profile(scheduler)
+    scheduler._prefill_memory_guard = True
+    current = 147 * 1024**3
+    dense = scheduler._admission_estimate(
+        num_prompt_tokens=233_472,
+        cached_tokens=0,
+        current=current,
+        text_only=False,
+    )
+    gathered = scheduler._admission_estimate(
+        num_prompt_tokens=233_472,
+        cached_tokens=0,
+        current=current,
+        text_only=True,
+    )
+    assert dense is not None and gathered is not None
+    scheduler._memory_hard_limit_bytes = (dense.estimated + gathered.estimated) // 2
+    scheduler._memory_abort_limit_bytes = 10**18
+    request = _make_request(233_472)
+    request.vlm_inputs_embeds = object()
+    with (
+        patch("omlx.scheduler.mx.get_active_memory", return_value=current),
+        patch("omlx.scheduler.get_phys_footprint", return_value=current),
+    ):
+        rejection = scheduler._preflight_memory_check(request)
+    assert rejection is not None


### PR DESCRIPTION
## Summary

Fixes #3350. A text-only continuation on Qwen3.8-Flash-Next reused 233472 prefix tokens, then the memory guard refused the remaining 5244 at `progress=0` (`current=147.56GB`, `predicted_transient=90.45GB`, cap 214GB). The 90.45GB is `last_delta × 1.3` from a leftover dense gulp. Gathered eligibility also rejected 3-D text mRoPE: parent `LanguageModel` tiles identical `(1, L)` positions to `(3, 1, L)` after the text-only cached-prefill rope-delta seed.

Broadcast-identical planes now take gathered QSA on prefill (indexer gets the text row, rotary gets the 3-D ids). Unequal planes stay fail-closed on mask+dense. Decode stays 2-D `(1, 1)` or absent.

Text-only admission, eviction, and chunked prefill charge a `qwen4_exp` profile (indexer still `Q × kv/r`, core capped at `indexer_budget`) when the request is text-only and the active monitor is that profile. Gathered vs dense is an argument, not a toggle on the shared monitor. Leftover dense `last_delta`/EWMA is ignored only on a gathered Qwen4 chunk whose last sample was not gathered. Image prefills keep the dense price. The Qwen4 profile resident path includes measured `fixed_state_bytes`.

## Test plan

- [x] broadcast `(3,1,L)` text mRoPE takes `contiguous_causal_gathered_qsa` on prefill; unequal planes do not
- [x] decode `(3,1,1)` equal planes do not take gathered
- [x] batched and at-budget paths still fail closed
- [x] Qwen4 gathered static is well under dense `Q × kv` (4.04GB vs 46.41GB at Q=4096, kv=233472)
- [x] leftover 69.58GB `last_delta` does not bind on a gathered Qwen4 chunk (~5.5GB predicted; 147+5.5 < 214); same gulp still binds when this chunk is dense
- [x] a gathered spike from this request still binds the next chunk
- [x] Qwen4 text-only preflight, eviction, and `_preflight_memory_check` use gathered; image / `text_only=False` stays dense
- [x] `estimate_resident_kv_bytes` on the Qwen4 profile moves by `set_fixed_state_bytes(123456789)`; `estimate_prompt_kv_bytes` does not
- [x] materialized equal-plane `(3,1,L)` prefill matches the official mask path
- [ ] CI: `pytest tests/ -m "not slow and not integration"`
- [ ] live #3350 continuation after overlay (scheduler + memory_monitor + language.py)