### PR TITLE
feat(mtp): OMLX_MTP_FIXED_DEPTH pin for the adaptive depth controller (A/B instrument)

### DIFF
--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -1801,6 +1801,21 @@ def _effective_loop_tax(model: Any) -> Optional[float]:
     return prior + (float(tax) - prior) * math.exp(-age / _STD_TAX_DECAY_S)
 
 
+_FIXED_DEPTH_ENV = "OMLX_MTP_FIXED_DEPTH"
+
+
+def _fixed_mtp_depth() -> Optional[int]:
+    """Experimental: pin the draft depth (None = adaptive controller)."""
+    raw = os.environ.get(_FIXED_DEPTH_ENV, "").strip()
+    if not raw:
+        return None
+    try:
+        d = int(raw)
+    except ValueError:
+        return None
+    return d if d > 0 else None
+
+
 class _DepthController:
     """Adaptive draft-depth selection.
 
@@ -1907,6 +1922,9 @@ class _DepthController:
             )
         self.max_depth = max(1, int(max_depth))
         self.cur = self.max_depth  # first cycle drafts deep; warmup sweeps down
+        _fixed = _fixed_mtp_depth()
+        if _fixed is not None:
+            self.cur = min(_fixed, self.max_depth)
         self.p = [0.6] * self.max_depth
         self.t: Dict[int, float] = {}
         self.t_age: Dict[int, float] = {}  # ms since each depth was measured
@@ -1935,6 +1953,11 @@ class _DepthController:
     ) -> None:
         self.cycles += 1
         used = max(0, min(int(used), self.max_depth))
+        _fixed = _fixed_mtp_depth()
+        if _fixed is not None:
+            # Pin: keep measuring (t/p EMAs stay fresh, park logic stays
+            # armed) but the draft depth is forced every cycle.
+            self.cur = min(_fixed, self.max_depth)
         accepted = max(0, min(int(accepted), used))
         # Acceptance: token-domain EMA (a property of model/content, not load).
         a = self.ALPHA


### PR DESCRIPTION
## Summary

Adds an opt-in environment knob that pins the MTP draft depth every cycle
while keeping the controller's measurement machinery (t/p EMAs, probes,
park logic) fully armed:

```bash
OMLX_MTP_FIXED_DEPTH=5   # adaptive controller by default; unset/0 = adaptive
```

## Why: measured on Qwen3.8-Flash-Next oQ4e, M3 Ultra, quiet GPU

We ran a fixed-depth sweep against the adaptive controller to check
whether its shallow settling leaves expected-value on the table:

| config | single-stream prose (MTP on, engine-timed, 5 runs) |
|---|---|
| adaptive (depth 5 max) | 52.4 tok/s |
| pinned depth 5 | 55.5 tok/s (+6%) |

The pin only wins ~6%: per-position conditional acceptance decays
(0.74 / 0.65 / 0.61 / 0.55 / 0.45 measured on prose), capping the
depth-5 expected value at ~2.8 tokens/cycle — the adaptive controller
already sits within ~6% of the achievable optimum and re-adapts to
content (tool-calling climbs to tok/cycle 3.1 at 87-92% acceptance on
its own).

So this knob is not a tuning recommendation — it is the **instrument we
used to establish that the controller is near-optimal**, and it makes
that class of experiment reproducible for anyone tuning other
model/content/hardware cells (it also isolates depth effects from the
controller's probe traffic).

## Implementation

- module-level `_fixed_mtp_depth()` env reader (None when unset/invalid)
- `__init__` pins the initial depth; `observe()` re-pins `cur` before the
  adaptive decision each cycle, so t[]/p[] EMAs, staleness probes and the
  depth-0 park path all keep running and stay meaningful when the pin is
  released
- 27/27 existing depth-controller tests pass unchanged

Companion performance notes issue with the full data (compile-lane
boundaries, load-sensitivity, depth study) follows.