### PR TITLE
Experimental distributed DeepSeek-V4 Vision support

### DIFF
--- a/docs/experimental/deepseek_v4_flash_vision_cluster.md
+++ b/docs/experimental/deepseek_v4_flash_vision_cluster.md
@@ -1,0 +1,147 @@
+# DeepSeek-V4-Flash-Vision two-Mac validation
+
+Status: experimental; single-Mac/loopback validated, physical two-Mac run pending.
+
+This path is intentionally specific to
+`deepseek-ai/DeepSeek-V4-Flash-Vision-Exp`. Rank 0 preprocesses images, owns
+the `vision.*`, `aligner.*`, and image-sentinel parameters, and broadcasts the
+merged MLX prompt embeddings. The existing DeepSeek-V4 pipeline owns the
+language prefill and decode. Other distributed VLM families and tensor
+parallelism fail closed.
+
+The public checkpoint is about 167.8 GB (156.3 GiB) before runtime buffers.
+That number is not a per-Mac fit guarantee. The signed planner output is the
+authority for per-rank weights, KV reserve, and headroom.
+
+## Prepare both Macs
+
+Use the same commit, absolute model path, Python, MLX, MLX-LM, and oMLX
+environment on Mac A and Mac B. Mac A is rank 0/coordinator.
+
+```bash
+git fetch origin
+git switch codex/deepseek-v4-vision-distributed
+uv sync --dev
+export DSV4_VISION_MODEL=/Users/SHARED/models/DeepSeek-V4-Flash-Vision-Exp
+test -f "$DSV4_VISION_MODEL/config.json"
+uv run omlx --version
+uv run python -c 'import mlx, mlx_lm; print(mlx.__version__, mlx_lm.__version__)'
+uv run omlx start
+```
+
+Replace `/Users/SHARED/...` with one identical absolute path on both Macs.
+In **Settings > Advanced**, enable **Distributed Inference**, save, and restart.
+Pair Mac B in Mac A's **Cluster** tab. Prefer the direct Thunderbolt addresses;
+use Ring first, then JACCL only after the baseline succeeds.
+
+## Ordered test procedure
+
+1. Verify connectivity on both Macs.
+
+   ```bash
+   uv run omlx cluster status --json | tee /tmp/omlx-cluster-status.json
+   uv run omlx cluster worker-smoke
+   uv run omlx cluster collective-smoke
+   uv run omlx cluster pipeline-smoke
+   ```
+
+   Success: every command exits zero and collective/pipeline smoke reports both
+   ranks. Capture route, interface, backend, and measured bandwidth on failure.
+
+2. Build the planner-only dry run on Mac A.
+
+   ```bash
+   uv run omlx cluster plan \
+     --model "$DSV4_VISION_MODEL" \
+     --node mac-a=128GiB \
+     --node mac-b=128GiB \
+     --reserve 16GiB \
+     --json | tee /tmp/dsv4-vision-plan.json
+   ```
+
+   Success: `supports_pipeline` is true, `tensor_parallel_size` is 1, rank 0
+   has non-zero `coordinator_weight_bytes`, rank 1 has zero, layer ranges are
+   contiguous with no gap/overlap, and both ranks have positive headroom. Rank
+   0 should normally receive fewer late language layers because it also owns
+   the ViT. Do not continue if either planned resident total exceeds its
+   capacity-minus-reserve.
+
+3. In Mac A's Cluster tab select the downloaded model, the two 128 GiB nodes,
+   a 16 GiB reserve, `tensor_parallel_size=1`, and Ring. Stage, review the exact
+   shard map, and activate. Request the model once to trigger lazy load.
+
+   Success: both ranks reach `ready`; rank 0 logs `vision_owner=true`; loaded
+   layer ranges equal `/tmp/dsv4-vision-plan.json`; measured parameter bytes
+   remain within the planner tolerance. If not, collect both rank markers and
+   logs from `config/model recognized`, `manifest scanned`, `loading_weights`,
+   and `validating`.
+
+4. Send a text-only request.
+
+   ```bash
+   export OMLX_URL=http://127.0.0.1:8000
+   export OMLX_MODEL=DeepSeek-V4-Flash-Vision-Exp
+   curl -fsS "$OMLX_URL/v1/chat/completions" \
+     -H 'Content-Type: application/json' \
+     -d '{"model":"'"$OMLX_MODEL"'","messages":[{"role":"user","content":"Reply with exactly: text path ready"}],"max_tokens":32}'
+   ```
+
+   Success: normal text response and no `vision_encode_begin` event.
+
+5. Send one short image request. Put a small local test image behind a URL
+   reachable by Mac A (or substitute a base64 data URL).
+
+   ```bash
+   export TEST_IMAGE_URL=http://127.0.0.1:8080/test.png
+   curl -fsS "$OMLX_URL/v1/chat/completions" \
+     -H 'Content-Type: application/json' \
+     -d '{"model":"'"$OMLX_MODEL"'","messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"'"$TEST_IMAGE_URL"'"}},{"type":"text","text":"Describe this image in one sentence."}]}],"max_tokens":64}'
+   ```
+
+   Success: one each of `vision_encode_begin`, `vision_encode_complete`,
+   `multimodal_embeddings`, `distributed_prefill_begin`,
+   `distributed_prefill_complete`, and `first_token`; only rank 0 reports an
+   image count. Both ranks must report the same expanded sequence length.
+
+6. Repeat step 5 with `"stream":true` and `curl -N`. Success is incremental
+   `data:` chunks ending in `[DONE]`, with one vision encode and continuous
+   decode after the first token.
+
+7. Send a different second image with the same dimensions. Success is a new
+   `vision_encode_begin` and a different content-keyed prompt-cache identity;
+   the first image's KV state must not be reused.
+
+8. Send a longer text prompt plus one image. Success is a single unchunked
+   image-bearing prefill, then ordinary decode. The vision tower must not run
+   again after prefill.
+
+9. During steps 5–8 capture the Cluster dashboard and:
+
+   ```bash
+   uv run omlx cluster status --json | tee /tmp/omlx-cluster-after-vlm.json
+   ```
+
+   Success: peak memory remains below each rank's approved ceiling and no rank
+   enters memory-pressure teardown. If it does, reduce context/prefill load or
+   increase reserve; do not treat aggregate 256 GiB as one address space.
+
+10. Gracefully unload the model in the Models/Cluster UI, verify both rank
+    processes exit, then load it again and repeat the text and one-image short
+    requests. Success is clean `teardown`, followed by two new `ready` ranks
+    and identical answers without stale cache state.
+
+## Capture checklist
+
+- [ ] Exact git commit, `uv run omlx --version`, Python, MLX, MLX-LM, macOS.
+- [ ] `/tmp/dsv4-vision-plan.json`; rank 0 late range plus coordinator bytes;
+      rank 1 early range and zero coordinator bytes.
+- [ ] Per-rank planned, measured, peak, reserve, and headroom bytes.
+- [ ] Complete stage logs from recognition through teardown; no prompt/image
+      contents or tensor dumps.
+- [ ] Ring/JACCL interface, route, collective bandwidth, and transport errors.
+- [ ] Model load time and image-encode time.
+- [ ] TTFT, prefill tok/s, decode tok/s, and peak memory per Mac.
+- [ ] Text, one-image, streaming, second-image, long-prompt, unload/reload results.
+
+Passing loopback tests does not prove Thunderbolt RDMA/JACCL correctness. Only
+record the backend as hardware-validated after the physical run completes.

--- a/docs/experimental/deepseek_v4_flash_vision_cluster.md
+++ b/docs/experimental/deepseek_v4_flash_vision_cluster.md
@@ -1,6 +1,7 @@
 # DeepSeek-V4-Flash-Vision two-Mac validation
 
-Status: experimental; single-Mac/loopback validated, physical two-Mac run pending.
+Status: experimental; single-Mac/loopback and the core physical two-Mac path
+validated. The latest crash-recovery hardening awaits another physical-pair run.
 
 This path is intentionally specific to
 `deepseek-ai/DeepSeek-V4-Flash-Vision-Exp`. Rank 0 preprocesses images, owns
@@ -35,6 +36,37 @@ Pair Mac B in Mac A's **Cluster** tab. Prefer the direct Thunderbolt addresses;
 use Ring first, then JACCL only after the baseline succeeds.
 
 ## Ordered test procedure
+
+### Single-Mac hardware canary
+
+Before a scarce two-Mac test window, run the download-free canary on any
+Apple-silicon Mac:
+
+```bash
+uv run omlx cluster hardware-canary --json \
+  | tee /tmp/omlx-hardware-canary.json
+```
+
+It uses the real Metal backend and runs the existing worker lifecycle,
+two-rank loopback all-sum, and unequal pipeline smokes. It also executes a tiny
+DeepSeek-V4 vision encoder and image-visibility attention call, asserting that
+a 2k-token text/image/text prompt isolates its image span and stays below a
+256 MiB transient bound. Finally, a separate process holds 128 MiB of evaluated
+Metal memory and ignores `SIGTERM`; the production distributed supervisor must
+escalate it, reap the complete process group, persist a simulated
+retained-memory reload quarantine, reject the reload, and clear the quarantine
+only after the capacity probe recovers.
+
+The allocation is deliberately too small to create memory pressure. It can be
+changed within the hard safety range of 16–512 MiB using
+`--allocation-mib`. The command reports a clear skip on non-Apple-silicon or
+Metal-unavailable hosts and always places temporary markers in a disposable
+directory.
+
+A pass validates the local Metal code paths and deterministic containment
+logic. It does **not** reproduce an IOGPU leak, load the full checkpoint, or
+validate cross-host Ring, Thunderbolt, or JACCL. Continue with the physical
+procedure below for those claims.
 
 1. Verify connectivity on both Macs.
 

--- a/docs/experimental/deepseek_v4_flash_vision_cluster.md
+++ b/docs/experimental/deepseek_v4_flash_vision_cluster.md
@@ -113,7 +113,9 @@ use Ring first, then JACCL only after the baseline succeeds.
 
 8. Send a longer text prompt plus one image. Success is a single unchunked
    image-bearing prefill, then ordinary decode. The vision tower must not run
-   again after prefill.
+   again after prefill. Include a tool-heavy OpenCode request of roughly 18k
+   prompt tokens: rank admission must use the local DeepSeek-V4 hybrid-attention
+   profile, not report the generic dense-SDPA false positive of roughly 40 GiB.
 
 9. During steps 5–8 capture the Cluster dashboard and:
 

--- a/docs/experimental/deepseek_v4_flash_vision_cluster.md
+++ b/docs/experimental/deepseek_v4_flash_vision_cluster.md
@@ -1,7 +1,14 @@
 # DeepSeek-V4-Flash-Vision two-Mac validation
 
-Status: experimental; single-Mac/loopback and the core physical two-Mac path
-validated. The latest crash-recovery hardening awaits another physical-pair run.
+Status: experimental. Physical 2× M5 Max / 128 GiB validation completed for
+the Ring backend on 2026-09-04 (commit `4cd08e33`): two-rank load, text,
+one-image, streaming, second-image cache isolation, ~10k-token text+image,
+~23k-token tool-heavy prefill, graceful unload/reload, and rank reaping all
+passed. The crash-recovery quarantine engaged correctly on a failed JACCL
+probe and is scoped per deployment. JACCL model serving is NOT yet validated
+on this revision: the Thunderbolt RDMA fabric had no IPv4 addresses and
+assigning them needs interactive sudo on both Macs. JACCL fails closed with a
+clear diagnostic in that state.
 
 This path is intentionally specific to
 `deepseek-ai/DeepSeek-V4-Flash-Vision-Exp`. Rank 0 preprocesses images, owns
@@ -166,6 +173,34 @@ procedure below for those claims.
     processes exit, then load it again and repeat the text and one-image short
     requests. Success is clean `teardown`, followed by two new `ready` ranks
     and identical answers without stale cache state.
+
+## Physical validation record (2026-09-04, 2× M5 Max 128 GiB)
+
+Revision `4cd08e33` (Ring backend over the Thunderbolt bridge subnet,
+oMLX 0.6.4 / MLX 0.32.2 / mlx-lm 0.31.3 / macOS 26.6.2 / Python 3.13.15):
+
+- Hardware canary: pass on both Macs (`ok: true`, `skipped: false`).
+- Planner: tensor parallel 1, rank 0 layers 22–43 with 932,786,176
+  coordinator bytes, rank 1 layers 0–22 with zero, contiguous, positive
+  headroom on both ranks, planned totals within capacity minus reserve.
+- Load: both ranks `ready`/`live`; layer ranges match the plan; measured
+  rank bytes 78.3 GiB (rank 0) / 80.9 GiB (rank 1); headroom 11.0 / 8.8 GiB.
+- Inference: text-only ok; one-image ok (119 prompt tokens, correct
+  description); streaming ok (22 SSE chunks ending in `[DONE]`); second
+  same-dimension image correctly described (no stale KV reuse); ~10k-token
+  text+image in 18.2 s with no stall; ~23k-token tool-heavy request in
+  24.4 s with prefix-cache reuse and no stall. Catalogue offers the
+  1,048,576-token multimodal context (no 128k fallback).
+- Teardown/reload: graceful unload reaped every rank process on both Macs;
+  reload returned two new `ready` ranks and repeated text/image requests
+  passed with no stale state.
+- Recovery: a JACCL probe without RDMA fabric failed closed
+  (`[jaccl] No IPv4-mapped GID for this device...`) and quarantined reloads
+  for that deployment only; Ring reloads were unaffected. Diagnostics no
+  longer warn on quarantine records after commit `4cd08e33`.
+- JACCL model serving remains unvalidated: `en1`/`en6`/`en2` had no IPv4
+  addresses (bridge `192.168.0.0/24` only) and repair needs interactive sudo
+  on both Macs. Do not mark JACCL hardware-validated from the Ring result.
 
 ## Capture checklist
 

--- a/docs/experimental/deepseek_v4_flash_vision_cluster.md
+++ b/docs/experimental/deepseek_v4_flash_vision_cluster.md
@@ -111,11 +111,14 @@ use Ring first, then JACCL only after the baseline succeeds.
    `vision_encode_begin` and a different content-keyed prompt-cache identity;
    the first image's KV state must not be reused.
 
-8. Send a longer text prompt plus one image. Success is a single unchunked
-   image-bearing prefill, then ordinary decode. The vision tower must not run
-   again after prefill. Include a tool-heavy OpenCode request of roughly 18k
-   prompt tokens: rank admission must use the local DeepSeek-V4 hybrid-attention
-   profile, not report the generic dense-SDPA false positive of roughly 40 GiB.
+8. Send a longer text prompt plus one image. Success is bounded, incremental
+   prefill with no chunk boundary inside an image-sentinel block, then ordinary
+   decode. The vision tower must run once for each image, not once per chunk.
+   Include a tool-heavy OpenCode request of roughly 18k prompt tokens: rank
+   admission must use the local DeepSeek-V4 hybrid-attention profile, not report
+   the generic dense-SDPA false positive of roughly 40 GiB. Also verify that the
+   catalogue offers the memory-supported multimodal context instead of stopping
+   at the old dense-KV estimate (commonly 128k).
 
 9. During steps 5–8 capture the Cluster dashboard and:
 

--- a/docs/experimental/deepseek_v4_vision_stability_validation.md
+++ b/docs/experimental/deepseek_v4_vision_stability_validation.md
@@ -1,0 +1,176 @@
+# DeepSeek V4 Vision stability validation
+
+Status: experimental. This note records an incident and defines evidence gates;
+it does not establish a root cause. Production rollout remains contingent on a
+physical two-Mac validation.
+
+## Refactor scope
+
+Based on PR #3354 head `cc113f9d` (fetched 2026-09-04). Current upstream main
+was fetched for comparison; this work does not merge unrelated main changes.
+
+- Queue the sequential Vision backend in the proxy. Waiting clients cannot
+  start a backend inactivity timer or cancel the request ahead of them.
+- Use backend SSE progress for both public streaming and non-streaming calls;
+  preserve one final public response for non-streaming callers.
+- Keep activity accounting correct through repeated cancellation. Map launch
+  and recovery failures to HTTP 503; preserve pending unload and memory
+  accounting if deferred cleanup fails.
+- Agree cache prefix lengths and successful SSD restores across ranks before
+  reuse. Convert local memory-probe failures into an agreed rejection.
+- Signal local and remote ranks before waiting for exit, retain worker identity
+  for verification, and honor quarantine even if writing its marker fails.
+- Bound fallback indexer score tiles and remove per-token GPU sentinel checks
+  using shared image spans. Release image preparation state as it is consumed.
+
+These address concrete failure paths, not a proven root cause for this incident.
+Actual throughput and post-crash driver recovery still require hardware evidence.
+
+Image admission now rejects more than 16 images per request, payloads over
+50 MiB (base64 size is checked before decoding), source images over 64 Mi-pixels,
+and resized inputs above 8192 ViT patches per image. These limits bound image
+preprocessing and encoding before large allocations.
+
+## Incident evidence
+
+The 2026-09-04 run used oMLX 0.6.4, MLX 0.32.2, mlx-lm 0.31.3, two ranks,
+JACCL, and `DeepSeek-V4-Flash-Vision-Exp`. The deployment became ready at
+12:46:48. Before failure, requests completed through prompts of 67,165 tokens;
+the logged 64,722-token request took 49.96 s and the 67,165-token request took
+44.81 s. These records do not include per-request wall-clock timestamps or
+vision stage markers.
+
+The primary recorded symptom is `rank-zero inference stream timed out: no
+rank-zero data for 300s while the cluster was ready`. The supervisor then
+stopped the deployment and reaped remote rank 1 as killed. No rank-zero exit
+status, signal, Metal/IOGPU diagnostic, or JACCL transport error is present.
+
+The follow-on errors are recovery containment: reload was quarantined because
+both rank processes had exited while live memory ceilings remained low. The
+reported reload requirements were 86.5 GiB (rank 0) and 88.6 GiB (rank 1),
+while immediately available capacity was about 42 GiB on each. Later requests
+returned 500, and unload returned 503. At 13:24:52 the service reported four
+consecutive failed health checks and restarted the service.
+
+Possible explanations include a rank-zero long-prefill/decode stall, a
+rank/transport failure, or retained driver memory after termination. The log
+cannot distinguish these. Python cannot force reclaim of memory retained by a
+Metal driver; the recovery quarantine must therefore remain authoritative until
+a capacity probe demonstrates recovery. Do not clear it by deleting markers or
+by changing system settings.
+
+## Cheapest local gates
+
+These commands use repository code and synthetic fixtures; they do not require
+the full checkpoint or a cluster. Run from the repository root:
+
+```bash
+.venv/bin/python -m pytest -q tests/test_cluster_launch.py -k 'quarantine or recovery'
+.venv/bin/python -m pytest -q tests/test_cluster_runtime.py -k 'marker or recovery'
+.venv/bin/python -m pytest -q tests/test_deepseek_v4_vision.py tests/test_deepseek_v4_patch.py
+.venv/bin/python -m pytest -q tests/test_distributed_engine.py tests/test_cluster_engine_pool.py
+.venv/bin/python -m pytest -q tests/test_cluster_prefill_guard.py tests/test_cluster_telemetry.py
+```
+
+The first two gates cover persisted quarantine and proof-of-recovery behavior.
+The vision tests cover tensor/embedding contracts with test fixtures. Route and
+seam tests cover failure responses without starting ranks. Record commit,
+Python, package versions, exit status, and the complete test output.
+
+The broader local regression command used for this refactor is:
+
+```bash
+.venv/bin/python -m pytest -q tests/test_cluster_*.py tests/test_distributed_engine.py \
+  tests/test_deepseek_v4_vision.py tests/test_deepseek_v4_patch.py \
+  tests/test_deepseek_v4_indexer_dispatch.py tests/test_deepseek_v4_wsdpa.py \
+  tests/test_server.py tests/test_engine_pool.py --disable-warnings
+```
+
+The repository's default pytest selection excludes slow/model-loading and live
+integration tests. MLX import still requires local Metal access; the test suite
+is not evidence of physical JACCL or full-model performance validation.
+
+Final local run (2026-09-04, Python 3.12.13): **1400 passed, 62 skipped** in
+80.74 seconds. `python -m compileall -q omlx tests` and `git diff --check` passed.
+Ruff reported no new diagnostics relative to the PR head; existing diagnostics
+in the large model patch and server files remain. The shared transport, queue
+cancellation, deferred teardown and HTTP error changes also received an
+independent Sol review with no actionable findings.
+
+If a local Apple-silicon hardware check is available, treat this as a separate
+gate and capture its JSON output:
+
+```bash
+.venv/bin/python -m omlx.cli cluster hardware-canary --json
+```
+
+It is intentionally small, but it still exercises Metal. It does not reproduce
+a full-checkpoint leak or validate physical JACCL.
+
+## Staged physical validation: 2x M5 Max, 128 GiB, JACCL
+
+Use identical commit, absolute checkpoint path, Python, MLX, mlx-lm, and oMLX
+configuration. Mac A is rank 0. Preserve the signed planner JSON and dashboard
+status for every stage. Do not proceed when either planned resident total is
+above capacity minus reserve.
+
+1. Record baseline memory, capacity, route/interface, JACCL version, and process
+   identities on both Macs. Run worker, collective, and pipeline smokes.
+2. Run the planner with two 128 GiB nodes and a conservative 16 GiB reserve.
+   Verify pipeline support, tensor parallel size 1, rank-0 coordinator bytes,
+   rank-1 zero coordinator bytes, contiguous ranges, and positive headroom.
+3. Load once and prove both ranks reach ready. Capture planned, measured, peak,
+   reserve, and headroom bytes, plus proof that both rank processes exit on
+   teardown.
+4. Send text-only, then one short image, then streamed one-image requests.
+   Require the expected vision encode, multimodal embedding, distributed
+   prefill, and first-token markers; rank 0 alone reports image ownership.
+5. Exercise context bands near 64k, 67k, and near 128k only after short tests
+   pass. Record TTFT, prefill/decode rates, expanded sequence length, peak
+   memory, and time since the previous stage. A request must fail before launch
+   when planner admission is insufficient; no rank may enter pressure teardown.
+6. Alternate two same-dimension but different-content images. Require distinct
+   content-keyed cache identities and one vision encode per image; no stale KV
+   reuse is acceptable.
+7. Cancel an in-flight streamed request at short, 64k, and 67k contexts. Require
+   bounded cancellation, rank-zero and rank-one proof of exit, and a recovered
+   memory baseline before retrying. A cancellation timeout is a failure even if
+   the HTTP client disconnects.
+8. Unload, prove complete rank/process-group exit, wait for capacity recovery,
+   reload, and repeat text plus one-image requests. Answers, stage counts, and
+   memory baselines must match the first pass within an agreed tolerance.
+
+Also queue two Vision requests behind a long request and cancel one waiter.
+Only the running request should reach the backend; the remaining waiter should
+complete afterward without worker reload. Test a public non-streaming response
+lasting longer than 300 seconds while rank-zero keeps reporting progress. In
+small-model fault tests, remove one rank's cached prefix or invalidate its SSD
+snapshot: both ranks must recompute together, then successfully serve a new
+request. A local admission probe error must reject on all ranks without a hang.
+
+For each request retain request size/type, context band, stream/cancel outcome,
+stage timestamps, rank exit evidence, per-rank memory samples, and the exact
+error. Do not retain prompt contents, images, or tensor dumps.
+
+Use identical prompts and cache state at `cc113f9d` and the refactor, recording
+five warm runs per context band, with native indexer availability recorded.
+Target median decode throughput within 5% and short-request TTFT within 10% of
+baseline; report long-prefill changes separately because bounding the fallback
+indexer may trade throughput for lower peak memory. Flag any missing
+rank-zero event for 300 s, any unexplained multi-minute gap, monotonic memory
+growth after completed requests, or a post-teardown baseline that does not
+recover. Treat the observed 300-second timeout as a hard failure, not a normal
+long-context result.
+
+## Optional fault testing
+
+Only after small synthetic fault tests pass, an operator may run hazardous
+full-size crash/kill tests on an isolated pair. These can retain driver memory,
+kill ranks, and require a reboot; they must not be used to justify production
+readiness. Capture supervisor escalation, complete process-group exit,
+quarantine persistence, capacity recovery, and refusal to reload while memory
+is retained. Never force this path with destructive shell commands or a sysctl
+change.
+
+Until the physical sequence above passes, classify the implementation as
+experimental and keep reload quarantine enabled.

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -3112,9 +3112,12 @@
 
             clusterModelContextLabel(model) {
                 const fit = this.clusterCatalogueFit(model?.model_path);
-                const tokens = Number(fit?.max_context_tokens || 0);
+                const multimodal = Number(
+                    fit?.max_multimodal_context_tokens || 0
+                );
+                const tokens = multimodal || Number(fit?.max_context_tokens || 0);
                 return fit?.fits === true && tokens > 0
-                    ? `Up to ${this.clusterTokens(tokens)} context`
+                    ? `Up to ${this.clusterTokens(tokens)}${multimodal > 0 ? ' multimodal' : ''} context`
                     : '';
             },
 
@@ -3122,7 +3125,11 @@
                 const declared = Number(model?.model_context_length || 8192);
                 const target = Number(requested || declared || 8192);
                 const fit = this.clusterCatalogueFit(model?.model_path);
-                const maximum = Number(fit?.max_context_tokens || 0);
+                const maximum = Number(
+                    fit?.max_multimodal_context_tokens
+                    || fit?.max_context_tokens
+                    || 0
+                );
                 return fit?.fits === true && maximum > 0
                     ? Math.min(target, maximum)
                     : target;
@@ -3137,7 +3144,11 @@
                     || model.model_context_length
                     || 0
                 );
-                const maximum = Number(fit?.max_context_tokens || 0);
+                const maximum = Number(
+                    fit?.max_multimodal_context_tokens
+                    || fit?.max_context_tokens
+                    || 0
+                );
                 if (fit?.fits !== true || maximum <= 0) {
                     // Catalogue assessment is asynchronous. Until it arrives,
                     // retain the last known-safe choice (8k on first use)

--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -891,6 +891,37 @@ def cluster_command(args) -> int:
             print(f"Elapsed:     {result['elapsed_seconds']:.3f}s")
         return 0
 
+    if action == "hardware-canary":
+        from .cluster.hardware_canary import (
+            HardwareCanaryError,
+            HardwareCanarySkipError,
+            run_local_hardware_canary,
+        )
+
+        try:
+            result = run_local_hardware_canary(
+                timeout=args.timeout,
+                allocation_mib=args.allocation_mib,
+            )
+        except HardwareCanarySkipError as exc:
+            result = {"ok": False, "skipped": True, "reason": str(exc)}
+            if args.json:
+                print(json.dumps(result, indent=2, sort_keys=True))
+            else:
+                print(f"oMLX Apple-silicon hardware canary skipped: {exc}")
+            return 0
+        except (HardwareCanaryError, OSError, RuntimeError, ValueError) as exc:
+            print(f"Cluster hardware canary failed: {exc}", file=sys.stderr)
+            return 1
+        if args.json:
+            print(json.dumps(result, indent=2, sort_keys=True))
+        else:
+            print("oMLX Apple-silicon hardware canary passed")
+            print("Checks:      worker, collective, pipeline, vision, crash recovery")
+            print(f"Elapsed:     {result['elapsed_seconds']:.3f}s")
+            print("Scope:       one Mac, two ranks over loopback")
+        return 0
+
     if action == "plan":
         import socket
 
@@ -1385,6 +1416,27 @@ Example directory structure:
         help="Overall pipeline deadline in seconds (default: 30)",
     )
     cluster_pipeline_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON",
+    )
+    cluster_hardware_parser = cluster_subparsers.add_parser(
+        "hardware-canary",
+        help="Run safe Metal, two-rank, and crash-recovery checks on one Mac",
+    )
+    cluster_hardware_parser.add_argument(
+        "--timeout",
+        type=_positive_float,
+        default=45.0,
+        help="Per-check deadline in seconds (default: 45)",
+    )
+    cluster_hardware_parser.add_argument(
+        "--allocation-mib",
+        type=_positive_int,
+        default=128,
+        help="Metal allocation held during fault injection, 16-512 MiB (default: 128)",
+    )
+    cluster_hardware_parser.add_argument(
         "--json",
         action="store_true",
         help="Emit machine-readable JSON",

--- a/omlx/cluster/catalogue.py
+++ b/omlx/cluster/catalogue.py
@@ -351,7 +351,7 @@ def assess_model(
         tensor_parallel_ok = bool(layout.supports_tensor_parallel)
     if pipeline_ok is None:
         pipeline_ok = bool(layout.supports_pipeline)
-    weight_bytes = layout.fixed_weight_bytes + sum(layout.layer_weight_bytes)
+    weight_bytes = layout.total_weight_bytes
     name = model_id or Path(layout.source).name
     nodes = list(nodes)
     last_reason = "no node budgets were supplied"

--- a/omlx/cluster/catalogue.py
+++ b/omlx/cluster/catalogue.py
@@ -70,6 +70,7 @@ class ModelFit:
     pipeline_stages: int = 1
     nodes_required: int = 0
     max_context_tokens: int = 0
+    max_multimodal_context_tokens: int = 0
     declared_context_tokens: int | None = None
     splittable: bool = True
     headroom_bytes: int = 0
@@ -153,6 +154,7 @@ class ModelFit:
             "pipeline_stages": self.pipeline_stages,
             "nodes_required": self.nodes_required,
             "max_context_tokens": self.max_context_tokens,
+            "max_multimodal_context_tokens": self.max_multimodal_context_tokens,
             "declared_context_tokens": self.declared_context_tokens,
             "context_is_limited": self.context_is_limited,
             "splittable": self.splittable,
@@ -287,7 +289,7 @@ def largest_context_that_fits(
     stages and per-node reserves, and would disagree with any shortcut here.
     """
 
-    if not layout.kv_bytes_per_token_per_layer:
+    if not layout.has_kv_cache_estimate:
         # Nothing is known about this model's KV growth — a synthetic layout
         # built from a download size, typically. Bisecting would return the
         # top of the ladder for every model, which is not an answer, it is a
@@ -391,10 +393,10 @@ def assess_model(
             workload_profile=workload_profile,
         )
         warnings: list[str] = []
-        if not context and layout.kv_bytes_per_token_per_layer:
+        if not context and layout.has_kv_cache_estimate:
             # Weights fit at the smallest context but nothing above it.
             context = _MIN_CONTEXT_TOKENS
-        if not layout.kv_bytes_per_token_per_layer:
+        if not layout.has_kv_cache_estimate:
             warnings.append(
                 "Context length is unknown: this model was planned from its "
                 "size, not its config. Download it for an exact answer."
@@ -414,6 +416,9 @@ def assess_model(
             pipeline_stages=stages,
             nodes_required=used,
             max_context_tokens=context,
+            max_multimodal_context_tokens=(
+                context if layout.supports_chunked_multimodal_prefill else 0
+            ),
             declared_context_tokens=declared_context_tokens,
             headroom_bytes=max(0, headroom),
             model_path=layout.source,
@@ -459,7 +464,7 @@ def assess_model(
                 ceiling_tokens=declared_context_tokens,
                 workload_profile=workload_profile,
             )
-            if not standalone_context and layout.kv_bytes_per_token_per_layer:
+            if not standalone_context and layout.has_kv_cache_estimate:
                 standalone_context = _MIN_CONTEXT_TOKENS
             break
 

--- a/omlx/cluster/deepseek_v4_vision_runtime.py
+++ b/omlx/cluster/deepseek_v4_vision_runtime.py
@@ -69,63 +69,101 @@ def install_deepseek_v4_vision_runtime(
 
     response_type = server_module.ResponseGenerator
     original_tokenize = response_type._tokenize
+    original_share_request = getattr(response_type, "_share_request", None)
     original_serve_single = getattr(response_type, "_serve_single", None)
     original_stream_generate = server_module.stream_generate
     base_model_key = provider.model_key
+    prepared_images_by_digest = {}
     provider.is_batchable = False
 
     def clear_request_state(instance=None):
         provider.model_key = base_model_key
         provider.model.set_vision_inputs(None)
+        prepared_images_by_digest.clear()
         if instance is not None:
             instance._omlx_prefill_step_size_override = False
 
+    def prepare_shared_request(self, request, args):
+        try:
+            messages, image_records = _text_messages_and_images(request.messages)
+            shared_request = replace(request, messages=messages)
+            prompt, _segments, _types, initial_state = original_tokenize(
+                self,
+                self.model_provider.tokenizer,
+                shared_request,
+                args,
+            )
+            image_token_id = self.model_provider.tokenizer.convert_tokens_to_ids(
+                IMAGE_PLACEHOLDER
+            )
+            if (
+                image_token_id is None
+                or image_token_id == self.model_provider.tokenizer.unk_token_id
+            ):
+                raise ValueError(
+                    "DeepSeek image placeholder is missing from tokenizer: "
+                    f"{IMAGE_PLACEHOLDER}"
+                )
+            prompt, prepared_images = prepare_token_ids(
+                prompt,
+                image_records,
+                image_token_id=int(image_token_id),
+                config=config,
+            )
+            digest = _image_digest(prepared_images)
+            prepared_images_by_digest.clear()
+            prepared_images_by_digest[digest] = prepared_images
+            metadata = ("ok", prompt, initial_state, digest)
+        except Exception as exc:
+            logger.exception("deepseek_v4_vision stage=multimodal_prompt_failed rank=0")
+            prepared_images_by_digest.clear()
+            try:
+                shared_request = replace(request, messages=[])
+            except TypeError:
+                shared_request = copy.copy(request)
+                shared_request.messages = []
+            metadata = ("error", type(exc).__name__, str(exc), None)
+        shared_request._omlx_vision_metadata = metadata
+        return shared_request
+
+    def share_request(self, request):
+        if rank == 0 and request is not None:
+            queue, request_payload, request_args = request
+            if _request_has_images(request_payload):
+                request_payload = prepare_shared_request(
+                    self,
+                    request_payload,
+                    request_args,
+                )
+                request = (queue, request_payload, request_args)
+        try:
+            shared_request = original_share_request(self, request)
+            if shared_request is None:
+                clear_request_state(self)
+            return shared_request
+        except Exception:
+            clear_request_state(self)
+            raise
+
     def tokenize(self, tokenizer, request, args):
         self._omlx_prefill_step_size_override = False
-        if not _request_has_images(request):
+        metadata = getattr(request, "_omlx_vision_metadata", None)
+        if metadata is None:
             clear_request_state(self)
             return original_tokenize(self, tokenizer, request, args)
-
-        payload = None
-        prepared_images = None
-        if rank == 0:
-            try:
-                messages, image_records = _text_messages_and_images(request.messages)
-                text_request = replace(request, messages=messages)
-                prompt, _segments, _types, initial_state = original_tokenize(
-                    self, tokenizer, text_request, args
-                )
-                image_token_id = tokenizer.convert_tokens_to_ids(IMAGE_PLACEHOLDER)
-                if image_token_id is None or image_token_id == tokenizer.unk_token_id:
-                    raise ValueError(
-                        "DeepSeek image placeholder is missing from tokenizer: "
-                        f"{IMAGE_PLACEHOLDER}"
-                    )
-                prompt, prepared_images = prepare_token_ids(
-                    prompt,
-                    image_records,
-                    image_token_id=int(image_token_id),
-                    config=config,
-                )
-                payload = (
-                    "ok",
-                    prompt,
-                    initial_state,
-                    _image_digest(prepared_images),
-                )
-            except Exception as exc:
-                logger.exception(
-                    "deepseek_v4_vision stage=multimodal_prompt_failed rank=0"
-                )
-                payload = ("error", type(exc).__name__, str(exc))
-
-        shared = self._share_object(payload)
-        if shared[0] == "error":
+        if not isinstance(metadata, tuple) or len(metadata) != 4:
+            raise RuntimeError("DeepSeek-V4 vision request metadata is invalid")
+        status, prompt_or_type, initial_state_or_message, digest = metadata
+        if status == "error":
             raise RuntimeError(
                 f"DeepSeek-V4 vision preprocessing failed on rank zero "
-                f"({shared[1]}): {shared[2]}"
+                f"({prompt_or_type}): {initial_state_or_message}"
             )
-        _, prompt, initial_state, digest = shared
+        if status != "ok" or not isinstance(digest, str):
+            raise RuntimeError("DeepSeek-V4 vision request metadata is invalid")
+        prompt = prompt_or_type
+        initial_state = initial_state_or_message
+        prepared_images = prepared_images_by_digest.get(digest) if rank == 0 else None
         self.model_provider.model.set_vision_inputs(prepared_images)
         self.model_provider.model_key = (*base_model_key, "vision", digest)
         self._omlx_prefill_step_size_override = True
@@ -192,6 +230,8 @@ def install_deepseek_v4_vision_runtime(
         yield from original_stream_generate(*args, **kwargs)
 
     response_type._tokenize = tokenize
+    if original_share_request is not None:
+        response_type._share_request = share_request
     if original_serve_single is not None:
         response_type._serve_single = serve_single
     server_module.stream_generate = stream_generate
@@ -205,6 +245,8 @@ def install_deepseek_v4_vision_runtime(
     finally:
         clear_request_state()
         response_type._tokenize = original_tokenize
+        if original_share_request is not None:
+            response_type._share_request = original_share_request
         if original_serve_single is not None:
             response_type._serve_single = original_serve_single
         server_module.stream_generate = original_stream_generate

--- a/omlx/cluster/deepseek_v4_vision_runtime.py
+++ b/omlx/cluster/deepseek_v4_vision_runtime.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MLX-LM server bridge for the coordinator-owned DeepSeek-V4 vision path."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import logging
+import time
+from contextlib import contextmanager
+from dataclasses import replace
+from typing import Any
+
+from omlx.deepseek_v4_vision import IMAGE_PLACEHOLDER
+from omlx.patches.deepseek_v4.vision_inputs import prepare_token_ids
+
+logger = logging.getLogger(__name__)
+_IMAGE_TYPES = frozenset({"image", "image_url", "input_image"})
+
+
+def _request_has_images(request: Any) -> bool:
+    for message in getattr(request, "messages", ()) or ():
+        for part in message.get("content", ()) if isinstance(message, dict) else ():
+            if isinstance(part, dict) and part.get("type") in _IMAGE_TYPES:
+                return True
+    return False
+
+
+def _text_messages_and_images(messages):
+    rendered = copy.deepcopy(messages)
+    images = []
+    for message in rendered:
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        replacement = []
+        for part in content:
+            if not isinstance(part, dict) or part.get("type") not in _IMAGE_TYPES:
+                replacement.append(part)
+                continue
+            images.append(part.get("image_url", part))
+            replacement.append({"type": "text", "text": IMAGE_PLACEHOLDER})
+        message["content"] = replacement
+    return rendered, images
+
+
+def _image_digest(images) -> str:
+    digest = hashlib.sha256()
+    for image in images:
+        digest.update(memoryview(image.patches))
+        digest.update(str((image.n_vit_h, image.n_vit_w, image.types)).encode())
+    return digest.hexdigest()
+
+
+@contextmanager
+def install_deepseek_v4_vision_runtime(
+    server_module: Any,
+    provider: Any,
+    *,
+    config: dict[str, Any],
+    rank: int,
+):
+    """Teach the pinned text server to perform one rank-zero VLM prefill.
+
+    Only rank zero downloads/decodes images and executes the ViT. Expanded
+    sentinel token IDs are shared through the existing small control
+    collective; MLX embeddings are broadcast natively inside the model.
+    """
+
+    response_type = server_module.ResponseGenerator
+    original_tokenize = response_type._tokenize
+    original_stream_generate = server_module.stream_generate
+    base_model_key = provider.model_key
+    provider.is_batchable = False
+
+    def tokenize(self, tokenizer, request, args):
+        if not _request_has_images(request):
+            self.model_provider.model_key = base_model_key
+            self.model_provider.model.set_vision_inputs(None)
+            return original_tokenize(self, tokenizer, request, args)
+
+        payload = None
+        prepared_images = None
+        if rank == 0:
+            try:
+                messages, image_records = _text_messages_and_images(request.messages)
+                text_request = replace(request, messages=messages)
+                prompt, _segments, _types, initial_state = original_tokenize(
+                    self, tokenizer, text_request, args
+                )
+                image_token_id = tokenizer.convert_tokens_to_ids(IMAGE_PLACEHOLDER)
+                if image_token_id is None or image_token_id == tokenizer.unk_token_id:
+                    raise ValueError(
+                        "DeepSeek image placeholder is missing from tokenizer: "
+                        f"{IMAGE_PLACEHOLDER}"
+                    )
+                prompt, prepared_images = prepare_token_ids(
+                    prompt,
+                    image_records,
+                    image_token_id=int(image_token_id),
+                    config=config,
+                )
+                payload = (
+                    "ok",
+                    prompt,
+                    initial_state,
+                    _image_digest(prepared_images),
+                )
+            except Exception as exc:
+                logger.exception(
+                    "deepseek_v4_vision stage=multimodal_prompt_failed rank=0"
+                )
+                payload = ("error", type(exc).__name__, str(exc))
+
+        shared = self._share_object(payload)
+        if shared[0] == "error":
+            raise RuntimeError(
+                f"DeepSeek-V4 vision preprocessing failed on rank zero "
+                f"({shared[1]}): {shared[2]}"
+            )
+        _, prompt, initial_state, digest = shared
+        self.model_provider.model.set_vision_inputs(prepared_images)
+        self.model_provider.model_key = (*base_model_key, "vision", digest)
+        logger.info(
+            "deepseek_v4_vision stage=multimodal_prompt_ready rank=%d "
+            "images=%d sequence_length=%d",
+            rank,
+            len(prepared_images or ()),
+            len(prompt),
+        )
+        # Image caches are content-keyed, not token-layout-keyed. A single
+        # segment also prevents the server from caching a system prefix that
+        # crosses the image replacement boundary.
+        return prompt, [prompt], ["assistant"], initial_state
+
+    def stream_generate(*args, **kwargs):
+        prompt = kwargs.get("prompt")
+        if prompt is None and len(args) >= 3:
+            prompt = args[2]
+        if provider.model_key != base_model_key and prompt is not None:
+            kwargs["prefill_step_size"] = max(
+                int(kwargs.get("prefill_step_size", 0) or 0), len(prompt)
+            )
+            started = time.perf_counter()
+            logger.info(
+                "deepseek_v4_vision stage=distributed_prefill_begin rank=%d "
+                "sequence_length=%d",
+                rank,
+                len(prompt),
+            )
+            first = True
+            steady = False
+            try:
+                for result in original_stream_generate(*args, **kwargs):
+                    if first:
+                        first = False
+                        logger.info(
+                            "deepseek_v4_vision stage=distributed_prefill_complete "
+                            "rank=%d elapsed_ms=%.1f",
+                            rank,
+                            (time.perf_counter() - started) * 1000,
+                        )
+                        logger.info(
+                            "deepseek_v4_vision stage=first_token rank=%d", rank
+                        )
+                    elif not steady:
+                        steady = True
+                        logger.info(
+                            "deepseek_v4_vision stage=steady_decode_begin rank=%d",
+                            rank,
+                        )
+                    yield result
+            finally:
+                logger.info("deepseek_v4_vision stage=request_complete rank=%d", rank)
+            return
+        yield from original_stream_generate(*args, **kwargs)
+
+    response_type._tokenize = tokenize
+    server_module.stream_generate = stream_generate
+    try:
+        logger.info(
+            "deepseek_v4_vision stage=runtime_ready rank=%d vision_owner=%s",
+            rank,
+            rank == 0,
+        )
+        yield
+    finally:
+        response_type._tokenize = original_tokenize
+        server_module.stream_generate = original_stream_generate
+        logger.info("deepseek_v4_vision stage=teardown rank=%d", rank)

--- a/omlx/cluster/deepseek_v4_vision_runtime.py
+++ b/omlx/cluster/deepseek_v4_vision_runtime.py
@@ -69,14 +69,21 @@ def install_deepseek_v4_vision_runtime(
 
     response_type = server_module.ResponseGenerator
     original_tokenize = response_type._tokenize
+    original_serve_single = getattr(response_type, "_serve_single", None)
     original_stream_generate = server_module.stream_generate
     base_model_key = provider.model_key
     provider.is_batchable = False
 
+    def clear_request_state(instance=None):
+        provider.model_key = base_model_key
+        provider.model.set_vision_inputs(None)
+        if instance is not None:
+            instance._omlx_prefill_step_size_override = False
+
     def tokenize(self, tokenizer, request, args):
+        self._omlx_prefill_step_size_override = False
         if not _request_has_images(request):
-            self.model_provider.model_key = base_model_key
-            self.model_provider.model.set_vision_inputs(None)
+            clear_request_state(self)
             return original_tokenize(self, tokenizer, request, args)
 
         payload = None
@@ -121,6 +128,7 @@ def install_deepseek_v4_vision_runtime(
         _, prompt, initial_state, digest = shared
         self.model_provider.model.set_vision_inputs(prepared_images)
         self.model_provider.model_key = (*base_model_key, "vision", digest)
+        self._omlx_prefill_step_size_override = True
         logger.info(
             "deepseek_v4_vision stage=multimodal_prompt_ready rank=%d "
             "images=%d sequence_length=%d",
@@ -132,6 +140,14 @@ def install_deepseek_v4_vision_runtime(
         # segment also prevents the server from caching a system prefix that
         # crosses the image replacement boundary.
         return prompt, [prompt], ["assistant"], initial_state
+
+    def serve_single(self, request):
+        try:
+            return original_serve_single(self, request)
+        finally:
+            # Keep the image digest through both cache lookup and insertion,
+            # then return ModelProvider to the identity expected by load().
+            clear_request_state(self)
 
     def stream_generate(*args, **kwargs):
         prompt = kwargs.get("prompt")
@@ -176,6 +192,8 @@ def install_deepseek_v4_vision_runtime(
         yield from original_stream_generate(*args, **kwargs)
 
     response_type._tokenize = tokenize
+    if original_serve_single is not None:
+        response_type._serve_single = serve_single
     server_module.stream_generate = stream_generate
     try:
         logger.info(
@@ -185,6 +203,9 @@ def install_deepseek_v4_vision_runtime(
         )
         yield
     finally:
+        clear_request_state()
         response_type._tokenize = original_tokenize
+        if original_serve_single is not None:
+            response_type._serve_single = original_serve_single
         server_module.stream_generate = original_stream_generate
         logger.info("deepseek_v4_vision stage=teardown rank=%d", rank)

--- a/omlx/cluster/deepseek_v4_vision_runtime.py
+++ b/omlx/cluster/deepseek_v4_vision_runtime.py
@@ -42,40 +42,7 @@ def vision_prefill_chunks(
         return ()
     configured = max(1, int(max_chunk_tokens))
 
-    spans: list[tuple[int, int]] = []
-    # An image block can have up to three alignment pads before IMAGE_START.
-    # Treat the complete contiguous sentinel run as the protected span. A
-    # prompt-cache hit may also leave this suffix part-way through a block.
-    start = None
-    saw_start = False
-    for index, token in enumerate(values):
-        kind = token - int(vocab_size)
-        if kind < 0:
-            if start is not None:
-                raise ValueError("DeepSeek image sentinel block is incomplete")
-            continue
-        if start is None:
-            if kind == IMAGE_END:
-                if index == 0:
-                    # The cached prefix can end immediately before IMAGE_END.
-                    spans.append((0, 1))
-                    continue
-                raise ValueError("DeepSeek image end sentinel has no start")
-            start = index
-            saw_start = kind == IMAGE_START
-            continue
-        if kind == IMAGE_START:
-            if saw_start:
-                raise ValueError("nested DeepSeek image sentinel blocks are invalid")
-            saw_start = True
-        elif kind == IMAGE_END:
-            if not saw_start and start != 0:
-                raise ValueError("DeepSeek image end sentinel has no start")
-            spans.append((start, index + 1))
-            start = None
-            saw_start = False
-    if start is not None:
-        raise ValueError("DeepSeek image sentinel block is incomplete")
+    spans = vision_token_spans(values, vocab_size=vocab_size)
 
     chunks: list[tuple[int, int]] = []
     position = 0
@@ -103,6 +70,53 @@ def vision_prefill_chunks(
         position = end
     append_text_until(total)
     return tuple(chunks)
+
+
+def vision_token_spans(
+    tokens,
+    *,
+    vocab_size: int,
+) -> tuple[tuple[int, int], ...]:
+    """Return image-sentinel spans, accepting a cache suffix inside a block."""
+
+    values = [int(token) for token in tokens]
+    spans: list[tuple[int, int]] = []
+    # An image block can have up to three alignment pads before IMAGE_START.
+    # Treat the complete contiguous sentinel run as the protected span. A
+    # prompt-cache hit may also leave this suffix part-way through a block.
+    start = None
+    saw_start = False
+    for index, token in enumerate(values):
+        kind = token - int(vocab_size)
+        if kind < 0:
+            if start is not None:
+                raise ValueError("DeepSeek image sentinel block is incomplete")
+            continue
+        if kind > IMAGE_END:
+            raise ValueError(f"invalid DeepSeek image sentinel kind {kind}")
+        if start is None:
+            if kind == IMAGE_END:
+                if index == 0:
+                    # The cached prefix can end immediately before IMAGE_END.
+                    spans.append((0, 1))
+                    continue
+                raise ValueError("DeepSeek image end sentinel has no start")
+            start = index
+            saw_start = kind == IMAGE_START
+            continue
+        if kind == IMAGE_START:
+            if saw_start:
+                raise ValueError("nested DeepSeek image sentinel blocks are invalid")
+            saw_start = True
+        elif kind == IMAGE_END:
+            if not saw_start and start != 0:
+                raise ValueError("DeepSeek image end sentinel has no start")
+            spans.append((start, index + 1))
+            start = None
+            saw_start = False
+    if start is not None:
+        raise ValueError("DeepSeek image sentinel block is incomplete")
+    return tuple(spans)
 
 
 def _prefill_prompt_chunk(model, prompt_cache, tokens, kwargs) -> None:
@@ -270,16 +284,22 @@ def install_deepseek_v4_vision_runtime(
             raise RuntimeError("DeepSeek-V4 vision request metadata is invalid")
         prompt = prompt_or_type
         initial_state = initial_state_or_message
-        prepared_images = prepared_images_by_digest.get(digest) if rank == 0 else None
-        self.model_provider.model.set_vision_inputs(prepared_images)
-        self.model_provider.model_key = (*base_model_key, "vision", digest)
-        self._omlx_prefill_step_size_override = True
+        prepared_images = prepared_images_by_digest.pop(digest, None) if rank == 0 else None
         model_args = getattr(self.model_provider.model, "args", None)
-        self._omlx_vision_vocab_size = int(
+        vocab_size = int(
             config.get("vocab_size")
             or getattr(model_args, "vocab_size", 0)
             or 0
         )
+        spans = (
+            vision_token_spans(prompt, vocab_size=vocab_size)
+            if vocab_size > 0
+            else ()
+        )
+        self.model_provider.model.set_vision_inputs(prepared_images, spans=spans)
+        self.model_provider.model_key = (*base_model_key, "vision", digest)
+        self._omlx_prefill_step_size_override = True
+        self._omlx_vision_vocab_size = vocab_size
         logger.info(
             "deepseek_v4_vision stage=multimodal_prompt_ready rank=%d "
             "images=%d sequence_length=%d",

--- a/omlx/cluster/deepseek_v4_vision_runtime.py
+++ b/omlx/cluster/deepseek_v4_vision_runtime.py
@@ -43,41 +43,65 @@ def vision_prefill_chunks(
     configured = max(1, int(max_chunk_tokens))
 
     spans: list[tuple[int, int]] = []
-    # A prompt-cache hit may leave this suffix part-way through an image
-    # block.  The model uses the same rule: any image sentinel in position
-    # zero means the current suffix starts inside a block.
-    first_kind = values[0] - int(vocab_size)
-    start = 0 if values[0] >= int(vocab_size) and first_kind != IMAGE_START else None
+    # An image block can have up to three alignment pads before IMAGE_START.
+    # Treat the complete contiguous sentinel run as the protected span. A
+    # prompt-cache hit may also leave this suffix part-way through a block.
+    start = None
+    saw_start = False
     for index, token in enumerate(values):
         kind = token - int(vocab_size)
-        if kind == IMAGE_START:
+        if kind < 0:
             if start is not None:
-                raise ValueError("nested DeepSeek image sentinel blocks are invalid")
+                raise ValueError("DeepSeek image sentinel block is incomplete")
+            continue
+        if start is None:
+            if kind == IMAGE_END:
+                if index == 0:
+                    # The cached prefix can end immediately before IMAGE_END.
+                    spans.append((0, 1))
+                    continue
+                raise ValueError("DeepSeek image end sentinel has no start")
             start = index
+            saw_start = kind == IMAGE_START
+            continue
+        if kind == IMAGE_START:
+            if saw_start:
+                raise ValueError("nested DeepSeek image sentinel blocks are invalid")
+            saw_start = True
         elif kind == IMAGE_END:
-            if start is None:
+            if not saw_start and start != 0:
                 raise ValueError("DeepSeek image end sentinel has no start")
             spans.append((start, index + 1))
             start = None
+            saw_start = False
     if start is not None:
         raise ValueError("DeepSeek image sentinel block is incomplete")
 
     chunks: list[tuple[int, int]] = []
     position = 0
     total = len(values)
-    while position < total:
-        # Return to the configured cadence after an image forced an early or
-        # oversized chunk. This preserves ordinary prompt-snapshot boundaries
-        # for the text suffix instead of shifting every later chunk.
-        boundary = min(((position // configured) + 1) * configured, total)
-        for begin, end in spans:
-            if begin < boundary < end:
-                boundary = begin if begin > position else end
-                break
-        if boundary <= position:  # pragma: no cover - defensive invariant
-            raise RuntimeError("could not construct an image-safe prefill chunk")
-        chunks.append((position, boundary))
-        position = boundary
+
+    def append_text_until(limit: int) -> None:
+        nonlocal position
+        while position < limit:
+            # Keep ordinary text chunks on the configured global cadence so
+            # prompt snapshots remain reusable across requests.
+            boundary = min(((position // configured) + 1) * configured, limit)
+            if boundary <= position:  # pragma: no cover - defensive invariant
+                raise RuntimeError("could not construct a text prefill chunk")
+            chunks.append((position, boundary))
+            position = boundary
+
+    for begin, end in spans:
+        append_text_until(begin)
+        # Isolate every image block even when it would fit inside a normal
+        # text chunk. Image visibility disables standard causal kernels for
+        # the whole model call; mixing surrounding text into that call can
+        # produce a much larger attention transient and hang Metal before the
+        # next progress keepalive.
+        chunks.append((begin, end))
+        position = end
+    append_text_until(total)
     return tuple(chunks)
 
 

--- a/omlx/cluster/deepseek_v4_vision_runtime.py
+++ b/omlx/cluster/deepseek_v4_vision_runtime.py
@@ -7,15 +7,96 @@ import copy
 import hashlib
 import logging
 import time
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from dataclasses import replace
 from typing import Any
 
-from omlx.deepseek_v4_vision import IMAGE_PLACEHOLDER
+from omlx.deepseek_v4_vision import (
+    IMAGE_END,
+    IMAGE_PLACEHOLDER,
+    IMAGE_START,
+)
 from omlx.patches.deepseek_v4.vision_inputs import prepare_token_ids
 
 logger = logging.getLogger(__name__)
 _IMAGE_TYPES = frozenset({"image", "image_url", "input_image"})
+
+
+def vision_prefill_chunks(
+    tokens,
+    *,
+    vocab_size: int,
+    max_chunk_tokens: int,
+) -> tuple[tuple[int, int], ...]:
+    """Partition a prompt without ever splitting an image sentinel block.
+
+    All ranks receive the same expanded token IDs, so this pure function also
+    gives them an identical sequence of model calls without another control
+    collective. Chunks stay at or below the configured prefill size unless an
+    image block itself is larger, in which case exactly that block sets the
+    minimum safe size.
+    """
+
+    values = [int(token) for token in tokens]
+    if not values:
+        return ()
+    configured = max(1, int(max_chunk_tokens))
+
+    spans: list[tuple[int, int]] = []
+    # A prompt-cache hit may leave this suffix part-way through an image
+    # block.  The model uses the same rule: any image sentinel in position
+    # zero means the current suffix starts inside a block.
+    first_kind = values[0] - int(vocab_size)
+    start = 0 if values[0] >= int(vocab_size) and first_kind != IMAGE_START else None
+    for index, token in enumerate(values):
+        kind = token - int(vocab_size)
+        if kind == IMAGE_START:
+            if start is not None:
+                raise ValueError("nested DeepSeek image sentinel blocks are invalid")
+            start = index
+        elif kind == IMAGE_END:
+            if start is None:
+                raise ValueError("DeepSeek image end sentinel has no start")
+            spans.append((start, index + 1))
+            start = None
+    if start is not None:
+        raise ValueError("DeepSeek image sentinel block is incomplete")
+
+    chunks: list[tuple[int, int]] = []
+    position = 0
+    total = len(values)
+    while position < total:
+        # Return to the configured cadence after an image forced an early or
+        # oversized chunk. This preserves ordinary prompt-snapshot boundaries
+        # for the text suffix instead of shifting every later chunk.
+        boundary = min(((position // configured) + 1) * configured, total)
+        for begin, end in spans:
+            if begin < boundary < end:
+                boundary = begin if begin > position else end
+                break
+        if boundary <= position:  # pragma: no cover - defensive invariant
+            raise RuntimeError("could not construct an image-safe prefill chunk")
+        chunks.append((position, boundary))
+        position = boundary
+    return tuple(chunks)
+
+
+def _prefill_prompt_chunk(model, prompt_cache, tokens, kwargs) -> None:
+    """Run one non-final prefill chunk exactly like mlx-lm ``generate_step``."""
+
+    import mlx.core as mx
+    from mlx_lm.generate import generation_stream, maybe_quantize_kv_cache
+
+    with mx.stream(generation_stream):
+        model(mx.array(tokens)[None], cache=prompt_cache)
+        maybe_quantize_kv_cache(
+            prompt_cache,
+            kwargs.get("quantized_kv_start", 0),
+            kwargs.get("kv_group_size", 64),
+            kwargs.get("kv_bits"),
+        )
+        mx.eval([cache.state for cache in prompt_cache])
+        mx.clear_cache()
 
 
 def _request_has_images(request: Any) -> bool:
@@ -82,6 +163,7 @@ def install_deepseek_v4_vision_runtime(
         prepared_images_by_digest.clear()
         if instance is not None:
             instance._omlx_prefill_step_size_override = False
+            instance._omlx_vision_vocab_size = None
 
     def prepare_shared_request(self, request, args):
         try:
@@ -147,6 +229,7 @@ def install_deepseek_v4_vision_runtime(
 
     def tokenize(self, tokenizer, request, args):
         self._omlx_prefill_step_size_override = False
+        self._omlx_vision_vocab_size = None
         metadata = getattr(request, "_omlx_vision_metadata", None)
         if metadata is None:
             clear_request_state(self)
@@ -167,6 +250,12 @@ def install_deepseek_v4_vision_runtime(
         self.model_provider.model.set_vision_inputs(prepared_images)
         self.model_provider.model_key = (*base_model_key, "vision", digest)
         self._omlx_prefill_step_size_override = True
+        model_args = getattr(self.model_provider.model, "args", None)
+        self._omlx_vision_vocab_size = int(
+            config.get("vocab_size")
+            or getattr(model_args, "vocab_size", 0)
+            or 0
+        )
         logger.info(
             "deepseek_v4_vision stage=multimodal_prompt_ready rank=%d "
             "images=%d sequence_length=%d",
@@ -192,27 +281,100 @@ def install_deepseek_v4_vision_runtime(
         if prompt is None and len(args) >= 3:
             prompt = args[2]
         if provider.model_key != base_model_key and prompt is not None:
-            kwargs["prefill_step_size"] = max(
-                int(kwargs.get("prefill_step_size", 0) or 0), len(prompt)
+            configured_step = max(
+                1, int(kwargs.get("prefill_step_size", 0) or 2048)
+            )
+            model = kwargs.get("model") or (args[0] if args else None)
+            model_args = getattr(model, "args", None)
+            vocab_size = int(
+                config.get("vocab_size")
+                or getattr(model_args, "vocab_size", 0)
+                or 0
+            )
+            chunks = (
+                vision_prefill_chunks(
+                    prompt,
+                    vocab_size=vocab_size,
+                    max_chunk_tokens=configured_step,
+                )
+                if vocab_size > 0
+                else ((0, len(prompt)),)
             )
             started = time.perf_counter()
             logger.info(
                 "deepseek_v4_vision stage=distributed_prefill_begin rank=%d "
-                "sequence_length=%d",
+                "sequence_length=%d chunks=%d max_chunk=%d",
                 rank,
                 len(prompt),
+                len(chunks),
+                max((end - start for start, end in chunks), default=0),
             )
+
+            # mlx-lm accepts one fixed prefill size. Process every variable
+            # image-safe prefix chunk here, then give its generator the final
+            # chunk and the already-advanced cache. This retains its sampling,
+            # logits-processor, cancellation, and cache-insertion behavior.
+            prompt_cache = kwargs.get("prompt_cache")
+            draft_model = kwargs.get("draft_model")
+            manual_chunks = bool(
+                len(chunks) > 1
+                and model is not None
+                and prompt_cache is not None
+                and draft_model is None
+            )
+            original_prompt_tokens = len(prompt)
+            processed = 0
+            progress = kwargs.get("prompt_progress_callback")
+            call_args = list(args)
+            call_kwargs = dict(kwargs)
+            if manual_chunks:
+                if progress is not None:
+                    progress(0, original_prompt_tokens)
+                for begin, end in chunks[:-1]:
+                    _prefill_prompt_chunk(
+                        model,
+                        prompt_cache,
+                        prompt[begin:end],
+                        kwargs,
+                    )
+                    processed = end
+                    if progress is not None:
+                        progress(processed, original_prompt_tokens)
+                tail_start, tail_end = chunks[-1]
+                tail = prompt[tail_start:tail_end]
+                if "prompt" in call_kwargs:
+                    call_kwargs["prompt"] = tail
+                elif len(call_args) >= 3:
+                    call_args[2] = tail
+                call_kwargs["prefill_step_size"] = max(
+                    configured_step, len(tail)
+                )
+                if progress is not None:
+                    call_kwargs["prompt_progress_callback"] = (
+                        lambda done, _total: progress(
+                            processed + int(done), original_prompt_tokens
+                        )
+                    )
+            else:
+                call_kwargs["prefill_step_size"] = max(
+                    configured_step,
+                    max((end - start for start, end in chunks), default=0),
+                )
+
             first = True
             steady = False
+            prompt_tps = None
             try:
-                for result in original_stream_generate(*args, **kwargs):
+                for result in original_stream_generate(*call_args, **call_kwargs):
                     if first:
                         first = False
+                        elapsed = time.perf_counter() - started
+                        prompt_tps = original_prompt_tokens / max(elapsed, 1e-9)
                         logger.info(
                             "deepseek_v4_vision stage=distributed_prefill_complete "
                             "rank=%d elapsed_ms=%.1f",
                             rank,
-                            (time.perf_counter() - started) * 1000,
+                            elapsed * 1000,
                         )
                         logger.info(
                             "deepseek_v4_vision stage=first_token rank=%d", rank
@@ -223,6 +385,13 @@ def install_deepseek_v4_vision_runtime(
                             "deepseek_v4_vision stage=steady_decode_begin rank=%d",
                             rank,
                         )
+                    if manual_chunks:
+                        with suppress(TypeError):
+                            result = replace(
+                                result,
+                                prompt_tokens=original_prompt_tokens,
+                                prompt_tps=prompt_tps,
+                            )
                     yield result
             finally:
                 logger.info("deepseek_v4_vision stage=request_complete rank=%d", rank)

--- a/omlx/cluster/deployment.py
+++ b/omlx/cluster/deployment.py
@@ -186,6 +186,9 @@ def _assignment_from_dict(payload: dict[str, Any]) -> PipelineAssignment:
             end_layer=int(payload["end_layer"]),
             layer_weight_bytes=int(payload["layer_weight_bytes"]),
             fixed_weight_bytes=int(payload["fixed_weight_bytes"]),
+            coordinator_weight_bytes=int(
+                payload.get("coordinator_weight_bytes", 0)
+            ),
             reserve_bytes=int(payload["reserve_bytes"]),
             capacity_bytes=int(payload["capacity_bytes"]),
             manual_memory_limit=bool(payload.get("manual_memory_limit", False)),
@@ -215,6 +218,7 @@ def _assignment_from_dict(payload: dict[str, Any]) -> PipelineAssignment:
         min(
             assignment.layer_weight_bytes,
             assignment.fixed_weight_bytes,
+            assignment.coordinator_weight_bytes,
             assignment.reserve_bytes,
             assignment.capacity_bytes,
             assignment.kv_cache_bytes,

--- a/omlx/cluster/hardware_canary.py
+++ b/omlx/cluster/hardware_canary.py
@@ -1,0 +1,378 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Small, download-free Apple-silicon regression canary."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import platform
+import select
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from collections.abc import Callable
+from contextlib import suppress
+from types import SimpleNamespace
+from typing import Any
+
+from .collective import run_local_collective_smoke, run_local_pipeline_smoke
+from .deployment import ClusterDeployment, ClusterHost
+from .launch import (
+    DistributedJobSupervisor,
+    DistributedMemoryRecoveryError,
+    _process_group_alive,
+)
+from .planner import PipelineAssignment
+from .supervisor import run_worker_smoke
+
+
+class HardwareCanaryError(RuntimeError):
+    """Raised when an Apple-silicon hardware assertion fails."""
+
+
+class HardwareCanarySkipError(RuntimeError):
+    """Raised when this host cannot execute the Metal canary."""
+
+
+def _require_metal() -> Any:
+    if platform.system() != "Darwin" or platform.machine().lower() != "arm64":
+        raise HardwareCanarySkipError("requires an Apple-silicon Mac")
+    try:
+        import mlx.core as mx
+    except ImportError as exc:
+        raise HardwareCanarySkipError("MLX is not installed") from exc
+    if not mx.metal.is_available():
+        raise HardwareCanarySkipError("the MLX Metal backend is unavailable")
+    return mx
+
+
+def _vision_prefill_metal_canary() -> dict[str, Any]:
+    """Exercise isolated image attention and the tiny ViT on real Metal."""
+
+    mx = _require_metal()
+    from omlx.cluster.deepseek_v4_vision_runtime import vision_prefill_chunks
+    from omlx.deepseek_v4_vision import (
+        IMAGE,
+        IMAGE_END,
+        IMAGE_NEWLINE,
+        IMAGE_START,
+    )
+    from omlx.patches.deepseek_v4 import apply_deepseek_v4_patch
+    from omlx.patches.deepseek_v4.vision_model import Aligner, ViT
+
+    # The vendored model is registered under its mlx-lm package name so its
+    # relative imports resolve exactly as they do during real model loading.
+    apply_deepseek_v4_patch()
+    from mlx_lm.models.deepseek_v4 import _apply_image_visibility_mask
+
+    vocab_size = 256
+    prefix = [7] * 1024
+    image = (
+        [vocab_size + IMAGE_START]
+        + [vocab_size + IMAGE] * 64
+        + [vocab_size + IMAGE_NEWLINE, vocab_size + IMAGE_END]
+    )
+    suffix = [11] * 1024
+    prompt = prefix + image + suffix
+    chunks = vision_prefill_chunks(
+        prompt,
+        vocab_size=vocab_size,
+        max_chunk_tokens=128,
+    )
+    image_chunks = [
+        (start, end)
+        for start, end in chunks
+        if any(token >= vocab_size for token in prompt[start:end])
+    ]
+    expected_image_chunk = (len(prefix), len(prefix) + len(image))
+    if image_chunks != [expected_image_chunk]:
+        raise HardwareCanaryError(
+            f"image span was not isolated from text: {image_chunks}"
+        )
+    if any(
+        end - start > 128 and (start, end) != expected_image_chunk
+        for start, end in chunks
+    ):
+        raise HardwareCanaryError("ordinary text exceeded the prefill chunk bound")
+
+    mx.synchronize()
+    mx.clear_cache()
+    baseline = int(mx.get_active_memory())
+    mx.reset_peak_memory()
+
+    token_array = mx.array([image])
+    visibility, applied = _apply_image_visibility_mask(
+        token_array,
+        None,
+        vocab_size,
+    )
+    if not applied or visibility is None:
+        raise HardwareCanaryError("image visibility mask was not applied")
+
+    length = len(image)
+    head_dim = 16
+    query = mx.ones((1, 2, length, head_dim), dtype=mx.float32)
+    key = mx.ones((1, 2, length, head_dim), dtype=mx.float32)
+    value = mx.arange(length * head_dim, dtype=mx.float32).reshape(
+        1, 1, length, head_dim
+    )
+    value = mx.broadcast_to(value, (1, 2, length, head_dim))
+    attention = mx.fast.scaled_dot_product_attention(
+        query,
+        key,
+        value,
+        scale=head_dim**-0.5,
+        mask=visibility,
+    )
+
+    config = SimpleNamespace(
+        vision_patch_size=2,
+        vision_dim=32,
+        vision_n_heads=4,
+        vision_inter_dim=64,
+        vision_n_layers=2,
+        vision_rope_theta=10_000.0,
+        vision_downsample_ratio=2,
+        hidden_size=48,
+    )
+    vision = ViT(config)
+    aligner = Aligner(config)
+    features = vision(mx.ones((64, 3, 2, 2)), 8, 8)
+    embeddings = aligner(features, 8, 8)
+    checksum = mx.sum(attention.astype(mx.float32)) + mx.sum(embeddings)
+    mx.eval(visibility, attention, features, embeddings, checksum)
+    value_sum = float(checksum.item())
+    if not math.isfinite(value_sum):
+        raise HardwareCanaryError("Metal vision result was not finite")
+    if tuple(embeddings.shape) != (16, 48):
+        raise HardwareCanaryError(
+            f"tiny aligner returned unexpected shape {embeddings.shape}"
+        )
+
+    peak = int(mx.get_peak_memory())
+    peak_delta = max(0, peak - baseline)
+    # This is intentionally generous across MLX releases while still catching
+    # an accidental full-context attention allocation in this 2k-token probe.
+    peak_limit = 256 * 1024**2
+    if peak_delta > peak_limit:
+        raise HardwareCanaryError(
+            "tiny vision prefill exceeded its 256 MiB Metal transient bound: "
+            f"{peak_delta} bytes"
+        )
+
+    del attention, embeddings, features, key, query, token_array, value, visibility
+    mx.synchronize()
+    mx.clear_cache()
+    return {
+        "ok": True,
+        "prompt_tokens": len(prompt),
+        "chunk_count": len(chunks),
+        "image_chunk": list(expected_image_chunk),
+        "image_tokens": length,
+        "visibility_cells": length * length,
+        "unisolated_attention_cells": len(prompt) * len(prompt),
+        "embedding_shape": [16, 48],
+        "metal_peak_delta_bytes": peak_delta,
+        "metal_peak_limit_bytes": peak_limit,
+        "checksum": value_sum,
+    }
+
+
+def _canary_deployment() -> ClusterDeployment:
+    capacity = 2 * 1024**3
+    assignments = (
+        PipelineAssignment("local-0", 0, 1, 2, 8 * 1024**2, 1024, 0, capacity),
+        PipelineAssignment("local-1", 1, 0, 1, 8 * 1024**2, 1024, 0, capacity),
+    )
+    return ClusterDeployment(
+        deployment_id="local-hardware-canary",
+        model="synthetic/hardware-canary",
+        backend="ring",
+        hosts=(
+            ClusterHost("local-0", "127.0.0.1", ("127.0.0.1",)),
+            ClusterHost("local-1", "127.0.0.1", ("127.0.0.1",)),
+        ),
+        assignments=assignments,
+        plan_hash="a" * 64,
+    )
+
+
+def _read_holder_ready(
+    process: subprocess.Popen[str], timeout: float
+) -> dict[str, Any]:
+    assert process.stdout is not None
+    readable, _, _ = select.select([process.stdout], [], [], timeout)
+    if not readable:
+        raise HardwareCanaryError("Metal allocation holder did not become ready")
+    line = process.stdout.readline()
+    try:
+        payload = json.loads(line)
+    except json.JSONDecodeError as exc:
+        raise HardwareCanaryError(
+            f"invalid Metal holder output: {line.strip()}"
+        ) from exc
+    if payload.get("type") != "metal_holder_ready":
+        raise HardwareCanaryError(f"unexpected Metal holder output: {payload}")
+    return payload
+
+
+def _crash_recovery_canary(*, allocation_mib: int, timeout: float) -> dict[str, Any]:
+    """Force teardown of a stuck Metal owner and check reload quarantine."""
+
+    _require_metal()
+    if not 16 <= allocation_mib <= 512:
+        raise ValueError("allocation_mib must be between 16 and 512")
+    allocation_bytes = allocation_mib * 1024**2
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "omlx.cluster.hardware_canary_worker",
+            "--allocation-bytes",
+            str(allocation_bytes),
+        ],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    process_group = process.pid
+    started_at = time.monotonic()
+    try:
+        ready = _read_holder_ready(process, min(timeout, 15.0))
+        with tempfile.TemporaryDirectory(prefix="omlx-hardware-canary-") as state_dir:
+            deployment = _canary_deployment()
+            supervisor = DistributedJobSupervisor(
+                deployment,
+                state_dir=state_dir,
+                stop_timeout=min(1.0, max(0.25, timeout / 10)),
+                recovery_timeout=min(5.0, timeout),
+                preflight=False,
+            )
+            supervisor.process = process
+            supervisor.stop()
+            if _process_group_alive(process_group):
+                raise HardwareCanaryError(
+                    f"fault-injected process group {process_group} survived teardown"
+                )
+            if process.returncode != -signal.SIGKILL:
+                raise HardwareCanaryError(
+                    "SIGTERM-ignoring Metal holder was not escalated to SIGKILL: "
+                    f"return code {process.returncode}"
+                )
+
+            # The operating system's free-memory estimate legitimately jitters.
+            # Use fixed ceilings here to test the persistent barrier itself:
+            # one failed reprobe must block reload, and full recovery must clear
+            # the marker. The live holder above independently covers process and
+            # Metal-allocation cleanup through the production supervisor.
+            baseline = 1024**3
+            low = baseline - 300 * 1024**2
+            supervisor._recovery_baseline_by_rank = {0: baseline, 1: baseline}
+            supervisor._write_recovery_quarantine("hardware canary retained memory")
+            marker = supervisor._recovery_marker_path()
+            recreated = DistributedJobSupervisor(
+                deployment,
+                state_dir=state_dir,
+                recovery_timeout=0,
+                preflight=False,
+            )
+            recreated._probe_recovery_capacity = lambda: [
+                {
+                    "rank": rank,
+                    "node_id": f"local-{rank}",
+                    "admission_ceiling_bytes": low,
+                }
+                for rank in (0, 1)
+            ]
+            try:
+                recreated._check_recovery_quarantine()
+            except DistributedMemoryRecoveryError:
+                pass
+            else:
+                raise HardwareCanaryError("retained-memory reload was not quarantined")
+            if not marker.is_file():
+                raise HardwareCanaryError("reload quarantine marker was not persisted")
+
+            recreated._probe_recovery_capacity = lambda: [
+                {
+                    "rank": rank,
+                    "node_id": f"local-{rank}",
+                    "admission_ceiling_bytes": baseline,
+                }
+                for rank in (0, 1)
+            ]
+            recreated._check_recovery_quarantine()
+            if marker.exists():
+                raise HardwareCanaryError("recovered-memory quarantine was not cleared")
+    finally:
+        if _process_group_alive(process_group):
+            with suppress(ProcessLookupError):
+                os.killpg(process_group, signal.SIGKILL)
+        if process.poll() is None:
+            try:
+                process.wait(timeout=2.0)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=2.0)
+        for stream in (process.stdout, process.stderr):
+            if stream is not None and not stream.closed:
+                stream.close()
+
+    return {
+        "ok": True,
+        "allocation_bytes": allocation_bytes,
+        "holder_active_memory_bytes": int(ready["active_memory_bytes"]),
+        "forced_signal": "SIGKILL",
+        "process_group_reaped": True,
+        "reload_blocked_while_retained": True,
+        "reload_allowed_after_recovery": True,
+        "elapsed_seconds": time.monotonic() - started_at,
+    }
+
+
+def run_local_hardware_canary(
+    *,
+    timeout: float = 45.0,
+    allocation_mib: int = 128,
+    worker_runner: Callable[..., dict[str, Any]] = run_worker_smoke,
+    collective_runner: Callable[..., dict[str, Any]] = run_local_collective_smoke,
+    pipeline_runner: Callable[..., dict[str, Any]] = run_local_pipeline_smoke,
+    vision_runner: Callable[..., dict[str, Any]] = _vision_prefill_metal_canary,
+    crash_runner: Callable[..., dict[str, Any]] = _crash_recovery_canary,
+) -> dict[str, Any]:
+    """Run the strongest safe, model-free cluster checks on one Mac."""
+
+    if timeout <= 0:
+        raise ValueError("timeout must be greater than zero")
+    if not 16 <= allocation_mib <= 512:
+        raise ValueError("allocation_mib must be between 16 and 512")
+    _require_metal()
+    started_at = time.monotonic()
+    checks = {
+        "worker": worker_runner(timeout=min(5.0, timeout)),
+        "collective": collective_runner(timeout=timeout),
+        "pipeline": pipeline_runner(timeout=timeout),
+        "vision_prefill": vision_runner(),
+        "crash_recovery": crash_runner(
+            allocation_mib=allocation_mib,
+            timeout=timeout,
+        ),
+    }
+    return {
+        "ok": True,
+        "skipped": False,
+        "platform": platform.platform(),
+        "python": platform.python_version(),
+        "checks": checks,
+        "elapsed_seconds": time.monotonic() - started_at,
+        "limitations": [
+            "loopback does not validate cross-host Ring, Thunderbolt, or JACCL",
+            "the tiny synthetic graph does not validate the full checkpoint",
+            "fault injection validates containment, not a real IOGPU driver leak",
+        ],
+    }

--- a/omlx/cluster/hardware_canary_worker.py
+++ b/omlx/cluster/hardware_canary_worker.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Private fault-injection worker for the local Apple-silicon canary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import signal
+import time
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--allocation-bytes", type=int, required=True)
+    args = parser.parse_args()
+
+    try:
+        import mlx.core as mx
+
+        if args.allocation_bytes <= 0:
+            raise ValueError("allocation must be positive")
+        # The supervisor has to escalate a rank which is stuck below Python's
+        # normal teardown path, as a Metal/JACCL collective can be. Keep the
+        # allocation modest; this worker tests ownership and cleanup, not OOM.
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        values = mx.ones((args.allocation_bytes // 4,), dtype=mx.float32)
+        checksum = mx.sum(values)
+        mx.eval(values, checksum)
+        print(
+            json.dumps(
+                {
+                    "type": "metal_holder_ready",
+                    "active_memory_bytes": int(mx.get_active_memory()),
+                    "allocation_bytes": int(args.allocation_bytes),
+                    "checksum": float(checksum.item()),
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
+        while True:
+            time.sleep(60)
+    except Exception as exc:  # pragma: no cover - reported to the parent
+        print(
+            f"oMLX Metal holder failed: {type(exc).__name__}: {exc}",
+            flush=True,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/omlx/cluster/inference_worker.py
+++ b/omlx/cluster/inference_worker.py
@@ -1281,6 +1281,15 @@ def run_worker(args: argparse.Namespace) -> int:
                     # than "nobody has asked anything for 45 seconds".
                     run("127.0.0.1", args.port, provider)
     except KeyboardInterrupt:
+        # A supervisor-driven SIGTERM is a clean shutdown request, but keep a
+        # terminal marker until the launcher has verified this PID exited.
+        # Coordinated multi-host teardown signals every rank first and checks
+        # them in a second pass; removing the marker here makes that safe
+        # identity check impossible and turns a graceful exit into a false
+        # unconfirmed-process quarantine.
+        preserve_failure_marker = True
+        with suppress(Exception):
+            marker.update("stopped", stop_reason="signal")
         return 0
     except Exception as exc:
         # An ordinary exception is the most useful evidence a failed remote

--- a/omlx/cluster/inference_worker.py
+++ b/omlx/cluster/inference_worker.py
@@ -1240,7 +1240,11 @@ def run_worker(args: argparse.Namespace) -> int:
                             "optimizations": optimizations,
                         }
                     )
+                # Vision must patch the base generator before telemetry creates
+                # its subclass. Then all ranks finish sharing the expanded
+                # prompt before telemetry enters cache/guard collectives.
                 with (
+                    vision_runtime,
                     install_server_telemetry(
                         marker,
                         execution=execution,
@@ -1271,7 +1275,6 @@ def run_worker(args: argparse.Namespace) -> int:
                         mlx_server,
                         provider.tokenizer,
                     ),
-                    vision_runtime,
                 ):
                     # install_server_telemetry also runs the idle heartbeat for
                     # the length of this block, so "stale" means stalled rather

--- a/omlx/cluster/inference_worker.py
+++ b/omlx/cluster/inference_worker.py
@@ -13,7 +13,7 @@ import tempfile
 import threading
 import time
 from collections.abc import Sequence
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager, nullcontext, suppress
 from datetime import UTC, datetime
 from functools import wraps
 from pathlib import Path
@@ -627,6 +627,7 @@ def _runtime_assignment(
         "end_layer": assignment.end_layer,
         "layer_count": assignment.layer_count,
         "planned_weight_bytes": assignment.planned_weight_bytes,
+        "coordinator_weight_bytes": assignment.coordinator_weight_bytes,
         "reserve_bytes": assignment.reserve_bytes,
         "capacity_bytes": assignment.capacity_bytes,
         "headroom_bytes": assignment.headroom_bytes,
@@ -749,7 +750,9 @@ def _validate_measured_weight_bytes(
     if measured_weight_bytes is None:
         return
     approved_parameter_bytes = (
-        assignment.fixed_weight_bytes + assignment.layer_weight_bytes
+        assignment.fixed_weight_bytes
+        + assignment.coordinator_weight_bytes
+        + assignment.layer_weight_bytes
     )
     relative_tolerance = (
         approved_parameter_bytes * _MEASURED_WEIGHT_RELATIVE_TOLERANCE_PERCENT + 99
@@ -838,6 +841,7 @@ def _guard_effective_stage(
     per_layer = assignment.layer_weight_bytes / planned_layers
     effective_bytes = int(
         assignment.fixed_weight_bytes
+        + assignment.coordinator_weight_bytes
         + per_layer * effective_layers
         + assignment.kv_cache_bytes
     )
@@ -962,6 +966,26 @@ def run_worker(args: argparse.Namespace) -> int:
     group = mx.distributed.init(backend=init_backend, strict=True)
     rank = group.rank()
     world_size = group.size()
+    try:
+        model_config = json.loads(
+            (Path(args.model).expanduser() / "config.json").read_text()
+        )
+    except OSError:
+        # ModelProvider remains the authority for ordinary text paths (and
+        # test doubles may use a repo ID rather than a local directory). The
+        # staged vision path always has its config sidecar locally.
+        model_config = {}
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"distributed model config is unreadable: {exc}") from exc
+    from omlx.deepseek_v4_vision import is_deepseek_v4_vision_config
+    from omlx.model_discovery import _has_vision_subconfig
+
+    deepseek_v4_vision = is_deepseek_v4_vision_config(model_config)
+    if _has_vision_subconfig(model_config) and not deepseek_v4_vision:
+        raise RuntimeError(
+            "unsupported distributed VLM family; only "
+            "DeepSeek-V4-Flash-Vision is enabled"
+        )
     if world_size != len(assignments):
         raise RuntimeError(
             f"runtime world size {world_size} does not match plan size "
@@ -983,6 +1007,8 @@ def run_worker(args: argparse.Namespace) -> int:
     marker.update(
         "loading",
         load_stage="initializing",
+        model_family=("deepseek_v4_vision" if deepseek_v4_vision else "text"),
+        vision_owner=(rank == 0 if deepseek_v4_vision else None),
         launcher_parent_pid=launcher_parent_pid,
     )
     marker.start_heartbeat()
@@ -1125,6 +1151,8 @@ def run_worker(args: argparse.Namespace) -> int:
                 ),
             ):
                 provider.load_default()
+            if deepseek_v4_vision:
+                provider.is_batchable = False
             protocol = _install_distributed_model_protocol(
                 provider.tokenizer,
                 args.model,
@@ -1150,6 +1178,18 @@ def run_worker(args: argparse.Namespace) -> int:
                 batchable=provider.is_batchable,
                 pipeline_parallel=tensor_parallel_size == 1,
             ) as optimizations:
+                vision_runtime = nullcontext()
+                if deepseek_v4_vision:
+                    from .deepseek_v4_vision_runtime import (
+                        install_deepseek_v4_vision_runtime,
+                    )
+
+                    vision_runtime = install_deepseek_v4_vision_runtime(
+                        mlx_server,
+                        provider,
+                        config=model_config,
+                        rank=rank,
+                    )
                 marker.update(
                     "ready",
                     load_stage="ready",
@@ -1231,6 +1271,7 @@ def run_worker(args: argparse.Namespace) -> int:
                         mlx_server,
                         provider.tokenizer,
                     ),
+                    vision_runtime,
                 ):
                     # install_server_telemetry also runs the idle heartbeat for
                     # the length of this block, so "stale" means stalled rather

--- a/omlx/cluster/launch.py
+++ b/omlx/cluster/launch.py
@@ -1434,10 +1434,11 @@ _PREFLIGHT_SCRIPT = (
     # surfaced as diagnostics because each rank loads its own matching wheel.
     "v['python']=platform.python_version()\n"
     "v['admission-ceiling-bytes']=int("
-    "ceiling_breakdown(sys.argv[4]).get('hard_limit',0))\n"
+    "ceiling_breakdown(sys.argv[5]).get('hard_limit',0))\n"
     "v['model-exists']=x.is_dir()\n"
     "if v['model-exists']:\n"
-    "    v.update(validate(x,int(sys.argv[2]),int(sys.argv[3])))\n"
+    "    v.update(validate(x,int(sys.argv[2]),int(sys.argv[3]),"
+    "rank=int(sys.argv[4])))\n"
     "print(json.dumps(v,sort_keys=True))"
 )
 
@@ -1469,6 +1470,7 @@ def preflight_remote_hosts(
             deployment.model,
             assignments[0].start_layer,
             assignments[0].end_layer,
+            rank=assignments[0].rank,
         )
         if local_model_exists
         else {}
@@ -1524,6 +1526,7 @@ def preflight_remote_hosts(
                 home_relative_model_path(deployment.model),
                 str(assignment.start_layer),
                 str(assignment.end_layer),
+                str(assignment.rank),
                 assignment.memory_guard_tier,
             ]
         )

--- a/omlx/cluster/launch.py
+++ b/omlx/cluster/launch.py
@@ -2005,22 +2005,34 @@ class DistributedJobSupervisor:
         process = self.process
         teardown_failures: list[str] = []
         verify_teardown = process is not None or self._teardown_incomplete
-        verify_recovery = process is not None or self._recovery_marker_path().is_file()
+        verify_recovery = (
+            process is not None
+            or self._recovery_required_reason is not None
+            or self._recovery_marker_path().is_file()
+        )
+        deadline = time.monotonic() + self.stop_timeout
         process_group = (
             process.pid if process is not None else self._pending_process_group
         )
+        if process_group is not None and _process_group_alive(process_group):
+            try:
+                os.killpg(process_group, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            except PermissionError:
+                teardown_failures.append(
+                    f"local launch process group {process_group} could not "
+                    "be signaled"
+                )
+        if verify_teardown:
+            # Signal remote ranks before spending the local grace period. A
+            # rank blocked in a collective cannot unwind while its peer is
+            # still serving, so serial local-then-remote teardown consumed
+            # both grace windows and routinely forced every rank through
+            # SIGKILL. The second pass below verifies death and escalates only
+            # ranks that did not honor this coordinated SIGTERM.
+            self._reap_remote_ranks(signal_only=True)
         if process_group is not None:
-            deadline = time.monotonic() + self.stop_timeout
-            if _process_group_alive(process_group):
-                try:
-                    os.killpg(process_group, signal.SIGTERM)
-                except ProcessLookupError:
-                    pass
-                except PermissionError:
-                    teardown_failures.append(
-                        f"local launch process group {process_group} could not "
-                        "be signaled"
-                    )
             if process is not None and process.poll() is None:
                 with suppress(subprocess.TimeoutExpired):
                     process.wait(
@@ -2062,12 +2074,19 @@ class DistributedJobSupervisor:
                 teardown_failures.append(
                     f"launcher process {process.pid} could not be reaped"
                 )
-        remote_reports = self._reap_remote_ranks()
+        remote_reports = (
+            self._reap_remote_ranks(
+                graceful_timeout=max(0.0, deadline - time.monotonic())
+            )
+            if verify_teardown
+            else []
+        )
         for report in remote_reports:
             if verify_teardown and report["action"] in {
                 "unreachable",
                 "kill-failed",
                 "identity-mismatch",
+                "pid-reused",
                 "marker-unreadable",
                 "no-marker",
                 "no-report",
@@ -2114,7 +2133,11 @@ class DistributedJobSupervisor:
             self._wait_for_memory_recovery()
 
     def _reap_remote_ranks(
-        self, *, runner: SSHRunner = subprocess.run
+        self,
+        *,
+        runner: SSHRunner = subprocess.run,
+        signal_only: bool = False,
+        graceful_timeout: float = 3.0,
     ) -> list[dict[str, Any]]:
         """Kill rank workers on peer hosts that the local group kill cannot reach.
 
@@ -2127,7 +2150,10 @@ class DistributedJobSupervisor:
         ``{state_dir}/{deployment_id}-rank-{rank}.json``. Read that marker
         over SSH, validate that the PID matches the expected deployment,
         plan, and rank, verify the process command line before signaling,
-        and escalate SIGTERM -> wait -> SIGKILL -> confirmed dead.
+        and escalate SIGTERM -> wait -> SIGKILL -> confirmed dead. During a
+        coordinated shutdown, ``signal_only`` sends TERM without waiting so
+        every collective peer gets its grace period at the same time; a later
+        call with a zero grace verifies and force-kills survivors.
 
         The marker file is deliberately left in place: it holds the rank's
         failure phase and error, which ``_runtime_failure_reason`` and the
@@ -2136,6 +2162,7 @@ class DistributedJobSupervisor:
         instead of passing as a clean stop.
         """
         reports: list[dict[str, Any]] = []
+        graceful_timeout = max(0.0, float(graceful_timeout))
         if not self.deployment or not self.deployment.hosts:
             return reports
         for rank, host in enumerate(self.deployment.hosts):
@@ -2194,7 +2221,10 @@ class DistributedJobSupervisor:
                 "  os.kill(pid,signal.SIGTERM)\n"
                 "except ProcessLookupError:\n"
                 "  out('already-dead'); raise SystemExit(0)\n"
-                "deadline=time.monotonic()+3.0\n"
+                f"signal_only={signal_only!r}\n"
+                "if signal_only:\n"
+                "  out('signaled'); raise SystemExit(0)\n"
+                f"deadline=time.monotonic()+{graceful_timeout!r}\n"
                 "while time.monotonic()<deadline:\n"
                 "  if is_dead(pid):\n"
                 "    out('terminated'); raise SystemExit(0)\n"
@@ -2391,42 +2421,52 @@ class DistributedJobSupervisor:
     def _check_recovery_quarantine(self) -> None:
         """Honor a previous crash quarantine before launching any process."""
 
-        if not self._recovery_marker_path().is_file():
+        marker_exists = self._recovery_marker_path().is_file()
+        # Persistence is best effort. Keep the fail-closed decision effective
+        # in this supervisor even when the state directory could not be
+        # written; otherwise a second start on the same object bypasses the
+        # recovery barrier that the first stop just established.
+        if not marker_exists and self._recovery_required_reason is None:
             return
-        try:
-            marker = json.loads(
-                self._recovery_marker_path().read_text(encoding="utf-8")
-            )
-            if marker.get("kind") == "unconfirmed_process":
-                marker_boot = str(marker.get("boot_session_id") or "")
-                current_boot = _boot_session_id()
-                if not marker_boot or not current_boot or marker_boot == current_boot:
-                    reason = str(
-                        marker.get("reason")
-                        or "a previous teardown could not confirm every rank exited"
-                    )
-                    self._phase = "teardown_failed"
-                    self._teardown_failure_reason = reason
-                    raise DistributedLaunchError(
-                        "Distributed reload remains quarantined because a rank "
-                        "process was not confirmed dead in this boot session: "
-                        f"{reason}. Reboot the affected host before retrying."
-                    )
-            baselines = marker.get("baseline_ceiling_bytes", {})
-            if isinstance(baselines, dict):
-                self._recovery_baseline_by_rank = {
-                    int(rank): int(ceiling)
-                    for rank, ceiling in baselines.items()
-                    if int(ceiling) > 0
-                }
-        except (OSError, TypeError, ValueError, json.JSONDecodeError):
-            # A malformed marker still means the previous teardown asked us
-            # not to launch. Re-probe against plan-fit and replace it with a
-            # valid marker if memory remains unavailable.
-            logger.warning(
-                "Distributed memory quarantine marker is unreadable: %s",
-                self._recovery_marker_path(),
-            )
+        if marker_exists:
+            try:
+                marker = json.loads(
+                    self._recovery_marker_path().read_text(encoding="utf-8")
+                )
+                if marker.get("kind") == "unconfirmed_process":
+                    marker_boot = str(marker.get("boot_session_id") or "")
+                    current_boot = _boot_session_id()
+                    if (
+                        not marker_boot
+                        or not current_boot
+                        or marker_boot == current_boot
+                    ):
+                        reason = str(
+                            marker.get("reason")
+                            or "a previous teardown could not confirm every rank exited"
+                        )
+                        self._phase = "teardown_failed"
+                        self._teardown_failure_reason = reason
+                        raise DistributedLaunchError(
+                            "Distributed reload remains quarantined because a rank "
+                            "process was not confirmed dead in this boot session: "
+                            f"{reason}. Reboot the affected host before retrying."
+                        )
+                baselines = marker.get("baseline_ceiling_bytes", {})
+                if isinstance(baselines, dict):
+                    self._recovery_baseline_by_rank = {
+                        int(rank): int(ceiling)
+                        for rank, ceiling in baselines.items()
+                        if int(ceiling) > 0
+                    }
+            except (OSError, TypeError, ValueError, json.JSONDecodeError):
+                # A malformed marker still means the previous teardown asked us
+                # not to launch. Re-probe against plan-fit and replace it with a
+                # valid marker if memory remains unavailable.
+                logger.warning(
+                    "Distributed memory quarantine marker is unreadable: %s",
+                    self._recovery_marker_path(),
+                )
         reason = self._recovery_failure()
         if reason is None:
             self._clear_recovery_quarantine()

--- a/omlx/cluster/launch.py
+++ b/omlx/cluster/launch.py
@@ -45,10 +45,19 @@ _LOG_HISTORY = 200
 _REMOTE_OUTPUT_LIMIT = 64 * 1024
 _FABRIC_INTERFACE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,63}$")
 _DEFAULT_CONNECTX_MIN_BYTES_PER_SECOND = 2 * 1024**3
+# Dynamic ceilings legitimately move a little while daemon bookkeeping and
+# SSH probes run. Keep the allowance small: a multi-GiB tolerance could admit
+# one reload after every crash and compound the very driver leak this barrier
+# exists to contain.
+_RECOVERY_CEILING_TOLERANCE_BYTES = 256 * 1024**2
 
 
 class DistributedLaunchError(RuntimeError):
     """Raised when a distributed job cannot become or remain ready."""
+
+
+class DistributedMemoryRecoveryError(DistributedLaunchError):
+    """Raised when ranks exited but accelerator memory is not reusable yet."""
 
 
 @dataclass(frozen=True)
@@ -121,6 +130,32 @@ def _wait_for_process_group_exit(process_group: int, timeout: float) -> bool:
             return False
         time.sleep(min(0.05, remaining))
     return True
+
+
+def _boot_session_id() -> str:
+    """Return a stable identifier that changes after a host reboot."""
+
+    linux_boot_id = Path("/proc/sys/kernel/random/boot_id")
+    try:
+        value = linux_boot_id.read_text(encoding="utf-8").strip()
+        if value:
+            return value
+    except OSError:
+        pass
+    try:
+        result = subprocess.run(
+            ["/usr/sbin/sysctl", "-n", "kern.boottime"],
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+            check=False,
+        )
+        value = result.stdout.strip()
+        if result.returncode == 0 and value:
+            return hashlib.sha256(value.encode()).hexdigest()
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return ""
 
 
 def _available_launch_ports(
@@ -1142,6 +1177,7 @@ def probe_remote_admission_ceiling(
     ssh_target: str,
     *,
     python_executable: str | None = None,
+    memory_guard_tier: str = "",
     timeout: float = 8.0,
     runner: SSHRunner = subprocess.run,
 ) -> int:
@@ -1173,24 +1209,36 @@ def probe_remote_admission_ceiling(
     except Exception:
         local_port = 8000
     ports = tuple(dict.fromkeys((local_port, 9000)))
-    script = (
-        "import json,urllib.request\n"
-        "ceiling=0\n"
-        f"for port in {ports!r}:\n"
-        "    try:\n"
-        "        with urllib.request.urlopen("
-        "'http://127.0.0.1:%d/health'%port,timeout=2) as response:\n"
-        "            health=json.load(response)\n"
-        "        ceiling=int(health.get('engine_pool',{}).get('final_ceiling',0))\n"
-        "        if ceiling>0:\n"
-        "            break\n"
-        "    except Exception:\n"
-        "        pass\n"
-        "if ceiling<=0:\n"
-        "    from omlx.cluster.memory_guard import ceiling_breakdown\n"
-        "    ceiling=int(ceiling_breakdown().get('hard_limit',0))\n"
-        "print(json.dumps({'admission_ceiling_bytes':ceiling}))"
-    )
+    if memory_guard_tier:
+        # Recovery checks must use the tier signed into this deployment. The
+        # peer daemon's /health value reflects its own current UI setting and
+        # can therefore be more permissive than the rank we are about to
+        # restart.
+        script = (
+            "import json\n"
+            "from omlx.cluster.memory_guard import ceiling_breakdown\n"
+            f"ceiling=int(ceiling_breakdown({memory_guard_tier!r}).get('hard_limit',0))\n"
+            "print(json.dumps({'admission_ceiling_bytes':ceiling}))"
+        )
+    else:
+        script = (
+            "import json,urllib.request\n"
+            "ceiling=0\n"
+            f"for port in {ports!r}:\n"
+            "    try:\n"
+            "        with urllib.request.urlopen("
+            "'http://127.0.0.1:%d/health'%port,timeout=2) as response:\n"
+            "            health=json.load(response)\n"
+            "        ceiling=int(health.get('engine_pool',{}).get('final_ceiling',0))\n"
+            "        if ceiling>0:\n"
+            "            break\n"
+            "    except Exception:\n"
+            "        pass\n"
+            "if ceiling<=0:\n"
+            "    from omlx.cluster.memory_guard import ceiling_breakdown\n"
+            "    ceiling=int(ceiling_breakdown().get('hard_limit',0))\n"
+            "print(json.dumps({'admission_ceiling_bytes':ceiling}))"
+        )
 
     def _read(executable: str) -> subprocess.CompletedProcess[str]:
         return _run_cluster_ssh(
@@ -1729,16 +1777,21 @@ class DistributedJobSupervisor:
         state_dir: str = "~/.omlx/cluster/runtime",
         load_timeout: float = 1800.0,
         stop_timeout: float = 10.0,
+        recovery_timeout: float = 10.0,
         preflight: bool = True,
     ) -> None:
-        if load_timeout <= 0 or stop_timeout <= 0:
-            raise ValueError("supervisor timeouts must be positive")
+        if load_timeout <= 0 or stop_timeout <= 0 or recovery_timeout < 0:
+            raise ValueError(
+                "load/stop timeouts must be positive and recovery timeout "
+                "must be non-negative"
+            )
         self.deployment = deployment
         self.python_executable = _validate_python_executable(python_executable)
         self.cwd = cwd
         self.state_dir = state_dir
         self.load_timeout = load_timeout
         self.stop_timeout = stop_timeout
+        self.recovery_timeout = recovery_timeout
         self.preflight = preflight
         self.process: subprocess.Popen[str] | None = None
         self.port: int | None = None
@@ -1746,6 +1799,11 @@ class DistributedJobSupervisor:
         self.ready_event: dict[str, Any] | None = None
         self.rank_ready_events: dict[int, dict[str, Any]] = {}
         self.failure_event: dict[str, Any] | None = None
+        self._recovery_required_reason: str | None = None
+        self._teardown_failure_reason: str | None = None
+        self._teardown_incomplete = False
+        self._pending_process_group: int | None = None
+        self._recovery_baseline_by_rank: dict[int, int] = {}
         self._phase = "stopped"
         self._temporary: tempfile.TemporaryDirectory[str] | None = None
         self._stdout = deque(maxlen=_LOG_HISTORY)
@@ -1760,12 +1818,17 @@ class DistributedJobSupervisor:
     def start(self) -> dict[str, Any]:
         if self.process is not None:
             raise RuntimeError("distributed job is already started")
+        self._check_recovery_quarantine()
         self._phase = "preflight"
         if self.preflight:
-            preflight_remote_hosts(
+            preflight_status = preflight_remote_hosts(
                 self.deployment,
                 python_executable=self.python_executable,
             )
+            self._recovery_baseline_by_rank = {
+                int(item["rank"]): int(item.get("admission_ceiling_bytes") or 0)
+                for item in preflight_status
+            }
 
         self._temporary = tempfile.TemporaryDirectory(prefix="omlx-distributed-launch-")
         hostfile = Path(self._temporary.name) / "hostfile.json"
@@ -1812,8 +1875,14 @@ class DistributedJobSupervisor:
             self._phase = "ready"
             self.ready_event = event
             return event
-        except Exception:
-            self._terminate()
+        except Exception as start_error:
+            try:
+                self._terminate()
+            except Exception as cleanup_error:
+                raise DistributedLaunchError(
+                    f"distributed start failed: {start_error}; cleanup also "
+                    f"failed: {cleanup_error}"
+                ) from start_error
             raise
 
     def _start_readers(self) -> None:
@@ -1934,13 +2003,25 @@ class DistributedJobSupervisor:
 
     def _terminate(self) -> None:
         process = self.process
-        if process is not None:
-            process_group = process.pid
+        teardown_failures: list[str] = []
+        verify_teardown = process is not None or self._teardown_incomplete
+        verify_recovery = process is not None or self._recovery_marker_path().is_file()
+        process_group = (
+            process.pid if process is not None else self._pending_process_group
+        )
+        if process_group is not None:
             deadline = time.monotonic() + self.stop_timeout
             if _process_group_alive(process_group):
-                with suppress(ProcessLookupError):
+                try:
                     os.killpg(process_group, signal.SIGTERM)
-            if process.poll() is None:
+                except ProcessLookupError:
+                    pass
+                except PermissionError:
+                    teardown_failures.append(
+                        f"local launch process group {process_group} could not "
+                        "be signaled"
+                    )
+            if process is not None and process.poll() is None:
                 with suppress(subprocess.TimeoutExpired):
                     process.wait(
                         timeout=max(0.0, deadline - time.monotonic())
@@ -1953,13 +2034,39 @@ class DistributedJobSupervisor:
             # group has disappeared.
             remaining = max(0.0, deadline - time.monotonic())
             if not _wait_for_process_group_exit(process_group, remaining):
-                with suppress(ProcessLookupError):
+                try:
                     os.killpg(process_group, signal.SIGKILL)
-                _wait_for_process_group_exit(process_group, 2.0)
-            if process.poll() is None:
+                except ProcessLookupError:
+                    pass
+                except PermissionError:
+                    teardown_failures.append(
+                        f"local launch process group {process_group} could not "
+                        "be killed"
+                    )
+                if not _wait_for_process_group_exit(process_group, 2.0):
+                    teardown_failures.append(
+                        f"local launch process group {process_group} survived SIGKILL"
+                    )
+            if process is not None and process.poll() is None:
                 with suppress(subprocess.TimeoutExpired):
                     process.wait(timeout=2.0)
-        self._reap_remote_ranks()
+            if process is not None and process.poll() is None:
+                teardown_failures.append(
+                    f"launcher process {process.pid} could not be reaped"
+                )
+        remote_reports = self._reap_remote_ranks()
+        for report in remote_reports:
+            if verify_teardown and report["action"] in {
+                "unreachable",
+                "kill-failed",
+                "identity-mismatch",
+                "marker-unreadable",
+                "no-marker",
+                "no-report",
+            }:
+                teardown_failures.append(
+                    f"rank {report['rank']} on {report['host']}: {report['action']}"
+                )
         for reader in self._readers:
             reader.join(timeout=0.5)
         self._readers.clear()
@@ -1978,7 +2085,29 @@ class DistributedJobSupervisor:
             self._temporary.cleanup()
             self._temporary = None
 
-    def _reap_remote_ranks(self, *, runner: SSHRunner = subprocess.run) -> None:
+        if teardown_failures:
+            self._teardown_incomplete = True
+            self._pending_process_group = process_group
+            self._phase = "teardown_failed"
+            self._teardown_failure_reason = "; ".join(teardown_failures)
+            self._write_recovery_quarantine(
+                self._teardown_failure_reason,
+                unconfirmed_process=True,
+            )
+            raise DistributedLaunchError(
+                "distributed teardown could not confirm every rank exited; "
+                "reload is blocked because a surviving rank may still own Metal "
+                "memory: " + self._teardown_failure_reason
+            )
+        self._teardown_incomplete = False
+        self._pending_process_group = None
+        self._teardown_failure_reason = None
+        if verify_recovery:
+            self._wait_for_memory_recovery()
+
+    def _reap_remote_ranks(
+        self, *, runner: SSHRunner = subprocess.run
+    ) -> list[dict[str, Any]]:
         """Kill rank workers on peer hosts that the local group kill cannot reach.
 
         ``mlx.launch`` runs each rank through SSH in its own process group on
@@ -1998,8 +2127,9 @@ class DistributedJobSupervisor:
         what it did as one JSON line so a failed reap is visible in the logs
         instead of passing as a clean stop.
         """
+        reports: list[dict[str, Any]] = []
         if not self.deployment or not self.deployment.hosts:
-            return
+            return reports
         for rank, host in enumerate(self.deployment.hosts):
             if host.ssh in _LOOPBACK_TARGETS:
                 continue
@@ -2089,6 +2219,9 @@ class DistributedJobSupervisor:
                     host.ssh,
                     exc,
                 )
+                reports.append(
+                    {"rank": rank, "host": host.ssh, "action": "unreachable"}
+                )
                 continue
             action = ""
             for line in reversed(completed.stdout.strip().splitlines()):
@@ -2125,6 +2258,197 @@ class DistributedJobSupervisor:
                     host.ssh,
                     completed.returncode,
                 )
+                action = "no-report"
+            reports.append({"rank": rank, "host": host.ssh, "action": action})
+        return reports
+
+    def _recovery_marker_path(self) -> Path:
+        return (
+            Path(self.state_dir).expanduser()
+            / f"{self.deployment.deployment_id}-memory-recovery.json"
+        )
+
+    def _probe_recovery_capacity(self) -> list[dict[str, Any]]:
+        """Read every host's live ceiling without starting another rank."""
+
+        from .memory_guard import ceiling_breakdown
+
+        assignments = sorted(self.deployment.assignments, key=lambda item: item.rank)
+        results: list[dict[str, Any]] = []
+        for host, assignment in zip(
+            self.deployment.hosts, assignments, strict=True
+        ):
+            if host.ssh in _LOOPBACK_TARGETS:
+                ceiling = int(
+                    ceiling_breakdown(assignment.memory_guard_tier).get(
+                        "hard_limit", 0
+                    )
+                )
+            else:
+                ceiling = probe_remote_admission_ceiling(
+                    host.ssh,
+                    python_executable=host.python_executable,
+                    memory_guard_tier=assignment.memory_guard_tier,
+                    timeout=min(8.0, max(1.0, self.stop_timeout)),
+                )
+            results.append(
+                {
+                    "rank": assignment.rank,
+                    "node_id": host.node_id,
+                    "admission_ceiling_bytes": ceiling,
+                }
+            )
+        return results
+
+    def _recovery_failure(self) -> str | None:
+        try:
+            status = self._probe_recovery_capacity()
+            _validate_deployment_admission(self.deployment, status)
+        except Exception as exc:  # noqa: BLE001 - an unreadable host is not safe
+            return str(exc) or type(exc).__name__
+        by_rank = {int(item["rank"]): item for item in status}
+        regressed: list[str] = []
+        gib = 1024**3
+        for assignment in self.deployment.assignments:
+            baseline = self._recovery_baseline_by_rank.get(assignment.rank, 0)
+            current = int(
+                by_rank.get(assignment.rank, {}).get("admission_ceiling_bytes") or 0
+            )
+            if baseline > 0 and current < baseline - _RECOVERY_CEILING_TOLERANCE_BYTES:
+                regressed.append(
+                    f"rank {assignment.rank} ({assignment.node_id}) recovered "
+                    f"only {current / gib:.1f} GiB of its {baseline / gib:.1f} "
+                    "GiB pre-launch ceiling"
+                )
+        if regressed:
+            return "; ".join(regressed)
+        return None
+
+    def _write_recovery_quarantine(
+        self, reason: str, *, unconfirmed_process: bool = False
+    ) -> None:
+        path = self._recovery_marker_path()
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            payload = {
+                "schema_version": 1,
+                "deployment_id": self.deployment.deployment_id,
+                "plan_hash": self.deployment.plan_hash,
+                "created_at": time.time(),
+                "reason": reason[:_LOG_LINE_LIMIT],
+                "kind": (
+                    "unconfirmed_process"
+                    if unconfirmed_process
+                    else "memory_recovery"
+                ),
+                "boot_session_id": _boot_session_id(),
+                "baseline_ceiling_bytes": {
+                    str(rank): ceiling
+                    for rank, ceiling in self._recovery_baseline_by_rank.items()
+                    if ceiling > 0
+                },
+            }
+            descriptor, temporary = tempfile.mkstemp(
+                prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+            )
+            try:
+                os.fchmod(descriptor, 0o600)
+                with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+                    json.dump(payload, stream, sort_keys=True)
+                    stream.write("\n")
+                    stream.flush()
+                    os.fsync(stream.fileno())
+                os.replace(temporary, path)
+            finally:
+                with suppress(FileNotFoundError):
+                    os.unlink(temporary)
+        except OSError:
+            # The in-memory supervisor still blocks this unload. Persistence
+            # only extends the quarantine across a daemon restart.
+            logger.exception("Could not persist distributed memory quarantine")
+
+    def _clear_recovery_quarantine(self) -> None:
+        with suppress(FileNotFoundError):
+            self._recovery_marker_path().unlink()
+
+    def _recovery_required_error(self, reason: str) -> DistributedMemoryRecoveryError:
+        return DistributedMemoryRecoveryError(
+            "All distributed rank processes exited, but their live memory "
+            "ceilings have not recovered enough to reload this plan. Reload is "
+            "quarantined to avoid compounding retained Metal/accelerator memory. "
+            f"{reason}. Wait for memory pressure to settle; if it does not, "
+            "reboot the affected Mac before retrying."
+        )
+
+    def _check_recovery_quarantine(self) -> None:
+        """Honor a previous crash quarantine before launching any process."""
+
+        if not self._recovery_marker_path().is_file():
+            return
+        try:
+            marker = json.loads(
+                self._recovery_marker_path().read_text(encoding="utf-8")
+            )
+            if marker.get("kind") == "unconfirmed_process":
+                marker_boot = str(marker.get("boot_session_id") or "")
+                current_boot = _boot_session_id()
+                if not marker_boot or not current_boot or marker_boot == current_boot:
+                    reason = str(
+                        marker.get("reason")
+                        or "a previous teardown could not confirm every rank exited"
+                    )
+                    self._phase = "teardown_failed"
+                    self._teardown_failure_reason = reason
+                    raise DistributedLaunchError(
+                        "Distributed reload remains quarantined because a rank "
+                        "process was not confirmed dead in this boot session: "
+                        f"{reason}. Reboot the affected host before retrying."
+                    )
+            baselines = marker.get("baseline_ceiling_bytes", {})
+            if isinstance(baselines, dict):
+                self._recovery_baseline_by_rank = {
+                    int(rank): int(ceiling)
+                    for rank, ceiling in baselines.items()
+                    if int(ceiling) > 0
+                }
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            # A malformed marker still means the previous teardown asked us
+            # not to launch. Re-probe against plan-fit and replace it with a
+            # valid marker if memory remains unavailable.
+            logger.warning(
+                "Distributed memory quarantine marker is unreadable: %s",
+                self._recovery_marker_path(),
+            )
+        reason = self._recovery_failure()
+        if reason is None:
+            self._clear_recovery_quarantine()
+            self._recovery_required_reason = None
+            logger.info(
+                "Distributed memory recovered for %s; clearing reload quarantine",
+                self.deployment.deployment_id,
+            )
+            return
+        self._phase = "recovery_required"
+        self._recovery_required_reason = reason
+        raise self._recovery_required_error(reason)
+
+    def _wait_for_memory_recovery(self) -> None:
+        """Require live capacity recovery after ranks have been fully reaped."""
+
+        deadline = time.monotonic() + self.recovery_timeout
+        while True:
+            reason = self._recovery_failure()
+            if reason is None:
+                self._clear_recovery_quarantine()
+                self._recovery_required_reason = None
+                return
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                self._write_recovery_quarantine(reason)
+                self._phase = "recovery_required"
+                self._recovery_required_reason = reason
+                raise self._recovery_required_error(reason)
+            time.sleep(min(0.5, remaining))
 
     def _exit_detail(self, returncode: int | None) -> str:
         failure_reason = self._failure_reason() or self._runtime_failure_reason()
@@ -2205,7 +2529,11 @@ class DistributedJobSupervisor:
             world_size=self.deployment.world_size,
             plan_hash=self.deployment.plan_hash,
             stderr_tail=tuple(self._stderr)[-20:],
-            failure_reason=self._failure_reason(),
+            failure_reason=(
+                self._failure_reason()
+                or self._teardown_failure_reason
+                or self._recovery_required_reason
+            ),
             ranks=tuple(
                 dict(self.rank_ready_events[rank])
                 for rank in sorted(self.rank_ready_events)

--- a/omlx/cluster/launch.py
+++ b/omlx/cluster/launch.py
@@ -2043,6 +2043,14 @@ class DistributedJobSupervisor:
                         f"local launch process group {process_group} could not "
                         "be killed"
                     )
+                # Reap the launcher before probing its process group again.
+                # A SIGKILLed group leader remains visible as a zombie until
+                # its parent calls wait(), so killpg(..., 0) otherwise reports
+                # a cleanly killed one-process group as still alive and leaves
+                # a false reboot-required quarantine behind.
+                if process is not None and process.poll() is None:
+                    with suppress(subprocess.TimeoutExpired):
+                        process.wait(timeout=2.0)
                 if not _wait_for_process_group_exit(process_group, 2.0):
                     teardown_failures.append(
                         f"local launch process group {process_group} survived SIGKILL"

--- a/omlx/cluster/planner.py
+++ b/omlx/cluster/planner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import re
 import struct
 import subprocess
@@ -33,6 +34,7 @@ _LAYER_PATTERNS = (re.compile(r"(?:^|\.)(?:layers|h|blocks|block)\.(\d+)(?:\.|$)
 # that fits its weights still dies on the first long prompt.
 _DEFAULT_CONTEXT_TOKENS = 8192
 _MEMORY_GUARD_TIERS = frozenset({"safe", "balanced", "aggressive", "custom"})
+logger = logging.getLogger(__name__)
 
 
 class PlanningError(ValueError):
@@ -94,6 +96,9 @@ class ModelLayout:
     source: str
     fixed_weight_bytes: int
     layer_weight_bytes: tuple[int, ...]
+    # Weights resident only on rank zero.  DeepSeek-V4 Vision keeps its ViT,
+    # aligner, and four sentinel embeddings beside the pipelined text model.
+    coordinator_weight_bytes: int = 0
     tensor_count: int = 0
     activation_bytes_per_token: int = 0
     tensor_parallel_heads: int = 1
@@ -119,6 +124,8 @@ class ModelLayout:
     def __post_init__(self) -> None:
         if self.fixed_weight_bytes < 0:
             raise ValueError("fixed_weight_bytes must be non-negative")
+        if self.coordinator_weight_bytes < 0:
+            raise ValueError("coordinator_weight_bytes must be non-negative")
         if not self.layer_weight_bytes:
             raise ValueError("at least one layer is required")
         if len(self.layer_weight_bytes) > _MAX_PIPELINE_LAYERS:
@@ -163,7 +170,11 @@ class ModelLayout:
 
     @property
     def total_weight_bytes(self) -> int:
-        return self.fixed_weight_bytes + sum(self.layer_weight_bytes)
+        return (
+            self.fixed_weight_bytes
+            + self.coordinator_weight_bytes
+            + sum(self.layer_weight_bytes)
+        )
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -171,6 +182,7 @@ class ModelLayout:
             "tensor_count": self.tensor_count,
             "layer_count": self.layer_count,
             "fixed_weight_bytes": self.fixed_weight_bytes,
+            "coordinator_weight_bytes": self.coordinator_weight_bytes,
             "layer_weight_bytes": list(self.layer_weight_bytes),
             "total_weight_bytes": self.total_weight_bytes,
             "activation_bytes_per_token": self.activation_bytes_per_token,
@@ -204,6 +216,9 @@ class ModelLayout:
                 source=str(payload.get("source", "")),
                 fixed_weight_bytes=int(payload["fixed_weight_bytes"]),
                 layer_weight_bytes=tuple(layers),
+                coordinator_weight_bytes=int(
+                    payload.get("coordinator_weight_bytes", 0)
+                ),
                 tensor_count=int(payload.get("tensor_count", 0)),
                 activation_bytes_per_token=int(
                     payload.get("activation_bytes_per_token", 0)
@@ -347,6 +362,7 @@ class PipelineAssignment:
     predicted_compute_seconds: float | None = None
     predicted_send_seconds: float | None = None
     predicted_stage_seconds: float | None = None
+    coordinator_weight_bytes: int = 0
 
     def __post_init__(self) -> None:
         # Normalised on the way in, not read leniently on the way out: this
@@ -370,7 +386,12 @@ class PipelineAssignment:
         # parallelism the stage's layers are already divided by the TP degree,
         # because shard_linear splits the projections inside each layer. Adding
         # ``sharded_weight_bytes`` on top double-counted the same weights.
-        return self.fixed_weight_bytes + self.layer_weight_bytes + self.kv_cache_bytes
+        return (
+            self.fixed_weight_bytes
+            + self.coordinator_weight_bytes
+            + self.layer_weight_bytes
+            + self.kv_cache_bytes
+        )
 
     @property
     def headroom_bytes(self) -> int:
@@ -389,6 +410,7 @@ class PipelineAssignment:
             "layer_count": self.layer_count,
             "layer_weight_bytes": self.layer_weight_bytes,
             "fixed_weight_bytes": self.fixed_weight_bytes,
+            "coordinator_weight_bytes": self.coordinator_weight_bytes,
             "planned_weight_bytes": self.planned_weight_bytes,
             "reserve_bytes": self.reserve_bytes,
             "capacity_bytes": self.capacity_bytes,
@@ -761,7 +783,14 @@ def _supports_pipeline(config: dict[str, Any]) -> bool:
     # ``pipeline()`` belongs to the mlx-lm implementation this model does not
     # use, so trusting it (as ``_declares_pipeline`` does) is the false positive
     # that offered pipeline for Qwen3.5/3.6-family VLMs and then failed at load.
+    from omlx.deepseek_v4_vision import is_deepseek_v4_vision_config
     from omlx.model_discovery import _has_vision_subconfig
+
+    # This family deliberately reuses the pipeline-capable DeepSeek-V4 text
+    # backbone.  Its vision sidecar is coordinator-only and does not pass
+    # through ``PipelineMixin.pipeline``.
+    if is_deepseek_v4_vision_config(config):
+        return _declares_pipeline(model_type)
 
     if _has_vision_subconfig(config):
         return False
@@ -997,7 +1026,15 @@ def inspect_safetensors_layout(model_path: str | Path) -> ModelLayout:
     if not root.is_dir():
         raise PlanningError(f"model path is not a directory: {root}")
 
+    config = _model_config(root)
+    from omlx.deepseek_v4_vision import (
+        is_deepseek_v4_vision_config,
+        is_deepseek_v4_vision_weight,
+    )
+
+    coordinator_vision = is_deepseek_v4_vision_config(config)
     fixed_bytes = 0
+    coordinator_bytes = 0
     layer_sizes: dict[int, int] = {}
     tensor_names: set[str] = set()
     tensor_count = 0
@@ -1028,13 +1065,16 @@ def inspect_safetensors_layout(model_path: str | Path) -> ModelLayout:
             if offsets[1] > offsets[0]:
                 intervals.append((offsets[0], offsets[1], name))
             tensor_bytes = offsets[1] - offsets[0]
-            layer_index = _tensor_layer_index(name)
-            if layer_index is None:
-                fixed_bytes += tensor_bytes
+            if coordinator_vision and is_deepseek_v4_vision_weight(name):
+                coordinator_bytes += tensor_bytes
             else:
-                layer_sizes[layer_index] = (
-                    layer_sizes.get(layer_index, 0) + tensor_bytes
-                )
+                layer_index = _tensor_layer_index(name)
+                if layer_index is None:
+                    fixed_bytes += tensor_bytes
+                else:
+                    layer_sizes[layer_index] = (
+                        layer_sizes.get(layer_index, 0) + tensor_bytes
+                    )
             tensor_count += 1
         intervals.sort()
         for previous, current in zip(intervals, intervals[1:]):
@@ -1054,7 +1094,7 @@ def inspect_safetensors_layout(model_path: str | Path) -> ModelLayout:
     # layers put a stage boundary over weights that do not exist at runtime,
     # and the last stage failed activation with end_layer beyond the model.
     declared_depth = _config_int(
-        _model_config(root), "num_hidden_layers", 0
+        config, "num_hidden_layers", 0
     )
     if declared_depth > 0 and max(layer_sizes) >= declared_depth:
         trimmed = {
@@ -1074,9 +1114,10 @@ def inspect_safetensors_layout(model_path: str | Path) -> ModelLayout:
         raise PlanningError(
             "safetensors layer indices must be contiguous and start at zero"
         )
-    return ModelLayout(
+    layout = ModelLayout(
         source=str(root.resolve()),
         fixed_weight_bytes=fixed_bytes,
+        coordinator_weight_bytes=coordinator_bytes,
         layer_weight_bytes=tuple(layer_sizes[index] for index in expected_indices),
         tensor_count=tensor_count,
         activation_bytes_per_token=_activation_bytes_per_token(root),
@@ -1084,16 +1125,31 @@ def inspect_safetensors_layout(model_path: str | Path) -> ModelLayout:
         tensor_parallel_kv_heads=_config_int(
             _model_config(root), "num_key_value_heads", 0
         ),
-        tensor_parallel_divisors=_tensor_parallel_divisors(_model_config(root)),
-        supports_tensor_parallel=_supports_tensor_parallel(_model_config(root)),
-        supports_pipeline=_supports_pipeline(_model_config(root)),
+        tensor_parallel_divisors=_tensor_parallel_divisors(config),
+        # The first implementation is pipeline-only: tensor sharding would
+        # replicate or partition the coordinator sidecar without an ownership
+        # contract.
+        supports_tensor_parallel=(
+            False if coordinator_vision else _supports_tensor_parallel(config)
+        ),
+        supports_pipeline=_supports_pipeline(config),
         kv_bytes_per_token_per_layer=_kv_bytes_per_token_per_layer(
-            _model_config(root)
+            config
         ),
         kv_replicated_across_tp=_kv_cache_replicated_across_tp(
-            _model_config(root)
+            config
         ),
     )
+    if coordinator_vision:
+        logger.info(
+            "deepseek_v4_vision stage=manifest_scanned tensors=%d "
+            "vision_bytes=%d fixed_bytes=%d language_layers=%d",
+            tensor_count,
+            coordinator_bytes,
+            fixed_bytes,
+            layout.layer_count,
+        )
+    return layout
 
 
 # Directory mtime + config mtime + per-shard (name, mtime, size). The shard
@@ -1274,6 +1330,7 @@ def _partition_layers(
     pipeline_nodes: Sequence[NodeBudget],
     *,
     fixed_weight_bytes: int,
+    coordinator_weight_bytes: int = 0,
     layer_resident_sizes: Sequence[int] | None = None,
     activation_bytes_per_token: int = 0,
     workload_profile: ExecutionProfileName = "balanced",
@@ -1319,6 +1376,9 @@ def _partition_layers(
         0: (((0.0, 0.0) + base_score if target_aware else base_score), (0,))
     }
     for node_index, node in enumerate(pipeline_nodes):
+        node_fixed_bytes = fixed_weight_bytes + (
+            coordinator_weight_bytes if node.rank == 0 else 0
+        )
         next_states: dict[
             int,
             tuple[tuple[float, ...], tuple[int, ...]],
@@ -1333,8 +1393,8 @@ def _partition_layers(
                 resident_layer_bytes = (
                     resident_prefix[end] - resident_prefix[start]
                 )
-                planned_weight_bytes = fixed_weight_bytes + layer_bytes
-                planned_resident_bytes = fixed_weight_bytes + resident_layer_bytes
+                planned_weight_bytes = node_fixed_bytes + layer_bytes
+                planned_resident_bytes = node_fixed_bytes + resident_layer_bytes
                 if planned_weight_bytes > node.weight_ceiling_bytes:
                     continue
                 if planned_resident_bytes > node.usable_bytes:
@@ -1386,11 +1446,21 @@ def _partition_layers(
     final = states.get(layer_count)
     if final is None:
         resident_capacity = sum(
-            max(0, node.usable_bytes - fixed_weight_bytes)
+            max(
+                0,
+                node.usable_bytes
+                - fixed_weight_bytes
+                - (coordinator_weight_bytes if node.rank == 0 else 0),
+            )
             for node in pipeline_nodes
         )
         weight_capacity = sum(
-            max(0, node.weight_ceiling_bytes - fixed_weight_bytes)
+            max(
+                0,
+                node.weight_ceiling_bytes
+                - fixed_weight_bytes
+                - (coordinator_weight_bytes if node.rank == 0 else 0),
+            )
             for node in pipeline_nodes
         )
         weight_shortfall = max(0, sum(layer_sizes) - weight_capacity)
@@ -1470,9 +1540,12 @@ def plan_unequal_pipeline(
     if len(set(node_ids)) != len(node_ids):
         raise ValueError("node IDs must be unique")
     for node in nodes:
-        if model.fixed_weight_bytes > node.usable_bytes:
+        node_fixed_bytes = model.fixed_weight_bytes + (
+            model.coordinator_weight_bytes if node.rank == 0 else 0
+        )
+        if node_fixed_bytes > node.usable_bytes:
             raise PlanningError(
-                f"replicated fixed weights do not fit node {node.node_id}"
+                f"fixed weights do not fit node {node.node_id}"
             )
 
     # MLX-LM sends activations from the highest rank (early layers) down to
@@ -1485,6 +1558,7 @@ def plan_unequal_pipeline(
             model.layer_weight_bytes,
             pipeline_nodes,
             fixed_weight_bytes=model.fixed_weight_bytes,
+            coordinator_weight_bytes=model.coordinator_weight_bytes,
             layer_resident_sizes=tuple(
                 weight_bytes + kv_bytes_per_layer
                 for weight_bytes in model.layer_weight_bytes
@@ -1504,7 +1578,15 @@ def plan_unequal_pipeline(
     for node, (start, end) in zip(pipeline_nodes, ranges):
         layer_weight_bytes = sum(model.layer_weight_bytes[start:end])
         kv_bytes = _kv_bytes_for_stage(model, end - start, context_tokens)
-        planned = model.fixed_weight_bytes + layer_weight_bytes + kv_bytes
+        coordinator_bytes = (
+            model.coordinator_weight_bytes if node.rank == 0 else 0
+        )
+        planned = (
+            model.fixed_weight_bytes
+            + coordinator_bytes
+            + layer_weight_bytes
+            + kv_bytes
+        )
         if planned > node.usable_bytes:
             raise PlanningError(
                 f"stage does not fit node {node.node_id} once KV cache for "
@@ -1527,6 +1609,7 @@ def plan_unequal_pipeline(
                 end_layer=end,
                 layer_weight_bytes=layer_weight_bytes,
                 fixed_weight_bytes=model.fixed_weight_bytes,
+                coordinator_weight_bytes=coordinator_bytes,
                 reserve_bytes=node.reserve_bytes,
                 capacity_bytes=node.capacity_bytes,
                 manual_memory_limit=node.manual_memory_limit,
@@ -1538,7 +1621,11 @@ def plan_unequal_pipeline(
                     model,
                     node,
                     layer_count=end - start,
-                    weight_bytes=model.fixed_weight_bytes + layer_weight_bytes,
+                    weight_bytes=(
+                        model.fixed_weight_bytes
+                        + coordinator_bytes
+                        + layer_weight_bytes
+                    ),
                 ),
                 predicted_compute_seconds=(
                     compute_seconds if performance_aware else None
@@ -1548,6 +1635,17 @@ def plan_unequal_pipeline(
             )
         )
     assignments.sort(key=lambda item: item.rank)
+
+    if model.coordinator_weight_bytes:
+        logger.info(
+            "deepseek_v4_vision stage=plan_constructed vision_rank=0 "
+            "vision_bytes=%d layer_ranges=%s",
+            model.coordinator_weight_bytes,
+            [
+                (item.rank, item.start_layer, item.end_layer)
+                for item in assignments
+            ],
+        )
 
     hash_payload = {
         "model": model.to_dict(),
@@ -1827,6 +1925,11 @@ def plan_hybrid(
         raise ValueError("at least one node is required")
     if tensor_parallel_size < 1:
         raise ValueError("tensor_parallel_size must be at least 1")
+    if tensor_parallel_size > 1 and model.coordinator_weight_bytes:
+        raise PlanningError(
+            "DeepSeek-V4 Vision distributed inference currently supports "
+            "pipeline parallelism only (tensor_parallel_size must be 1)"
+        )
     if len(nodes) % tensor_parallel_size != 0:
         raise PlanningError(
             f"world size {len(nodes)} is not divisible by tensor_parallel_size "

--- a/omlx/cluster/planner.py
+++ b/omlx/cluster/planner.py
@@ -113,6 +113,17 @@ class ModelLayout:
     # proportion to the layers it holds, so a plan that fits the weights
     # still fits once a long prompt fills the cache.
     kv_bytes_per_token_per_layer: int = 0
+    # Architectures with heterogeneous caches cannot be represented by the
+    # uniform field above.  These two optional arrays describe an affine
+    # resident-cache bound for each transformer layer:
+    #
+    #   fixed[layer] + context_tokens * per_token[layer]
+    #
+    # DeepSeek V4 uses this for its 128-token rotating local cache plus its
+    # ratio-4 / ratio-128 compressed pools.  Empty tuples preserve the legacy
+    # uniform layout for every other architecture.
+    kv_bytes_per_token_by_layer: tuple[int, ...] = ()
+    kv_fixed_bytes_by_layer: tuple[int, ...] = ()
     # MLA models keep one latent cache per layer that every tensor-parallel
     # member holds whole; sharding divides the heads, not this cache.
     kv_replicated_across_tp: bool = False
@@ -120,6 +131,11 @@ class ModelLayout:
     # Whether mlx-lm can split this architecture into pipeline stages. False
     # means the model runs on one node or not at all, however well it fits.
     supports_pipeline: bool = False
+    # Whether the distributed runtime can prefill long multimodal prompts in
+    # bounded chunks without splitting an image-sentinel block. This is kept
+    # separate from the resident context estimate so the catalogue never
+    # implies that a text-only limit is automatically safe for images.
+    supports_chunked_multimodal_prefill: bool = False
 
     def __post_init__(self) -> None:
         if self.fixed_weight_bytes < 0:
@@ -144,6 +160,20 @@ class ModelLayout:
             raise ValueError("tensor_parallel_kv_heads must be non-negative")
         if self.kv_bytes_per_token_per_layer < 0:
             raise ValueError("kv_bytes_per_token_per_layer must be non-negative")
+        for name, values in (
+            ("kv_bytes_per_token_by_layer", self.kv_bytes_per_token_by_layer),
+            ("kv_fixed_bytes_by_layer", self.kv_fixed_bytes_by_layer),
+        ):
+            if values and len(values) != len(self.layer_weight_bytes):
+                raise ValueError(f"{name} must have one entry per model layer")
+            if any(value < 0 for value in values):
+                raise ValueError(f"{name} values must be non-negative")
+        if bool(self.kv_bytes_per_token_by_layer) != bool(
+            self.kv_fixed_bytes_by_layer
+        ):
+            raise ValueError(
+                "per-layer KV token and fixed byte arrays must be set together"
+            )
         if self.tensor_parallel_kv_heads == 0:
             object.__setattr__(
                 self, "tensor_parallel_kv_heads", self.tensor_parallel_heads
@@ -176,6 +206,13 @@ class ModelLayout:
             + sum(self.layer_weight_bytes)
         )
 
+    @property
+    def has_kv_cache_estimate(self) -> bool:
+        return bool(
+            self.kv_bytes_per_token_per_layer > 0
+            or self.kv_bytes_per_token_by_layer
+        )
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "source": self.source,
@@ -191,7 +228,14 @@ class ModelLayout:
             "tensor_parallel_divisors": list(self.tensor_parallel_divisors),
             "supports_tensor_parallel": self.supports_tensor_parallel,
             "supports_pipeline": self.supports_pipeline,
+            "supports_chunked_multimodal_prefill": (
+                self.supports_chunked_multimodal_prefill
+            ),
             "kv_bytes_per_token_per_layer": self.kv_bytes_per_token_per_layer,
+            "kv_bytes_per_token_by_layer": list(
+                self.kv_bytes_per_token_by_layer
+            ),
+            "kv_fixed_bytes_by_layer": list(self.kv_fixed_bytes_by_layer),
             "kv_replicated_across_tp": self.kv_replicated_across_tp,
         }
 
@@ -234,6 +278,14 @@ class ModelLayout:
                 kv_bytes_per_token_per_layer=int(
                     payload.get("kv_bytes_per_token_per_layer", 0)
                 ),
+                kv_bytes_per_token_by_layer=tuple(
+                    int(value)
+                    for value in payload.get("kv_bytes_per_token_by_layer", ())
+                ),
+                kv_fixed_bytes_by_layer=tuple(
+                    int(value)
+                    for value in payload.get("kv_fixed_bytes_by_layer", ())
+                ),
                 kv_replicated_across_tp=bool(
                     payload.get("kv_replicated_across_tp", False)
                 ),
@@ -241,6 +293,9 @@ class ModelLayout:
                     payload.get("supports_tensor_parallel", False)
                 ),
                 supports_pipeline=bool(payload.get("supports_pipeline", False)),
+                supports_chunked_multimodal_prefill=bool(
+                    payload.get("supports_chunked_multimodal_prefill", False)
+                ),
             )
         except (KeyError, TypeError, ValueError) as exc:
             raise PlanningError(f"model layout is malformed: {exc}") from exc
@@ -909,6 +964,76 @@ def _kv_bytes_per_token_per_layer(config: dict[str, Any]) -> int:
     return kv_heads * head_dim * 2 * dtype_size
 
 
+def _deepseek_v4_kv_layout(
+    config: dict[str, Any],
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """Return a conservative affine resident-cache layout for DeepSeek V4.
+
+    The runtime stores one 128-token local K-only rotating cache in every
+    layer. Ratio-4 layers additionally retain main and index pools; ratio-128
+    layers retain only the main pool. Pool remainder/carry buffers are fixed,
+    while completed rows grow linearly with context. This mirrors
+    ``_DeepSeekV4PrefillMemoryProfile.estimate_resident_kv_bytes`` with a
+    one-token resident chunk, rounded upward where a ratio does not divide a
+    dimension exactly.
+    """
+
+    model_type = str(config.get("model_type", "") or "")
+    ratios = config.get("compress_ratios")
+    num_layers = _config_int(config, "num_hidden_layers", 0)
+    if (
+        not model_type.startswith("deepseek_v4")
+        or not isinstance(ratios, list)
+        or num_layers <= 0
+        or len(ratios) < num_layers
+    ):
+        return (), ()
+    ratios = ratios[:num_layers]
+    if any(
+        not isinstance(ratio, int)
+        or isinstance(ratio, bool)
+        or ratio not in (0, 4, 128)
+        for ratio in ratios
+    ):
+        return (), ()
+
+    head_dim = _config_int(config, "head_dim", 0)
+    sliding_window = _config_int(config, "sliding_window", 0)
+    index_head_dim = _config_int(config, "index_head_dim", 0)
+    if head_dim <= 0 or sliding_window <= 0 or index_head_dim <= 0:
+        return (), ()
+
+    dtype_size = 2
+    local_fixed = sliding_window * head_dim * dtype_size
+    per_token: list[int] = []
+    fixed: list[int] = []
+
+    def pooled_linear_bytes(dim: int, ratio: int) -> int:
+        return (dim * dtype_size + ratio - 1) // ratio
+
+    def pooled_fixed_bytes(dim: int, ratio: int, *, overlap: bool) -> int:
+        projection_dim = dim * (2 if overlap else 1)
+        elements = 2 * ratio * projection_dim
+        if overlap:
+            elements += 2 * ratio * projection_dim
+        return elements * dtype_size
+
+    for ratio in ratios:
+        linear = 0
+        constant = local_fixed
+        if ratio == 4:
+            linear += pooled_linear_bytes(head_dim, ratio)
+            linear += pooled_linear_bytes(index_head_dim, ratio)
+            constant += pooled_fixed_bytes(head_dim, ratio, overlap=True)
+            constant += pooled_fixed_bytes(index_head_dim, ratio, overlap=True)
+        elif ratio == 128:
+            linear += pooled_linear_bytes(head_dim, ratio)
+            constant += pooled_fixed_bytes(head_dim, ratio, overlap=False)
+        per_token.append(linear)
+        fixed.append(constant)
+    return tuple(per_token), tuple(fixed)
+
+
 def _attention_head_count(model_path: Path) -> int:
     """Attention heads per layer, which bounds the tensor-parallel degree.
 
@@ -1114,6 +1239,7 @@ def inspect_safetensors_layout(model_path: str | Path) -> ModelLayout:
         raise PlanningError(
             "safetensors layer indices must be contiguous and start at zero"
         )
+    kv_by_layer, kv_fixed_by_layer = _deepseek_v4_kv_layout(config)
     layout = ModelLayout(
         source=str(root.resolve()),
         fixed_weight_bytes=fixed_bytes,
@@ -1133,9 +1259,12 @@ def inspect_safetensors_layout(model_path: str | Path) -> ModelLayout:
             False if coordinator_vision else _supports_tensor_parallel(config)
         ),
         supports_pipeline=_supports_pipeline(config),
+        supports_chunked_multimodal_prefill=coordinator_vision,
         kv_bytes_per_token_per_layer=_kv_bytes_per_token_per_layer(
             config
         ),
+        kv_bytes_per_token_by_layer=kv_by_layer,
+        kv_fixed_bytes_by_layer=kv_fixed_by_layer,
         kv_replicated_across_tp=_kv_cache_replicated_across_tp(
             config
         ),
@@ -1552,7 +1681,10 @@ def plan_unequal_pipeline(
     # rank zero (late layers / HTTP coordinator), so partition in reverse rank.
     pipeline_nodes = tuple(sorted(nodes, key=lambda item: item.rank, reverse=True))
     performance_aware = all(node.performance is not None for node in pipeline_nodes)
-    kv_bytes_per_layer = _kv_bytes_for_stage(model, 1, context_tokens)
+    layer_kv_bytes = tuple(
+        _kv_bytes_for_stage(model, index, index + 1, context_tokens)
+        for index in range(model.layer_count)
+    )
     try:
         ranges = _partition_layers(
             model.layer_weight_bytes,
@@ -1560,15 +1692,17 @@ def plan_unequal_pipeline(
             fixed_weight_bytes=model.fixed_weight_bytes,
             coordinator_weight_bytes=model.coordinator_weight_bytes,
             layer_resident_sizes=tuple(
-                weight_bytes + kv_bytes_per_layer
-                for weight_bytes in model.layer_weight_bytes
+                weight_bytes + kv_bytes
+                for weight_bytes, kv_bytes in zip(
+                    model.layer_weight_bytes, layer_kv_bytes
+                )
             ),
             activation_bytes_per_token=model.activation_bytes_per_token,
             workload_profile=workload_profile,
             microbatch_size=microbatch_size,
         )
     except PlanningError as exc:
-        if kv_bytes_per_layer:
+        if any(layer_kv_bytes):
             raise PlanningError(
                 f"model weights and KV cache for {context_tokens} tokens do not "
                 f"fit the supplied per-node budgets: {exc}"
@@ -1577,7 +1711,7 @@ def plan_unequal_pipeline(
     assignments: list[PipelineAssignment] = []
     for node, (start, end) in zip(pipeline_nodes, ranges):
         layer_weight_bytes = sum(model.layer_weight_bytes[start:end])
-        kv_bytes = _kv_bytes_for_stage(model, end - start, context_tokens)
+        kv_bytes = _kv_bytes_for_stage(model, start, end, context_tokens)
         coordinator_bytes = (
             model.coordinator_weight_bytes if node.rank == 0 else 0
         )
@@ -1616,11 +1750,14 @@ def plan_unequal_pipeline(
                 role=node.role,
                 memory_guard_tier=node.memory_guard_tier,
                 kv_cache_bytes=kv_bytes,
-                kv_bytes_per_token=_kv_bytes_per_token_for_stage(model, end - start),
+                kv_bytes_per_token=_kv_bytes_per_token_for_stage(
+                    model, start, end
+                ),
                 max_context_tokens=_max_context_for_stage(
                     model,
                     node,
-                    layer_count=end - start,
+                    start_layer=start,
+                    end_layer=end,
                     weight_bytes=(
                         model.fixed_weight_bytes
                         + coordinator_bytes
@@ -1783,7 +1920,8 @@ def format_shard_plan(plan: ShardPlan) -> str:
 
 def _kv_bytes_for_stage(
     model: ModelLayout,
-    layer_count: int,
+    start_layer: int,
+    end_layer: int,
     context_tokens: int,
     tensor_parallel_size: int = 1,
 ) -> int:
@@ -1795,9 +1933,20 @@ def _kv_bytes_for_stage(
     is not per-head and stays whole on every member.
     """
 
-    if model.kv_bytes_per_token_per_layer <= 0 or context_tokens <= 0:
+    if context_tokens <= 0 or not model.has_kv_cache_estimate:
         return 0
-    total = model.kv_bytes_per_token_per_layer * layer_count * context_tokens
+    if not (0 <= start_layer <= end_layer <= model.layer_count):
+        raise ValueError("KV layer range is outside the model")
+    if model.kv_bytes_per_token_by_layer:
+        linear = sum(model.kv_bytes_per_token_by_layer[start_layer:end_layer])
+        fixed = sum(model.kv_fixed_bytes_by_layer[start_layer:end_layer])
+        total = fixed + linear * context_tokens
+    else:
+        total = (
+            model.kv_bytes_per_token_per_layer
+            * (end_layer - start_layer)
+            * context_tokens
+        )
     if model.kv_replicated_across_tp:
         return total
     return total // max(1, tensor_parallel_size)
@@ -1805,14 +1954,22 @@ def _kv_bytes_for_stage(
 
 def _kv_bytes_per_token_for_stage(
     model: ModelLayout,
-    layer_count: int,
+    start_layer: int,
+    end_layer: int,
     tensor_parallel_size: int = 1,
 ) -> int:
     """What one more token of context costs this node."""
 
-    if model.kv_bytes_per_token_per_layer <= 0:
+    if not model.has_kv_cache_estimate:
         return 0
-    per_token = model.kv_bytes_per_token_per_layer * layer_count
+    if model.kv_bytes_per_token_by_layer:
+        per_token = sum(
+            model.kv_bytes_per_token_by_layer[start_layer:end_layer]
+        )
+    else:
+        per_token = (
+            model.kv_bytes_per_token_per_layer * (end_layer - start_layer)
+        )
     if model.kv_replicated_across_tp:
         return per_token
     return per_token // max(1, tensor_parallel_size)
@@ -1822,7 +1979,8 @@ def _max_context_for_stage(
     model: ModelLayout,
     node: NodeBudget,
     *,
-    layer_count: int,
+    start_layer: int,
+    end_layer: int,
     weight_bytes: int,
     tensor_parallel_size: int = 1,
 ) -> int:
@@ -1837,11 +1995,16 @@ def _max_context_for_stage(
     """
 
     per_token = _kv_bytes_per_token_for_stage(
-        model, layer_count, tensor_parallel_size
+        model, start_layer, end_layer, tensor_parallel_size
     )
     if per_token <= 0:
         return 0
-    spare = node.usable_bytes - weight_bytes
+    fixed = 0
+    if model.kv_fixed_bytes_by_layer:
+        fixed = sum(model.kv_fixed_bytes_by_layer[start_layer:end_layer])
+        if not model.kv_replicated_across_tp:
+            fixed //= max(1, tensor_parallel_size)
+    spare = node.usable_bytes - weight_bytes - fixed
     return max(0, spare // per_token)
 
 
@@ -2020,24 +2183,28 @@ def plan_hybrid(
     # the same degree when assignments are materialised below. A replicated
     # MLA cache is the exception: every member pays it whole, so at the
     # aggregate level one layer costs the group N caches.
-    kv_bytes_per_layer = _kv_bytes_for_stage(model, 1, context_tokens)
-    if model.kv_replicated_across_tp:
-        kv_bytes_per_layer *= tensor_parallel_size
+    layer_kv_bytes = tuple(
+        _kv_bytes_for_stage(model, index, index + 1, context_tokens)
+        * (tensor_parallel_size if model.kv_replicated_across_tp else 1)
+        for index in range(model.layer_count)
+    )
     try:
         ranges = _partition_layers(
             model.layer_weight_bytes,
             stage_budgets,
             fixed_weight_bytes=model.fixed_weight_bytes,
             layer_resident_sizes=tuple(
-                weight_bytes + kv_bytes_per_layer
-                for weight_bytes in model.layer_weight_bytes
+                weight_bytes + kv_bytes
+                for weight_bytes, kv_bytes in zip(
+                    model.layer_weight_bytes, layer_kv_bytes
+                )
             ),
             activation_bytes_per_token=model.activation_bytes_per_token,
             workload_profile=workload_profile,
             microbatch_size=microbatch_size,
         )
     except PlanningError as exc:
-        if kv_bytes_per_layer:
+        if any(layer_kv_bytes):
             raise PlanningError(
                 f"model weights and KV cache for {context_tokens} tokens do not "
                 f"fit the supplied per-node budgets: {exc}"
@@ -2054,7 +2221,7 @@ def plan_hybrid(
         per_member = stage_layer_bytes // tensor_parallel_size
         remainder = stage_layer_bytes % tensor_parallel_size
         kv_bytes = _kv_bytes_for_stage(
-            model, end - start, context_tokens, tensor_parallel_size
+            model, start, end, context_tokens, tensor_parallel_size
         )
         for tp_rank, node in enumerate(group):
             held_layer_bytes = per_member + (1 if tp_rank < remainder else 0)
@@ -2088,12 +2255,13 @@ def plan_hybrid(
                     tensor_parallel_size=tensor_parallel_size,
                     kv_cache_bytes=kv_bytes,
                     kv_bytes_per_token=_kv_bytes_per_token_for_stage(
-                        model, end - start, tensor_parallel_size
+                        model, start, end, tensor_parallel_size
                     ),
                     max_context_tokens=_max_context_for_stage(
                         model,
                         node,
-                        layer_count=end - start,
+                        start_layer=start,
+                        end_layer=end,
                         weight_bytes=model.fixed_weight_bytes + held_layer_bytes,
                         tensor_parallel_size=tensor_parallel_size,
                     ),

--- a/omlx/cluster/prefill_guard.py
+++ b/omlx/cluster/prefill_guard.py
@@ -125,6 +125,7 @@ class RankPrefillGuard:
         cached_tokens: int = 0,
         request_id: str | None = None,
         current_usage_bytes: int | None = None,
+        prefill_step_size: int | None = None,
     ) -> None:
         """Raise ``PrefillMemoryExceededError`` if this prompt will not fit."""
 
@@ -140,13 +141,14 @@ class RankPrefillGuard:
             if current_usage_bytes is None
             else max(0, int(current_usage_bytes))
         )
+        step = self._step if prefill_step_size is None else max(1, int(prefill_step_size))
         try:
             raise_if_prefill_exceeds(
                 self._monitor,
                 prefill_memory_guard=True,
                 hard_limit_bytes=self._ceiling,
                 current_usage_bytes=usage,
-                prefill_step_size=self._step,
+                prefill_step_size=step,
                 num_prompt_tokens=int(num_prompt_tokens),
                 cached_tokens=max(0, int(cached_tokens)),
                 request_id=request_id,
@@ -170,6 +172,7 @@ class RankPrefillGuard:
         request_id: str | None = None,
         current_usage_bytes: int | None = None,
         mx_module: Any | None = None,
+        prefill_step_size: int | None = None,
     ) -> None:
         """Make prefill admission one rank-agreed decision.
 
@@ -189,6 +192,7 @@ class RankPrefillGuard:
                 cached_tokens=cached_tokens,
                 request_id=request_id,
                 current_usage_bytes=current_usage_bytes,
+                prefill_step_size=prefill_step_size,
             )
         except PrefillMemoryExceededError as exc:
             local_error = exc

--- a/omlx/cluster/prefill_guard.py
+++ b/omlx/cluster/prefill_guard.py
@@ -64,11 +64,25 @@ def rank_monitor(
 
     heads = int(getattr(monitor, "_num_attention_heads", 0) or kv_heads)
     dtype_size = float(getattr(monitor, "_dtype_size", 2) or 2)
+    compute_dtype_size = float(
+        getattr(monitor, "_score_dtype_size", dtype_size) or dtype_size
+    )
     kv_override = getattr(monitor, "_kv_bytes_per_token_override", None)
+    rotating_layer_specs = getattr(monitor, "_rotating_layer_specs", ())
+    prefill_memory_profile = getattr(monitor, "_prefill_memory_profile", None)
+    ane_prefill_transient_bytes = int(
+        getattr(monitor, "_ane_prefill_transient_bytes", 0) or 0
+    )
+    detected_kv_layers = getattr(monitor, "_num_kv_cache_layers", None)
 
     # Pipeline: this rank stores KV for its own layers only.
     stage_layers = int(layer_count) if layer_count else num_layers
     stage_layers = max(1, min(stage_layers, num_layers or stage_layers))
+    stage_kv_layers = (
+        stage_layers
+        if detected_kv_layers is None
+        else max(0, min(int(detected_kv_layers), stage_layers))
+    )
 
     # Tensor parallel: heads are split across ranks, so both the KV this rank
     # stores and the attention transient it computes shrink with the shard.
@@ -85,8 +99,12 @@ def rank_monitor(
         head_dim=head_dim,
         dtype_size=dtype_size,
         num_attention_heads=heads,
-        num_kv_cache_layers=stage_layers,
+        num_kv_cache_layers=stage_kv_layers,
+        compute_dtype_size=compute_dtype_size,
         kv_bytes_per_token=kv_override,
+        rotating_layer_specs=rotating_layer_specs,
+        prefill_memory_profile=prefill_memory_profile,
+        ane_prefill_transient_bytes=ane_prefill_transient_bytes,
     )
     return monitor
 
@@ -141,7 +159,9 @@ class RankPrefillGuard:
             if current_usage_bytes is None
             else max(0, int(current_usage_bytes))
         )
-        step = self._step if prefill_step_size is None else max(1, int(prefill_step_size))
+        step = (
+            self._step if prefill_step_size is None else max(1, int(prefill_step_size))
+        )
         try:
             raise_if_prefill_exceeds(
                 self._monitor,

--- a/omlx/cluster/prefill_guard.py
+++ b/omlx/cluster/prefill_guard.py
@@ -205,7 +205,12 @@ class RankPrefillGuard:
 
         from omlx.exceptions import PrefillMemoryExceededError
 
-        local_error: PrefillMemoryExceededError | None = None
+        # Every local failure has to become a vote.  Memory probes and model
+        # estimators are best-effort code and can raise something other than
+        # PrefillMemoryExceededError (for example an MLX runtime error).  Letting
+        # that exception escape here strands peers in this rank-agreement
+        # collective, or in the first model collective that follows it.
+        local_error: Exception | None = None
         try:
             self.check(
                 num_prompt_tokens,
@@ -214,7 +219,7 @@ class RankPrefillGuard:
                 current_usage_bytes=current_usage_bytes,
                 prefill_step_size=prefill_step_size,
             )
-        except PrefillMemoryExceededError as exc:
+        except Exception as exc:
             local_error = exc
 
         if mx_module is None:

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -1606,6 +1606,7 @@ def _run_staging_job(
                 end_layer=assignment.end_layer,
                 present=present,
                 shards=shards,
+                rank=assignment.rank,
             )
             needed = tuple(
                 name

--- a/omlx/cluster/runtime.py
+++ b/omlx/cluster/runtime.py
@@ -15,6 +15,9 @@ from .performance import ExecutionSettings, NodePerformanceProfile
 
 _MAX_MARKERS = 64
 _MAX_MARKER_BYTES = 64 * 1024
+# Written by the launcher (see launch.DistributedSupervisor._recovery_marker_path)
+# into the same state directory. These are quarantine records, not rank markers.
+_RECOVERY_MARKER_SUFFIX = "-memory-recovery.json"
 _PHASES = {"loading", "ready", "peer_lost", "launcher_lost", "failed"}
 _LOAD_STAGES = {"initializing", "loading_weights", "validating", "ready"}
 _BACKENDS = {"ring", "jaccl", "jaccl-ring"}
@@ -577,7 +580,16 @@ def read_runtime_markers(
 
     jobs: list[dict[str, Any]] = []
     warnings: list[str] = []
-    candidates = [path for path in entries if path.name.endswith(".json")]
+    candidates = [
+        path
+        for path in entries
+        if path.name.endswith(".json")
+        # Memory-recovery quarantine records share this directory but use a
+        # different schema enforced separately by the launcher. Reporting them
+        # here produced a spurious "invalid string fields" warning on every
+        # diagnostics read after a quarantined teardown.
+        and not path.name.endswith(_RECOVERY_MARKER_SUFFIX)
+    ]
     if len(candidates) > _MAX_MARKERS:
         warnings.append(f"runtime marker limit exceeded; showing first {_MAX_MARKERS}")
     for path in candidates[:_MAX_MARKERS]:

--- a/omlx/cluster/staging.py
+++ b/omlx/cluster/staging.py
@@ -51,6 +51,7 @@ class ShardInfo:
     size_bytes: int
     layers: frozenset[int]
     has_shared_tensors: bool  # embeddings, lm_head, norms — not layer-scoped
+    has_coordinator_tensors: bool = False  # rank-zero ViT/aligner/sentinels
 
 
 @dataclass(frozen=True)
@@ -115,6 +116,14 @@ def index_shards(model_path: str | Path) -> tuple[ShardInfo, ...]:
     files = sorted(root.glob("*.safetensors"))
     if not files:
         raise ValueError(f"no safetensors files in {root}")
+    from omlx.deepseek_v4_vision import is_deepseek_v4_vision_config
+
+    try:
+        coordinator_vision = is_deepseek_v4_vision_config(
+            json.loads((root / "config.json").read_text())
+        )
+    except (OSError, json.JSONDecodeError):
+        coordinator_vision = False
 
     names_by_file: dict[str, list[str]] = {}
     index = root / "model.safetensors.index.json"
@@ -131,18 +140,25 @@ def index_shards(model_path: str | Path) -> tuple[ShardInfo, ...]:
             names = _safetensors_tensor_names(path)
         layers = set()
         shared = False
+        coordinator = False
+        from omlx.deepseek_v4_vision import is_deepseek_v4_vision_weight
+
         for name in names:
-            match = _LAYER.search(name)
-            if match:
-                layers.add(int(match.group(1)))
+            if coordinator_vision and is_deepseek_v4_vision_weight(name):
+                coordinator = True
             else:
-                shared = True
+                match = _LAYER.search(name)
+                if match:
+                    layers.add(int(match.group(1)))
+                else:
+                    shared = True
         shards.append(
             ShardInfo(
                 name=path.name,
                 size_bytes=path.stat().st_size,
                 layers=frozenset(layers),
                 has_shared_tensors=shared,
+                has_coordinator_tensors=coordinator,
             )
         )
     return tuple(shards)
@@ -152,6 +168,8 @@ def shards_for_stage(
     shards: Sequence[ShardInfo],
     start_layer: int,
     end_layer: int,
+    *,
+    rank: int = 0,
 ) -> tuple[ShardInfo, ...]:
     """Files a rank needs to serve layers ``[start_layer, end_layer)``.
 
@@ -164,7 +182,11 @@ def shards_for_stage(
     return tuple(
         shard
         for shard in shards
-        if (shard.layers & wanted) or shard.has_shared_tensors
+        if (
+            (shard.layers & wanted)
+            or shard.has_shared_tensors
+            or (rank == 0 and shard.has_coordinator_tensors)
+        )
     )
 
 
@@ -220,6 +242,14 @@ def _indexed_shards(model_path: str | Path) -> tuple[ShardInfo, ...] | None:
     if not index.is_file():
         return None
     payload = json.loads(index.read_text())
+    from omlx.deepseek_v4_vision import is_deepseek_v4_vision_config
+
+    try:
+        coordinator_vision = is_deepseek_v4_vision_config(
+            json.loads((root / "config.json").read_text())
+        )
+    except (OSError, json.JSONDecodeError):
+        coordinator_vision = False
     weight_map = payload.get("weight_map")
     if not isinstance(weight_map, dict) or not weight_map:
         raise ValueError(f"{index.name} does not contain a weight map")
@@ -236,18 +266,25 @@ def _indexed_shards(model_path: str | Path) -> tuple[ShardInfo, ...] | None:
         path = root / filename
         layers: set[int] = set()
         shared = False
+        coordinator = False
+        from omlx.deepseek_v4_vision import is_deepseek_v4_vision_weight
+
         for name in names:
-            match = _LAYER.search(name)
-            if match:
-                layers.add(int(match.group(1)))
+            if coordinator_vision and is_deepseek_v4_vision_weight(name):
+                coordinator = True
             else:
-                shared = True
+                match = _LAYER.search(name)
+                if match:
+                    layers.add(int(match.group(1)))
+                else:
+                    shared = True
         shards.append(
             ShardInfo(
                 name=filename,
                 size_bytes=path.stat().st_size if path.is_file() else 0,
                 layers=frozenset(layers),
                 has_shared_tensors=shared,
+                has_coordinator_tensors=coordinator,
             )
         )
     return tuple(shards)
@@ -344,6 +381,7 @@ def model_staging_inventory(model_path: str | Path) -> dict[str, Any]:
                 "size_bytes": shard.size_bytes,
                 "layers": sorted(shard.layers),
                 "has_shared_tensors": shard.has_shared_tensors,
+                "has_coordinator_tensors": shard.has_coordinator_tensors,
             }
             for shard in shards
         ],
@@ -394,6 +432,7 @@ def remote_model_staging_inventory(
             size_bytes = int(item["size_bytes"])
             layers = frozenset(int(layer) for layer in item["layers"])
             shared = item["has_shared_tensors"] is True
+            coordinator = item.get("has_coordinator_tensors") is True
         except (KeyError, TypeError, ValueError) as exc:
             raise RuntimeError(f"invalid shard entry from {ssh_target}") from exc
         if Path(name).name != name or size_bytes < 0 or min(layers, default=0) < 0:
@@ -404,6 +443,7 @@ def remote_model_staging_inventory(
                 size_bytes=size_bytes,
                 layers=layers,
                 has_shared_tensors=shared,
+                has_coordinator_tensors=coordinator,
             )
         )
 
@@ -429,6 +469,7 @@ def plan_staging(
     end_layer: int,
     present: dict[str, int] | None = None,
     shards: Sequence[ShardInfo] | None = None,
+    rank: int = 0,
 ) -> StagingPlan:
     """Work out what one node still needs.
 
@@ -438,7 +479,7 @@ def plan_staging(
     """
 
     shards = tuple(shards) if shards is not None else index_shards(model_path)
-    required = shards_for_stage(shards, start_layer, end_layer)
+    required = shards_for_stage(shards, start_layer, end_layer, rank=rank)
     present = present or {}
     missing = tuple(
         shard for shard in required if present.get(shard.name) != shard.size_bytes
@@ -473,6 +514,7 @@ def plan_cluster_staging(
             end_layer=assignment.end_layer,
             present=present_by_node.get(assignment.node_id),
             shards=shards,
+            rank=getattr(assignment, "rank", 0),
         )
         for assignment in assignments
     )
@@ -556,6 +598,7 @@ def stage_manifest(
                 end_layer=assignment.end_layer,
                 present=present_by_node.get(assignment.node_id),
                 shards=shards,
+                rank=getattr(assignment, "rank", 0),
             )
             for assignment in assignments
         )

--- a/omlx/cluster/staging.py
+++ b/omlx/cluster/staging.py
@@ -326,6 +326,8 @@ def validate_staged_model(
     model_path: str | Path,
     start_layer: int,
     end_layer: int,
+    *,
+    rank: int = 0,
 ) -> dict[str, Any]:
     """Prove one rank has its assigned stage, not an unnecessary full model.
 
@@ -343,7 +345,7 @@ def validate_staged_model(
 
     indexed = _indexed_shards(root)
     shards = indexed if indexed is not None else index_shards(root)
-    required = shards_for_stage(shards, start_layer, end_layer)
+    required = shards_for_stage(shards, start_layer, end_layer, rank=rank)
     missing = tuple(shard.name for shard in required if not (root / shard.name).is_file())
     corrupt: list[str] = []
     for shard in required:

--- a/omlx/cluster/telemetry.py
+++ b/omlx/cluster/telemetry.py
@@ -938,10 +938,21 @@ def install_server_telemetry(
                 # Keeping the rank vote inside that boundary rejects just this
                 # request; raising from its later cache lookup kills the whole
                 # generation thread.
+                guard_kwargs = {
+                    "cached_tokens": len(prompt) - len(rest),
+                    "mx_module": mx,
+                }
+                if getattr(self, "_omlx_prefill_step_size_override", False):
+                    # The vision runtime prefills the uncached image-bearing
+                    # suffix in one call. Size admission for that actual call,
+                    # without changing the server's configured chunk size.
+                    guard_kwargs["prefill_step_size"] = max(
+                        snapshot_step,
+                        len(rest),
+                    )
                 prefill_guard.check_collective(
                     len(prompt),
-                    cached_tokens=len(prompt) - len(rest),
-                    mx_module=mx,
+                    **guard_kwargs,
                 )
             except Exception:
                 self.prompt_cache.discard_prefetched_cache()

--- a/omlx/cluster/telemetry.py
+++ b/omlx/cluster/telemetry.py
@@ -575,9 +575,11 @@ class RuntimeTelemetry:
         self._last_publish_at = now
         try:
             self._marker.update("ready", metrics=snapshot)
-        except OSError:
-            # Runtime visibility is deliberately fail-soft. A full disk or
-            # unavailable state directory must never interrupt generation.
+        except Exception as exc:
+            # Runtime visibility is deliberately fail-soft.  In a distributed
+            # worker even a rank-local marker implementation bug must not make
+            # that rank leave before its peers reach the next collective.
+            logger.debug("Runtime marker update failed: %s", exc)
             return
 
 
@@ -700,7 +702,13 @@ def install_server_telemetry(
         # and the sequential generate_step rejects an empty prompt, so a full
         # hit must leave the last token unprocessed. The cap is computed from
         # the broadcast prompt length, so it is identical on every rank.
-        local = set(ssd_store.present_boundaries(model, tokens))
+        try:
+            local = set(ssd_store.present_boundaries(model, tokens))
+        except Exception as exc:
+            # Presence probing is rank-local I/O.  Treat a broken local store
+            # as an empty one, then still contribute the zero vote below.
+            logger.debug("Prompt snapshot presence probe failed: %s", exc)
+            local = set()
         candidates = candidate_boundaries(len(tokens) - 1, snapshot_step)
         if not candidates:
             return 0
@@ -710,6 +718,40 @@ def install_server_telemetry(
         vote = mx.array([1 if c in local else 0 for c in candidates], dtype=mx.int32)
         agreed = mx.distributed.all_sum(vote).tolist()
         return agreed_boundary(candidates, agreed, world_size)
+
+    def agree_memory_cache(
+        cache: Any,
+        rest: list[int],
+        tokens: list[int],
+    ) -> tuple[Any, list[int]]:
+        """Use an in-memory prefix only when every rank found the same length.
+
+        The MLX-LM prompt cache is rank-local.  An eviction or failed lookup on
+        one worker must not let the other ranks start model execution from a
+        different cache position.  Gathering one integer is cheap and makes
+        both the cached-token admission input and the model suffix symmetric.
+        """
+
+        if world_size <= 1:
+            return cache, rest
+        cached = len(tokens) - len(rest) if cache is not None else 0
+        gathered = mx.distributed.all_gather(
+            mx.array([cached], dtype=mx.int32)
+        ).tolist()
+        counts = [int(value) for value in gathered]
+        if len(counts) == world_size and all(value == cached for value in counts):
+            return cache, rest
+        return None, list(tokens)
+
+    def agree_loaded_snapshot(loaded: Any) -> Any | None:
+        """Publish a restored snapshot only when every rank loaded its shard."""
+
+        if world_size <= 1:
+            return loaded
+        loaded_ranks = mx.distributed.all_sum(
+            mx.array(1 if loaded is not None else 0, dtype=mx.int32)
+        ).item()
+        return loaded if int(loaded_ranks) == world_size else None
 
     class TelemetryBatchGenerator(original_batch_generator):
         def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -819,7 +861,13 @@ def install_server_telemetry(
 
     class TelemetryPromptCache(original_prompt_cache):
         def _fetch_observed(self, model: Any, tokens: list[int]) -> Any:
-            cache, rest = super().fetch_nearest_cache(model, tokens)
+            try:
+                cache, rest = super().fetch_nearest_cache(model, tokens)
+            except Exception as exc:
+                # A corrupt rank-local entry is a miss.  All ranks still reach
+                # agree_memory_cache below, which prevents asymmetric reuse.
+                logger.debug("In-memory prompt cache lookup failed: %s", exc)
+                cache, rest = None, list(tokens)
             telemetry.observe_cache_lookup(
                 prompt_tokens=len(tokens),
                 remaining_tokens=len(rest),
@@ -830,24 +878,35 @@ def install_server_telemetry(
 
         def _lookup(self, model: Any, tokens: list[int]) -> Any:
             cache, rest = self._fetch_observed(model, tokens)
-            if cache is not None and not rest and tokens:
-                # MLX-LM's exact-hit branch returns an empty rest, unlike its
-                # shorter/longer branches which cap the prefix at len - 1. The
-                # pinned batched server dies inserting a fully consumed
-                # request (insert_segments indexes seq[-1]) and the sequential
-                # generate_step rejects an empty prompt, so hand back the last
-                # token: trimmed off the hit when the cache supports it,
-                # recomputed from scratch when it does not.
-                from mlx_lm.models.cache import (
-                    can_trim_prompt_cache,
-                    trim_prompt_cache,
-                )
+            try:
+                if cache is not None and not rest and tokens:
+                    # MLX-LM's exact-hit branch returns an empty rest, unlike its
+                    # shorter/longer branches which cap the prefix at len - 1. The
+                    # pinned batched server dies inserting a fully consumed
+                    # request (insert_segments indexes seq[-1]) and the sequential
+                    # generate_step rejects an empty prompt, so hand back the last
+                    # token: trimmed off the hit when the cache supports it,
+                    # recomputed from scratch when it does not.
+                    from mlx_lm.models.cache import (
+                        can_trim_prompt_cache,
+                        trim_prompt_cache,
+                    )
 
-                if can_trim_prompt_cache(cache):
-                    trim_prompt_cache(cache, 1)
-                    rest = list(tokens[-1:])
-                else:
-                    cache, rest = None, list(tokens)
+                    if can_trim_prompt_cache(cache):
+                        trim_prompt_cache(cache, 1)
+                        rest = list(tokens[-1:])
+                    else:
+                        cache, rest = None, list(tokens)
+            except Exception as exc:
+                # Trimming an exact hit is rank-local cache work too.  Convert
+                # a bad entry into a miss before entering the agreement call.
+                logger.debug("In-memory prompt cache normalization failed: %s", exc)
+                cache, rest = None, list(tokens)
+            if cache is not None and len(rest) >= len(tokens):
+                # A zero-length prefix has no reusable state and should be
+                # represented identically to an ordinary miss on every rank.
+                cache, rest = None, list(tokens)
+            cache, rest = agree_memory_cache(cache, rest, tokens)
             # Record the full prompt so the boundary-snapshot callback can key
             # its writes; it runs later on this same generation thread.
             snapshot_ctx.model = model
@@ -860,7 +919,12 @@ def install_server_telemetry(
                 # path, whose byte-based eviction can diverge across ranks.
                 boundary = agree_ssd_boundary(model, tokens)
                 if cache is None and boundary > 0:
-                    loaded = ssd_store.load(model, tokens, boundary)
+                    try:
+                        loaded = ssd_store.load(model, tokens, boundary)
+                    except Exception as exc:
+                        logger.debug("Prompt snapshot restore failed: %s", exc)
+                        loaded = None
+                    loaded = agree_loaded_snapshot(loaded)
                     if loaded is not None:
                         cache, rest = loaded, list(tokens[boundary:])
             return cache, rest

--- a/omlx/cluster/telemetry.py
+++ b/omlx/cluster/telemetry.py
@@ -943,13 +943,31 @@ def install_server_telemetry(
                     "mx_module": mx,
                 }
                 if getattr(self, "_omlx_prefill_step_size_override", False):
-                    # The vision runtime prefills the uncached image-bearing
-                    # suffix in one call. Size admission for that actual call,
-                    # without changing the server's configured chunk size.
-                    guard_kwargs["prefill_step_size"] = max(
-                        snapshot_step,
-                        len(rest),
+                    # The vision runtime uses variable chunks so no boundary
+                    # crosses an image block. Price the largest actual call,
+                    # not the whole prompt and not merely the configured step.
+                    from .deepseek_v4_vision_runtime import vision_prefill_chunks
+
+                    vocab_size = int(
+                        getattr(self, "_omlx_vision_vocab_size", 0) or 0
                     )
+                    if vocab_size > 0:
+                        chunks = vision_prefill_chunks(
+                            rest,
+                            vocab_size=vocab_size,
+                            max_chunk_tokens=snapshot_step,
+                        )
+                        guard_kwargs["prefill_step_size"] = max(
+                            (end - start for start, end in chunks),
+                            default=snapshot_step,
+                        )
+                    else:
+                        # Fail safe for tests/third-party providers without
+                        # exposed model args. Real DeepSeek V4 configs always
+                        # provide vocab_size.
+                        guard_kwargs["prefill_step_size"] = max(
+                            snapshot_step, len(rest)
+                        )
                 prefill_guard.check_collective(
                     len(prompt),
                     **guard_kwargs,

--- a/omlx/deepseek_v4_vision.py
+++ b/omlx/deepseek_v4_vision.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Narrow capability helpers for DeepSeek-V4-Flash-Vision checkpoints.
+
+The experimental checkpoint deliberately keeps ``model_type=deepseek_v4`` and
+stores its vision configuration as flat top-level fields.  Consequently the
+usual ``vision_config`` heuristic cannot distinguish it from the text model.
+Keep that distinction in one dependency-free module so discovery, planning,
+and the distributed runtime make the same fail-closed decision.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+IMAGE_PLACEHOLDER = "<｜deepseek_image｜>"
+IMAGE_START, IMAGE_PAD, IMAGE, IMAGE_NEWLINE, IMAGE_END = range(5)
+
+_REQUIRED_POSITIVE_FIELDS = (
+    "vision_n_layers",
+    "vision_dim",
+    "vision_n_heads",
+    "vision_inter_dim",
+    "vision_patch_size",
+    "vision_downsample_ratio",
+    "vision_max_n_token",
+    "vision_min_pixels",
+    "vision_max_wh_ratio",
+)
+_REQUIRED_POSITIVE_NUMERIC_FIELDS = ("vision_rope_theta",)
+_COORDINATOR_EXACT_WEIGHTS = frozenset(
+    {"image_start", "image_end", "image_newline", "image_pad"}
+)
+
+
+def is_deepseek_v4_vision_config(config: Mapping[str, Any] | None) -> bool:
+    """Return whether *config* has the checkpoint's exact multimodal shape.
+
+    Requiring all published flat fields is intentional.  A regular DeepSeek-V4
+    config has the same model type and causal-LM architecture, and must remain
+    on the text path.
+    """
+
+    if not isinstance(config, Mapping):
+        return False
+    model_type = config.get("model_type")
+    if (
+        not isinstance(model_type, str)
+        or model_type.lower().replace("-", "_") != "deepseek_v4"
+    ):
+        return False
+    for field in _REQUIRED_POSITIVE_FIELDS:
+        value = config.get(field)
+        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+            return False
+    for field in _REQUIRED_POSITIVE_NUMERIC_FIELDS:
+        value = config.get(field)
+        if not isinstance(value, (int, float)) or isinstance(value, bool) or value <= 0:
+            return False
+    return True
+
+
+def is_deepseek_v4_vision_weight(name: str) -> bool:
+    """Return whether a checkpoint tensor is owned by coordinator/rank zero."""
+
+    normalized = name.removeprefix("model.")
+    return (
+        normalized.startswith("vision.")
+        or normalized.startswith("aligner.")
+        or normalized in _COORDINATOR_EXACT_WEIGHTS
+    )
+
+
+def require_supported_distributed_vlm(config: Mapping[str, Any]) -> None:
+    """Fail closed unless a VLM is the explicitly supported DS-V4 family."""
+
+    if is_deepseek_v4_vision_config(config):
+        return
+    raise ValueError(
+        "distributed VLM inference is experimental and currently supports only "
+        "DeepSeek-V4-Flash-Vision checkpoints with the published flat vision "
+        "configuration"
+    )

--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -227,6 +227,20 @@ class DistributedBatchedEngine(BatchedEngine):
             ],
         )
         config = await asyncio.to_thread(load_config, metadata_path)
+        from ..deepseek_v4_vision import (
+            is_deepseek_v4_vision_config,
+            require_supported_distributed_vlm,
+        )
+        from ..model_discovery import _has_vision_subconfig
+
+        if _has_vision_subconfig(config):
+            require_supported_distributed_vlm(config)
+            logger.info(
+                "DeepSeek-V4 Vision distributed capability recognized: "
+                "rank 0 owns vision preprocessing/encoder; language uses pipeline"
+            )
+        elif is_deepseek_v4_vision_config(config):  # defensive if heuristics change
+            require_supported_distributed_vlm(config)
         self._model_type = config.get("model_type")
         self._tokenizer = await asyncio.to_thread(
             load_tokenizer,

--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -164,6 +164,7 @@ class DistributedBatchedEngine(BatchedEngine):
         )
         self._client: httpx.AsyncClient | None = None
         self._model_type: str | None = None
+        self._supports_multimodal_fallback = False
         self._active_requests = 0
         self._active_lock = asyncio.Lock()
         self._peer_health: tuple[float, bool, str] | None = None
@@ -193,6 +194,12 @@ class DistributedBatchedEngine(BatchedEngine):
         return self._model_type
 
     @property
+    def supports_multimodal_fallback(self) -> bool:
+        """Whether public chat APIs must preserve multimodal content parts."""
+
+        return self._supports_multimodal_fallback
+
+    @property
     def prefix_cache_enabled(self) -> bool:
         # MLX-LM owns a rank-local LRU prompt cache. It is intentionally not
         # exposed as oMLX's block-aware cache because those formats differ.
@@ -207,6 +214,7 @@ class DistributedBatchedEngine(BatchedEngine):
         if self._loaded:
             return
         self._validate_model_settings()
+        self._supports_multimodal_fallback = False
 
         # Tokenizer/config metadata stays in the oMLX process. No model weights
         # are loaded here.
@@ -233,13 +241,14 @@ class DistributedBatchedEngine(BatchedEngine):
         )
         from ..model_discovery import _has_vision_subconfig
 
+        deepseek_v4_vision = is_deepseek_v4_vision_config(config)
         if _has_vision_subconfig(config):
             require_supported_distributed_vlm(config)
             logger.info(
                 "DeepSeek-V4 Vision distributed capability recognized: "
                 "rank 0 owns vision preprocessing/encoder; language uses pipeline"
             )
-        elif is_deepseek_v4_vision_config(config):  # defensive if heuristics change
+        elif deepseek_v4_vision:  # defensive if heuristics change
             require_supported_distributed_vlm(config)
         self._model_type = config.get("model_type")
         self._tokenizer = await asyncio.to_thread(
@@ -248,16 +257,21 @@ class DistributedBatchedEngine(BatchedEngine):
             {"trust_remote_code": self.deployment.trust_remote_code},
             config.get("eos_token_id"),
         )
+        self._supports_multimodal_fallback = deepseek_v4_vision
 
         try:
             await asyncio.to_thread(self._supervisor.start)
         except Exception:
             self._tokenizer = None
             self._model_type = None
+            self._supports_multimodal_fallback = False
             raise
         endpoint = self._supervisor.endpoint
         if endpoint is None:
             await asyncio.to_thread(self._supervisor.stop)
+            self._tokenizer = None
+            self._model_type = None
+            self._supports_multimodal_fallback = False
             raise DistributedLaunchError("distributed endpoint was not created")
         self._client = self._new_client(endpoint)
         self._loaded = True
@@ -301,6 +315,7 @@ class DistributedBatchedEngine(BatchedEngine):
             finally:
                 self._tokenizer = None
                 self._model_type = None
+                self._supports_multimodal_fallback = False
                 self._loaded = False
         logger.info("Distributed engine stopped: %s", self.deployment.deployment_id)
 

--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -585,6 +585,26 @@ class DistributedBatchedEngine(BatchedEngine):
             prepared.append(copied)
         return prepared
 
+    def count_chat_tokens(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict] | None = None,
+        chat_template_kwargs: dict[str, Any] | None = None,
+        is_partial: bool | None = None,
+    ) -> int:
+        """Count coordinator text without rendering media parts as strings."""
+
+        if self._supports_multimodal_fallback:
+            from ..utils.image import extract_images_from_messages
+
+            messages, _, _ = extract_images_from_messages(messages)
+        return super().count_chat_tokens(
+            messages,
+            tools,
+            chat_template_kwargs=chat_template_kwargs,
+            is_partial=is_partial,
+        )
+
     @staticmethod
     def _normalize_backend_tool_calls(
         tool_calls: Any,

--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -10,7 +10,8 @@ import math
 import os
 import time
 from collections.abc import AsyncIterator
-from contextlib import suppress
+from contextlib import aclosing, suppress
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -166,7 +167,7 @@ class DistributedBatchedEngine(BatchedEngine):
         self._model_type: str | None = None
         self._supports_multimodal_fallback = False
         self._active_requests = 0
-        self._active_lock = asyncio.Lock()
+        self._vision_request_lock = asyncio.Lock()
         self._lifecycle_lock = asyncio.Lock()
         self._teardown_tasks: set[asyncio.Task[None]] = set()
         self._peer_health: tuple[float, bool, str] | None = None
@@ -209,6 +210,10 @@ class DistributedBatchedEngine(BatchedEngine):
             except asyncio.CancelledError as exc:
                 if cancellation is None:
                     cancellation = exc
+            except Exception:
+                if cancellation is None:
+                    raise
+                break
         if cancellation is not None:
             try:
                 task.result()
@@ -734,23 +739,39 @@ class DistributedBatchedEngine(BatchedEngine):
             )
         return normalized or None
 
-    @staticmethod
-    def _join_reasoning_and_content(reasoning: Any, content: Any) -> str:
-        """Carry private structured reasoning through GenerationOutput safely."""
+    async def _enter_request(self, client: httpx.AsyncClient) -> bool:
+        """Queue sequential Vision work before opening a private HTTP request.
 
-        reasoning_text = reasoning if isinstance(reasoning, str) else ""
-        content_text = content if isinstance(content, str) else ""
-        if reasoning_text:
-            return f"<think>{reasoning_text}</think>{content_text}"
-        return content_text
+        The Vision worker cannot batch requests. Sending queued work to its
+        HTTP server starts the read timeout before generation can begin, and
+        cancelling that socket then tears down the healthy, busy deployment.
+        Waiting here avoids both hazards without reducing worker concurrency.
+        """
 
-    async def _enter_request(self) -> None:
-        async with self._active_lock:
-            self._active_requests += 1
+        serialized = self._supports_multimodal_fallback
+        self._active_requests += 1
+        acquired = False
+        try:
+            if serialized:
+                await self._vision_request_lock.acquire()
+                acquired = True
+                if self._client is not client or not self._loaded:
+                    raise DistributedInferenceError(
+                        "distributed deployment changed while request was queued"
+                    )
+            return serialized
+        except BaseException:
+            if acquired:
+                self._vision_request_lock.release()
+            self._active_requests -= 1
+            raise
 
-    async def _leave_request(self) -> None:
-        async with self._active_lock:
-            self._active_requests = max(0, self._active_requests - 1)
+    async def _leave_request(self, serialized: bool) -> None:
+        # Event-loop-owned counters need no suspension, including when teardown
+        # is interrupted by a second cancellation.
+        self._active_requests = max(0, self._active_requests - 1)
+        if serialized:
+            self._vision_request_lock.release()
 
     async def chat(
         self,
@@ -782,101 +803,41 @@ class DistributedBatchedEngine(BatchedEngine):
                 tools=tools,
                 **kwargs,
             )
-        if not self._loaded:
-            await self.start()
-        client = await self._ensure_available()
-        payload = self._chat_payload(
-            messages=messages,
-            tools=tools,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            top_p=top_p,
-            top_k=top_k,
-            min_p=min_p,
-            repetition_penalty=repetition_penalty,
-            presence_penalty=presence_penalty,
-            stop=kwargs.pop("stop", None),
-            stream=False,
-            kwargs=kwargs,
+        return await self._collect_stream(
+            self.stream_chat(
+                messages=messages,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                top_k=top_k,
+                min_p=min_p,
+                repetition_penalty=repetition_penalty,
+                presence_penalty=presence_penalty,
+                tools=tools,
+                **kwargs,
+            )
         )
-        await self._enter_request()
-        started_at = time.monotonic()
-        try:
-            response = await client.post("/v1/chat/completions", json=payload)
-            if response.status_code >= 400:
-                detail = self._backend_error_detail(response)
-                for retry_payload in _reasoning_effort_retry_payloads(payload, detail):
-                    response = await client.post(
-                        "/v1/chat/completions", json=retry_payload
-                    )
-                    if response.status_code < 400:
-                        break
-            self._raise_for_backend(response)
-            body = response.json()
-        except httpx.ReadTimeout as exc:
-            error = self._read_timeout_error(stream=False)
-            await self._teardown_failed_request(
-                client,
-                reason="rank-zero request read timeout",
-            )
-            raise error from exc
-        except asyncio.CancelledError:
-            await self._teardown_failed_request(
-                client,
-                reason="cancelled rank-zero request",
-            )
-            raise
-        except httpx.TransportError as exc:
-            try:
-                error = await self._transport_failure_error(
-                    exc,
-                    stream=False,
-                )
-            finally:
-                await self._teardown_failed_request(
-                    client,
-                    reason=(
-                        "rank-zero request transport failure "
-                        f"({type(exc).__name__})"
-                    ),
-                )
-            raise error from exc
-        except json.JSONDecodeError as exc:
-            raise DistributedInferenceError(
-                "rank-zero backend returned invalid chat JSON"
-            ) from exc
-        finally:
-            await self._leave_request()
 
-        try:
-            choice = body["choices"][0]
-            message = choice["message"]
-            usage = body["usage"]
-            details = usage.get("prompt_tokens_details") or {}
-            tool_calls = self._normalize_backend_tool_calls(message.get("tool_calls"))
-            text = self._join_reasoning_and_content(
-                message.get("reasoning") or message.get("reasoning_content"),
-                message.get("content"),
-            )
-            return GenerationOutput(
-                text=text,
-                new_text=text,
-                prompt_tokens=int(usage["prompt_tokens"]),
-                completion_tokens=int(usage["completion_tokens"]),
-                finish_reason=(
-                    "tool_calls"
-                    if tool_calls
-                    else (choice.get("finish_reason") or "stop")
-                ),
-                tool_calls=tool_calls,
-                cached_tokens=int(details.get("cached_tokens", 0)),
-                generated_at=started_at,
-                generated_until=time.monotonic(),
-            )
-        except (IndexError, KeyError, TypeError, ValueError) as exc:
-            raise DistributedInferenceError(
-                "rank-zero backend returned an invalid chat completion"
-            ) from exc
+    @staticmethod
+    async def _collect_stream(
+        stream: AsyncIterator[GenerationOutput],
+    ) -> GenerationOutput:
+        """Use backend progress for public non-streaming requests too.
+
+        MLX-LM sends no keepalives on a non-streaming socket. A healthy long
+        generation would therefore trip the inactivity timeout and kill all
+        ranks. Consume the normal SSE path and retain only its final output,
+        sharing timeout, cancellation, usage and protocol handling.
+        """
+
+        final = None
+        async with aclosing(stream):
+            async for output in stream:
+                if output.finished:
+                    final = output
+        if final is None:
+            raise DistributedInferenceError("rank-zero stream returned no final output")
+        return replace(final, new_text=final.text)
 
     async def stream_chat(
         self,
@@ -936,7 +897,7 @@ class DistributedBatchedEngine(BatchedEngine):
         backend_tool_calls: dict[int, dict[str, Any]] = {}
         request_resolved = False
 
-        await self._enter_request()
+        serialized = await self._enter_request(client)
         try:
             # A client that always sends an unsupported reasoning_effort must
             # never turn this into an unbounded retry loop: `attempts` is
@@ -1116,12 +1077,14 @@ class DistributedBatchedEngine(BatchedEngine):
             )
             raise error from exc
         finally:
-            if not request_resolved:
-                await self._teardown_failed_request(
-                    client,
-                    reason="abandoned or failed rank-zero chat stream",
-                )
-            await self._leave_request()
+            try:
+                if not request_resolved:
+                    await self._teardown_failed_request(
+                        client,
+                        reason="abandoned or failed rank-zero chat stream",
+                    )
+            finally:
+                await self._leave_request(serialized)
 
         pending_final_text = ""
         if reasoning_open:
@@ -1166,90 +1129,20 @@ class DistributedBatchedEngine(BatchedEngine):
         stop: list[str] | None = None,
         **kwargs: Any,
     ) -> GenerationOutput:
-        if not self._loaded:
-            await self.start()
-        client = await self._ensure_available()
-        payload = self._completion_payload(
-            prompt=prompt,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            top_p=top_p,
-            top_k=top_k,
-            min_p=min_p,
-            repetition_penalty=repetition_penalty,
-            presence_penalty=presence_penalty,
-            stop=stop,
-            stream=False,
-            kwargs=kwargs,
+        return await self._collect_stream(
+            self.stream_generate(
+                prompt=prompt,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                top_k=top_k,
+                min_p=min_p,
+                repetition_penalty=repetition_penalty,
+                presence_penalty=presence_penalty,
+                stop=stop,
+                **kwargs,
+            )
         )
-        await self._enter_request()
-        started_at = time.monotonic()
-        try:
-            response = await client.post("/v1/completions", json=payload)
-            if response.status_code >= 400:
-                detail = self._backend_error_detail(response)
-                for retry_payload in _reasoning_effort_retry_payloads(payload, detail):
-                    response = await client.post(
-                        "/v1/completions", json=retry_payload
-                    )
-                    if response.status_code < 400:
-                        break
-            self._raise_for_backend(response)
-            body = response.json()
-        except httpx.ReadTimeout as exc:
-            error = self._read_timeout_error(stream=False)
-            await self._teardown_failed_request(
-                client,
-                reason="rank-zero request read timeout",
-            )
-            raise error from exc
-        except asyncio.CancelledError:
-            await self._teardown_failed_request(
-                client,
-                reason="cancelled rank-zero request",
-            )
-            raise
-        except httpx.TransportError as exc:
-            try:
-                error = await self._transport_failure_error(
-                    exc,
-                    stream=False,
-                )
-            finally:
-                await self._teardown_failed_request(
-                    client,
-                    reason=(
-                        "rank-zero request transport failure "
-                        f"({type(exc).__name__})"
-                    ),
-                )
-            raise error from exc
-        except json.JSONDecodeError as exc:
-            raise DistributedInferenceError(
-                "rank-zero backend returned invalid completion JSON"
-            ) from exc
-        finally:
-            await self._leave_request()
-
-        try:
-            choice = body["choices"][0]
-            usage = body["usage"]
-            details = usage.get("prompt_tokens_details") or {}
-            text = choice.get("text") or ""
-            return GenerationOutput(
-                text=text,
-                new_text=text,
-                prompt_tokens=int(usage["prompt_tokens"]),
-                completion_tokens=int(usage["completion_tokens"]),
-                finish_reason=choice.get("finish_reason") or "stop",
-                cached_tokens=int(details.get("cached_tokens", 0)),
-                generated_at=started_at,
-                generated_until=time.monotonic(),
-            )
-        except (IndexError, KeyError, TypeError, ValueError) as exc:
-            raise DistributedInferenceError(
-                "rank-zero backend returned an invalid completion"
-            ) from exc
 
     async def stream_generate(
         self,
@@ -1290,7 +1183,7 @@ class DistributedBatchedEngine(BatchedEngine):
         request_started_at = time.monotonic()
         request_resolved = False
 
-        await self._enter_request()
+        serialized = await self._enter_request(client)
         try:
             # See stream_chat for the retry-bound rationale.
             attempts = [payload]
@@ -1418,12 +1311,14 @@ class DistributedBatchedEngine(BatchedEngine):
             )
             raise error from exc
         finally:
-            if not request_resolved:
-                await self._teardown_failed_request(
-                    client,
-                    reason="abandoned or failed rank-zero completion stream",
-                )
-            await self._leave_request()
+            try:
+                if not request_resolved:
+                    await self._teardown_failed_request(
+                        client,
+                        reason="abandoned or failed rank-zero completion stream",
+                    )
+            finally:
+                await self._leave_request(serialized)
 
         finished_at = time.monotonic()
         await self._record_strategy_benchmark(

--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -167,6 +167,8 @@ class DistributedBatchedEngine(BatchedEngine):
         self._supports_multimodal_fallback = False
         self._active_requests = 0
         self._active_lock = asyncio.Lock()
+        self._lifecycle_lock = asyncio.Lock()
+        self._teardown_tasks: set[asyncio.Task[None]] = set()
         self._peer_health: tuple[float, bool, str] | None = None
         self._peer_health_lock = asyncio.Lock()
 
@@ -188,6 +190,32 @@ class DistributedBatchedEngine(BatchedEngine):
                 max_keepalive_connections=8,
             ),
         )
+
+    @staticmethod
+    async def _run_supervisor_operation(operation: Any) -> Any:
+        """Finish a blocking supervisor operation before propagating cancellation.
+
+        ``asyncio.to_thread`` cannot stop its worker when the awaiting task is
+        cancelled. Releasing the lifecycle lock at that point would allow a
+        second start or stop to race the still-running supervisor operation.
+        Shield the worker and defer cancellation until its result is known.
+        """
+
+        task = asyncio.create_task(asyncio.to_thread(operation))
+        cancellation: asyncio.CancelledError | None = None
+        while not task.done():
+            try:
+                await asyncio.shield(task)
+            except asyncio.CancelledError as exc:
+                if cancellation is None:
+                    cancellation = exc
+        if cancellation is not None:
+            try:
+                task.result()
+            except BaseException as exc:
+                raise cancellation from exc
+            raise cancellation
+        return task.result()
 
     @property
     def model_type(self) -> str | None:
@@ -211,77 +239,79 @@ class DistributedBatchedEngine(BatchedEngine):
         return self._supervisor.status().to_dict()
 
     async def start(self) -> None:
-        if self._loaded:
-            return
-        self._validate_model_settings()
-        self._supports_multimodal_fallback = False
+        async with self._lifecycle_lock:
+            if self._loaded:
+                return
+            self._validate_model_settings()
 
-        # Tokenizer/config metadata stays in the oMLX process. No model weights
-        # are loaded here.
-        from mlx_lm.utils import _download, load_config, load_tokenizer
+            # Tokenizer/config metadata stays in the oMLX process. No model weights
+            # are loaded here.
+            from mlx_lm.utils import _download, load_config, load_tokenizer
 
-        metadata_path = await asyncio.to_thread(
-            _download,
-            self.deployment.model,
-            allow_patterns=[
-                "*.json",
-                "*.py",
-                "tokenizer.model",
-                "*.tiktoken",
-                "tiktoken.model",
-                "*.txt",
-                "*.jsonl",
-                "*.jinja",
-            ],
-        )
-        config = await asyncio.to_thread(load_config, metadata_path)
-        from ..deepseek_v4_vision import (
-            is_deepseek_v4_vision_config,
-            require_supported_distributed_vlm,
-        )
-        from ..model_discovery import _has_vision_subconfig
-
-        deepseek_v4_vision = is_deepseek_v4_vision_config(config)
-        if _has_vision_subconfig(config):
-            require_supported_distributed_vlm(config)
-            logger.info(
-                "DeepSeek-V4 Vision distributed capability recognized: "
-                "rank 0 owns vision preprocessing/encoder; language uses pipeline"
+            metadata_path = await asyncio.to_thread(
+                _download,
+                self.deployment.model,
+                allow_patterns=[
+                    "*.json",
+                    "*.py",
+                    "tokenizer.model",
+                    "*.tiktoken",
+                    "tiktoken.model",
+                    "*.txt",
+                    "*.jsonl",
+                    "*.jinja",
+                ],
             )
-        elif deepseek_v4_vision:  # defensive if heuristics change
-            require_supported_distributed_vlm(config)
-        self._model_type = config.get("model_type")
-        self._tokenizer = await asyncio.to_thread(
-            load_tokenizer,
-            metadata_path,
-            {"trust_remote_code": self.deployment.trust_remote_code},
-            config.get("eos_token_id"),
-        )
-        self._supports_multimodal_fallback = deepseek_v4_vision
+            config = await asyncio.to_thread(load_config, metadata_path)
+            from ..deepseek_v4_vision import (
+                is_deepseek_v4_vision_config,
+                require_supported_distributed_vlm,
+            )
+            from ..model_discovery import _has_vision_subconfig
 
-        try:
-            await asyncio.to_thread(self._supervisor.start)
-        except Exception:
-            self._tokenizer = None
-            self._model_type = None
-            self._supports_multimodal_fallback = False
-            raise
-        endpoint = self._supervisor.endpoint
-        if endpoint is None:
-            await asyncio.to_thread(self._supervisor.stop)
-            self._tokenizer = None
-            self._model_type = None
-            self._supports_multimodal_fallback = False
-            raise DistributedLaunchError("distributed endpoint was not created")
-        self._client = self._new_client(endpoint)
-        self._loaded = True
-        logger.info(
-            "Distributed engine ready: model=%s ranks=%d backend=%s plan=%s",
-            self.deployment.model,
-            self.deployment.world_size,
-            self.deployment.backend,
-            self.deployment.plan_hash[:16],
-        )
+            deepseek_v4_vision = is_deepseek_v4_vision_config(config)
+            if _has_vision_subconfig(config):
+                require_supported_distributed_vlm(config)
+                logger.info(
+                    "DeepSeek-V4 Vision distributed capability recognized: "
+                    "rank 0 owns vision preprocessing/encoder; language uses pipeline"
+                )
+            elif deepseek_v4_vision:  # defensive if heuristics change
+                require_supported_distributed_vlm(config)
+            model_type = config.get("model_type")
+            tokenizer = await asyncio.to_thread(
+                load_tokenizer,
+                metadata_path,
+                {"trust_remote_code": self.deployment.trust_remote_code},
+                config.get("eos_token_id"),
+            )
+
+            try:
+                await self._run_supervisor_operation(self._supervisor.start)
+            except asyncio.CancelledError:
+                try:
+                    await self._run_supervisor_operation(self._supervisor.stop)
+                except Exception:  # noqa: BLE001 - preserve cancellation
+                    logger.exception(
+                        "Could not stop distributed deployment after cancelled start"
+                    )
+                raise
+            endpoint = self._supervisor.endpoint
+            if endpoint is None:
+                await self._run_supervisor_operation(self._supervisor.stop)
+                raise DistributedLaunchError("distributed endpoint was not created")
+            self._client = self._new_client(endpoint)
+            self._tokenizer = tokenizer
+            self._model_type = model_type
+            self._supports_multimodal_fallback = deepseek_v4_vision
+            self._loaded = True
+            logger.info(
+                "Distributed engine ready: model=%s ranks=%d backend=%s plan=%s",
+                self.deployment.model,
+                self.deployment.world_size,
+                self.deployment.backend,
+                self.deployment.plan_hash[:16],
+            )
 
     def _validate_model_settings(self) -> None:
         settings = self._model_settings
@@ -305,36 +335,102 @@ class DistributedBatchedEngine(BatchedEngine):
             )
 
     async def stop(self) -> None:
-        client, self._client = self._client, None
-        try:
-            if client is not None:
-                await client.aclose()
-        finally:
+        async with self._lifecycle_lock:
+            client, self._client = self._client, None
+            self._loaded = False
+            self._peer_health = None
             try:
-                await asyncio.to_thread(self._supervisor.stop)
+                if client is not None:
+                    await client.aclose()
             finally:
-                self._tokenizer = None
-                self._model_type = None
-                self._supports_multimodal_fallback = False
-                self._loaded = False
+                try:
+                    await self._run_supervisor_operation(self._supervisor.stop)
+                finally:
+                    self._tokenizer = None
+                    self._model_type = None
+                    self._supports_multimodal_fallback = False
         logger.info("Distributed engine stopped: %s", self.deployment.deployment_id)
 
-    def _ensure_available(self) -> httpx.AsyncClient:
+    async def _fail_closed(
+        self,
+        client: httpx.AsyncClient,
+        *,
+        reason: str,
+    ) -> None:
+        """Stop every rank after an abandoned private request.
+
+        MLX-LM cannot observe a disconnected socket while blocked inside a
+        prefill kernel or collective. Closing the HTTP client alone can leave
+        that work resident indefinitely, so the only safe cancellation boundary
+        is the supervisor-owned process group. One abandoned request therefore
+        cancels every concurrent request on this distributed deployment.
+
+        The client identity check prevents a stale request from stopping a job
+        that another lifecycle operation has already replaced.
+        """
+
+        async with self._lifecycle_lock:
+            if self._client is not client:
+                return
+            self._client = None
+            self._loaded = False
+            self._peer_health = None
+            logger.warning(
+                "Stopping distributed deployment %s after %s",
+                self.deployment.deployment_id,
+                reason,
+            )
+            try:
+                await client.aclose()
+            except Exception:  # noqa: BLE001 - teardown must continue to ranks
+                logger.exception("Could not close failed rank-zero client")
+            try:
+                await self._run_supervisor_operation(self._supervisor.stop)
+            except Exception:  # noqa: BLE001 - preserve the request failure
+                logger.exception(
+                    "Could not fully stop failed distributed deployment %s",
+                    self.deployment.deployment_id,
+                )
+
+    async def _teardown_failed_request(
+        self,
+        client: httpx.AsyncClient,
+        *,
+        reason: str,
+    ) -> None:
+        """Run fail-closed teardown even if the request is cancelled again."""
+
+        task = asyncio.create_task(self._fail_closed(client, reason=reason))
+        self._teardown_tasks.add(task)
+        task.add_done_callback(self._teardown_tasks.discard)
+        await asyncio.shield(task)
+
+    async def _ensure_available(self) -> httpx.AsyncClient:
         client = self._client
         status = self._supervisor.status()
         if not self._loaded or client is None:
             raise DistributedInferenceError("distributed engine is not loaded")
-        if status.returncode is not None:
+        if status.returncode is not None or status.failure_reason:
             detail = status.failure_reason or ""
             tail = " · ".join(
                 line.strip() for line in status.stderr_tail[-3:] if line.strip()
             )[:1000]
             if tail and tail not in detail:
                 detail = f"{detail} · Worker log: {tail}" if detail else tail
-            suffix = f": {detail}" if detail else ""
-            raise DistributedInferenceError(
-                f"distributed job exited with code {status.returncode}{suffix}"
+            if status.returncode is not None:
+                suffix = f": {detail}" if detail else ""
+                error = DistributedInferenceError(
+                    f"distributed job exited with code {status.returncode}{suffix}"
+                )
+            else:
+                error = DistributedInferenceError(
+                    f"distributed cluster failure: {detail}"
+                )
+            await self._teardown_failed_request(
+                client,
+                reason="reported distributed supervisor failure",
             )
+            raise error
         return client
 
     def _read_timeout_error(self, *, stream: bool) -> DistributedInferenceError:
@@ -688,7 +784,7 @@ class DistributedBatchedEngine(BatchedEngine):
             )
         if not self._loaded:
             await self.start()
-        client = self._ensure_available()
+        client = await self._ensure_available()
         payload = self._chat_payload(
             messages=messages,
             tools=tools,
@@ -718,12 +814,33 @@ class DistributedBatchedEngine(BatchedEngine):
             self._raise_for_backend(response)
             body = response.json()
         except httpx.ReadTimeout as exc:
-            raise self._read_timeout_error(stream=False) from exc
-        except httpx.HTTPError as exc:
-            raise await self._transport_failure_error(
-                exc,
-                stream=False,
-            ) from exc
+            error = self._read_timeout_error(stream=False)
+            await self._teardown_failed_request(
+                client,
+                reason="rank-zero request read timeout",
+            )
+            raise error from exc
+        except asyncio.CancelledError:
+            await self._teardown_failed_request(
+                client,
+                reason="cancelled rank-zero request",
+            )
+            raise
+        except httpx.TransportError as exc:
+            try:
+                error = await self._transport_failure_error(
+                    exc,
+                    stream=False,
+                )
+            finally:
+                await self._teardown_failed_request(
+                    client,
+                    reason=(
+                        "rank-zero request transport failure "
+                        f"({type(exc).__name__})"
+                    ),
+                )
+            raise error from exc
         except json.JSONDecodeError as exc:
             raise DistributedInferenceError(
                 "rank-zero backend returned invalid chat JSON"
@@ -793,7 +910,7 @@ class DistributedBatchedEngine(BatchedEngine):
             return
         if not self._loaded:
             await self.start()
-        client = self._ensure_available()
+        client = await self._ensure_available()
         payload = self._chat_payload(
             messages=messages,
             tools=tools,
@@ -817,6 +934,7 @@ class DistributedBatchedEngine(BatchedEngine):
         request_started_at = time.monotonic()
         reasoning_open = False
         backend_tool_calls: dict[int, dict[str, Any]] = {}
+        request_resolved = False
 
         await self._enter_request()
         try:
@@ -843,13 +961,21 @@ class DistributedBatchedEngine(BatchedEngine):
                         if attempt_index + 1 < len(attempts):
                             attempt_index += 1
                             continue
+                        request_resolved = True
                         self._raise_for_backend(response)
                     async for line in response.aiter_lines():
                         if not line.startswith("data:"):
                             continue
                         data = line.removeprefix("data:").strip()
-                        if not data or data == "[DONE]":
+                        if not data:
                             continue
+                        if data == "[DONE]":
+                            if finish_reason is None:
+                                raise DistributedInferenceError(
+                                    "rank-zero chat stream ended before a terminal event"
+                                )
+                            request_resolved = True
+                            break
                         try:
                             event = json.loads(data)
                         except json.JSONDecodeError as exc:
@@ -967,19 +1093,34 @@ class DistributedBatchedEngine(BatchedEngine):
                                 generated_until=now,
                                 first_token_at=first_token_at,
                             )
+                    if not request_resolved:
+                        raise DistributedInferenceError(
+                            "rank-zero chat stream ended before [DONE]"
+                        )
                     break
         except (TypeError, ValueError) as exc:
             raise DistributedInferenceError(
                 "rank-zero backend emitted invalid chat token counts"
             ) from exc
         except httpx.ReadTimeout as exc:
-            raise self._read_timeout_error(stream=True) from exc
-        except httpx.HTTPError as exc:
-            raise await self._transport_failure_error(
+            error = self._read_timeout_error(stream=True)
+            raise error from exc
+        except asyncio.CancelledError:
+            raise
+        except GeneratorExit:
+            raise
+        except httpx.TransportError as exc:
+            error = await self._transport_failure_error(
                 exc,
                 stream=True,
-            ) from exc
+            )
+            raise error from exc
         finally:
+            if not request_resolved:
+                await self._teardown_failed_request(
+                    client,
+                    reason="abandoned or failed rank-zero chat stream",
+                )
             await self._leave_request()
 
         pending_final_text = ""
@@ -1027,7 +1168,7 @@ class DistributedBatchedEngine(BatchedEngine):
     ) -> GenerationOutput:
         if not self._loaded:
             await self.start()
-        client = self._ensure_available()
+        client = await self._ensure_available()
         payload = self._completion_payload(
             prompt=prompt,
             max_tokens=max_tokens,
@@ -1056,12 +1197,33 @@ class DistributedBatchedEngine(BatchedEngine):
             self._raise_for_backend(response)
             body = response.json()
         except httpx.ReadTimeout as exc:
-            raise self._read_timeout_error(stream=False) from exc
-        except httpx.HTTPError as exc:
-            raise await self._transport_failure_error(
-                exc,
-                stream=False,
-            ) from exc
+            error = self._read_timeout_error(stream=False)
+            await self._teardown_failed_request(
+                client,
+                reason="rank-zero request read timeout",
+            )
+            raise error from exc
+        except asyncio.CancelledError:
+            await self._teardown_failed_request(
+                client,
+                reason="cancelled rank-zero request",
+            )
+            raise
+        except httpx.TransportError as exc:
+            try:
+                error = await self._transport_failure_error(
+                    exc,
+                    stream=False,
+                )
+            finally:
+                await self._teardown_failed_request(
+                    client,
+                    reason=(
+                        "rank-zero request transport failure "
+                        f"({type(exc).__name__})"
+                    ),
+                )
+            raise error from exc
         except json.JSONDecodeError as exc:
             raise DistributedInferenceError(
                 "rank-zero backend returned invalid completion JSON"
@@ -1104,7 +1266,7 @@ class DistributedBatchedEngine(BatchedEngine):
     ) -> AsyncIterator[GenerationOutput]:
         if not self._loaded:
             await self.start()
-        client = self._ensure_available()
+        client = await self._ensure_available()
         payload = self._completion_payload(
             prompt=prompt,
             max_tokens=max_tokens,
@@ -1126,6 +1288,7 @@ class DistributedBatchedEngine(BatchedEngine):
         full_text = ""
         first_token_at: float | None = None
         request_started_at = time.monotonic()
+        request_resolved = False
 
         await self._enter_request()
         try:
@@ -1149,13 +1312,21 @@ class DistributedBatchedEngine(BatchedEngine):
                         if attempt_index + 1 < len(attempts):
                             attempt_index += 1
                             continue
+                        request_resolved = True
                         self._raise_for_backend(response)
                     async for line in response.aiter_lines():
                         if not line.startswith("data:"):
                             continue
                         data = line.removeprefix("data:").strip()
-                        if not data or data == "[DONE]":
+                        if not data:
                             continue
+                        if data == "[DONE]":
+                            if finish_reason is None:
+                                raise DistributedInferenceError(
+                                    "rank-zero completion stream ended before a terminal event"
+                                )
+                            request_resolved = True
+                            break
                         try:
                             event = json.loads(data)
                         except json.JSONDecodeError as exc:
@@ -1224,19 +1395,34 @@ class DistributedBatchedEngine(BatchedEngine):
                                 generated_until=now,
                                 first_token_at=first_token_at,
                             )
+                    if not request_resolved:
+                        raise DistributedInferenceError(
+                            "rank-zero completion stream ended before [DONE]"
+                        )
                     break
         except (TypeError, ValueError) as exc:
             raise DistributedInferenceError(
                 "rank-zero backend emitted invalid token counts"
             ) from exc
         except httpx.ReadTimeout as exc:
-            raise self._read_timeout_error(stream=True) from exc
-        except httpx.HTTPError as exc:
-            raise await self._transport_failure_error(
+            error = self._read_timeout_error(stream=True)
+            raise error from exc
+        except asyncio.CancelledError:
+            raise
+        except GeneratorExit:
+            raise
+        except httpx.TransportError as exc:
+            error = await self._transport_failure_error(
                 exc,
                 stream=True,
-            ) from exc
+            )
+            raise error from exc
         finally:
+            if not request_resolved:
+                await self._teardown_failed_request(
+                    client,
+                    reason="abandoned or failed rank-zero completion stream",
+                )
             await self._leave_request()
 
         finished_at = time.monotonic()
@@ -1347,15 +1533,7 @@ class DistributedBatchedEngine(BatchedEngine):
         round trip per peer and is cached for ``_PEER_HEALTH_TTL`` seconds.
         """
 
-        status = self._supervisor.status()
-        if status.returncode is not None:
-            raise DistributedInferenceError(
-                f"distributed job exited with code {status.returncode}"
-            )
-        if status.failure_reason:
-            raise DistributedInferenceError(
-                f"distributed cluster failure: {status.failure_reason}"
-            )
+        client = await self._ensure_available()
         cached = self._peer_health
         if cached is None or time.monotonic() - cached[0] >= _PEER_HEALTH_TTL:
             async with self._peer_health_lock:
@@ -1389,17 +1567,24 @@ class DistributedBatchedEngine(BatchedEngine):
                         )
                     self._peer_health = cached
         if not cached[1]:
-            raise DistributedInferenceError(
-                f"cluster is not serving: {cached[2]}"
+            error = DistributedInferenceError(f"cluster is not serving: {cached[2]}")
+            await self._teardown_failed_request(
+                client,
+                reason="unhealthy distributed peer",
             )
+            raise error
 
     async def preflight_chat(self, *args: Any, **kwargs: Any) -> None:
         self._validate_request_features(kwargs)
+        if not self._loaded:
+            await self.start()
         await self._require_healthy_cluster()
         return None
 
     async def preflight_completion(self, *args: Any, **kwargs: Any) -> None:
         self._validate_request_features(kwargs)
+        if not self._loaded:
+            await self.start()
         await self._require_healthy_cluster()
         return None
 
@@ -1425,13 +1610,9 @@ class DistributedBatchedEngine(BatchedEngine):
         reason: str | None = None,
         error_code: str | None = None,
     ) -> int:
-        # Closing the private client disconnects all rank-zero handlers. The
-        # MLX-LM handler cancels their generation contexts in ``finally``.
         active = self._active_requests
-        client, self._client = self._client, None
-        if client is not None:
-            await client.aclose()
-            endpoint = self._supervisor.endpoint
-            if endpoint is not None and self._loaded:
-                self._client = self._new_client(endpoint)
+        # MLX-LM may be blocked inside a prefill kernel and unable to observe a
+        # closed private socket. Abort must use the supervisor's bounded local
+        # and remote process reaping rather than leave rank work resident.
+        await self.stop()
         return active

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -1336,15 +1336,18 @@ class EnginePool:
             return False
 
         reason = entry.pending_unload_reason
-        entry.pending_unload_reason = None
-        entry.pending_unload_allow_pinned = False
-        entry.abort_requested = False
         logger.warning(
             "Unloading pending model '%s' after activity drained (%s)",
             model_id,
             reason,
         )
         await self._unload_engine(model_id)
+        # A failed teardown must keep both the retry intent and the admission
+        # gate. In particular, driver-retained memory is still accounted until
+        # the distributed supervisor confirms recovery.
+        entry.pending_unload_reason = None
+        entry.pending_unload_allow_pinned = False
+        entry.abort_requested = False
         return True
 
     def _finish_pending_unload_task(
@@ -1759,11 +1762,21 @@ class EnginePool:
             return loaded.engine
 
     async def _release_engine_lease(self, model_id: str) -> None:
+        from .cluster.launch import DistributedLaunchError
+
         async with self._lock:
             e = self._entries.get(model_id)
             if e is not None and e.in_use > 0:
                 e.in_use -= 1
-            await self._unload_pending_if_idle_locked(model_id)
+            try:
+                await self._unload_pending_if_idle_locked(model_id)
+            except DistributedLaunchError as exc:
+                # The lease is released; deferred cleanup is a separate
+                # operation. Do not replace a request's original exception (or
+                # its completed response) with a recovery quarantine error.
+                # _unload_engine retains the engine and memory accounting, and
+                # the pending flag keeps new admissions blocked until retry.
+                logger.warning("Deferred distributed unload for %s: %s", model_id, exc)
 
     def _finish_lease_release_task(self, task: asyncio.Task[None]) -> None:
         self._lease_release_tasks.discard(task)

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -2606,7 +2606,12 @@ class EnginePool:
             # Check if DFlash is enabled -- takes priority over engine type
             # since DFlash has its own model loading pipeline
             engine = None
-            deployment = deployment if effective_type == "batched" else None
+            # Registry admission already limits distributed serving to text
+            # models and the explicitly gated DeepSeek-V4 vision family. Keep
+            # that deployment authoritative even when discovery labels the
+            # public entry as VLM; dropping it here would load the complete
+            # checkpoint in the coordinator instead of dispatching through the
+            # approved pipeline plan.
             if deployment is None and model_settings is not None:
                 dflash_enabled = getattr(model_settings, "dflash_enabled", False)
                 dflash_draft = getattr(model_settings, "dflash_draft_model", None)
@@ -2796,7 +2801,7 @@ class EnginePool:
                         f"(fallback from DFlash)"
                     )
 
-                elif force_lm and entry.engine_type == "vlm":
+                elif deployment is None and force_lm and entry.engine_type == "vlm":
                     # force_lm created a BatchedEngine but mlx-lm can't
                     # load this VLM model -- fall back to VLMBatchedEngine.
                     logger.warning(
@@ -2834,7 +2839,7 @@ class EnginePool:
                         f"Successfully loaded {model_id} as VLM "
                         f"(fallback from force_lm)"
                     )
-                elif entry.engine_type == "vlm":
+                elif deployment is None and entry.engine_type == "vlm":
                     # VLM loading failed -- fall back to LLM (BatchedEngine)
                     logger.warning(
                         f"VLM loading failed for {model_id}, "

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -23,7 +23,7 @@ from collections import OrderedDict
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from .cluster.deployment import ClusterDeployment
@@ -316,8 +316,19 @@ class EnginePool:
             deployment = getattr(entry.engine, "deployment", None)
             return deployment if isinstance(deployment, ClusterDeployment) else None
         registry = self._cluster_registry
-        if registry is None or entry.engine_type != "batched":
+        if registry is None:
             return None
+        if entry.engine_type != "batched":
+            from .deepseek_v4_vision import is_deepseek_v4_vision_config
+
+            try:
+                config = json.loads(
+                    Path(entry.model_path, "config.json").read_text()
+                )
+            except (OSError, json.JSONDecodeError):
+                return None
+            if not is_deepseek_v4_vision_config(config):
+                return None
         return registry.get_for_model(entry.model_path)
 
     def _entry_resident_size(self, entry: EngineEntry) -> int:
@@ -899,7 +910,7 @@ class EnginePool:
         )
 
     def resolve_cluster_model_id(self, model_path: str) -> str:
-        """Resolve one downloaded LLM path to its public oMLX model ID.
+        """Resolve one downloaded cluster-capable path to its public model ID.
 
         Cluster deployments are keyed by canonical model path while the public
         API and the engine pool are keyed by model ID.  Activation must join
@@ -923,11 +934,21 @@ class EnginePool:
         if not matches:
             raise ModelNotFoundError(model_path, list(self._entries.keys()))
         model_id, entry = self._select_cluster_path_match(matches)
-        if entry.engine_type != "batched":
+        config: dict[str, Any] = {}
+        try:
+            decoded = json.loads(Path(entry.model_path, "config.json").read_text())
+            if isinstance(decoded, dict):
+                config = decoded
+        except (OSError, json.JSONDecodeError):
+            pass
+        from .deepseek_v4_vision import is_deepseek_v4_vision_config
+
+        supported_vision = is_deepseek_v4_vision_config(config)
+        if entry.engine_type != "batched" and not supported_vision:
             raise ValueError(
                 f"Model '{model_id}' is a {entry.model_type} model. "
-                "Distributed cluster inference currently supports text LLM "
-                "models only."
+                "Distributed cluster inference supports text LLM models only, "
+                "plus the explicitly gated DeepSeek-V4-Flash-Vision family."
             )
         return model_id
 
@@ -961,11 +982,20 @@ class EnginePool:
         ]
         if exact:
             model_id, entry = self._select_cluster_path_match(exact)
-            if entry.engine_type != "batched":
+            from .deepseek_v4_vision import is_deepseek_v4_vision_config
+
+            try:
+                existing_config = json.loads(config_path.read_text())
+            except (OSError, json.JSONDecodeError):
+                existing_config = {}
+            if (
+                entry.engine_type != "batched"
+                and not is_deepseek_v4_vision_config(existing_config)
+            ):
                 raise ValueError(
                     f"Model '{model_id}' is already registered as "
                     f"{entry.model_type}; stop or remove that local model "
-                    "before activating it as a text cluster model."
+                    "before activating it as a cluster model."
                 )
             return model_id, False
 
@@ -988,10 +1018,13 @@ class EnginePool:
         context = config.get("max_position_embeddings")
         if not isinstance(context, int) or context <= 0:
             context = None
+        from .deepseek_v4_vision import is_deepseek_v4_vision_config
+
+        model_type = "vlm" if is_deepseek_v4_vision_config(config) else "llm"
         self._entries[model_id] = EngineEntry(
             model_id=model_id,
             model_path=str(path),
-            model_type="llm",
+            model_type=model_type,
             engine_type="batched",
             estimated_size=int(estimated_size),
             config_model_type=str(config.get("model_type") or ""),

--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -828,7 +828,13 @@ class MemoryMonitor:
         # raised false-positive 400s on small prompts.
         eff_chunk = min(chunk_size, new_tokens)
         full_kv_len = new_tokens + max(cached_tokens, 0)
-        attn = self._estimate_sdpa_activation_bytes(eff_chunk, full_kv_len)
+        attn = (
+            self._prefill_memory_profile.estimate_prefill_transient_bytes(
+                eff_chunk, full_kv_len
+            )
+            if self._prefill_memory_profile is not None
+            else self._estimate_sdpa_activation_bytes(eff_chunk, full_kv_len)
+        )
 
         # KV growth attributable to this request: only the new tokens.
         # The cached portion is already counted in the caller's current-usage
@@ -1226,14 +1232,29 @@ def make_prefill_memory_profile(
     *,
     compute_dtype_size: float,
     wsdpa_dtype_supported: bool = False,
+    layer_ratios: Sequence[int] | None = None,
 ) -> PrefillMemoryProfile | None:
-    """Build the one model-specific prefill strategy currently required."""
+    """Build the one model-specific prefill strategy currently required.
+
+    ``layer_ratios`` narrows a pipeline model to the layers resident in the
+    current process.  The model config continues to describe the full network
+    after mlx-lm applies pipeline sharding, so using its unsliced ratios in a
+    rank-local admission guard would charge every rank for every layer.
+    """
     model_type = str(_cfg_get(config, "model_type", "") or "")
     if not model_type.startswith("deepseek_v4"):
         return None
 
-    num_layers = _cfg_get(config, "num_hidden_layers")
-    ratios = _cfg_get(config, "compress_ratios")
+    ratios = (
+        layer_ratios
+        if layer_ratios is not None
+        else _cfg_get(config, "compress_ratios")
+    )
+    num_layers = (
+        len(layer_ratios)
+        if layer_ratios is not None
+        else _cfg_get(config, "num_hidden_layers")
+    )
     if (
         not _pos_int(num_layers)
         or not isinstance(ratios, Sequence)
@@ -1528,13 +1549,25 @@ def set_model_info_from_model(monitor: "MemoryMonitor", model: Any) -> None:
             num_heads = _cfg_get(config, "num_attention_heads") or num_kv_heads
             head_dim = hidden_size // num_heads
 
-        # Determine dtype size
-        dtype_size = 2  # Default float16
-        if hasattr(model, "dtype"):
-            if model.dtype == mx.float32:
-                dtype_size = 4
-            elif model.dtype == mx.bfloat16:
-                dtype_size = 2
+        # Determine the activation dtype from an explicit model property or,
+        # for mlx-lm text models, the embedding weight that produces the
+        # hidden-state stream.  The latter is how DeepSeek V4 exposes it.
+        model_dtype = getattr(model, "dtype", None)
+        if model_dtype is None:
+            model_body = getattr(model, "model", None)
+            embed_tokens = getattr(model_body, "embed_tokens", None)
+            embed_weight = getattr(embed_tokens, "weight", None)
+            model_dtype = getattr(embed_weight, "dtype", None)
+
+        def _dtype_matches(dtype: Any, expected: Any) -> bool:
+            if dtype is None:
+                return False
+            try:
+                return bool(dtype == expected)
+            except (TypeError, ValueError):
+                return False
+
+        dtype_size = 4 if _dtype_matches(model_dtype, mx.float32) else 2
 
         # Extract num_attention_heads (query heads) for SDPA peak estimation
         num_attention_heads = (
@@ -1569,6 +1602,33 @@ def set_model_info_from_model(monitor: "MemoryMonitor", model: Any) -> None:
             config, cache_list, dtype_size
         ) or estimate_mla_kv_bytes_per_token(config, cache_list, dtype_size)
 
+        # mlx-lm leaves the full config attached after pipeline sharding.  Its
+        # PipelineMixin records the resident half-open layer range on the
+        # language-model body; slice the DeepSeek V4 ratio schedule so the
+        # specialized cache/transient profile remains rank-local.
+        layer_ratios = None
+        ratios = _cfg_get(config, "compress_ratios")
+        pipeline_model = getattr(model, "model", None)
+        start_idx = getattr(pipeline_model, "start_idx", None)
+        end_idx = getattr(pipeline_model, "end_idx", None)
+        if (
+            isinstance(ratios, Sequence)
+            and not isinstance(ratios, (str, bytes))
+            and isinstance(start_idx, int)
+            and not isinstance(start_idx, bool)
+            and isinstance(end_idx, int)
+            and not isinstance(end_idx, bool)
+            and 0 <= start_idx < end_idx <= len(ratios)
+        ):
+            layer_ratios = tuple(ratios[start_idx:end_idx])
+
+        prefill_memory_profile = make_prefill_memory_profile(
+            config,
+            compute_dtype_size=dtype_size,
+            wsdpa_dtype_supported=_dtype_matches(model_dtype, mx.bfloat16),
+            layer_ratios=layer_ratios,
+        )
+
         # Truthiness alone isn't enough — MagicMock proxies leaking through the
         # descent (test scaffolds that don't fully spec ``model.config``) are
         # truthy but fail any later numeric comparison (``> 128`` etc.) deep
@@ -1586,6 +1646,7 @@ def set_model_info_from_model(monitor: "MemoryMonitor", model: Any) -> None:
                 compute_dtype_size=dtype_size,
                 kv_bytes_per_token=kv_bytes_per_token,
                 rotating_layer_specs=rotating_layer_specs,
+                prefill_memory_profile=prefill_memory_profile,
                 ane_prefill_transient_bytes=_ane_prefill_transient_bytes(model),
             )
             logger.debug(

--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -1234,17 +1234,14 @@ def make_prefill_memory_profile(
     wsdpa_dtype_supported: bool = False,
     layer_ratios: Sequence[int] | None = None,
 ) -> PrefillMemoryProfile | None:
-    """Build the one model-specific prefill strategy currently required.
-
-    ``layer_ratios`` narrows a pipeline model to the layers resident in the
-    current process.  The model config continues to describe the full network
-    after mlx-lm applies pipeline sharding, so using its unsliced ratios in a
-    rank-local admission guard would charge every rank for every layer.
-    """
+    """Build a model-specific prefill strategy when the uniform formulas fail."""
     model_type = str(_cfg_get(config, "model_type", "") or "")
     if not model_type.startswith("deepseek_v4"):
         return None
 
+    # ``layer_ratios`` narrows a pipeline model to the layers resident in the
+    # current process. The config still describes the full network after
+    # pipeline sharding, so unsliced ratios would charge each rank for all layers.
     ratios = (
         layer_ratios
         if layer_ratios is not None

--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -568,10 +568,13 @@ def _has_vision_subconfig(config: dict) -> bool:
     Used by the VLM classifier in :func:`detect_model_type` and by other
     paths (``oq``, admin model info) that need to ask "is this a VLM?".
     """
+    from .deepseek_v4_vision import is_deepseek_v4_vision_config
+
     return (
         bool(config.get("vision_config"))
         or bool(config.get("vit_config"))
         or bool(config.get("mm_vision_tower"))
+        or is_deepseek_v4_vision_config(config)
     )
 
 

--- a/omlx/patches/deepseek_v4/README.md
+++ b/omlx/patches/deepseek_v4/README.md
@@ -13,7 +13,7 @@ pinned mlx-lm v0.31.3 (`ed1fca4`) without modifying the upstream package.
 
 | File | Source | Notes |
 |---|---|---|
-| `deepseek_v4_model.py` | PR 1192 `mlx_lm/models/deepseek_v4.py` | 1:1 copy — do not edit |
+| `deepseek_v4_model.py` | adapted from PR 1192 `mlx_lm/models/deepseek_v4.py` | oMLX pipeline and distributed-vision extensions |
 | `hyper_connection.py` | PR 1192 `mlx_lm/models/hyper_connection.py` | 1:1 copy — do not edit |
 | `cache_extras.py` | PR 1192 `mlx_lm/models/cache.py` lines 903-1447 | PoolingCache + BatchPoolingCache, 1:1 |
 | `utils_patch.py` | adapted from PR 1192 `mlx_lm/utils.py` | replacement `load_model` + `_load_safetensors` |
@@ -53,7 +53,9 @@ When mlx-lm merges PR 1192 upstream, simply:
 
 ## Synchronizing with PR 1192 updates
 
-If PR 1192 adds new commits before merge, refresh the 1:1 sources:
+If PR 1192 adds new commits before merge, refresh the unchanged source and
+reapply the documented oMLX pipeline and distributed-vision extensions; do not
+blindly overwrite `deepseek_v4_model.py`:
 
 ```bash
 SHA=<new_head_sha>

--- a/omlx/patches/deepseek_v4/deepseek_v4_model.py
+++ b/omlx/patches/deepseek_v4/deepseek_v4_model.py
@@ -174,6 +174,19 @@ class ModelArgs(BaseModelArgs):
     tie_word_embeddings: bool = False
     topk_method: str = "noaux_tc"
     use_native_ratio128_attention: bool = True
+    # DeepSeek-V4-Flash-Vision-Exp uses flat top-level vision fields rather
+    # than a nested vision_config. Zero keeps ordinary DeepSeek-V4 text models
+    # byte-for-byte on their existing path.
+    vision_n_layers: int = 0
+    vision_dim: int = 1024
+    vision_n_heads: int = 16
+    vision_inter_dim: int = 2816
+    vision_patch_size: int = 14
+    vision_rope_theta: float = 10000.0
+    vision_downsample_ratio: int = 3
+    vision_max_n_token: int = 384
+    vision_min_pixels: int = 147456
+    vision_max_wh_ratio: int = 8
 
     def __post_init__(self):
         if not self.compress_ratios:
@@ -841,32 +854,63 @@ class MoEGate(nn.Module):
         self.scoring_func = config.scoring_func
         self.routed_scaling_factor = config.routed_scaling_factor
         self.norm_topk_prob = config.norm_topk_prob
+        self.vocab_size = config.vocab_size
+        self.vision = config.vision_n_layers > 0
         self.weight = mx.zeros((self.num_experts, self.hidden_dim))
         if self.hash:
             self.tid2eid = mx.zeros((config.vocab_size, self.top_k), dtype=mx.int32)
-        else:
+        if not self.hash or self.vision:
             self.e_score_correction_bias = mx.zeros(
+                (self.num_experts,), dtype=mx.float32
+            )
+        if self.vision:
+            self.e_score_correction_bias_vl = mx.zeros(
                 (self.num_experts,), dtype=mx.float32
             )
 
     def __call__(self, x: mx.array, input_ids: Optional[mx.array] = None):
         logits = decode_matmul(x, self.weight.T)
 
+        image_mask = None
+        if self.vision:
+            if input_ids is None:
+                raise ValueError("DeepSeek-V4 Vision routing requires input_ids.")
+            image_mask = input_ids >= self.vocab_size
         if self.hash:
             if input_ids is None:
                 raise ValueError("DeepSeek-V4 hash routing requires input_ids.")
-            inds, weights = _hash_expert_select(
-                input_ids,
-                logits,
-                self.tid2eid,
-                self.routed_scaling_factor,
-                self.norm_topk_prob,
-                self.scoring_func,
-            )
+            if image_mask is None:
+                inds, weights = _hash_expert_select(
+                    input_ids,
+                    logits,
+                    self.tid2eid,
+                    self.routed_scaling_factor,
+                    self.norm_topk_prob,
+                    self.scoring_func,
+                )
+            else:
+                safe_ids = mx.where(image_mask, 0, input_ids)
+                scores = _score_func(logits.astype(mx.float32), self.scoring_func)
+                inds = self.tid2eid[safe_ids]
+                vision_inds = mx.argpartition(
+                    -(scores + self.e_score_correction_bias_vl),
+                    kth=self.top_k - 1,
+                    axis=-1,
+                )[..., : self.top_k]
+                inds = mx.where(image_mask[..., None], vision_inds, inds)
+                weights = mx.take_along_axis(scores, inds, axis=-1)
+                if self.scoring_func != "softmax" and self.norm_topk_prob:
+                    weights /= weights.sum(axis=-1, keepdims=True) + 1e-20
+                weights *= self.routed_scaling_factor
         else:
+            bias = self.e_score_correction_bias
+            if image_mask is not None:
+                bias = mx.where(
+                    image_mask[..., None], self.e_score_correction_bias_vl, bias
+                )
             inds, weights = _expert_select(
                 logits,
-                self.e_score_correction_bias,
+                bias,
                 self.top_k,
                 self.routed_scaling_factor,
                 self.norm_topk_prob,
@@ -2193,8 +2237,15 @@ class DeepseekV4Model(PipelineMixin, nn.Module):
         self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hc_head = HyperHead(config)
 
-    def __call__(self, inputs: mx.array, cache: Optional[Any] = None) -> mx.array:
-        h = self.embed_tokens(inputs)
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[Any] = None,
+        *,
+        inputs_embeds: Optional[mx.array] = None,
+    ) -> mx.array:
+        safe_inputs = mx.where(inputs >= self.vocab_size, 0, inputs)
+        h = self.embed_tokens(safe_inputs) if inputs_embeds is None else inputs_embeds
         h = mx.broadcast_to(
             h[:, :, None, :],
             (h.shape[0], h.shape[1], self.args.hc_mult, h.shape[2]),
@@ -2217,6 +2268,25 @@ class DeepseekV4Model(PipelineMixin, nn.Module):
             window_size=self.args.sliding_window,
             return_array=True,
         )
+        if inputs.shape[1] > 1 and bool(mx.any(inputs >= self.vocab_size).item()):
+            # The checkpoint's sparse local attention extends visibility across
+            # each complete image sentinel block. It otherwise uses ordinary
+            # one-dimensional token positions.
+            visible = mx.zeros(
+                (inputs.shape[1], inputs.shape[1]), dtype=mx.bool_
+            )
+            for row in inputs.tolist():
+                start = None
+                for index, token in enumerate(row):
+                    kind = int(token) - self.vocab_size
+                    if kind == 0:
+                        start = index
+                    elif kind == 4 and start is not None:
+                        visible = visible.at[start : index + 1, start : index + 1].add(
+                            True
+                        )
+                        start = None
+            mask = visible if mask is None else (mask | visible)
 
         if pipeline_rank < pipeline_size - 1:
             h = mx.distributed.recv_like(h, (pipeline_rank + 1))
@@ -2248,9 +2318,131 @@ class Model(nn.Module):
         self.model_type = config.model_type
         self.model = DeepseekV4Model(config)
         self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self._vision_group = mx.distributed.init()
+        self._vision_rank = int(self._vision_group.rank())
+        self._vision_inputs = None
+        if config.vision_n_layers > 0 and self._vision_rank == 0:
+            from omlx.patches.deepseek_v4.vision_model import Aligner, ViT
+
+            self.vision = ViT(config)
+            self.aligner = Aligner(config)
+            self.image_start = mx.zeros((config.hidden_size,))
+            self.image_end = mx.zeros((config.hidden_size,))
+            self.image_newline = mx.zeros((config.hidden_size,))
+            self.image_pad = mx.zeros((config.hidden_size,))
+
+    @property
+    def is_vision_model(self) -> bool:
+        return self.args.vision_n_layers > 0
+
+    def set_vision_inputs(self, images) -> None:
+        """Install one request's preprocessed images on coordinator only."""
+
+        self._vision_inputs = images if self._vision_rank == 0 else None
+
+    def _vision_embeddings(self, inputs: mx.array) -> mx.array:
+        import time
+
+        logger = logging.getLogger(__name__)
+        dtype = self.model.embed_tokens.weight.dtype
+        shape = (inputs.shape[0], inputs.shape[1], self.args.hidden_size)
+        encode_error = None
+        if self._vision_rank == 0:
+            try:
+                if not self._vision_inputs:
+                    raise RuntimeError(
+                        "image sentinel tokens reached the model without "
+                        "rank-zero vision inputs"
+                    )
+                safe = mx.where(inputs >= self.args.vocab_size, 0, inputs)
+                embeddings = self.model.embed_tokens(safe)
+                params = mx.stack(
+                    [
+                        self.image_start,
+                        self.image_pad,
+                        self.image_pad,
+                        self.image_newline,
+                        self.image_end,
+                    ]
+                )
+                started = time.perf_counter()
+                logger.info(
+                    "deepseek_v4_vision stage=vision_encode_begin images=%d",
+                    len(self._vision_inputs),
+                )
+                for image in self._vision_inputs:
+                    patches = mx.array(image.patches, dtype=mx.bfloat16)
+                    features = self.aligner(
+                        self.vision(patches, image.n_vit_h, image.n_vit_w),
+                        image.n_vit_h,
+                        image.n_vit_w,
+                    )
+                    features = features[
+                        mx.array(image.permutation, dtype=mx.uint32)
+                    ]
+                    types = mx.array(image.types, dtype=mx.uint32)
+                    block = params[types]
+                    positions = mx.array(
+                        [i for i, kind in enumerate(image.types) if kind == 2],
+                        dtype=mx.uint32,
+                    )
+                    block = block.at[positions].add(features - block[positions])
+                    current = embeddings[
+                        0, image.start : image.start + block.shape[0]
+                    ]
+                    embeddings = embeddings.at[
+                        0, image.start : image.start + block.shape[0]
+                    ].add(block - current)
+                mx.eval(embeddings)
+                logger.info(
+                    "deepseek_v4_vision stage=vision_encode_complete images=%d "
+                    "elapsed_ms=%.1f",
+                    len(self._vision_inputs),
+                    (time.perf_counter() - started) * 1000,
+                )
+            except Exception as exc:
+                encode_error = exc
+                embeddings = mx.zeros(shape, dtype=dtype)
+                logger.exception(
+                    "deepseek_v4_vision stage=vision_encode_failed rank=0"
+                )
+        else:
+            embeddings = mx.zeros(shape, dtype=dtype)
+        self._vision_inputs = None
+        if self._vision_group.size() > 1:
+            # Synchronize success before the large embedding collective so a
+            # coordinator-side decode/encode failure cannot strand peers.
+            local_status = mx.array(
+                int(self._vision_rank == 0 and encode_error is None),
+                dtype=mx.int32,
+            )
+            status = mx.distributed.all_sum(local_status, group=self._vision_group)
+            mx.eval(status)
+            if int(status.item()) != 1:
+                message = "DeepSeek-V4 vision encoding failed on rank zero"
+                if encode_error is not None:
+                    raise RuntimeError(message) from encode_error
+                raise RuntimeError(message)
+            embeddings = mx.distributed.all_sum(
+                embeddings, group=self._vision_group
+            )
+        elif encode_error is not None:
+            raise RuntimeError("DeepSeek-V4 vision encoding failed") from encode_error
+        logger.info(
+            "deepseek_v4_vision stage=multimodal_embeddings shape=%s dtype=%s "
+            "sequence_length=%d",
+            tuple(embeddings.shape),
+            embeddings.dtype,
+            int(embeddings.shape[1]),
+        )
+        return embeddings
 
     def __call__(self, inputs: mx.array, cache: Optional[Any] = None):
-        return self.lm_head(self.model(inputs, cache))
+        multimodal = self.is_vision_model and bool(
+            mx.any(inputs >= self.args.vocab_size).item()
+        )
+        embeddings = self._vision_embeddings(inputs) if multimodal else None
+        return self.lm_head(self.model(inputs, cache, inputs_embeds=embeddings))
 
     @property
     def layers(self):

--- a/omlx/patches/deepseek_v4/deepseek_v4_model.py
+++ b/omlx/patches/deepseek_v4/deepseek_v4_model.py
@@ -565,18 +565,13 @@ def _overlap_compress_kv(kv, gate, ape, head_dim):
 # Pooled-axis tile for the MLX indexer fallback (used when the native
 # glm_moe_dsa extension is not built). The native dsa_indexer_scores kernel
 # keeps the (heads, L, P) score tensor in registers; the fallback has to
-# materialize it, and at ratio 4 with a 512-token chunk P = ctx/4, so the
-# intermediate is (1, 64, 512, ctx/4) fp32 — 8.3 GiB at 273k context, read
-# five more times. Worse, 64*512*P crosses 2**31 elements at ctx = 256k, the
-# boundary where mlx's int32 kernel indexing silently zeros the tail and
-# corrupts top-k selection. Tiling keeps each matmul under 2**31 elements;
-# the memory estimator separately accounts for lazy evaluation retaining
-# multiple score shards at once.
+# materialize it. At ratio 4 with a 512-token chunk, a 67k-token context is
+# already a 2 GiB FP32 temporary in every ratio-4 layer. Bound each fallback
+# matmul to 256 MiB; one-token decode stays well below this threshold and
+# therefore keeps its single-launch path.
 _INDEXER_POOL_TILE = 16384
-# mlx kernels index with int32, so a tensor at or past 2**31 elements has its
-# tail silently zeroed. Stay a factor of 2 below that. For a 512-token chunk
-# with 64 index heads this is reached at P = ctx/4 ~= 32768, i.e. ctx ~= 128k.
-_INDEXER_MAX_ELEMS = 2**30
+# This is also far below MLX's 2**31-element int32 indexing boundary.
+_INDEXER_MAX_ELEMS = 2**26
 _DEEPSEEK_V4_INDEXER_FALLBACK_WARNED = False
 _DEEPSEEK_V4_M2_MMA_SCORE = os.getenv(
     "OMLX_DSV4F_M2_MMA_SCORE", "1"
@@ -1536,28 +1531,27 @@ class Indexer(nn.Module):
         kf = pooled[:, None].swapaxes(-1, -2).astype(mx.float32)  # (B, 1, Dh, P)
         n_pool = pooled.shape[1]
         n_elems = qf.shape[0] * qf.shape[1] * qf.shape[2] * n_pool
-        if n_elems < _INDEXER_MAX_ELEMS:
-            # Single matmul: fastest, and the intermediate is safely indexable.
+        if n_elems <= _INDEXER_MAX_ELEMS:
+            # Single matmul: fastest when the materialized score tensor is small.
             scores = _indexer_head_reduce(qf @ kf, weights, self.scale)
         else:
-            # Only past the int32 indexing limit is tiling worth its cost:
-            # splitting the pooled axis adds matmul launches and a full-width
-            # concatenate (measured: ~1.2x slower slope at 273k), but an
-            # intermediate over 2**31 elements is silently zeroed by mlx's
-            # int32 kernel indexing, which corrupts top-k selection. Choose
-            # the largest tile that stays under the limit so the split is as
-            # coarse as correctness allows.
+            # Keep the expensive head dimension inside bounded score shards.
+            # The concatenated values have already reduced that dimension, so
+            # their aggregate is H times smaller than the unbounded temporary.
             per_pool = max(1, qf.shape[0] * qf.shape[1] * qf.shape[2])
-            tile = max(1024, min(_INDEXER_POOL_TILE, _INDEXER_MAX_ELEMS // per_pool))
-            scores = mx.concatenate(
-                [
-                    _indexer_head_reduce(
-                        qf @ kf[..., s : s + tile], weights, self.scale
-                    )
-                    for s in range(0, n_pool, tile)
-                ],
-                axis=-1,
-            )
+            tile = max(1, min(_INDEXER_POOL_TILE, _INDEXER_MAX_ELEMS // per_pool))
+            reduced_tiles = []
+            for start in range(0, n_pool, tile):
+                reduced = _indexer_head_reduce(
+                    qf @ kf[..., start : start + tile], weights, self.scale
+                )
+                # MLX may otherwise schedule every independent matmul before
+                # the concatenate and retain all per-head score shards. Eagerly
+                # materialize the H-reduced result so the next tile can reuse
+                # the bounded temporary allocation.
+                mx.eval(reduced)
+                reduced_tiles.append(reduced)
+            scores = mx.concatenate(reduced_tiles, axis=-1)
         if pmask is not None:
             scores = mx.where(
                 pmask if pmask.ndim == 3 else pmask[None],
@@ -2391,6 +2385,7 @@ class Model(nn.Module):
         self._vision_group = mx.distributed.init()
         self._vision_rank = int(self._vision_group.rank())
         self._vision_inputs = None
+        self._vision_spans = ()
         self._vision_blocks = {}
         if config.vision_n_layers > 0 and self._vision_rank == 0:
             from omlx.patches.deepseek_v4.vision_model import Aligner, ViT
@@ -2406,11 +2401,85 @@ class Model(nn.Module):
     def is_vision_model(self) -> bool:
         return self.args.vision_n_layers > 0
 
-    def set_vision_inputs(self, images) -> None:
+    def set_vision_inputs(self, images, *, spans=()) -> None:
         """Install one request's preprocessed images on coordinator only."""
 
         self._vision_inputs = images if self._vision_rank == 0 else None
+        if spans:
+            self._vision_spans = tuple((int(start), int(end)) for start, end in spans)
+        elif images:
+            self._vision_spans = tuple(
+                (int(image.start), int(image.start) + len(image.types))
+                for image in images
+            )
+        else:
+            self._vision_spans = ()
         self._vision_blocks = {}
+
+    def _prune_vision_state(self, offset: int) -> None:
+        """Drop images already represented by the fetched prompt cache."""
+
+        self._vision_spans = tuple(
+            (start, end) for start, end in self._vision_spans if end > offset
+        )
+        if self._vision_rank != 0:
+            return
+        self._vision_inputs = tuple(
+            image
+            for image in self._vision_inputs or ()
+            if image.start + len(image.types) > offset
+        )
+        pending_starts = {image.start for image in self._vision_inputs}
+        self._vision_blocks = {
+            start: block
+            for start, block in self._vision_blocks.items()
+            if start in pending_starts
+        }
+
+    def _encode_vision_images(self, inputs: mx.array, offset: int):
+        """Encode rank-zero image slices in a short-lived local scope."""
+
+        if not self._vision_inputs:
+            raise RuntimeError(
+                "image sentinel tokens reached the model without "
+                "rank-zero vision inputs"
+            )
+        safe = mx.where(inputs >= self.args.vocab_size, 0, inputs)
+        embeddings = self.model.embed_tokens(safe)
+        params = mx.stack(
+            [
+                self.image_start,
+                self.image_pad,
+                self.image_pad,
+                self.image_newline,
+                self.image_end,
+            ]
+        )
+        image_slices = _image_embedding_slices(
+            self._vision_inputs, offset, inputs.shape[1]
+        )
+        for image, destination, source in image_slices:
+            block = self._vision_blocks.get(image.start)
+            if block is None:
+                patches = mx.array(image.patches, dtype=mx.bfloat16)
+                features = self.aligner(
+                    self.vision(patches, image.n_vit_h, image.n_vit_w),
+                    image.n_vit_h,
+                    image.n_vit_w,
+                )
+                features = features[mx.array(image.permutation, dtype=mx.uint32)]
+                types = mx.array(image.types, dtype=mx.uint32)
+                block = params[types]
+                positions = mx.array(
+                    [i for i, kind in enumerate(image.types) if kind == 2],
+                    dtype=mx.uint32,
+                )
+                block = block.at[positions].add(features - block[positions])
+                self._vision_blocks[image.start] = block
+            current = embeddings[0, destination]
+            embeddings = embeddings.at[0, destination].add(block[source] - current)
+        mx.eval(embeddings)
+        return embeddings, len(image_slices)
 
     def _vision_embeddings(self, inputs: mx.array, offset: int = 0) -> mx.array:
         import time
@@ -2421,59 +2490,26 @@ class Model(nn.Module):
         encode_error = None
         if self._vision_rank == 0:
             try:
-                if not self._vision_inputs:
-                    raise RuntimeError(
-                        "image sentinel tokens reached the model without "
-                        "rank-zero vision inputs"
-                    )
-                safe = mx.where(inputs >= self.args.vocab_size, 0, inputs)
-                embeddings = self.model.embed_tokens(safe)
-                params = mx.stack(
-                    [
-                        self.image_start,
-                        self.image_pad,
-                        self.image_pad,
-                        self.image_newline,
-                        self.image_end,
-                    ]
-                )
-                image_slices = _image_embedding_slices(
-                    self._vision_inputs, offset, inputs.shape[1]
-                )
                 started = time.perf_counter()
+                suffix_end = offset + inputs.shape[1]
+                image_count = sum(
+                    image.start < suffix_end
+                    and image.start + len(image.types) > offset
+                    for image in self._vision_inputs or ()
+                )
                 logger.info(
                     "deepseek_v4_vision stage=vision_encode_begin images=%d",
-                    len(image_slices),
+                    image_count,
                 )
-                for image, destination, source in image_slices:
-                    block = self._vision_blocks.get(image.start)
-                    if block is None:
-                        patches = mx.array(image.patches, dtype=mx.bfloat16)
-                        features = self.aligner(
-                            self.vision(patches, image.n_vit_h, image.n_vit_w),
-                            image.n_vit_h,
-                            image.n_vit_w,
-                        )
-                        features = features[
-                            mx.array(image.permutation, dtype=mx.uint32)
-                        ]
-                        types = mx.array(image.types, dtype=mx.uint32)
-                        block = params[types]
-                        positions = mx.array(
-                            [i for i, kind in enumerate(image.types) if kind == 2],
-                            dtype=mx.uint32,
-                        )
-                        block = block.at[positions].add(features - block[positions])
-                        self._vision_blocks[image.start] = block
-                    current = embeddings[0, destination]
-                    embeddings = embeddings.at[0, destination].add(
-                        block[source] - current
-                    )
-                mx.eval(embeddings)
+                embeddings, encoded_count = Model._encode_vision_images(
+                    self, inputs, offset
+                )
+                if encoded_count != image_count:  # pragma: no cover - invariant
+                    raise RuntimeError("DeepSeek-V4 image slice count changed")
                 logger.info(
                     "deepseek_v4_vision stage=vision_encode_complete images=%d "
                     "elapsed_ms=%.1f",
-                    len(image_slices),
+                    image_count,
                     (time.perf_counter() - started) * 1000,
                 )
             except Exception as exc:
@@ -2500,6 +2536,9 @@ class Model(nn.Module):
             for start, block in self._vision_blocks.items()
             if start in pending_starts
         }
+        self._vision_spans = tuple(
+            (start, end) for start, end in self._vision_spans if end > suffix_end
+        )
         if self._vision_group.size() > 1:
             # Synchronize success before the large embedding collective so a
             # coordinator-side decode/encode failure cannot strand peers.
@@ -2523,6 +2562,9 @@ class Model(nn.Module):
             mx.eval(embeddings)
         elif encode_error is not None:
             raise RuntimeError("DeepSeek-V4 vision encoding failed") from encode_error
+        # The returned embeddings are materialized above. Release transient
+        # ViT/aligner buffers before the much larger language-model prefill.
+        mx.clear_cache()
         logger.info(
             "deepseek_v4_vision stage=multimodal_embeddings shape=%s dtype=%s "
             "sequence_length=%d",
@@ -2533,14 +2575,16 @@ class Model(nn.Module):
         return embeddings
 
     def __call__(self, inputs: mx.array, cache: Optional[Any] = None):
-        multimodal = self.is_vision_model and bool(
-            mx.any(inputs >= self.args.vocab_size).item()
-        )
-        embeddings = (
-            self._vision_embeddings(inputs, _cache_offset(cache))
-            if multimodal
-            else None
-        )
+        embeddings = None
+        if self.is_vision_model and self._vision_spans:
+            offset = _cache_offset(cache)
+            Model._prune_vision_state(self, offset)
+            suffix_end = offset + inputs.shape[1]
+            if any(
+                start < suffix_end and end > offset
+                for start, end in self._vision_spans
+            ):
+                embeddings = self._vision_embeddings(inputs, offset)
         return self.lm_head(self.model(inputs, cache, inputs_embeds=embeddings))
 
     @property

--- a/omlx/patches/deepseek_v4/deepseek_v4_model.py
+++ b/omlx/patches/deepseek_v4/deepseek_v4_model.py
@@ -219,7 +219,10 @@ def make_quantization_config(model):
     }
     shared_experts = {k: mxfp8 for k, _ in flat_modules if ".ffn.shared_experts." in k}
     attn = {
-        k: mxfp8 for k, _ in flat_modules if ".attn.w" in k or ".attn.indexer.wq" in k
+        k: mxfp8
+        for k, _ in flat_modules
+        if not k.startswith("vision.")
+        and (".attn.w" in k or ".attn.indexer.wq" in k)
     }
     # MTP fusion projections. Lightning checkpoints use e_proj/h_proj;
     # embedded DSpark uses main_proj on stage 0. These ship as e4m3 weight +
@@ -453,6 +456,83 @@ def _extend_mask(mask: Optional[mx.array], pool_mask: Optional[mx.array], N: int
     full_mask = mx.concatenate([mask, pool_mask], axis=-1)
 
     return full_mask
+
+
+def _apply_image_visibility_mask(
+    inputs: mx.array,
+    mask: Optional[mx.array],
+    vocab_size: int,
+) -> Tuple[Optional[mx.array], bool]:
+    """Add full visibility for image spans in the current cache-aware suffix."""
+    batch, length = inputs.shape
+    if length <= 1 or not bool(mx.any(inputs >= vocab_size).item()):
+        return mask, False
+
+    source_length = mask.shape[-1] if mask is not None else length
+    suffix_start = source_length - length
+    visible = mx.zeros((batch, length, source_length), dtype=mx.bool_)
+    has_image_span = False
+    for batch_index, row in enumerate(inputs.tolist()):
+        start = 0 if row and int(row[0]) >= vocab_size else None
+        for index, token in enumerate(row):
+            kind = int(token) - vocab_size
+            if kind == 0:
+                start = index
+            elif kind < 0:
+                start = None
+            elif kind == 4 and start is not None:
+                visible = visible.at[
+                    batch_index,
+                    start : index + 1,
+                    suffix_start + start : suffix_start + index + 1,
+                ].add(True)
+                has_image_span = True
+                start = None
+        if start is not None:
+            visible = visible.at[
+                batch_index,
+                start:length,
+                suffix_start + start : suffix_start + length,
+            ].add(True)
+            has_image_span = True
+
+    if not has_image_span:
+        return mask, False
+    visible = visible[0] if batch == 1 else visible[:, None]
+    return (visible if mask is None else mask | visible), True
+
+
+def _image_embedding_slices(images, offset: int, length: int):
+    """Map absolute image blocks to destination/source slices in a suffix."""
+    suffix_end = offset + length
+    slices = []
+    for image in images or ():
+        image_end = image.start + len(image.types)
+        overlap_start = max(offset, image.start)
+        overlap_end = min(suffix_end, image_end)
+        if overlap_start < overlap_end:
+            slices.append(
+                (
+                    image,
+                    slice(overlap_start - offset, overlap_end - offset),
+                    slice(overlap_start - image.start, overlap_end - image.start),
+                )
+            )
+    return slices
+
+
+def _cache_offset(cache: Optional[Any]) -> int:
+    if not cache:
+        return 0
+    cache_item = cache[0]
+    if isinstance(cache_item, CacheList):
+        cache_item = cache_item[0]
+    offset = getattr(cache_item, "offset", 0)
+    if isinstance(offset, mx.array):
+        if offset.size != 1:
+            raise ValueError("DeepSeek-V4 Vision requires a scalar cache offset.")
+        offset = offset.item()
+    return int(offset)
 
 
 @partial(mx.compile, shapeless=True)
@@ -2268,32 +2348,22 @@ class DeepseekV4Model(PipelineMixin, nn.Module):
             window_size=self.args.sliding_window,
             return_array=True,
         )
-        if inputs.shape[1] > 1 and bool(mx.any(inputs >= self.vocab_size).item()):
-            # The checkpoint's sparse local attention extends visibility across
-            # each complete image sentinel block. It otherwise uses ordinary
-            # one-dimensional token positions.
-            visible = mx.zeros(
-                (inputs.shape[1], inputs.shape[1]), dtype=mx.bool_
-            )
-            for row in inputs.tolist():
-                start = None
-                for index, token in enumerate(row):
-                    kind = int(token) - self.vocab_size
-                    if kind == 0:
-                        start = index
-                    elif kind == 4 and start is not None:
-                        visible = visible.at[start : index + 1, start : index + 1].add(
-                            True
-                        )
-                        start = None
-            mask = visible if mask is None else (mask | visible)
+        mask, image_visibility = _apply_image_visibility_mask(
+            inputs, mask, self.vocab_size
+        )
 
         if pipeline_rank < pipeline_size - 1:
             h = mx.distributed.recv_like(h, (pipeline_rank + 1))
 
         for layer, layer_cache in zip(self.pipeline_layers, cache):
-            # This mask was created above from the model's own cache/window.
-            h = layer(h, mask, layer_cache, inputs, _standard_mask=True)
+            # Optimized kernels may reconstruct only the standard causal mask.
+            h = layer(
+                h,
+                mask,
+                layer_cache,
+                inputs,
+                _standard_mask=not image_visibility,
+            )
 
         _materialize_cache_arrays(cache)
 
@@ -2321,6 +2391,7 @@ class Model(nn.Module):
         self._vision_group = mx.distributed.init()
         self._vision_rank = int(self._vision_group.rank())
         self._vision_inputs = None
+        self._vision_blocks = {}
         if config.vision_n_layers > 0 and self._vision_rank == 0:
             from omlx.patches.deepseek_v4.vision_model import Aligner, ViT
 
@@ -2339,8 +2410,9 @@ class Model(nn.Module):
         """Install one request's preprocessed images on coordinator only."""
 
         self._vision_inputs = images if self._vision_rank == 0 else None
+        self._vision_blocks = {}
 
-    def _vision_embeddings(self, inputs: mx.array) -> mx.array:
+    def _vision_embeddings(self, inputs: mx.array, offset: int = 0) -> mx.array:
         import time
 
         logger = logging.getLogger(__name__)
@@ -2365,39 +2437,43 @@ class Model(nn.Module):
                         self.image_end,
                     ]
                 )
+                image_slices = _image_embedding_slices(
+                    self._vision_inputs, offset, inputs.shape[1]
+                )
                 started = time.perf_counter()
                 logger.info(
                     "deepseek_v4_vision stage=vision_encode_begin images=%d",
-                    len(self._vision_inputs),
+                    len(image_slices),
                 )
-                for image in self._vision_inputs:
-                    patches = mx.array(image.patches, dtype=mx.bfloat16)
-                    features = self.aligner(
-                        self.vision(patches, image.n_vit_h, image.n_vit_w),
-                        image.n_vit_h,
-                        image.n_vit_w,
+                for image, destination, source in image_slices:
+                    block = self._vision_blocks.get(image.start)
+                    if block is None:
+                        patches = mx.array(image.patches, dtype=mx.bfloat16)
+                        features = self.aligner(
+                            self.vision(patches, image.n_vit_h, image.n_vit_w),
+                            image.n_vit_h,
+                            image.n_vit_w,
+                        )
+                        features = features[
+                            mx.array(image.permutation, dtype=mx.uint32)
+                        ]
+                        types = mx.array(image.types, dtype=mx.uint32)
+                        block = params[types]
+                        positions = mx.array(
+                            [i for i, kind in enumerate(image.types) if kind == 2],
+                            dtype=mx.uint32,
+                        )
+                        block = block.at[positions].add(features - block[positions])
+                        self._vision_blocks[image.start] = block
+                    current = embeddings[0, destination]
+                    embeddings = embeddings.at[0, destination].add(
+                        block[source] - current
                     )
-                    features = features[
-                        mx.array(image.permutation, dtype=mx.uint32)
-                    ]
-                    types = mx.array(image.types, dtype=mx.uint32)
-                    block = params[types]
-                    positions = mx.array(
-                        [i for i, kind in enumerate(image.types) if kind == 2],
-                        dtype=mx.uint32,
-                    )
-                    block = block.at[positions].add(features - block[positions])
-                    current = embeddings[
-                        0, image.start : image.start + block.shape[0]
-                    ]
-                    embeddings = embeddings.at[
-                        0, image.start : image.start + block.shape[0]
-                    ].add(block - current)
                 mx.eval(embeddings)
                 logger.info(
                     "deepseek_v4_vision stage=vision_encode_complete images=%d "
                     "elapsed_ms=%.1f",
-                    len(self._vision_inputs),
+                    len(image_slices),
                     (time.perf_counter() - started) * 1000,
                 )
             except Exception as exc:
@@ -2408,7 +2484,22 @@ class Model(nn.Module):
                 )
         else:
             embeddings = mx.zeros(shape, dtype=dtype)
-        self._vision_inputs = None
+        suffix_end = offset + inputs.shape[1]
+        self._vision_inputs = (
+            tuple(
+                image
+                for image in self._vision_inputs or ()
+                if image.start + len(image.types) > suffix_end
+            )
+            if encode_error is None
+            else None
+        )
+        pending_starts = {image.start for image in self._vision_inputs or ()}
+        self._vision_blocks = {
+            start: block
+            for start, block in self._vision_blocks.items()
+            if start in pending_starts
+        }
         if self._vision_group.size() > 1:
             # Synchronize success before the large embedding collective so a
             # coordinator-side decode/encode failure cannot strand peers.
@@ -2441,7 +2532,11 @@ class Model(nn.Module):
         multimodal = self.is_vision_model and bool(
             mx.any(inputs >= self.args.vocab_size).item()
         )
-        embeddings = self._vision_embeddings(inputs) if multimodal else None
+        embeddings = (
+            self._vision_embeddings(inputs, _cache_offset(cache))
+            if multimodal
+            else None
+        )
         return self.lm_head(self.model(inputs, cache, inputs_embeds=embeddings))
 
     @property

--- a/omlx/patches/deepseek_v4/deepseek_v4_model.py
+++ b/omlx/patches/deepseek_v4/deepseek_v4_model.py
@@ -2517,6 +2517,10 @@ class Model(nn.Module):
             embeddings = mx.distributed.all_sum(
                 embeddings, group=self._vision_group
             )
+            # Rank zero's pipeline stage replaces this value with recv_like().
+            # Materialize first so its lazy collective cannot be pruned while
+            # peers wait for the embedding broadcast.
+            mx.eval(embeddings)
         elif encode_error is not None:
             raise RuntimeError("DeepSeek-V4 vision encoding failed") from encode_error
         logger.info(

--- a/omlx/patches/deepseek_v4/tokenizer_patch.py
+++ b/omlx/patches/deepseek_v4/tokenizer_patch.py
@@ -227,12 +227,23 @@ def apply_load_patch() -> bool:
             )
         if wrapper._tool_parser is None:
             wrapper._tool_parser = _tp.parse_tool_call
+        if wrapper._tool_parser is _tp.parse_tool_call:
+            # Normalize marker metadata even when tokenizer_config_extra (or a
+            # future published config) selected our parser before this wrapper
+            # ran.  mlx-lm otherwise keeps the context-free token cache that
+            # cannot match canonical DeepSeek V4 output.
             wrapper._tool_call_start = _tp.tool_call_start
             wrapper._tool_call_end = _tp.tool_call_end
             try:
                 wrapper._tool_call_start_tokens = tuple(
                     wrapper._tokenizer.encode(
-                        _tp.tool_call_start, add_special_tokens=False
+                        # The canonical DSML form puts the first invoke on the
+                        # next line.  Encode that context as well: DeepSeek's
+                        # tokenizer merges the closing ``>`` and newline into
+                        # one token, so encoding the bare marker produces a
+                        # sequence that can never match generated tool calls.
+                        _tp.tool_call_start + "\n",
+                        add_special_tokens=False,
                     )
                 )
                 wrapper._tool_call_end_tokens = tuple(

--- a/omlx/patches/deepseek_v4/vision_inputs.py
+++ b/omlx/patches/deepseek_v4/vision_inputs.py
@@ -1,0 +1,242 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DeepSeek-V4 Vision image-token layout and rank-zero preprocessing.
+
+The arithmetic is derived from the public checkpoint's reference
+``inference/image_processor.py``.  It intentionally has no MLX dependency so
+the layout contract can be tested on Linux CI.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+from urllib.request import urlopen
+
+import numpy as np
+from PIL import Image, ImageOps
+
+from omlx.deepseek_v4_vision import (
+    IMAGE,
+    IMAGE_END,
+    IMAGE_NEWLINE,
+    IMAGE_PAD,
+    IMAGE_START,
+)
+
+COMPRESS_PAD_TO = 4
+_MAX_IMAGE_BYTES = 50 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class ImageInput:
+    start: int
+    patches: np.ndarray
+    n_vit_h: int
+    n_vit_w: int
+    types: tuple[int, ...]
+    permutation: tuple[int, ...]
+
+
+def grid_tokens(
+    height: int, width: int, patch_size: int, downsample_ratio: int
+) -> tuple[int, int, int]:
+    n_llm_h = math.ceil((height // patch_size) / downsample_ratio)
+    n_llm_w = math.ceil((width // patch_size) / downsample_ratio)
+    count = n_llm_h * (n_llm_w + 1) + 2
+    if n_llm_h % 2:
+        count += n_llm_w + 1
+    count += (n_llm_h + 1) // 2 * (n_llm_w + 1) % 2 * 2
+    return n_llm_h, n_llm_w, count
+
+
+def _solve_resize_ratio(height, width, patch, ratio, budget):
+    aspect = height / width
+    max_w_float = math.sqrt((budget - 2) / aspect + 0.25) - 0.5
+    max_h_float = max_w_float * aspect
+    if max_w_float < 1.0:
+        max_w = 1
+        max_h = (budget - 2) // (max_w + 1)
+        max_h -= max_h % 2
+        best_w, best_h = max_w * patch * ratio, max_h * patch * ratio
+    elif max_h_float < 2.0:
+        max_h = 2
+        max_w = (budget - 2) // max_h - 1
+        if max_w <= 1:
+            raise ValueError("image aspect ratio cannot fit the token budget")
+        best_w, best_h = max_w * patch * ratio, max_h * patch * ratio
+    else:
+        max_w, max_h = math.floor(max_w_float), math.floor(max_h_float)
+        max_h -= max_h % 2
+        scale = min(max_w * patch * ratio / width, max_h * patch * ratio / height)
+        best_w = math.floor(width * scale / patch) * patch
+        best_h = math.floor(height * scale / patch) * patch
+    n_h, n_w, count = grid_tokens(best_h, best_w, patch, ratio)
+    return n_h, n_w, best_h, best_w, count
+
+
+def safe_resize(height, width, best_h, best_w, patch, ratio, max_tokens):
+    limit = max_tokens - (COMPRESS_PAD_TO - 1)
+    n_h, n_w, count = grid_tokens(best_h, best_w, patch, ratio)
+    budget = limit
+    while count > limit:
+        n_h, n_w, best_h, best_w, count = _solve_resize_ratio(
+            height, width, patch, ratio, budget
+        )
+        budget -= 1
+    return n_h, n_w, best_h, best_w
+
+
+def build_image_block(
+    n_llm_h: int, n_llm_w: int, start_pos: int
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """Return checkpoint sentinel types and aligner-to-N-layout permutation."""
+
+    compress_pad = COMPRESS_PAD_TO - 1 - start_pos % COMPRESS_PAD_TO
+    pad_h = n_llm_h % 2
+    rows = n_llm_h + pad_h
+    row_len = n_llm_w + 1
+    pad_last = (rows // 2 * row_len % 2) * 2
+
+    types = ([IMAGE] * n_llm_w + [IMAGE_NEWLINE]) * n_llm_h
+    types += [IMAGE_PAD] * (row_len * pad_h)
+    order = np.arange(rows * row_len).reshape(rows // 2, 2, row_len)
+    order = order.transpose(0, 2, 1).reshape(-1)
+    image_index = np.full(rows * row_len, -1, dtype=np.int64)
+    image_index.reshape(rows, row_len)[:n_llm_h, :n_llm_w] = np.arange(
+        n_llm_h * n_llm_w
+    ).reshape(n_llm_h, n_llm_w)
+    permutation = image_index[order]
+    permutation = tuple(int(v) for v in permutation if v >= 0)
+    ordered_types = [types[int(index)] for index in order]
+    block = (
+        [IMAGE_PAD] * compress_pad
+        + [IMAGE_START]
+        + ordered_types
+        + [IMAGE_PAD] * pad_last
+        + [IMAGE_END]
+    )
+    return tuple(block), permutation
+
+
+def _image_bytes(record: Any) -> bytes:
+    if isinstance(record, str):
+        record = {"url": record}
+    if not isinstance(record, Mapping):
+        raise ValueError("image input must be a URL/data record")
+    raw = record.get("data")
+    if isinstance(raw, bytes):
+        payload = raw
+    elif isinstance(raw, str):
+        payload = base64.b64decode(raw, validate=True)
+    else:
+        source = record.get("source")
+        if isinstance(source, Mapping):
+            if source.get("data") is not None:
+                payload = base64.b64decode(str(source["data"]), validate=True)
+            else:
+                record = {"url": source.get("url")}
+                payload = b""
+        else:
+            payload = b""
+        if not payload:
+            url = record.get("url") or record.get("image_url")
+            if isinstance(url, Mapping):
+                url = url.get("url")
+            if not isinstance(url, str) or not url:
+                raise ValueError("image record has no data or URL")
+            if url.startswith("data:"):
+                header, separator, encoded = url.partition(",")
+                if not separator or ";base64" not in header:
+                    raise ValueError("only base64 image data URLs are supported")
+                payload = base64.b64decode(encoded, validate=True)
+            elif url.startswith(("https://", "http://")):
+                with urlopen(url, timeout=30) as response:  # noqa: S310
+                    payload = response.read(_MAX_IMAGE_BYTES + 1)
+            else:
+                raise ValueError("image URL must use http(s) or a base64 data URL")
+    if not payload or len(payload) > _MAX_IMAGE_BYTES:
+        raise ValueError("image payload is empty or exceeds 50 MiB")
+    return payload
+
+
+def load_image(record: Any, config: Mapping[str, Any]):
+    patch = int(config["vision_patch_size"])
+    with Image.open(io.BytesIO(_image_bytes(record))) as source:
+        image = source.convert("RGB")
+    width, height = image.size
+    max_ratio = int(config.get("vision_max_wh_ratio", 8) or 8)
+    if width > height * max_ratio:
+        width = height * max_ratio
+    min_pixels = int(config.get("vision_min_pixels", 147456) or 147456)
+    if 0 < width * height < min_pixels:
+        scale = math.sqrt(min_pixels / (width * height))
+        width, height = int(width * scale), int(height * scale)
+    best_w = math.ceil(width / patch) * patch
+    best_h = math.ceil(height / patch) * patch
+    downsample = int(config["vision_downsample_ratio"])
+    n_llm_h, n_llm_w, best_h, best_w = safe_resize(
+        height,
+        width,
+        best_h,
+        best_w,
+        patch,
+        downsample,
+        int(config["vision_max_n_token"]),
+    )
+    n_vit_h, n_vit_w = best_h // patch, best_w // patch
+    if image.width >= max_ratio * image.height:
+        image = image.resize((best_w, best_h))
+    else:
+        image = ImageOps.pad(image, (best_w, best_h), color=(127, 127, 127))
+    pixels = np.asarray(image, dtype=np.float32).transpose(2, 0, 1) / 255.0
+    pixels = (pixels - 0.5) / 0.5
+    patches = pixels.reshape(3, n_vit_h, patch, n_vit_w, patch)
+    patches = patches.transpose(1, 3, 0, 2, 4).reshape(
+        n_vit_h * n_vit_w, 3, patch, patch
+    )
+    return patches, n_vit_h, n_vit_w, n_llm_h, n_llm_w
+
+
+def prepare_token_ids(
+    prompt_tokens: Sequence[int],
+    images: Sequence[Any],
+    *,
+    image_token_id: int,
+    config: Mapping[str, Any],
+) -> tuple[list[int], tuple[ImageInput, ...]]:
+    """Expand placeholders and preprocess images in deterministic prompt order."""
+
+    placeholders = sum(int(token) == image_token_id for token in prompt_tokens)
+    if placeholders != len(images):
+        raise ValueError(
+            f"found {placeholders} DeepSeek image placeholders but received "
+            f"{len(images)} images"
+        )
+    vocab_size = int(config["vocab_size"])
+    tokens: list[int] = []
+    prepared: list[ImageInput] = []
+    image_iterator = iter(images)
+    for token in prompt_tokens:
+        if int(token) != image_token_id:
+            tokens.append(int(token))
+            continue
+        patches, n_vit_h, n_vit_w, n_llm_h, n_llm_w = load_image(
+            next(image_iterator), config
+        )
+        types, permutation = build_image_block(n_llm_h, n_llm_w, len(tokens))
+        prepared.append(
+            ImageInput(
+                start=len(tokens),
+                patches=patches,
+                n_vit_h=n_vit_h,
+                n_vit_w=n_vit_w,
+                types=types,
+                permutation=permutation,
+            )
+        )
+        tokens.extend(vocab_size + kind for kind in types)
+    return tokens, tuple(prepared)

--- a/omlx/patches/deepseek_v4/vision_inputs.py
+++ b/omlx/patches/deepseek_v4/vision_inputs.py
@@ -29,6 +29,9 @@ from omlx.deepseek_v4_vision import (
 
 COMPRESS_PAD_TO = 4
 _MAX_IMAGE_BYTES = 50 * 1024 * 1024
+_MAX_IMAGES_PER_REQUEST = 16
+_MAX_SOURCE_PIXELS = 64 * 1024 * 1024
+_MAX_VISION_PATCHES = 8192
 
 
 @dataclass(frozen=True)
@@ -131,12 +134,12 @@ def _image_bytes(record: Any) -> bytes:
     if isinstance(raw, bytes):
         payload = raw
     elif isinstance(raw, str):
-        payload = base64.b64decode(raw, validate=True)
+        payload = _decode_base64(raw)
     else:
         source = record.get("source")
         if isinstance(source, Mapping):
             if source.get("data") is not None:
-                payload = base64.b64decode(str(source["data"]), validate=True)
+                payload = _decode_base64(str(source["data"]))
             else:
                 record = {"url": source.get("url")}
                 payload = b""
@@ -152,7 +155,7 @@ def _image_bytes(record: Any) -> bytes:
                 header, separator, encoded = url.partition(",")
                 if not separator or ";base64" not in header:
                     raise ValueError("only base64 image data URLs are supported")
-                payload = base64.b64decode(encoded, validate=True)
+                payload = _decode_base64(encoded)
             elif url.startswith(("https://", "http://")):
                 with urlopen(url, timeout=30) as response:  # noqa: S310
                     payload = response.read(_MAX_IMAGE_BYTES + 1)
@@ -163,11 +166,22 @@ def _image_bytes(record: Any) -> bytes:
     return payload
 
 
+def _decode_base64(encoded: str) -> bytes:
+    # Reject before b64decode allocates another large buffer. With validate=True
+    # there is no whitespace to discount, so this is a strict encoded-size cap.
+    max_encoded = 4 * math.ceil(_MAX_IMAGE_BYTES / 3)
+    if len(encoded) > max_encoded:
+        raise ValueError("image payload exceeds 50 MiB")
+    return base64.b64decode(encoded, validate=True)
+
+
 def load_image(record: Any, config: Mapping[str, Any]):
     patch = int(config["vision_patch_size"])
     with Image.open(io.BytesIO(_image_bytes(record))) as source:
+        width, height = source.size
+        if width <= 0 or height <= 0 or width * height > _MAX_SOURCE_PIXELS:
+            raise ValueError("decoded image dimensions exceed the 64 Mi-pixel limit")
         image = source.convert("RGB")
-    width, height = image.size
     max_ratio = int(config.get("vision_max_wh_ratio", 8) or 8)
     if width > height * max_ratio:
         width = height * max_ratio
@@ -188,6 +202,10 @@ def load_image(record: Any, config: Mapping[str, Any]):
         int(config["vision_max_n_token"]),
     )
     n_vit_h, n_vit_w = best_h // patch, best_w // patch
+    if n_vit_h * n_vit_w > _MAX_VISION_PATCHES:
+        raise ValueError(
+            "resized image exceeds the 8192-patch vision-encoder limit"
+        )
     if image.width >= max_ratio * image.height:
         image = image.resize((best_w, best_h))
     else:
@@ -215,6 +233,11 @@ def prepare_token_ids(
         raise ValueError(
             f"found {placeholders} DeepSeek image placeholders but received "
             f"{len(images)} images"
+        )
+    if len(images) > _MAX_IMAGES_PER_REQUEST:
+        raise ValueError(
+            "DeepSeek-V4 Vision accepts at most "
+            f"{_MAX_IMAGES_PER_REQUEST} images per request"
         )
     vocab_size = int(config["vocab_size"])
     tokens: list[int] = []

--- a/omlx/patches/deepseek_v4/vision_model.py
+++ b/omlx/patches/deepseek_v4/vision_model.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Small MLX port of the public DeepSeek-V4 Vision ViT and aligner."""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+def _vision_cos_sin(n_h: int, n_w: int, dim: int, theta: float):
+    inv = 1.0 / (theta ** (mx.arange(0, dim, 2, dtype=mx.float32) / dim))
+    hpos = mx.broadcast_to(mx.arange(n_h)[:, None], (n_h, n_w))
+    wpos = mx.broadcast_to(mx.arange(n_w)[None], (n_h, n_w))
+    positions = mx.stack([hpos, wpos], axis=-1).reshape(-1, 2, 1)
+    frequencies = positions.astype(mx.float32) * inv
+    frequencies = frequencies.reshape(frequencies.shape[0], -1)
+    return mx.cos(frequencies)[:, None], mx.sin(frequencies)[:, None]
+
+
+def _apply_rotary(x: mx.array, cos: mx.array, sin: mx.array) -> mx.array:
+    dtype = x.dtype
+    x = x.astype(mx.float32)
+    first, second = mx.split(x, 2, axis=-1)
+    return mx.concatenate(
+        [first * cos - second * sin, second * cos + first * sin], axis=-1
+    ).astype(dtype)
+
+
+class PatchEmbed(nn.Module):
+    def __init__(self, config):
+        patch = config.vision_patch_size
+        self.proj = nn.Linear(3 * patch * patch, config.vision_dim, bias=True)
+
+    def __call__(self, x):
+        return self.proj(x.reshape(x.shape[0], -1))
+
+
+class Attention(nn.Module):
+    def __init__(self, config):
+        self.n_heads = config.vision_n_heads
+        self.head_dim = config.vision_dim // config.vision_n_heads
+        self.wqkv = nn.Linear(config.vision_dim, 3 * config.vision_dim, bias=True)
+        self.wo = nn.Linear(config.vision_dim, config.vision_dim, bias=True)
+
+    def __call__(self, x, cos, sin):
+        count = x.shape[0]
+        q, k, v = mx.split(
+            self.wqkv(x).reshape(count, self.n_heads, 3 * self.head_dim),
+            3,
+            axis=-1,
+        )
+        q, k = _apply_rotary(q, cos, sin), _apply_rotary(k, cos, sin)
+        q, k, v = (value.transpose(1, 0, 2)[None] for value in (q, k, v))
+        output = mx.fast.scaled_dot_product_attention(
+            q, k, v, scale=self.head_dim**-0.5
+        )
+        return self.wo(output[0].transpose(1, 0, 2).reshape(count, -1))
+
+
+class MLP(nn.Module):
+    def __init__(self, config):
+        self.w1 = nn.Linear(config.vision_dim, 2 * config.vision_inter_dim, bias=False)
+        self.w2 = nn.Linear(config.vision_inter_dim, config.vision_dim, bias=False)
+
+    def __call__(self, x):
+        gate, up = mx.split(self.w1(x), 2, axis=-1)
+        return self.w2(nn.silu(gate) * up)
+
+
+class Block(nn.Module):
+    def __init__(self, config):
+        self.norm1 = nn.RMSNorm(config.vision_dim, eps=1e-6)
+        self.attn = Attention(config)
+        self.norm2 = nn.RMSNorm(config.vision_dim, eps=1e-6)
+        self.mlp = MLP(config)
+
+    def __call__(self, x, cos, sin):
+        x = x + self.attn(self.norm1(x), cos, sin)
+        return x + self.mlp(self.norm2(x))
+
+
+class ViT(nn.Module):
+    """Full bidirectional attention over one image with 2-D RoPE."""
+
+    def __init__(self, config):
+        self.rope_dim = config.vision_dim // config.vision_n_heads // 2
+        self.rope_theta = config.vision_rope_theta
+        self.patch_embed = PatchEmbed(config)
+        self.blocks = [Block(config) for _ in range(config.vision_n_layers)]
+        self.norm = nn.RMSNorm(config.vision_dim, eps=1e-6)
+
+    def __call__(self, patches, n_h: int, n_w: int):
+        x = self.patch_embed(patches)
+        cos, sin = _vision_cos_sin(n_h, n_w, self.rope_dim, self.rope_theta)
+        for block in self.blocks:
+            x = block(x, cos, sin)
+        return self.norm(x)
+
+
+class Aligner(nn.Module):
+    def __init__(self, config):
+        self.downsample_ratio = config.vision_downsample_ratio
+        input_dim = config.vision_dim * self.downsample_ratio**2
+        self.w1 = nn.Linear(input_dim, config.hidden_size, bias=True)
+        self.w2 = nn.Linear(config.hidden_size, config.hidden_size, bias=True)
+
+    def __call__(self, x, n_h: int, n_w: int):
+        ratio = self.downsample_ratio
+        x = x.reshape(n_h, n_w, -1)
+        x = mx.pad(x, ((0, -n_h % ratio), (0, -n_w % ratio), (0, 0)))
+        out_h, out_w = x.shape[0] // ratio, x.shape[1] // ratio
+        x = x.reshape(out_h, ratio, out_w, ratio, x.shape[-1])
+        # Match torch.unfold on channel-first input: C, kernel-H, kernel-W.
+        x = x.transpose(0, 2, 4, 1, 3).reshape(out_h * out_w, -1)
+        return self.w2(nn.gelu(self.w1(x)))

--- a/omlx/patches/deepseek_v4/vision_model.py
+++ b/omlx/patches/deepseek_v4/vision_model.py
@@ -44,10 +44,9 @@ class Attention(nn.Module):
 
     def __call__(self, x, cos, sin):
         count = x.shape[0]
-        q, k, v = mx.split(
-            self.wqkv(x).reshape(count, self.n_heads, 3 * self.head_dim),
-            3,
-            axis=-1,
+        q, k, v = (
+            value.reshape(count, self.n_heads, self.head_dim)
+            for value in mx.split(self.wqkv(x), 3, axis=-1)
         )
         q, k = _apply_rotary(q, cos, sin), _apply_rotary(k, cos, sin)
         q, k, v = (value.transpose(1, 0, 2)[None] for value in (q, k, v))

--- a/omlx/patches/mlx_lm_mtp/deepseek_v4_model.py
+++ b/omlx/patches/mlx_lm_mtp/deepseek_v4_model.py
@@ -185,6 +185,9 @@ def _patch_deepseek_v4_model_call(dsv4: Any) -> None:
     if _is_our_method(cls, "__call__", "_omlx_mtp_call_marker"):
         return
 
+    original_call = getattr(cls, "_omlx_mtp_base_call", cls.__call__)
+    cls._omlx_mtp_base_call = original_call
+
     import mlx.core as mx
     from mlx_lm.models.base import create_attention_mask
 
@@ -197,7 +200,16 @@ def _patch_deepseek_v4_model_call(dsv4: Any) -> None:
         cache=None,
         return_raw_hidden: bool = False,
         return_dspark_hidden: bool = False,
+        *,
+        inputs_embeds=None,
     ):
+        if inputs_embeds is not None:
+            return original_call(
+                self,
+                inputs,
+                cache,
+                inputs_embeds=inputs_embeds,
+            )
         h = self.embed_tokens(inputs)
         h = mx.broadcast_to(
             h[:, :, None, :],
@@ -295,6 +307,8 @@ def _patch_model(dsv4: Any) -> None:
     materialize_cache_arrays = dsv4._materialize_cache_arrays
 
     original_init = cls.__init__
+    original_call = getattr(cls, "_omlx_mtp_base_call", cls.__call__)
+    cls._omlx_mtp_base_call = original_call
 
     def __init__(self, config):
         original_init(self, config)
@@ -352,6 +366,13 @@ def _patch_model(dsv4: Any) -> None:
         n_confirmed: int = 0,
         skip_lm_head: bool = False,
     ):
+        if (
+            getattr(self, "is_vision_model", False)
+            and not getattr(self, "_omlx_mtp_decode_enabled", False)
+            and not return_hidden
+            and not skip_lm_head
+        ):
+            return original_call(self, inputs, cache)
         if skip_lm_head:
             # Chunked prefill discards per-chunk logits (the prompt's final
             # token is scored by the first decode step instead). Run the

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -175,6 +175,7 @@ from .api.utils import (
     prepare_system_messages_for_template,
     uses_native_reasoning_content,
 )
+from .cluster.launch import DistributedLaunchError
 from .engine import BaseEngine, VLMBatchedEngine
 from .engine.distributed import DistributedInferenceError
 from .engine.embedding import EmbeddingEngine
@@ -825,9 +826,10 @@ async def scheduler_queue_full_handler(
     )
 
 
+@app.exception_handler(DistributedLaunchError)
 @app.exception_handler(DistributedInferenceError)
 async def distributed_unavailable_handler(
-    request: FastAPIRequest, exc: DistributedInferenceError
+    request: FastAPIRequest, exc: DistributedInferenceError | DistributedLaunchError
 ):
     """Map a failed distributed cluster check to a clean HTTP 503.
 

--- a/tests/test_cluster_catalogue.py
+++ b/tests/test_cluster_catalogue.py
@@ -100,6 +100,31 @@ def test_context_is_reported_not_just_whether_the_weights_load():
     assert fit.max_context_tokens >= 2048
 
 
+def test_hybrid_vision_cache_reports_memory_supported_multimodal_context():
+    ratios = [0] + [ratio for _ in range(20) for ratio in (128, 4)] + [128, 0]
+    per_token = tuple(0 if ratio == 0 else 320 if ratio == 4 else 8 for ratio in ratios)
+    fixed = tuple(
+        131_072 if ratio == 0 else 172_032 if ratio == 4 else 393_216
+        for ratio in ratios
+    )
+    layout = ModelLayout(
+        source="deepseek-v4-vision",
+        fixed_weight_bytes=0,
+        layer_weight_bytes=(GiB,) * 43,
+        kv_bytes_per_token_by_layer=per_token,
+        kv_fixed_bytes_by_layer=fixed,
+        supports_pipeline=True,
+        supports_chunked_multimodal_prefill=True,
+    )
+
+    fit = assess_model(layout, _nodes(54), model_id="deepseek-v4-vision")
+
+    assert fit.fits
+    assert fit.max_context_tokens == 1_048_576
+    assert fit.max_multimodal_context_tokens == 1_048_576
+    assert fit.to_dict()["max_multimodal_context_tokens"] == 1_048_576
+
+
 def test_a_tighter_cluster_supports_less_context():
     """The same model on less memory must not claim the same context."""
 

--- a/tests/test_cluster_cli.py
+++ b/tests/test_cluster_cli.py
@@ -18,6 +18,7 @@ def test_cluster_help_is_exposed():
     assert "worker-smoke" in result.stdout
     assert "collective-smoke" in result.stdout
     assert "pipeline-smoke" in result.stdout
+    assert "hardware-canary" in result.stdout
     assert "plan" in result.stdout
 
 

--- a/tests/test_cluster_engine_pool.py
+++ b/tests/test_cluster_engine_pool.py
@@ -9,6 +9,7 @@ import pytest
 from omlx.cluster.deployment import ClusterDeployment, ClusterHost
 from omlx.cluster.planner import PipelineAssignment
 from omlx.engine_pool import EngineEntry, EnginePool
+from omlx.exceptions import ModelUnavailableError
 
 
 def _deployment(model_path: str) -> ClusterDeployment:
@@ -36,6 +37,32 @@ def _entry(model_path: str) -> EngineEntry:
         engine_type="batched",
         estimated_size=300,
     )
+
+
+def _vision_entry(model_path) -> EngineEntry:
+    model_path.mkdir()
+    (model_path / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "deepseek_v4",
+                "vision_n_layers": 32,
+                "vision_dim": 1024,
+                "vision_n_heads": 16,
+                "vision_inter_dim": 2816,
+                "vision_patch_size": 14,
+                "vision_rope_theta": 10000.0,
+                "vision_downsample_ratio": 3,
+                "vision_max_n_token": 384,
+                "vision_min_pixels": 147456,
+                "vision_max_wh_ratio": 8,
+            }
+        )
+    )
+    entry = _entry(str(model_path))
+    entry.model_id = "deepseek-v4-vision"
+    entry.model_type = "vlm"
+    entry.engine_type = "vlm"
+    return entry
 
 
 def test_engine_pool_admits_only_rank_zero_resident_weight(tmp_path):
@@ -205,6 +232,71 @@ def test_cluster_model_path_accepts_gated_deepseek_v4_vision(tmp_path):
     assert (
         pool.resolve_cluster_model_id(str(model_path)) == "deepseek-v4-vision"
     )
+
+
+@pytest.mark.parametrize("force_lm", [False, True])
+async def test_gated_vision_deployment_uses_distributed_engine(
+    tmp_path,
+    monkeypatch,
+    force_lm,
+):
+    entry = _vision_entry(tmp_path / "deepseek-v4-vision")
+    deployment = _deployment(entry.model_path)
+    pool = EnginePool()
+    pool._entries[entry.model_id] = entry
+    pool._cluster_registry = SimpleNamespace(
+        get_for_model=lambda model: deployment if model == entry.model_path else None
+    )
+    engine = SimpleNamespace(start=AsyncMock(), stop=AsyncMock())
+    distributed = MagicMock(return_value=engine)
+    local_vlm = MagicMock(side_effect=AssertionError("local VLM load attempted"))
+    local_llm = MagicMock(side_effect=AssertionError("local LLM load attempted"))
+    monkeypatch.setattr(
+        "omlx.engine.distributed.DistributedBatchedEngine", distributed
+    )
+    monkeypatch.setattr("omlx.engine_pool.VLMBatchedEngine", local_vlm)
+    monkeypatch.setattr("omlx.engine_pool.BatchedEngine", local_llm)
+
+    await pool._load_engine(entry.model_id, force_lm=force_lm)
+
+    distributed.assert_called_once()
+    engine.start.assert_awaited_once()
+    assert entry.engine is engine
+    local_vlm.assert_not_called()
+    local_llm.assert_not_called()
+
+
+async def test_failed_gated_vision_deployment_never_falls_back_locally(
+    tmp_path,
+    monkeypatch,
+):
+    entry = _vision_entry(tmp_path / "deepseek-v4-vision")
+    deployment = _deployment(entry.model_path)
+    pool = EnginePool()
+    pool._entries[entry.model_id] = entry
+    pool._cluster_registry = SimpleNamespace(
+        get_for_model=lambda model: deployment if model == entry.model_path else None
+    )
+    engine = SimpleNamespace(
+        start=AsyncMock(side_effect=RuntimeError("rank start failed")),
+        stop=AsyncMock(),
+    )
+    local_vlm = MagicMock(side_effect=AssertionError("local VLM load attempted"))
+    local_llm = MagicMock(side_effect=AssertionError("local LLM load attempted"))
+    monkeypatch.setattr(
+        "omlx.engine.distributed.DistributedBatchedEngine",
+        MagicMock(return_value=engine),
+    )
+    monkeypatch.setattr("omlx.engine_pool.VLMBatchedEngine", local_vlm)
+    monkeypatch.setattr("omlx.engine_pool.BatchedEngine", local_llm)
+    monkeypatch.setattr(pool, "_schedule_failed_load_reclaim", MagicMock())
+
+    with pytest.raises(ModelUnavailableError, match="rank start failed"):
+        await pool._load_engine(entry.model_id)
+
+    assert entry.engine is None
+    local_vlm.assert_not_called()
+    local_llm.assert_not_called()
 
 
 def test_remote_only_cluster_model_gets_a_batched_pool_entry(tmp_path):

--- a/tests/test_cluster_engine_pool.py
+++ b/tests/test_cluster_engine_pool.py
@@ -382,3 +382,45 @@ async def test_failed_distributed_teardown_keeps_supervisor_reachable(tmp_path):
 
     assert entry.engine is engine
     assert pool.current_model_memory == 90
+
+
+async def test_quarantined_lease_release_preserves_error_and_pending_retry(tmp_path):
+    from omlx.cluster.launch import DistributedMemoryRecoveryError
+
+    pool = EnginePool()
+    model_path = str(tmp_path / "nemotron")
+    entry = _entry(model_path)
+    stop = AsyncMock(side_effect=DistributedMemoryRecoveryError("retained memory"))
+    engine = SimpleNamespace(deployment=_deployment(model_path), stop=stop)
+    entry.engine = engine
+    entry.in_use = 1
+    entry.is_pinned = True
+    entry.pending_unload_reason = "manual unload"
+    entry.pending_unload_allow_pinned = True
+    entry.abort_requested = True
+    pool._entries[entry.model_id] = entry
+    pool._current_model_memory = 90
+
+    # The cleanup in a request's finally block must not mask the real failure.
+    with pytest.raises(ValueError, match="original request failure"):
+        try:
+            raise ValueError("original request failure")
+        finally:
+            await pool.release_engine(entry.model_id)
+
+    assert entry.in_use == 0
+    assert entry.engine is engine
+    assert pool.current_model_memory == 90
+    assert entry.pending_unload_reason == "manual unload"
+    assert entry.pending_unload_allow_pinned is True
+    assert entry.abort_requested is True
+
+    # Once recovery succeeds, retry really removes the engine and accounting.
+    stop.side_effect = None
+    async with pool._lock:
+        assert await pool._unload_pending_if_idle_locked(entry.model_id)
+    assert entry.engine is None
+    assert pool.current_model_memory == 0
+    assert entry.pending_unload_reason is None
+    assert entry.pending_unload_allow_pinned is False
+    assert entry.abort_requested is False

--- a/tests/test_cluster_engine_pool.py
+++ b/tests/test_cluster_engine_pool.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -173,6 +174,37 @@ def test_cluster_model_path_rejects_non_text_model(tmp_path):
 
     with pytest.raises(ValueError, match="text LLM models only"):
         pool.resolve_cluster_model_id(str(model_path))
+
+
+def test_cluster_model_path_accepts_gated_deepseek_v4_vision(tmp_path):
+    model_path = tmp_path / "deepseek-v4-vision"
+    model_path.mkdir()
+    (model_path / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "deepseek_v4",
+                "vision_n_layers": 32,
+                "vision_dim": 1024,
+                "vision_n_heads": 16,
+                "vision_inter_dim": 2816,
+                "vision_patch_size": 14,
+                "vision_rope_theta": 10000.0,
+                "vision_downsample_ratio": 3,
+                "vision_max_n_token": 384,
+                "vision_min_pixels": 147456,
+                "vision_max_wh_ratio": 8,
+            }
+        )
+    )
+    pool = EnginePool()
+    entry = _entry(str(model_path))
+    entry.model_type = "vlm"
+    entry.engine_type = "vlm"
+    pool._entries["deepseek-v4-vision"] = entry
+
+    assert (
+        pool.resolve_cluster_model_id(str(model_path)) == "deepseek-v4-vision"
+    )
 
 
 def test_remote_only_cluster_model_gets_a_batched_pool_entry(tmp_path):

--- a/tests/test_cluster_hardware_canary.py
+++ b/tests/test_cluster_hardware_canary.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit coverage for the opt-in Apple-silicon hardware canary."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from omlx.cluster import hardware_canary
+
+
+def test_hardware_canary_composes_all_five_checks(monkeypatch):
+    monkeypatch.setattr(hardware_canary, "_require_metal", lambda: object())
+    worker = Mock(return_value={"ok": True})
+    collective = Mock(return_value={"ok": True})
+    pipeline = Mock(return_value={"ok": True})
+    vision = Mock(return_value={"ok": True})
+    crash = Mock(return_value={"ok": True})
+
+    result = hardware_canary.run_local_hardware_canary(
+        timeout=12,
+        allocation_mib=64,
+        worker_runner=worker,
+        collective_runner=collective,
+        pipeline_runner=pipeline,
+        vision_runner=vision,
+        crash_runner=crash,
+    )
+
+    assert result["ok"] is True
+    assert set(result["checks"]) == {
+        "worker",
+        "collective",
+        "pipeline",
+        "vision_prefill",
+        "crash_recovery",
+    }
+    worker.assert_called_once_with(timeout=5.0)
+    collective.assert_called_once_with(timeout=12)
+    pipeline.assert_called_once_with(timeout=12)
+    vision.assert_called_once_with()
+    crash.assert_called_once_with(allocation_mib=64, timeout=12)
+
+
+def test_hardware_canary_rejects_unsafe_allocation_before_running_checks(monkeypatch):
+    require_metal = Mock()
+    monkeypatch.setattr(hardware_canary, "_require_metal", require_metal)
+
+    with pytest.raises(ValueError, match="between 16 and 512"):
+        hardware_canary.run_local_hardware_canary(allocation_mib=15)
+
+    require_metal.assert_not_called()
+
+
+@pytest.mark.parametrize("allocation_mib", [0, 15, 513])
+def test_crash_canary_rejects_unsafe_allocation_sizes(monkeypatch, allocation_mib):
+    monkeypatch.setattr(hardware_canary, "_require_metal", lambda: object())
+
+    with pytest.raises(ValueError, match="between 16 and 512"):
+        hardware_canary._crash_recovery_canary(
+            allocation_mib=allocation_mib,
+            timeout=1,
+        )
+
+
+def test_canary_deployment_is_small_and_loopback_only():
+    deployment = hardware_canary._canary_deployment()
+
+    assert deployment.world_size == 2
+    assert {host.ssh for host in deployment.hosts} == {"127.0.0.1"}
+    assert (
+        max(item.planned_weight_bytes for item in deployment.assignments) < 16 * 1024**2
+    )

--- a/tests/test_cluster_inference_worker.py
+++ b/tests/test_cluster_inference_worker.py
@@ -509,10 +509,10 @@ def _staged_model(assignment) -> Any:
     )
 
 
-def _worker_argv(tmp_path, *, extra=()):
+def _worker_argv(tmp_path, *, extra=(), model="org/model"):
     return [
         "--model",
-        "org/model",
+        str(model),
         "--backend",
         "ring",
         "--port",
@@ -541,6 +541,7 @@ def _run_rank(
     ceiling: int = 107 * GiB,
     wired_result=(0, None),
     assignment_honored: bool = False,
+    vision: bool = False,
 ):
     """Drive ``run_worker`` through its real argv, recording what it did.
 
@@ -570,6 +571,7 @@ def _run_rank(
         "build_guard_kwargs": None,
         "marker_while_serving": None,
         "pin_at_load": None,
+        "runtime_contexts": [],
     }
 
     # --- process boundaries: never reached in a test -----------------------
@@ -677,7 +679,11 @@ def _run_rank(
 
     @contextlib.contextmanager
     def fake_telemetry(_marker, **_kwargs):
-        yield SimpleNamespace()
+        record["runtime_contexts"].append("telemetry_enter")
+        try:
+            yield SimpleNamespace()
+        finally:
+            record["runtime_contexts"].append("telemetry_exit")
 
     monkeypatch.setattr(inference_worker, "install_server_telemetry", fake_telemetry)
 
@@ -686,6 +692,22 @@ def _run_rank(
         return SimpleNamespace(active=False)
 
     monkeypatch.setattr(inference_worker, "build_guard", fake_build_guard)
+
+    from omlx.cluster import deepseek_v4_vision_runtime
+
+    @contextlib.contextmanager
+    def fake_vision_runtime(*_args, **_kwargs):
+        record["runtime_contexts"].append("vision_enter")
+        try:
+            yield None
+        finally:
+            record["runtime_contexts"].append("vision_exit")
+
+    monkeypatch.setattr(
+        deepseek_v4_vision_runtime,
+        "install_deepseek_v4_vision_runtime",
+        fake_vision_runtime,
+    )
 
     class SpyWatchdog:
         def __init__(self, hosts_by_rank, **kwargs):
@@ -700,12 +722,48 @@ def _run_rank(
 
     pipeline_patch.clear_assigned_stage()
     try:
-        args = build_parser().parse_args(_worker_argv(tmp_path, extra=argv_extra))
+        model = "org/model"
+        if vision:
+            model = tmp_path / "vision-model"
+            model.mkdir()
+            (model / "config.json").write_text(
+                json.dumps(
+                    {
+                        "model_type": "deepseek_v4",
+                        "vision_n_layers": 2,
+                        "vision_dim": 8,
+                        "vision_n_heads": 2,
+                        "vision_inter_dim": 16,
+                        "vision_patch_size": 2,
+                        "vision_rope_theta": 10_000.0,
+                        "vision_downsample_ratio": 2,
+                        "vision_max_n_token": 32,
+                        "vision_min_pixels": 16,
+                        "vision_max_wh_ratio": 8,
+                    }
+                )
+            )
+        args = build_parser().parse_args(
+            _worker_argv(tmp_path, extra=argv_extra, model=model)
+        )
         record["exit_code"] = inference_worker.run_worker(args)
         record["pin_after"] = pipeline_patch.assigned_stage()
     finally:
         pipeline_patch.clear_assigned_stage()
     return record
+
+
+def test_vision_runtime_enters_before_telemetry_and_exits_after_it(
+    monkeypatch, tmp_path
+):
+    record = _run_rank(monkeypatch, tmp_path, vision=True)
+
+    assert record["runtime_contexts"] == [
+        "vision_enter",
+        "telemetry_enter",
+        "telemetry_exit",
+        "vision_exit",
+    ]
 
 
 def test_worker_refuses_excess_resident_weights_before_ready(monkeypatch, tmp_path):

--- a/tests/test_cluster_inference_worker.py
+++ b/tests/test_cluster_inference_worker.py
@@ -542,6 +542,7 @@ def _run_rank(
     wired_result=(0, None),
     assignment_honored: bool = False,
     vision: bool = False,
+    interrupt_serving: bool = False,
 ):
     """Drive ``run_worker`` through its real argv, recording what it did.
 
@@ -629,6 +630,8 @@ def _run_rank(
         record["serve_address"] = (host, port)
         written = list(tmp_path.glob("*.json"))
         record["marker_while_serving"] = json.loads(written[0].read_text())
+        if interrupt_serving:
+            raise KeyboardInterrupt
 
     monkeypatch.setattr(mlx_server, "ModelProvider", FakeProvider)
     monkeypatch.setattr(mlx_server, "run", fake_run)
@@ -1168,6 +1171,24 @@ def test_the_marker_is_removed_when_the_rank_exits_cleanly(monkeypatch, tmp_path
     _run_rank(monkeypatch, tmp_path, rank=0)
 
     assert list(tmp_path.glob("*.json")) == []
+
+
+def test_supervisor_signal_leaves_terminal_marker_for_reap_verification(
+    monkeypatch, tmp_path
+):
+    record = _run_rank(
+        monkeypatch,
+        tmp_path,
+        rank=0,
+        interrupt_serving=True,
+    )
+
+    assert record["exit_code"] == 0
+    markers = list(tmp_path.glob("*.json"))
+    assert len(markers) == 1
+    marker = json.loads(markers[0].read_text())
+    assert marker["phase"] == "stopped"
+    assert marker["stop_reason"] == "signal"
 
 
 class _ThinkTokenizer:

--- a/tests/test_cluster_launch.py
+++ b/tests/test_cluster_launch.py
@@ -3,6 +3,7 @@
 import io
 import json
 import platform
+import shlex
 import signal
 import stat
 import subprocess
@@ -406,6 +407,10 @@ def test_remote_preflight_uses_prompt_free_noninteractive_ssh():
     assert "from omlx._version import __version__" in argv[-1]
     assert "package_version(n)" in argv[-1]
     assert "import omlx.adapter.output_parser" in argv[-1]
+    remote_argv = shlex.split(argv[-1])
+    assert remote_argv[-5:] == ["org/model", "0", "3", "1", "balanced"]
+    assert "rank=int(sys.argv[4])" in remote_argv[2]
+    assert "ceiling_breakdown(sys.argv[5])" in remote_argv[2]
     assert kwargs["timeout"] == 8.0
     assert kwargs["check"] is False
 
@@ -549,13 +554,19 @@ def test_remote_preflight_requires_matching_model_identity(
 ):
     model = tmp_path / "nemotron"
     model.mkdir()
+    validated_ranks = []
+
+    def validate(_path, _start, _end, *, rank):
+        validated_ranks.append(rank)
+        return {
+            "model_identity": "local",
+            "stage_ready": True,
+        }
+
     monkeypatch.setattr(
         launch,
         "validate_staged_model",
-        lambda path, start, end: {
-            "model_identity": "local",
-            "stage_ready": True,
-        },
+        validate,
     )
     versions = _local_runtime_versions() | {
         "cluster-protocol": CLUSTER_PROTOCOL_VERSION,
@@ -579,6 +590,7 @@ def test_remote_preflight_requires_matching_model_identity(
             python_executable="/opt/omlx/bin/python",
             runner=runner,
         )
+    assert validated_ranks == [0]
 
 
 def test_remote_preflight_rejects_an_incomplete_rank_stage(
@@ -590,7 +602,7 @@ def test_remote_preflight_rejects_an_incomplete_rank_stage(
     monkeypatch.setattr(
         launch,
         "validate_staged_model",
-        lambda path, start, end: {
+        lambda path, start, end, *, rank: {
             "model_identity": "same",
             "stage_ready": True,
         },

--- a/tests/test_cluster_launch.py
+++ b/tests/test_cluster_launch.py
@@ -314,7 +314,7 @@ def test_supervisor_stop_kills_rank_left_after_launcher_exits(monkeypatch):
         "killpg",
         lambda pgid, sig: signals.append((pgid, sig)),
     )
-    monkeypatch.setattr(supervisor, "_reap_remote_ranks", lambda: [])
+    monkeypatch.setattr(supervisor, "_reap_remote_ranks", lambda **_kwargs: [])
     monkeypatch.setattr(supervisor, "_wait_for_memory_recovery", lambda: None)
 
     supervisor.stop()
@@ -356,13 +356,86 @@ def test_supervisor_stop_reaps_group_when_launcher_already_exited(monkeypatch):
         "killpg",
         lambda pgid, sig: signals.append((pgid, sig)),
     )
-    monkeypatch.setattr(supervisor, "_reap_remote_ranks", lambda: [])
+    monkeypatch.setattr(supervisor, "_reap_remote_ranks", lambda **_kwargs: [])
     monkeypatch.setattr(supervisor, "_wait_for_memory_recovery", lambda: None)
 
     supervisor.stop()
 
     assert signals == [(43211, signal.SIGTERM)]
     assert supervisor.process is None
+
+
+def test_supervisor_signals_remote_rank_before_waiting_for_local_group(monkeypatch):
+    class Launcher:
+        pid = 43214
+        stdout = None
+        stderr = None
+        returncode = None
+
+        def poll(self):
+            return self.returncode
+
+        def wait(self, timeout):
+            events.append(("launcher-wait", timeout))
+            self.returncode = 0
+            return 0
+
+    supervisor = launch.DistributedJobSupervisor(
+        _deployment(),
+        preflight=False,
+        stop_timeout=0.1,
+    )
+    supervisor.process = Launcher()
+    events = []
+
+    monkeypatch.setattr(launch, "_process_group_alive", lambda _pgid: True)
+    monkeypatch.setattr(
+        launch,
+        "_wait_for_process_group_exit",
+        lambda _pgid, _timeout: True,
+    )
+    monkeypatch.setattr(
+        launch.os,
+        "killpg",
+        lambda _pgid, sig: events.append(("local-signal", sig)),
+    )
+
+    def reap(**kwargs):
+        events.append(("remote-reap", kwargs))
+        return []
+
+    monkeypatch.setattr(supervisor, "_reap_remote_ranks", reap)
+    monkeypatch.setattr(supervisor, "_wait_for_memory_recovery", lambda: None)
+
+    supervisor.stop()
+
+    assert events[0] == ("local-signal", signal.SIGTERM)
+    assert events[1] == ("remote-reap", {"signal_only": True})
+    assert events[2][0] == "launcher-wait"
+    assert events[-1][0] == "remote-reap"
+    assert 0 < events[-1][1]["graceful_timeout"] <= supervisor.stop_timeout
+
+
+def test_supervisor_retry_gives_remote_rank_grace_without_local_group(monkeypatch):
+    supervisor = launch.DistributedJobSupervisor(
+        _deployment(),
+        preflight=False,
+        stop_timeout=0.1,
+    )
+    supervisor._teardown_incomplete = True
+    supervisor._pending_process_group = None
+    calls = []
+    monkeypatch.setattr(
+        supervisor,
+        "_reap_remote_ranks",
+        lambda **kwargs: calls.append(kwargs) or [],
+    )
+
+    supervisor.stop()
+
+    assert calls[0] == {"signal_only": True}
+    assert 0 < calls[1]["graceful_timeout"] <= supervisor.stop_timeout
+    assert supervisor.status().phase == "stopped"
 
 
 def test_supervisor_refuses_clean_teardown_when_rank_group_survives(
@@ -389,7 +462,7 @@ def test_supervisor_refuses_clean_teardown_when_rank_group_survives(
         launch, "_wait_for_process_group_exit", lambda _pgid, _timeout: False
     )
     monkeypatch.setattr(launch.os, "killpg", lambda _pgid, _sig: None)
-    monkeypatch.setattr(supervisor, "_reap_remote_ranks", lambda: [])
+    monkeypatch.setattr(supervisor, "_reap_remote_ranks", lambda **_kwargs: [])
 
     with pytest.raises(DistributedLaunchError, match="survived SIGKILL"):
         supervisor.stop()
@@ -402,6 +475,45 @@ def test_supervisor_refuses_clean_teardown_when_rank_group_survives(
     )
     with pytest.raises(DistributedLaunchError, match="not confirmed dead"):
         recreated._check_recovery_quarantine()
+
+
+def test_supervisor_refuses_clean_teardown_when_remote_pid_identity_changed(
+    monkeypatch, tmp_path
+):
+    class Launcher:
+        pid = 43215
+        stdout = None
+        stderr = None
+        returncode = 0
+
+        def poll(self):
+            return self.returncode
+
+    supervisor = launch.DistributedJobSupervisor(
+        _deployment(),
+        preflight=False,
+        stop_timeout=0.1,
+        state_dir=str(tmp_path),
+    )
+    supervisor.process = Launcher()
+    monkeypatch.setattr(launch, "_process_group_alive", lambda _pgid: False)
+    monkeypatch.setattr(
+        launch,
+        "_wait_for_process_group_exit",
+        lambda _pgid, _timeout: True,
+    )
+    monkeypatch.setattr(
+        supervisor,
+        "_reap_remote_ranks",
+        lambda **_kwargs: [
+            {"rank": 1, "host": "studio.local", "action": "pid-reused"}
+        ],
+    )
+
+    with pytest.raises(DistributedLaunchError, match="pid-reused"):
+        supervisor.stop()
+
+    assert supervisor._recovery_marker_path().is_file()
 
 
 def test_supervisor_reaps_sigkilled_group_leader_before_liveness_recheck(
@@ -439,7 +551,7 @@ def test_supervisor_reaps_sigkilled_group_leader_before_liveness_recheck(
         lambda _pgid, _timeout: launcher.returncode is not None,
     )
     monkeypatch.setattr(launch.os, "killpg", lambda _pgid, _sig: None)
-    monkeypatch.setattr(supervisor, "_reap_remote_ranks", lambda: [])
+    monkeypatch.setattr(supervisor, "_reap_remote_ranks", lambda **_kwargs: [])
     monkeypatch.setattr(supervisor, "_wait_for_memory_recovery", lambda: None)
 
     supervisor.stop()
@@ -508,6 +620,52 @@ def test_recovery_requires_prelaunch_ceiling_not_merely_plan_fit(monkeypatch):
 
     assert reason is not None
     assert "recovered only 95.0 GiB of its 100.0 GiB pre-launch ceiling" in reason
+
+
+def test_recovery_quarantine_survives_marker_write_failure(monkeypatch, tmp_path):
+    supervisor = launch.DistributedJobSupervisor(
+        _deployment(), preflight=False, state_dir=str(tmp_path), recovery_timeout=0
+    )
+    monkeypatch.setattr(
+        supervisor,
+        "_probe_recovery_capacity",
+        lambda: [
+            {"rank": 0, "admission_ceiling_bytes": 1},
+            {"rank": 1, "admission_ceiling_bytes": 1},
+        ],
+    )
+    monkeypatch.setattr(supervisor, "_write_recovery_quarantine", lambda _reason: None)
+
+    with pytest.raises(DistributedMemoryRecoveryError):
+        supervisor._wait_for_memory_recovery()
+
+    assert not supervisor._recovery_marker_path().exists()
+    with pytest.raises(DistributedMemoryRecoveryError, match="quarantined"):
+        supervisor._check_recovery_quarantine()
+
+
+def test_repeated_stop_rechecks_in_memory_recovery_quarantine(monkeypatch, tmp_path):
+    supervisor = launch.DistributedJobSupervisor(
+        _deployment(), preflight=False, state_dir=str(tmp_path)
+    )
+    supervisor._recovery_required_reason = "accelerator memory is still retained"
+    recovery_checks = []
+    remote_reaps = []
+    monkeypatch.setattr(
+        supervisor,
+        "_reap_remote_ranks",
+        lambda **kwargs: remote_reaps.append(kwargs) or [],
+    )
+    monkeypatch.setattr(
+        supervisor,
+        "_wait_for_memory_recovery",
+        lambda: recovery_checks.append(True),
+    )
+
+    supervisor.stop()
+
+    assert recovery_checks == [True]
+    assert remote_reaps == []
 
 
 def test_remote_preflight_uses_prompt_free_noninteractive_ssh():

--- a/tests/test_cluster_launch.py
+++ b/tests/test_cluster_launch.py
@@ -18,6 +18,7 @@ from omlx.cluster.deployment import ClusterDeployment, ClusterHost
 from omlx.cluster.launch import (
     CudaFabricProbeHost,
     DistributedLaunchError,
+    DistributedMemoryRecoveryError,
     _available_launch_ports,
     _cluster_ssh_argv,
     _install_cluster_ssh_wrapper,
@@ -313,6 +314,8 @@ def test_supervisor_stop_kills_rank_left_after_launcher_exits(monkeypatch):
         "killpg",
         lambda pgid, sig: signals.append((pgid, sig)),
     )
+    monkeypatch.setattr(supervisor, "_reap_remote_ranks", lambda: [])
+    monkeypatch.setattr(supervisor, "_wait_for_memory_recovery", lambda: None)
 
     supervisor.stop()
 
@@ -353,11 +356,114 @@ def test_supervisor_stop_reaps_group_when_launcher_already_exited(monkeypatch):
         "killpg",
         lambda pgid, sig: signals.append((pgid, sig)),
     )
+    monkeypatch.setattr(supervisor, "_reap_remote_ranks", lambda: [])
+    monkeypatch.setattr(supervisor, "_wait_for_memory_recovery", lambda: None)
 
     supervisor.stop()
 
     assert signals == [(43211, signal.SIGTERM)]
     assert supervisor.process is None
+
+
+def test_supervisor_refuses_clean_teardown_when_rank_group_survives(
+    monkeypatch, tmp_path
+):
+    class Launcher:
+        pid = 43212
+        stdout = None
+        stderr = None
+        returncode = 0
+
+        def poll(self):
+            return self.returncode
+
+    supervisor = launch.DistributedJobSupervisor(
+        _deployment(),
+        preflight=False,
+        stop_timeout=0.1,
+        state_dir=str(tmp_path),
+    )
+    supervisor.process = Launcher()
+    monkeypatch.setattr(launch, "_process_group_alive", lambda _pgid: True)
+    monkeypatch.setattr(
+        launch, "_wait_for_process_group_exit", lambda _pgid, _timeout: False
+    )
+    monkeypatch.setattr(launch.os, "killpg", lambda _pgid, _sig: None)
+    monkeypatch.setattr(supervisor, "_reap_remote_ranks", lambda: [])
+
+    with pytest.raises(DistributedLaunchError, match="survived SIGKILL"):
+        supervisor.stop()
+
+    assert supervisor.process is None
+    assert supervisor._recovery_marker_path().is_file()
+
+    recreated = launch.DistributedJobSupervisor(
+        _deployment(), preflight=False, state_dir=str(tmp_path)
+    )
+    with pytest.raises(DistributedLaunchError, match="not confirmed dead"):
+        recreated._check_recovery_quarantine()
+
+
+def test_supervisor_quarantines_reload_until_live_capacity_recovers(
+    monkeypatch, tmp_path
+):
+    supervisor = launch.DistributedJobSupervisor(
+        _deployment(),
+        preflight=False,
+        state_dir=str(tmp_path),
+        recovery_timeout=0,
+    )
+    monkeypatch.setattr(
+        supervisor,
+        "_probe_recovery_capacity",
+        lambda: [
+            {"rank": 0, "admission_ceiling_bytes": 1},
+            {"rank": 1, "admission_ceiling_bytes": 1},
+        ],
+    )
+
+    with pytest.raises(DistributedMemoryRecoveryError, match="quarantined"):
+        supervisor._wait_for_memory_recovery()
+
+    marker = supervisor._recovery_marker_path()
+    assert marker.is_file()
+
+    recreated = launch.DistributedJobSupervisor(
+        _deployment(), preflight=False, state_dir=str(tmp_path)
+    )
+    monkeypatch.setattr(
+        recreated,
+        "_probe_recovery_capacity",
+        lambda: [
+            {"rank": 0, "admission_ceiling_bytes": 1024},
+            {"rank": 1, "admission_ceiling_bytes": 1024},
+        ],
+    )
+
+    recreated._check_recovery_quarantine()
+
+    assert not marker.exists()
+
+
+def test_recovery_requires_prelaunch_ceiling_not_merely_plan_fit(monkeypatch):
+    gib = 1024**3
+    supervisor = launch.DistributedJobSupervisor(
+        _deployment(), preflight=False, recovery_timeout=0
+    )
+    supervisor._recovery_baseline_by_rank = {0: 100 * gib, 1: 100 * gib}
+    monkeypatch.setattr(
+        supervisor,
+        "_probe_recovery_capacity",
+        lambda: [
+            {"rank": 0, "admission_ceiling_bytes": 95 * gib},
+            {"rank": 1, "admission_ceiling_bytes": 100 * gib},
+        ],
+    )
+
+    reason = supervisor._recovery_failure()
+
+    assert reason is not None
+    assert "recovered only 95.0 GiB of its 100.0 GiB pre-launch ceiling" in reason
 
 
 def test_remote_preflight_uses_prompt_free_noninteractive_ssh():

--- a/tests/test_cluster_launch.py
+++ b/tests/test_cluster_launch.py
@@ -404,6 +404,50 @@ def test_supervisor_refuses_clean_teardown_when_rank_group_survives(
         recreated._check_recovery_quarantine()
 
 
+def test_supervisor_reaps_sigkilled_group_leader_before_liveness_recheck(
+    monkeypatch, tmp_path
+):
+    class Launcher:
+        pid = 43213
+        stdout = None
+        stderr = None
+        returncode = None
+        wait_calls = 0
+
+        def poll(self):
+            return self.returncode
+
+        def wait(self, timeout):
+            self.wait_calls += 1
+            if self.wait_calls == 1:
+                raise subprocess.TimeoutExpired("launcher", timeout)
+            self.returncode = -signal.SIGKILL
+            return self.returncode
+
+    launcher = Launcher()
+    supervisor = launch.DistributedJobSupervisor(
+        _deployment(),
+        preflight=False,
+        stop_timeout=0.1,
+        state_dir=str(tmp_path),
+    )
+    supervisor.process = launcher
+    monkeypatch.setattr(launch, "_process_group_alive", lambda _pgid: True)
+    monkeypatch.setattr(
+        launch,
+        "_wait_for_process_group_exit",
+        lambda _pgid, _timeout: launcher.returncode is not None,
+    )
+    monkeypatch.setattr(launch.os, "killpg", lambda _pgid, _sig: None)
+    monkeypatch.setattr(supervisor, "_reap_remote_ranks", lambda: [])
+    monkeypatch.setattr(supervisor, "_wait_for_memory_recovery", lambda: None)
+
+    supervisor.stop()
+
+    assert launcher.returncode == -signal.SIGKILL
+    assert not supervisor._recovery_marker_path().exists()
+
+
 def test_supervisor_quarantines_reload_until_live_capacity_recovers(
     monkeypatch, tmp_path
 ):

--- a/tests/test_cluster_planner.py
+++ b/tests/test_cluster_planner.py
@@ -54,6 +54,57 @@ def test_inspect_safetensors_layout_reads_headers_without_loading_tensors(tmp_pa
     assert layout.tensor_count == 5
 
 
+def test_deepseek_v4_vision_layout_charges_sidecar_only_to_rank_zero(tmp_path):
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "deepseek_v4",
+                "num_hidden_layers": 4,
+                "vision_n_layers": 2,
+                "vision_dim": 8,
+                "vision_n_heads": 2,
+                "vision_inter_dim": 16,
+                "vision_patch_size": 2,
+                "vision_rope_theta": 10000.0,
+                "vision_downsample_ratio": 2,
+                "vision_max_n_token": 16,
+                "vision_min_pixels": 16,
+                "vision_max_wh_ratio": 8,
+            }
+        )
+    )
+    _write_safetensors(
+        tmp_path / "model.safetensors",
+        [
+            ("embed.weight", 20),
+            ("vision.patch_embed.proj.weight", 50),
+            ("vision.blocks.0.attn.wqkv.weight", 70),
+            ("aligner.w1.weight", 30),
+            ("image_start", 10),
+            *((f"layers.{index}.weight", 100) for index in range(4)),
+        ],
+    )
+
+    layout = inspect_safetensors_layout(tmp_path)
+    assert layout.fixed_weight_bytes == 20
+    assert layout.coordinator_weight_bytes == 160
+    assert layout.layer_weight_bytes == (100, 100, 100, 100)
+
+    plan = plan_unequal_pipeline(
+        layout,
+        [
+            NodeBudget(node_id="coordinator", capacity_bytes=480, rank=0),
+            NodeBudget(node_id="worker", capacity_bytes=480, rank=1),
+        ],
+        context_tokens=0,
+    )
+    coordinator, worker = plan.assignments
+    assert coordinator.coordinator_weight_bytes == 160
+    assert worker.coordinator_weight_bytes == 0
+    assert coordinator.layer_count < worker.layer_count
+    assert plan.cluster_resident_weight_bytes == 600
+
+
 def test_inspect_safetensors_layout_rejects_offset_past_file(tmp_path):
     header = {
         "model.layers.0.weight": {
@@ -489,7 +540,7 @@ def test_a_misspelled_role_is_refused_rather_than_quietly_made_headless():
         )
     # Case and padding are the UI's business, not a reason to refuse a launch.
     assert NodeBudget(
-        node_id="macbook", capacity_bytes=100 * GIB, role=" WorkStation "
+            node_id="macbook", capacity_bytes=100 * GIB, role=" WorkStation "
     ).role == "workstation"
 
 

--- a/tests/test_cluster_planner.py
+++ b/tests/test_cluster_planner.py
@@ -70,6 +70,12 @@ def test_deepseek_v4_vision_layout_charges_sidecar_only_to_rank_zero(tmp_path):
                 "vision_max_n_token": 16,
                 "vision_min_pixels": 16,
                 "vision_max_wh_ratio": 8,
+                "num_attention_heads": 64,
+                "num_key_value_heads": 1,
+                "head_dim": 512,
+                "sliding_window": 128,
+                "index_head_dim": 128,
+                "compress_ratios": [0, 4, 128, 4],
             }
         )
     )
@@ -89,6 +95,15 @@ def test_deepseek_v4_vision_layout_charges_sidecar_only_to_rank_zero(tmp_path):
     assert layout.fixed_weight_bytes == 20
     assert layout.coordinator_weight_bytes == 160
     assert layout.layer_weight_bytes == (100, 100, 100, 100)
+    assert layout.kv_bytes_per_token_by_layer == (0, 320, 8, 320)
+    assert layout.kv_fixed_bytes_by_layer == (
+        131_072,
+        172_032,
+        393_216,
+        172_032,
+    )
+    assert layout.supports_chunked_multimodal_prefill is True
+    assert ModelLayout.from_dict(layout.to_dict()) == layout
 
     plan = plan_unequal_pipeline(
         layout,
@@ -103,6 +118,48 @@ def test_deepseek_v4_vision_layout_charges_sidecar_only_to_rank_zero(tmp_path):
     assert worker.coordinator_weight_bytes == 0
     assert coordinator.layer_count < worker.layer_count
     assert plan.cluster_resident_weight_bytes == 600
+
+
+def test_deepseek_v4_hybrid_kv_layout_supports_one_million_tokens():
+    from omlx.cluster.planner import _deepseek_v4_kv_layout
+
+    ratios = [0] + [ratio for _ in range(20) for ratio in (128, 4)] + [128, 0]
+    per_token, fixed = _deepseek_v4_kv_layout(
+        {
+            "model_type": "deepseek_v4",
+            "num_hidden_layers": 43,
+            "head_dim": 512,
+            "sliding_window": 128,
+            "index_head_dim": 128,
+            "compress_ratios": ratios,
+        }
+    )
+
+    assert len(per_token) == len(fixed) == 43
+    assert per_token.count(320) == 20
+    assert per_token.count(8) == 21
+    assert per_token.count(0) == 2
+    assert sum(per_token) == 6_568
+
+    model = ModelLayout(
+        source="deepseek-v4",
+        fixed_weight_bytes=0,
+        layer_weight_bytes=(GIB,) * 43,
+        kv_bytes_per_token_by_layer=per_token,
+        kv_fixed_bytes_by_layer=fixed,
+        supports_pipeline=True,
+        supports_chunked_multimodal_prefill=True,
+    )
+    plan = plan_unequal_pipeline(
+        model,
+        [NodeBudget(node_id="mac", capacity_bytes=50 * GIB, rank=0)],
+        context_tokens=1_000_000,
+    )
+
+    assignment = plan.assignments[0]
+    assert assignment.kv_bytes_per_token == 6_568
+    assert assignment.kv_cache_bytes == sum(fixed) + 6_568_000_000
+    assert assignment.headroom_bytes > 0
 
 
 def test_inspect_safetensors_layout_rejects_offset_past_file(tmp_path):

--- a/tests/test_cluster_prefill_guard.py
+++ b/tests/test_cluster_prefill_guard.py
@@ -94,6 +94,30 @@ def test_cached_tokens_are_not_charged_twice():
     guard.check(150_000, cached_tokens=149_000, current_usage_bytes=4 * GiB)
 
 
+def test_request_prefill_step_override_sizes_peak_without_mutating_guard():
+    tokens = 120_000
+    usage = 2 * GiB
+    monitor = rank_monitor(_Model(), layer_count=16)
+    configured_peak = monitor.estimate_prefill_peak_bytes(tokens, 2048)
+    request_peak = monitor.estimate_prefill_peak_bytes(tokens, 16_384)
+    assert configured_peak < request_peak
+    guard = RankPrefillGuard(
+        monitor,
+        ceiling_bytes=int(usage + (configured_peak + request_peak) / 2),
+        prefill_step_size=2048,
+    )
+
+    guard.check(tokens, current_usage_bytes=usage)
+    with pytest.raises(PrefillMemoryExceededError):
+        guard.check(
+            tokens,
+            current_usage_bytes=usage,
+            prefill_step_size=16_384,
+        )
+
+    assert guard._step == 2048
+
+
 # --- The desync rule: all ranks vote and leave the request together. ---------
 
 

--- a/tests/test_cluster_prefill_guard.py
+++ b/tests/test_cluster_prefill_guard.py
@@ -208,6 +208,7 @@ class _CollectiveMX:
     def __init__(self, *, rank, votes):
         self._rank = rank
         self._votes = votes
+        self.last_vote = None
         self.distributed = self
 
     def init(self):
@@ -222,7 +223,8 @@ class _CollectiveMX:
     def array(self, value):
         return value
 
-    def all_sum(self, _value):
+    def all_sum(self, value):
+        self.last_vote = value
         return _CollectiveValue(self._votes)
 
 
@@ -247,6 +249,20 @@ def test_collective_admission_allows_every_rank_to_continue():
         current_usage_bytes=1 * GiB,
         mx_module=mx,
     )
+
+
+def test_an_unexpected_local_probe_failure_votes_before_it_is_raised():
+    guard = _guard(ceiling=64 * GiB, rank=0)
+    mx = _CollectiveMX(rank=0, votes=[1, 0])
+
+    def _probe_failed(*_args, **_kwargs):
+        raise RuntimeError("memory probe failed")
+
+    guard.check = _probe_failed
+    with pytest.raises(RuntimeError, match="memory probe failed"):
+        guard.check_collective(2048, mx_module=mx)
+
+    assert mx.last_vote == [1, 0]
 
 
 def test_an_unreadable_model_disables_the_guard():

--- a/tests/test_cluster_prefill_guard.py
+++ b/tests/test_cluster_prefill_guard.py
@@ -3,10 +3,14 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+import mlx.core as mx
 import pytest
 
 from omlx.cluster.prefill_guard import RankPrefillGuard, build_guard, rank_monitor
 from omlx.exceptions import PrefillMemoryExceededError
+from omlx.memory_monitor import MemoryMonitor
 
 GiB = 1024**3
 
@@ -116,6 +120,70 @@ def test_request_prefill_step_override_sizes_peak_without_mutating_guard():
         )
 
     assert guard._step == 2048
+
+
+def test_deepseek_v4_pipeline_guard_uses_rank_local_hybrid_profile(monkeypatch):
+    """A long tool prompt plus one image must not be priced as dense 64-head SDPA.
+
+    The vision bridge intentionally prefills the image-bearing suffix in one
+    call.  At 18k tokens the generic head_dim=512 fallback is about 40 GiB,
+    which falsely rejects the OpenCode request before the model can use its
+    compressed/sparse DeepSeek V4 kernels.
+    """
+
+    from omlx.patches.deepseek_v4 import wsdpa_attention
+
+    monkeypatch.setattr(
+        "omlx.memory_monitor.native_indexer_eligible", lambda **_kwargs: True
+    )
+    monkeypatch.setattr(
+        wsdpa_attention,
+        "wsdpa_prefill_route_active",
+        lambda **_kwargs: True,
+    )
+
+    ratios = [0] + [4 if i % 2 else 128 for i in range(41)] + [0]
+    config = SimpleNamespace(
+        model_type="deepseek_v4",
+        num_hidden_layers=43,
+        num_key_value_heads=1,
+        num_attention_heads=64,
+        head_dim=512,
+        hidden_size=4096,
+        sliding_window=128,
+        index_n_heads=64,
+        index_head_dim=128,
+        index_topk=512,
+        compress_ratios=ratios,
+    )
+    embedding = SimpleNamespace(weight=SimpleNamespace(dtype=mx.bfloat16))
+    language = SimpleNamespace(start_idx=21, end_idx=43, embed_tokens=embedding)
+    model = SimpleNamespace(args=config, model=language)
+
+    rank_local = rank_monitor(model, layer_count=22)
+    assert rank_local is not None
+    profile = rank_local._prefill_memory_profile
+    assert profile is not None
+    assert profile.local_layers == 22
+    assert profile.ratio4_layers == ratios[21:43].count(4)
+    assert profile.ratio128_layers == ratios[21:43].count(128)
+
+    tokens = 18_000
+    hybrid_peak = rank_local.estimate_prefill_peak_bytes(tokens, tokens)
+    generic = MemoryMonitor(max_kv_cache_memory=None, eviction_enabled=False)
+    generic.set_model_info(
+        num_layers=22,
+        num_kv_heads=1,
+        head_dim=512,
+        dtype_size=2,
+        num_attention_heads=64,
+        num_kv_cache_layers=22,
+        compute_dtype_size=2,
+    )
+    dense_peak = generic.estimate_prefill_peak_bytes(tokens, tokens)
+
+    assert dense_peak > 40 * GiB
+    assert hybrid_peak < 8 * GiB
 
 
 # --- The desync rule: all ranks vote and leave the request together. ---------

--- a/tests/test_cluster_prompt_snapshot_integration.py
+++ b/tests/test_cluster_prompt_snapshot_integration.py
@@ -340,12 +340,6 @@ def test_vision_digest_key_lives_through_request_cache_then_is_cleared(
         def set_vision_inputs(self, images):
             self.inputs.append(images)
 
-    provider = SimpleNamespace(
-        model=Model(),
-        model_key=("canonical", None, None),
-        is_batchable=True,
-    )
-
     class Cache:
         def fetch_nearest_cache(self, model_key, prompt):
             cache_keys.append(("fetch", model_key))
@@ -359,14 +353,19 @@ def test_vision_digest_key_lives_through_request_cache_then_is_cleared(
             self.model_provider = provider
             self.prompt_cache = Cache()
 
-        def _share_object(self, payload):
-            return payload
+        def _share_request(self, request):
+            return request
 
         def _tokenize(self, _tokenizer, _request, _args):
             return [99], [[99]], ["assistant"], "normal"
 
         def _serve_single(self, request):
-            prompt = self._tokenize(request.tokenizer, request, request.args)[0]
+            _queue, request_payload, request_args = request
+            prompt = self._tokenize(
+                self.model_provider.tokenizer,
+                request_payload,
+                request_args,
+            )[0]
             cache, rest = self.prompt_cache.fetch_nearest_cache(
                 self.model_provider.model_key,
                 prompt,
@@ -398,16 +397,18 @@ def test_vision_digest_key_lives_through_request_cache_then_is_cleared(
         convert_tokens_to_ids=lambda _token: 99,
         unk_token_id=-1,
     )
+    provider = SimpleNamespace(
+        model=Model(),
+        model_key=("canonical", None, None),
+        tokenizer=tokenizer,
+        is_batchable=True,
+    )
 
     @dataclass
     class Request:
-        tokenizer: object
-        args: object
         messages: list
 
     request = Request(
-        tokenizer,
-        SimpleNamespace(),
         [
             {
                 "role": "user",
@@ -418,11 +419,14 @@ def test_vision_digest_key_lives_through_request_cache_then_is_cleared(
 
     with install_deepseek_v4_vision_runtime(server, provider, config={}, rank=0):
         generator = ResponseGenerator()
+        shared_request = generator._share_request(
+            (object(), request, SimpleNamespace())
+        )
         if fail_generation:
             with pytest.raises(RuntimeError, match="generation failed"):
-                generator._serve_single(request)
+                generator._serve_single(shared_request)
         else:
-            generator._serve_single(request)
+            generator._serve_single(shared_request)
 
         assert provider.model_key == ("canonical", None, None)
         assert provider.model.inputs[-1] is None

--- a/tests/test_cluster_prompt_snapshot_integration.py
+++ b/tests/test_cluster_prompt_snapshot_integration.py
@@ -5,6 +5,7 @@ prefill and restore the longest prefix on a later miss."""
 from types import SimpleNamespace
 
 import mlx.core as mx
+import pytest
 from mlx_lm.models.cache import KVCache
 
 from omlx.cluster.telemetry import install_server_telemetry
@@ -304,3 +305,128 @@ def test_batched_capture_restores_on_a_later_batched_miss(tmp_path, monkeypatch)
 
     assert restored is not None
     assert rest == [999, 998]
+
+
+@pytest.mark.parametrize("fail_generation", [False, True])
+def test_vision_digest_key_lives_through_request_cache_then_is_cleared(
+    monkeypatch,
+    fail_generation,
+):
+    from dataclasses import dataclass
+
+    from omlx.cluster import deepseek_v4_vision_runtime
+    from omlx.cluster.deepseek_v4_vision_runtime import (
+        install_deepseek_v4_vision_runtime,
+    )
+
+    prepared = SimpleNamespace(
+        patches=b"pixels",
+        n_vit_h=2,
+        n_vit_w=2,
+        types=(0, 1, 2),
+    )
+    monkeypatch.setattr(
+        deepseek_v4_vision_runtime,
+        "prepare_token_ids",
+        lambda *_args, **_kwargs: ([1, 2, 3, 4], (prepared,)),
+    )
+    cache_keys = []
+    stream_steps = []
+
+    class Model:
+        def __init__(self):
+            self.inputs = []
+
+        def set_vision_inputs(self, images):
+            self.inputs.append(images)
+
+    provider = SimpleNamespace(
+        model=Model(),
+        model_key=("canonical", None, None),
+        is_batchable=True,
+    )
+
+    class Cache:
+        def fetch_nearest_cache(self, model_key, prompt):
+            cache_keys.append(("fetch", model_key))
+            return None, prompt
+
+        def insert_cache(self, model_key, _prompt, _cache):
+            cache_keys.append(("insert", model_key))
+
+    class ResponseGenerator:
+        def __init__(self):
+            self.model_provider = provider
+            self.prompt_cache = Cache()
+
+        def _share_object(self, payload):
+            return payload
+
+        def _tokenize(self, _tokenizer, _request, _args):
+            return [99], [[99]], ["assistant"], "normal"
+
+        def _serve_single(self, request):
+            prompt = self._tokenize(request.tokenizer, request, request.args)[0]
+            cache, rest = self.prompt_cache.fetch_nearest_cache(
+                self.model_provider.model_key,
+                prompt,
+            )
+            list(
+                server.stream_generate(
+                    prompt=rest,
+                    prompt_cache=cache,
+                    prefill_step_size=2,
+                )
+            )
+            self.prompt_cache.insert_cache(
+                self.model_provider.model_key,
+                prompt,
+                cache,
+            )
+
+    def stream_generate(*_args, **kwargs):
+        stream_steps.append(kwargs["prefill_step_size"])
+        if fail_generation:
+            raise RuntimeError("generation failed")
+        yield "token"
+
+    server = SimpleNamespace(
+        ResponseGenerator=ResponseGenerator,
+        stream_generate=stream_generate,
+    )
+    tokenizer = SimpleNamespace(
+        convert_tokens_to_ids=lambda _token: 99,
+        unk_token_id=-1,
+    )
+
+    @dataclass
+    class Request:
+        tokenizer: object
+        args: object
+        messages: list
+
+    request = Request(
+        tokenizer,
+        SimpleNamespace(),
+        [
+            {
+                "role": "user",
+                "content": [{"type": "image_url", "image_url": {"url": "image"}}],
+            }
+        ],
+    )
+
+    with install_deepseek_v4_vision_runtime(server, provider, config={}, rank=0):
+        generator = ResponseGenerator()
+        if fail_generation:
+            with pytest.raises(RuntimeError, match="generation failed"):
+                generator._serve_single(request)
+        else:
+            generator._serve_single(request)
+
+        assert provider.model_key == ("canonical", None, None)
+        assert provider.model.inputs[-1] is None
+
+    assert stream_steps == [4]
+    assert [len(key) for _, key in cache_keys] == ([5] if fail_generation else [5, 5])
+    assert {key[-2] for _, key in cache_keys} == {"vision"}

--- a/tests/test_cluster_prompt_snapshot_integration.py
+++ b/tests/test_cluster_prompt_snapshot_integration.py
@@ -337,7 +337,7 @@ def test_vision_digest_key_lives_through_request_cache_then_is_cleared(
         def __init__(self):
             self.inputs = []
 
-        def set_vision_inputs(self, images):
+        def set_vision_inputs(self, images, *, spans=()):
             self.inputs.append(images)
 
     class Cache:

--- a/tests/test_cluster_runtime.py
+++ b/tests/test_cluster_runtime.py
@@ -346,3 +346,26 @@ def test_runtime_markers_ignore_symlinks_and_invalid_json(tmp_path):
 
     assert result["jobs"] == []
     assert len(result["warnings"]) == 2
+
+
+def test_runtime_markers_skip_memory_recovery_quarantine(tmp_path):
+    (tmp_path / "job.json").write_text(json.dumps(_marker()))
+    (tmp_path / "nemotron-pool-memory-recovery.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "deployment_id": "nemotron-pool",
+                "plan_hash": "b" * 64,
+                "created_at": 1788508364.0,
+                "reason": "rank 1 on peer: no-marker",
+                "kind": "unconfirmed_process",
+                "boot_session_id": "boot",
+                "baseline_ceiling_bytes": {"0": 115448725504, "1": 115448725504},
+            }
+        )
+    )
+
+    result = read_runtime_markers(tmp_path)
+
+    assert result["warnings"] == []
+    assert [job["rank"] for job in result["jobs"]] == [1]

--- a/tests/test_cluster_staging.py
+++ b/tests/test_cluster_staging.py
@@ -87,6 +87,35 @@ def test_a_stage_gets_only_its_shards_plus_shared(tmp_path):
     assert "model-00000.safetensors" not in names, "must not ship other stages' layers"
 
 
+def test_deepseek_vision_only_shard_is_staged_only_to_rank_zero(tmp_path):
+    root = _model(tmp_path / "m", layers=4, per_file=2)
+    (root / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "deepseek_v4",
+                "vision_n_layers": 2,
+                "vision_dim": 8,
+                "vision_n_heads": 2,
+                "vision_inter_dim": 16,
+                "vision_patch_size": 2,
+                "vision_rope_theta": 10000.0,
+                "vision_downsample_ratio": 2,
+                "vision_max_n_token": 16,
+                "vision_min_pixels": 16,
+                "vision_max_wh_ratio": 8,
+            }
+        )
+    )
+    _write_shard(root, "vision.safetensors", ["vision.blocks.0.attn.wqkv.weight"])
+    shards = index_shards(root)
+
+    coordinator = {s.name for s in shards_for_stage(shards, 2, 4, rank=0)}
+    worker = {s.name for s in shards_for_stage(shards, 0, 2, rank=1)}
+
+    assert "vision.safetensors" in coordinator
+    assert "vision.safetensors" not in worker
+
+
 def test_plan_reports_the_saving(tmp_path):
     root = _model(tmp_path / "m", layers=8, per_file=2)
     plan = plan_staging(root, node_id="mbp", start_layer=6, end_layer=8)

--- a/tests/test_cluster_staging.py
+++ b/tests/test_cluster_staging.py
@@ -290,6 +290,43 @@ def test_rank_validation_rejects_a_missing_assigned_shard(tmp_path):
     assert status["missing_files"] == ["model-00006.safetensors"]
 
 
+def test_rank_one_validation_does_not_require_rank_zero_vision_shards(tmp_path):
+    root = _model(tmp_path / "m", layers=4, per_file=2, with_index=True)
+    (root / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "deepseek_v4",
+                "vision_n_layers": 2,
+                "vision_dim": 8,
+                "vision_n_heads": 2,
+                "vision_inter_dim": 16,
+                "vision_patch_size": 2,
+                "vision_rope_theta": 10000.0,
+                "vision_downsample_ratio": 2,
+                "vision_max_n_token": 16,
+                "vision_min_pixels": 16,
+                "vision_max_wh_ratio": 8,
+            }
+        )
+    )
+    vision = "vision.safetensors"
+    vision_tensor = "vision.blocks.0.attn.wqkv.weight"
+    _write_shard(root, vision, [vision_tensor])
+    index_path = root / "model.safetensors.index.json"
+    index = json.loads(index_path.read_text())
+    index["weight_map"][vision_tensor] = vision
+    index_path.write_text(json.dumps(index))
+    (root / vision).unlink()
+
+    worker = validate_staged_model(root, 2, 4, rank=1)
+    coordinator = validate_staged_model(root, 2, 4, rank=0)
+
+    assert worker["stage_ready"] is True
+    assert vision not in worker["required_files"]
+    assert coordinator["stage_ready"] is False
+    assert coordinator["missing_files"] == [vision]
+
+
 def test_cluster_plan_covers_every_layer_across_nodes(tmp_path):
     root = _model(tmp_path / "m", layers=8, per_file=2)
 

--- a/tests/test_cluster_telemetry.py
+++ b/tests/test_cluster_telemetry.py
@@ -390,7 +390,10 @@ def test_vision_sharing_precedes_telemetry_collectives_and_guards_actual_suffix(
     monkeypatch.setattr(
         deepseek_v4_vision_runtime,
         "prepare_token_ids",
-        lambda *_args, **_kwargs: (list(range(10)), (prepared,)),
+        lambda *_args, **_kwargs: (
+            [1, 2, 100, 101, 102, 103, 104, 3, 4, 5],
+            (prepared,),
+        ),
     )
 
     class Model:
@@ -460,16 +463,27 @@ def test_vision_sharing_precedes_telemetry_collectives_and_guards_actual_suffix(
     args = SimpleNamespace(prefill_step_size=4)
 
     with (
-        install_deepseek_v4_vision_runtime(mlx_server, provider, config={}, rank=0),
+        install_deepseek_v4_vision_runtime(
+            mlx_server, provider, config={"vocab_size": 100}, rank=0
+        ),
         install_server_telemetry(_Marker(), prefill_guard=guard, prefill_step_size=4),
     ):
         generator = mlx_server.ResponseGenerator()
         _queue, shared_request, shared_args = generator._share_request(
             (object(), request, args)
         )
-        assert generator._tokenize(tokenizer, shared_request, shared_args)[0] == list(
-            range(10)
-        )
+        assert generator._tokenize(tokenizer, shared_request, shared_args)[0] == [
+            1,
+            2,
+            100,
+            101,
+            102,
+            103,
+            104,
+            3,
+            4,
+            5,
+        ]
         assert len(provider.model_key) == 5
 
     assert events == [
@@ -480,7 +494,7 @@ def test_vision_sharing_precedes_telemetry_collectives_and_guards_actual_suffix(
     ]
     assert guard.call[0] == (10,)
     assert guard.call[1]["cached_tokens"] == 3
-    assert guard.call[1]["prefill_step_size"] == 7
+    assert guard.call[1]["prefill_step_size"] == 4
     assert args.prefill_step_size == 4
     assert provider.model_key == ("model", None, None)
     assert provider.model.images is None

--- a/tests/test_cluster_telemetry.py
+++ b/tests/test_cluster_telemetry.py
@@ -368,6 +368,119 @@ def test_server_patch_binds_batch_uid_and_restores_mlx_lm_classes(monkeypatch):
     assert mlx_server.BatchGenerator is FakeBatchGenerator
 
 
+def test_vision_sharing_precedes_telemetry_collectives_and_guards_actual_suffix(
+    monkeypatch,
+):
+    from dataclasses import dataclass
+
+    import mlx_lm.server as mlx_server
+
+    from omlx.cluster import deepseek_v4_vision_runtime
+    from omlx.cluster.deepseek_v4_vision_runtime import (
+        install_deepseek_v4_vision_runtime,
+    )
+
+    events = []
+    prepared = SimpleNamespace(
+        patches=b"pixels",
+        n_vit_h=2,
+        n_vit_w=2,
+        types=(0, 1, 2),
+    )
+    monkeypatch.setattr(
+        deepseek_v4_vision_runtime,
+        "prepare_token_ids",
+        lambda *_args, **_kwargs: (list(range(10)), (prepared,)),
+    )
+
+    class Model:
+        def set_vision_inputs(self, images):
+            self.images = images
+
+    provider = SimpleNamespace(
+        model=Model(),
+        model_key=("model", None, None),
+        is_batchable=True,
+    )
+
+    class FakeResponseGenerator:
+        def __init__(self):
+            self.model_provider = provider
+            self.prompt_cache = mlx_server.LRUPromptCache()
+
+        def _share_object(self, payload):
+            events.append("share_vision_prompt")
+            return payload
+
+        def _tokenize(self, _tokenizer, _request, _args):
+            events.append("rank_zero_tokenize")
+            return [1, 99, 2], [[1, 99, 2]], ["assistant"], "normal"
+
+    class FakeBatchGenerator:
+        pass
+
+    class FakePromptCache:
+        def fetch_nearest_cache(self, _model, tokens):
+            events.append("cache_lookup")
+            return "cache", tokens[3:]
+
+        def __len__(self):
+            return 1
+
+        @property
+        def nbytes(self):
+            return 64
+
+    class Guard:
+        def check_collective(self, *args, **kwargs):
+            events.append("guard_collective")
+            self.call = args, kwargs
+
+    guard = Guard()
+    monkeypatch.setattr(mlx_server, "ResponseGenerator", FakeResponseGenerator)
+    monkeypatch.setattr(mlx_server, "BatchGenerator", FakeBatchGenerator)
+    monkeypatch.setattr(mlx_server, "LRUPromptCache", FakePromptCache)
+
+    @dataclass
+    class Request:
+        messages: list
+
+    request = Request(
+        [
+            {
+                "role": "user",
+                "content": [{"type": "image_url", "image_url": {"url": "image"}}],
+            }
+        ]
+    )
+    tokenizer = SimpleNamespace(
+        convert_tokens_to_ids=lambda _token: 99,
+        unk_token_id=-1,
+    )
+    args = SimpleNamespace(prefill_step_size=4)
+
+    with (
+        install_deepseek_v4_vision_runtime(mlx_server, provider, config={}, rank=0),
+        install_server_telemetry(_Marker(), prefill_guard=guard, prefill_step_size=4),
+    ):
+        generator = mlx_server.ResponseGenerator()
+        assert generator._tokenize(tokenizer, request, args)[0] == list(range(10))
+        assert len(provider.model_key) == 5
+
+    assert events == [
+        "rank_zero_tokenize",
+        "share_vision_prompt",
+        "cache_lookup",
+        "guard_collective",
+    ]
+    assert guard.call[0] == (10,)
+    assert guard.call[1]["cached_tokens"] == 3
+    assert guard.call[1]["prefill_step_size"] == 7
+    assert args.prefill_step_size == 4
+    assert provider.model_key == ("model", None, None)
+    assert provider.model.images is None
+
+
 def test_sequential_distributed_cancellation_exits_all_ranks_without_upstream_error(
     monkeypatch,
 ):

--- a/tests/test_cluster_telemetry.py
+++ b/tests/test_cluster_telemetry.py
@@ -397,20 +397,14 @@ def test_vision_sharing_precedes_telemetry_collectives_and_guards_actual_suffix(
         def set_vision_inputs(self, images):
             self.images = images
 
-    provider = SimpleNamespace(
-        model=Model(),
-        model_key=("model", None, None),
-        is_batchable=True,
-    )
-
     class FakeResponseGenerator:
         def __init__(self):
             self.model_provider = provider
             self.prompt_cache = mlx_server.LRUPromptCache()
 
-        def _share_object(self, payload):
-            events.append("share_vision_prompt")
-            return payload
+        def _share_request(self, request):
+            events.append("share_request")
+            return request
 
         def _tokenize(self, _tokenizer, _request, _args):
             events.append("rank_zero_tokenize")
@@ -457,6 +451,12 @@ def test_vision_sharing_precedes_telemetry_collectives_and_guards_actual_suffix(
         convert_tokens_to_ids=lambda _token: 99,
         unk_token_id=-1,
     )
+    provider = SimpleNamespace(
+        model=Model(),
+        model_key=("model", None, None),
+        tokenizer=tokenizer,
+        is_batchable=True,
+    )
     args = SimpleNamespace(prefill_step_size=4)
 
     with (
@@ -464,12 +464,17 @@ def test_vision_sharing_precedes_telemetry_collectives_and_guards_actual_suffix(
         install_server_telemetry(_Marker(), prefill_guard=guard, prefill_step_size=4),
     ):
         generator = mlx_server.ResponseGenerator()
-        assert generator._tokenize(tokenizer, request, args)[0] == list(range(10))
+        _queue, shared_request, shared_args = generator._share_request(
+            (object(), request, args)
+        )
+        assert generator._tokenize(tokenizer, shared_request, shared_args)[0] == list(
+            range(10)
+        )
         assert len(provider.model_key) == 5
 
     assert events == [
         "rank_zero_tokenize",
-        "share_vision_prompt",
+        "share_request",
         "cache_lookup",
         "guard_collective",
     ]

--- a/tests/test_cluster_telemetry.py
+++ b/tests/test_cluster_telemetry.py
@@ -196,7 +196,7 @@ def test_queue_observer_preserves_mlx_lm_queue_contract():
 def test_telemetry_marker_failure_never_interrupts_inference():
     class BrokenMarker:
         def update(self, phase, **extra):
-            raise OSError("disk unavailable")
+            raise RuntimeError("marker implementation failed")
 
     telemetry = RuntimeTelemetry(BrokenMarker(), publish_interval=0)
 
@@ -368,6 +368,153 @@ def test_server_patch_binds_batch_uid_and_restores_mlx_lm_classes(monkeypatch):
     assert mlx_server.BatchGenerator is FakeBatchGenerator
 
 
+def test_rank_local_memory_cache_hit_is_dropped_when_a_peer_missed(monkeypatch):
+    import mlx.core as mx
+    import mlx_lm.server as mlx_server
+
+    class FakeResponseGenerator:
+        def __init__(self):
+            self.model_provider = SimpleNamespace(model_key="model")
+            self.prompt_cache = mlx_server.LRUPromptCache()
+
+        def _tokenize(self, *_args):
+            prompt = [1, 2, 3, 4]
+            return prompt, [prompt], ["assistant"], "normal"
+
+    class FakeBatchGenerator:
+        pass
+
+    class FakePromptCache:
+        def fetch_nearest_cache(self, _model, tokens):
+            return "rank-local-cache", tokens[2:]
+
+        def __len__(self):
+            return 1
+
+        @property
+        def nbytes(self):
+            return 64
+
+    class Group:
+        @staticmethod
+        def size():
+            return 2
+
+    class Gathered:
+        @staticmethod
+        def tolist():
+            return [2, 0]
+
+    calls = []
+    guard = SimpleNamespace(
+        check_collective=lambda *args, **kwargs: calls.append((args, kwargs))
+    )
+    monkeypatch.setattr(mlx_server, "ResponseGenerator", FakeResponseGenerator)
+    monkeypatch.setattr(mlx_server, "BatchGenerator", FakeBatchGenerator)
+    monkeypatch.setattr(mlx_server, "LRUPromptCache", FakePromptCache)
+    monkeypatch.setattr(mx.distributed, "init", lambda: Group())
+    monkeypatch.setattr(mx.distributed, "all_gather", lambda _value: Gathered())
+
+    with install_server_telemetry(_Marker(), prefill_guard=guard):
+        generator = mlx_server.ResponseGenerator()
+        tokenized = generator._tokenize(None, None, None)
+        assert generator.prompt_cache.fetch_nearest_cache(
+            "model", tokenized[0]
+        ) == (None, tokenized[0])
+
+    assert calls[0][1]["cached_tokens"] == 0
+
+
+def test_snapshot_restore_is_dropped_when_one_rank_cannot_load(
+    monkeypatch, tmp_path
+):
+    import mlx.core as mx
+    import mlx_lm.server as mlx_server
+
+    from omlx.cluster import prompt_snapshot_cache
+
+    class FakeResponseGenerator:
+        def __init__(self):
+            self.model_provider = SimpleNamespace(model_key="model")
+            self.prompt_cache = mlx_server.LRUPromptCache()
+
+        def _tokenize(self, *_args):
+            prompt = [1, 2, 3, 4, 5]
+            return prompt, [prompt], ["assistant"], "normal"
+
+    class FakeBatchGenerator:
+        pass
+
+    class FakePromptCache:
+        def fetch_nearest_cache(self, _model, tokens):
+            return None, tokens
+
+        def __len__(self):
+            return 0
+
+        @property
+        def nbytes(self):
+            return 0
+
+    class FakeStore:
+        def __init__(self, directory, **_kwargs):
+            self.directory = tmp_path / "snapshots"
+            self.directory.mkdir()
+
+        def present_boundaries(self, _model, _tokens):
+            return (2,)
+
+        def load(self, _model, _tokens, boundary):
+            assert boundary == 2
+            return ["local-snapshot"]
+
+    class Group:
+        @staticmethod
+        def size():
+            return 2
+
+    class CollectiveValue:
+        def __init__(self, value):
+            self.value = value
+
+        def tolist(self):
+            return self.value
+
+        def item(self):
+            return self.value
+
+    reductions = iter((CollectiveValue([0, 2]), CollectiveValue(1)))
+    guard_calls = []
+    guard = SimpleNamespace(
+        check_collective=lambda *args, **kwargs: guard_calls.append((args, kwargs))
+    )
+    monkeypatch.setattr(mlx_server, "ResponseGenerator", FakeResponseGenerator)
+    monkeypatch.setattr(mlx_server, "BatchGenerator", FakeBatchGenerator)
+    monkeypatch.setattr(mlx_server, "LRUPromptCache", FakePromptCache)
+    monkeypatch.setattr(prompt_snapshot_cache, "SSDPromptSnapshotStore", FakeStore)
+    monkeypatch.setattr(mx.distributed, "init", lambda: Group())
+    monkeypatch.setattr(
+        mx.distributed,
+        "all_gather",
+        lambda _value: CollectiveValue([0, 0]),
+    )
+    monkeypatch.setattr(mx.distributed, "all_sum", lambda _value: next(reductions))
+
+    with install_server_telemetry(
+        _Marker(),
+        prefill_guard=guard,
+        ssd_cache_dir=str(tmp_path / "snapshots"),
+        prefill_step_size=2,
+    ):
+        generator = mlx_server.ResponseGenerator()
+        tokenized = generator._tokenize(None, None, None)
+        assert generator.prompt_cache.fetch_nearest_cache(
+            "model", tokenized[0]
+        ) == (None, tokenized[0])
+
+    assert guard_calls[0][1]["cached_tokens"] == 0
+
+
 def test_vision_sharing_precedes_telemetry_collectives_and_guards_actual_suffix(
     monkeypatch,
 ):
@@ -397,8 +544,9 @@ def test_vision_sharing_precedes_telemetry_collectives_and_guards_actual_suffix(
     )
 
     class Model:
-        def set_vision_inputs(self, images):
+        def set_vision_inputs(self, images, *, spans=()):
             self.images = images
+            self.spans = spans
 
     class FakeResponseGenerator:
         def __init__(self):

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -1982,6 +1982,7 @@ class TestDeepSeekV4VisionSuffixes:
             _vision_rank=0,
             _vision_group=_Group(),
             _vision_inputs=(first, second),
+            _vision_spans=((0, 3), (5, 8)),
             _vision_blocks={},
         )
 
@@ -1993,6 +1994,28 @@ class TestDeepSeekV4VisionSuffixes:
         assert vision.calls == [2]
         assert embeddings[0, 1:4].tolist() == [[10, 10], [2, 2], [40, 40]]
         assert fake._vision_inputs == ()
+
+    def test_cached_prefix_prunes_covered_image_arrays_and_blocks(
+        self, applied_patch
+    ):
+        import sys
+
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+        first = SimpleNamespace(start=0, types=(0, 2, 4))
+        second = SimpleNamespace(start=5, types=(0, 2, 4))
+        retained = object()
+        fake = SimpleNamespace(
+            _vision_rank=0,
+            _vision_inputs=(first, second),
+            _vision_spans=((0, 3), (5, 8)),
+            _vision_blocks={0: object(), 5: retained},
+        )
+
+        dsv4.Model._prune_vision_state(fake, offset=4)
+
+        assert fake._vision_inputs == (second,)
+        assert fake._vision_spans == ((5, 8),)
+        assert fake._vision_blocks == {5: retained}
 
     def test_distributed_vision_embeddings_are_materialized_before_pipeline(
         self, applied_patch, monkeypatch
@@ -2032,6 +2055,7 @@ class TestDeepSeekV4VisionSuffixes:
             _vision_rank=1,
             _vision_group=_Group(),
             _vision_inputs=None,
+            _vision_spans=((0, 1),),
             _vision_blocks={},
         )
 
@@ -2131,6 +2155,10 @@ class TestDeepSeekV4VisionSuffixes:
             args=SimpleNamespace(vocab_size=100),
             is_vision_model=True,
             _omlx_mtp_decode_enabled=False,
+            _vision_rank=0,
+            _vision_inputs=(),
+            _vision_spans=((5, 8),),
+            _vision_blocks={},
             _vision_embeddings=vision_embeddings,
             model=inner,
             lm_head=lambda hidden: hidden,
@@ -2658,10 +2686,8 @@ class TestSparseCompressedAttentionIndexerSkip:
 class TestIndexerFallbackTiling:
     """The MLX indexer fallback (used when the native glm_moe_dsa kernel is
     not built) tiles the pooled axis so its (B, heads, L, P) intermediate
-    never crosses 2**31 elements — the boundary where mlx int32 kernel
-    indexing silently zeroes the tail and corrupts top-k selection at
-    >256k context — while keeping top-k selection identical to the untiled
-    reduction."""
+    stays memory-bounded while keeping top-k selection identical to the
+    untiled reduction."""
 
     def _reduce_and_ref(self):
         # The patch registers deepseek_v4_model.py as mlx_lm.models.deepseek_v4
@@ -2779,9 +2805,66 @@ class TestIndexerFallbackTiling:
                 int((ia != ib).sum()) == 0
             ), f"top-k differs at pool_count={pool_count}"
 
-    def test_tile_stays_under_int32_index_limit(self, applied_patch):
-        # The prefill chunk is 512 and index heads are 64; the tiled matmul
-        # output must stay below 2**31 elements at any context length.
+    def test_forced_tiled_fallback_matches_single_matmul(
+        self, applied_patch, monkeypatch
+    ):
+        mx, dm = self._reduce_and_ref()
+        config = dm.ModelArgs(
+            hidden_size=8,
+            q_lora_rank=8,
+            qk_rope_head_dim=2,
+            num_hidden_layers=1,
+            compress_ratios=[4],
+            index_n_heads=2,
+            index_head_dim=4,
+            index_topk=4,
+        )
+        indexer = dm.Indexer(config, compress_ratio=4)
+        mx.random.seed(9)
+        x = mx.random.normal((1, 3, 8))
+        pooled = mx.random.normal((1, 13, 4))
+        q = mx.random.normal((1, 2, 3, 4))
+        weights = mx.random.normal((1, 3, 2))
+        monkeypatch.setattr(
+            dm.Compressor,
+            "__call__",
+            lambda self, _x, _cache, _offset: pooled,
+        )
+
+        monkeypatch.setattr(dm, "_INDEXER_MAX_ELEMS", 1_000_000)
+        untiled = indexer(
+            x,
+            q_residual=x,
+            position_rope=None,
+            pool_cache=None,
+            offset=0,
+            projected_q=q,
+            projected_weights=weights,
+        )
+        monkeypatch.setattr(dm, "_INDEXER_MAX_ELEMS", 24)
+        tiled = indexer(
+            x,
+            q_residual=x,
+            position_rope=None,
+            pool_cache=None,
+            offset=0,
+            projected_q=q,
+            projected_weights=weights,
+        )
+        mx.eval(untiled, tiled)
+
+        assert untiled.tolist() == tiled.tolist()
+
+    def test_tile_bounds_long_context_prefill_but_not_decode(self, applied_patch):
+        # A 512-token prefill at the last successful 67k-token context would
+        # otherwise materialize ~2 GiB of FP32 scores in each ratio-4 layer.
         _, dm = self._reduce_and_ref()
-        assert 64 * 512 * dm._INDEXER_POOL_TILE < 2**31
-        assert dm._INDEXER_MAX_ELEMS < 2**31
+        per_pool = 64 * 512
+        tile = min(dm._INDEXER_POOL_TILE, dm._INDEXER_MAX_ELEMS // per_pool)
+        assert tile == 2048
+        assert per_pool * tile * 4 == 256 * 1024 * 1024
+
+        # One-token decode at the same context remains below the threshold,
+        # avoiding extra launches in the steady-state hot path.
+        pooled_at_67k = 67_165 // 4
+        assert 64 * pooled_at_67k < dm._INDEXER_MAX_ELEMS

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -1865,6 +1865,234 @@ class TestMakeQuantizationConfigMtp:
             "mode": "mxfp8",
         }
 
+    def test_vision_attention_is_not_forced_to_language_mxfp8(self, applied_patch):
+        import mlx.nn as nn
+
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+
+        class _Attention(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.wqkv = nn.Linear(8, 24)
+
+        class _Block(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.attn = _Attention()
+
+        class _Vision(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.blocks = [_Block()]
+
+        class _ModelStub(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.vision = _Vision()
+                self.language = _Block()
+
+        qcfg = dsv4.make_quantization_config(_ModelStub())
+        assert qcfg["language.attn.wqkv"]["mode"] == "mxfp8"
+        assert "vision.blocks.0.attn.wqkv" not in qcfg
+
+
+class TestDeepSeekV4VisionSuffixes:
+    def test_image_embedding_slices_cover_cache_offset_and_multiple_images(
+        self, applied_patch
+    ):
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+        first = SimpleNamespace(start=1, types=(0, 2, 4))
+        second = SimpleNamespace(start=6, types=(0, 2, 2, 4))
+
+        def normalized(offset, length):
+            return [
+                (
+                    image.start,
+                    destination.start,
+                    destination.stop,
+                    source.start,
+                    source.stop,
+                )
+                for image, destination, source in dsv4._image_embedding_slices(
+                    (first, second), offset, length
+                )
+            ]
+
+        assert normalized(0, 1) == []
+        assert normalized(2, 1) == [(1, 0, 1, 1, 2)]
+        assert normalized(4, 2) == []
+        assert normalized(3, 5) == [(1, 0, 1, 2, 3), (6, 3, 5, 0, 2)]
+        assert normalized(10, 2) == []
+
+    def test_cached_image_is_not_encoded_when_later_image_overlaps_suffix(
+        self, applied_patch
+    ):
+        import mlx.core as mx
+
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+
+        class _Embedding:
+            weight = mx.zeros((100, 2))
+
+            def __call__(self, token_ids):
+                return mx.broadcast_to(token_ids[..., None], (*token_ids.shape, 2))
+
+        class _Vision:
+            def __init__(self):
+                self.calls = []
+
+            def __call__(self, patches, _height, _width):
+                marker = int(patches[0, 0, 0, 0].item())
+                self.calls.append(marker)
+                return mx.array([[marker]], dtype=mx.float32)
+
+        class _Group:
+            @staticmethod
+            def size():
+                return 1
+
+        first = SimpleNamespace(
+            start=0,
+            types=(0, 2, 4),
+            patches=[[[[1]], [[1]], [[1]]]],
+            n_vit_h=1,
+            n_vit_w=1,
+            permutation=(0,),
+        )
+        second = SimpleNamespace(
+            start=5,
+            types=(0, 2, 4),
+            patches=[[[[2]], [[2]], [[2]]]],
+            n_vit_h=1,
+            n_vit_w=1,
+            permutation=(0,),
+        )
+        vision = _Vision()
+        fake = SimpleNamespace(
+            args=SimpleNamespace(vocab_size=100, hidden_size=2),
+            model=SimpleNamespace(embed_tokens=_Embedding()),
+            image_start=mx.full((2,), 10),
+            image_pad=mx.full((2,), 20),
+            image_newline=mx.full((2,), 30),
+            image_end=mx.full((2,), 40),
+            vision=vision,
+            aligner=lambda features, _height, _width: mx.broadcast_to(
+                features, (features.shape[0], 2)
+            ),
+            _vision_rank=0,
+            _vision_group=_Group(),
+            _vision_inputs=(first, second),
+            _vision_blocks={},
+        )
+
+        embeddings = dsv4.Model._vision_embeddings(
+            fake, mx.array([[9, 100, 102, 104, 8]]), offset=4
+        )
+        mx.eval(embeddings)
+
+        assert vision.calls == [2]
+        assert embeddings[0, 1:4].tolist() == [[10, 10], [2, 2], [40, 40]]
+        assert fake._vision_inputs == ()
+
+    def test_cached_visibility_mask_disables_standard_kernel_path(
+        self, applied_patch
+    ):
+        import mlx.core as mx
+
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+
+        class _Embedding:
+            def __call__(self, inputs):
+                return mx.zeros((*inputs.shape, 2))
+
+        class _Cache:
+            offset = 3
+
+            @staticmethod
+            def make_mask(length, **_kwargs):
+                rows = mx.arange(3, 3 + length)[:, None]
+                columns = mx.arange(3 + length)[None]
+                return rows >= columns
+
+        class _Layer:
+            def __call__(self, h, mask, _cache, _inputs, *, _standard_mask):
+                self.mask = mask
+                self.standard = _standard_mask
+                return h
+
+        layer = _Layer()
+        fake = SimpleNamespace(
+            args=SimpleNamespace(hc_mult=1, sliding_window=128),
+            vocab_size=100,
+            embed_tokens=_Embedding(),
+            pipeline_rank=0,
+            pipeline_size=1,
+            pipeline_layers=[layer],
+            hc_head=lambda h: h,
+            norm=lambda h: h,
+        )
+
+        dsv4.DeepseekV4Model.__call__(
+            fake,
+            mx.array([[102, 103, 104]]),
+            cache=[_Cache()],
+            inputs_embeds=mx.zeros((1, 3, 2)),
+        )
+
+        assert layer.standard is False
+        assert layer.mask.shape == (3, 6)
+        assert bool(mx.all(layer.mask[:, 3:6]).item())
+
+        dsv4.DeepseekV4Model.__call__(
+            fake,
+            mx.array([[1, 2, 3]]),
+            cache=[_Cache()],
+            inputs_embeds=mx.zeros((1, 3, 2)),
+        )
+        assert layer.standard is True
+
+    def test_mtp_disabled_outer_model_preserves_vision_embedding_path(
+        self, applied_patch
+    ):
+        import mlx.core as mx
+
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+        expected = mx.full((1, 3, 2), 7)
+
+        class _Inner:
+            def __call__(self, inputs, cache, *, inputs_embeds=None):
+                self.inputs = inputs
+                self.cache = cache
+                self.inputs_embeds = inputs_embeds
+                return inputs_embeds
+
+        class _Cache:
+            offset = 5
+
+        inner = _Inner()
+        seen = {}
+
+        def vision_embeddings(inputs, offset):
+            seen.update(inputs=inputs, offset=offset)
+            return expected
+
+        fake = SimpleNamespace(
+            args=SimpleNamespace(vocab_size=100),
+            is_vision_model=True,
+            _omlx_mtp_decode_enabled=False,
+            _vision_embeddings=vision_embeddings,
+            model=inner,
+            lm_head=lambda hidden: hidden,
+        )
+        inputs = mx.array([[102, 103, 104]])
+        cache = [_Cache()]
+
+        output = dsv4.Model.__call__(fake, inputs, cache)
+
+        assert output is expected
+        assert seen == {"inputs": inputs, "offset": 5}
+        assert inner.inputs_embeds is expected
+
 
 class TestDeepSeekV4SanitizeAffineSwitchMLP:
     """Sanitize should enable the FP16 affine routed-MoE fast path."""

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -290,6 +290,142 @@ class TestTokenizerPatch:
         # Class name preserved for any introspection.
         assert tu.AutoTokenizer.__name__ == "AutoTokenizer"
 
+    @pytest.mark.parametrize(
+        "preconfigured_parser",
+        (False, True),
+        ids=("injected-parser", "preconfigured-parser"),
+    )
+    def test_dsml_start_tokens_include_canonical_newline_context(
+        self, tmp_path, preconfigured_parser
+    ):
+        """The direct mlx-lm server must enter its tool state for V4 DSML.
+
+        DeepSeek's tokenizer can merge ``>\n`` into one token.  Caching an
+        encoding of only the bare opening marker therefore does not match the
+        canonical marker followed by the first invoke on the next line.
+        """
+        script = textwrap.dedent(
+            """
+            import json
+            import sys
+            from pathlib import Path
+            from types import SimpleNamespace
+
+            import mlx_lm.tokenizer_utils as tokenizer_utils
+
+            model_path = Path(sys.argv[1])
+            preconfigured_parser = sys.argv[2] == "true"
+            (model_path / "config.json").write_text(
+                json.dumps({"model_type": "deepseek_v4"})
+            )
+
+            start = "<｜DSML｜tool_calls>"
+            end = "</｜DSML｜tool_calls>"
+
+            class ContextSensitiveTokenizer:
+                def encode(self, text, add_special_tokens=False):
+                    assert add_special_tokens is False
+                    if text == start:
+                        return [10, 11]
+                    if text == start + "\\n":
+                        return [10, 12]
+                    if text == end:
+                        return [13, 14]
+                    raise AssertionError(f"unexpected encoding request: {text!r}")
+
+            class Wrapper(SimpleNamespace):
+                eos_token_ids = (0,)
+                has_thinking = False
+
+                @property
+                def has_tool_calling(self):
+                    return self._tool_parser is not None
+
+                @property
+                def tool_call_start(self):
+                    return self._tool_call_start
+
+                @property
+                def tool_call_end(self):
+                    return self._tool_call_end
+
+                @property
+                def tool_call_start_tokens(self):
+                    return self._tool_call_start_tokens
+
+                @property
+                def tool_call_end_tokens(self):
+                    return self._tool_call_end_tokens
+
+                def encode(self, text, add_special_tokens=False):
+                    return self._tokenizer.encode(text, add_special_tokens)
+
+                def convert_ids_to_tokens(self, token_id):
+                    return str(token_id)
+
+            parser = None
+            if preconfigured_parser:
+                from omlx.patches.deepseek_v4 import tool_parser_v4
+
+                parser = tool_parser_v4.parse_tool_call
+
+            wrapper = Wrapper(
+                _tokenizer=ContextSensitiveTokenizer(),
+                _chat_template=None,
+                _tool_parser=parser,
+                _tool_call_start=None,
+                _tool_call_end=None,
+                _tool_call_start_tokens=(10, 11),
+                _tool_call_end_tokens=(13, 14),
+            )
+            tokenizer_utils.load = lambda *args, **kwargs: wrapper
+
+            from omlx.patches.deepseek_v4.tokenizer_patch import apply_load_patch
+
+            assert apply_load_patch() is True
+            loaded = tokenizer_utils.load(model_path)
+            assert loaded.tool_call_start == start
+            assert loaded.tool_call_start_tokens == (10, 12)
+
+            from mlx_lm.server import ResponseGenerator
+
+            generator = object.__new__(ResponseGenerator)
+            generator._state_machine_cache = {}
+            machine, _ = generator._make_state_machine(
+                "deepseek-v4-test", loaded, [], "normal"
+            )
+
+            state = machine.make_state()
+            current = "normal"
+            for token in (10, 12):
+                state, _, current = machine.match(state, token)
+            assert current == "tool"
+
+            for token in (13, 14):
+                state, _, current = machine.match(state, token)
+            assert current == "normal"
+            """
+        )
+        env = dict(os.environ)
+        env["PYTHONDONTWRITEBYTECODE"] = "1"
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-B",
+                "-c",
+                script,
+                str(tmp_path),
+                str(preconfigured_parser).lower(),
+            ],
+            cwd=Path(__file__).resolve().parents[1],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+
     def test_passthrough_on_success(self, applied_patch):
         """When upstream AutoTokenizer.from_pretrained succeeds, the wrapper
         must return its result unmodified — no fallback path taken."""

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -1994,6 +1994,57 @@ class TestDeepSeekV4VisionSuffixes:
         assert embeddings[0, 1:4].tolist() == [[10, 10], [2, 2], [40, 40]]
         assert fake._vision_inputs == ()
 
+    def test_distributed_vision_embeddings_are_materialized_before_pipeline(
+        self, applied_patch, monkeypatch
+    ):
+        import mlx.core as mx
+
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+        original_eval = mx.eval
+        events = []
+
+        class _Group:
+            @staticmethod
+            def size():
+                return 2
+
+        class _Embedding:
+            weight = mx.zeros((100, 2), dtype=mx.bfloat16)
+
+        def all_sum(value, *, group):
+            assert isinstance(group, _Group)
+            kind = "status" if value.dtype == mx.int32 else "embeddings"
+            events.append(f"all_sum_{kind}")
+            if kind == "status":
+                return mx.array(1, dtype=mx.int32)
+            return mx.ones_like(value)
+
+        def tracked_eval(value):
+            kind = "status" if value.dtype == mx.int32 else "embeddings"
+            events.append(f"eval_{kind}")
+            return original_eval(value)
+
+        monkeypatch.setattr(mx.distributed, "all_sum", all_sum)
+        monkeypatch.setattr(mx, "eval", tracked_eval)
+        fake = SimpleNamespace(
+            args=SimpleNamespace(vocab_size=100, hidden_size=2),
+            model=SimpleNamespace(embed_tokens=_Embedding()),
+            _vision_rank=1,
+            _vision_group=_Group(),
+            _vision_inputs=None,
+            _vision_blocks={},
+        )
+
+        embeddings = dsv4.Model._vision_embeddings(fake, mx.array([[100]]))
+
+        assert embeddings.tolist() == [[[1, 1]]]
+        assert events == [
+            "all_sum_status",
+            "eval_status",
+            "all_sum_embeddings",
+            "eval_embeddings",
+        ]
+
     def test_cached_visibility_mask_disables_standard_kernel_path(
         self, applied_patch
     ):

--- a/tests/test_deepseek_v4_vision.py
+++ b/tests/test_deepseek_v4_vision.py
@@ -13,6 +13,7 @@ from PIL import Image
 
 from omlx.cluster.deepseek_v4_vision_runtime import (
     install_deepseek_v4_vision_runtime,
+    vision_prefill_chunks,
 )
 from omlx.deepseek_v4_vision import (
     IMAGE,
@@ -94,6 +95,55 @@ def test_one_and_multiple_images_expand_in_prompt_order():
     assert len(tokens) == 3 + sum(len(image.types) for image in images)
     assert all(token >= 100 for token in tokens if token not in {1, 2, 3})
     assert IMAGE_PLACEHOLDER.startswith("<")
+
+
+def test_vision_prefill_chunks_never_split_an_image_block():
+    prompt = [1, 100, 101, 102, 103, 104, 2, 3, 4]
+
+    chunks = vision_prefill_chunks(
+        prompt,
+        vocab_size=100,
+        max_chunk_tokens=4,
+    )
+
+    assert chunks == ((0, 1), (1, 6), (6, 8), (8, 9))
+    assert [prompt[start:end] for start, end in chunks] == [
+        [1],
+        [100, 101, 102, 103, 104],
+        [2, 3],
+        [4],
+    ]
+
+
+def test_vision_prefill_chunks_accept_a_cache_suffix_inside_an_image():
+    chunks = vision_prefill_chunks(
+        [101, 102, 103, 104, 7, 8],
+        vocab_size=100,
+        max_chunk_tokens=2,
+    )
+
+    assert chunks == ((0, 4), (4, 6))
+
+
+def test_vision_prefill_chunks_accept_an_image_at_prompt_start():
+    assert vision_prefill_chunks(
+        [100, 101, 102, 103, 104, 7],
+        vocab_size=100,
+        max_chunk_tokens=3,
+    ) == ((0, 5), (5, 6))
+
+
+@pytest.mark.parametrize(
+    ("prompt", "message"),
+    [
+        ([1, 104], "has no start"),
+        ([1, 100, 101], "incomplete"),
+        ([1, 100, 100, 104], "nested"),
+    ],
+)
+def test_vision_prefill_chunks_reject_malformed_sentinels(prompt, message):
+    with pytest.raises(ValueError, match=message):
+        vision_prefill_chunks(prompt, vocab_size=100, max_chunk_tokens=4)
 
 
 def test_tiny_vision_encoder_and_aligner_produce_language_embeddings():
@@ -220,7 +270,70 @@ def test_rank_zero_runtime_dispatches_image_prefill_and_streaming():
     assert segments == [prompt]
     assert state == "normal"
     assert streamed == ["first", "second"]
-    assert seen["prefill_step_size"] == len(prompt)
+    assert seen["prefill_step_size"] == 2048
+
+
+def test_runtime_prefills_variable_image_safe_chunks(monkeypatch):
+    from omlx.cluster import deepseek_v4_vision_runtime
+
+    prefills = []
+    progress = []
+    seen = {}
+
+    class Model:
+        def set_vision_inputs(self, images):
+            self.images = images
+
+    class ResponseGenerator:
+        def _tokenize(self, *_args):
+            return [], [], [], "normal"
+
+    def stream_generate(*_args, **kwargs):
+        seen.update(kwargs)
+        callback = kwargs["prompt_progress_callback"]
+        callback(0, len(kwargs["prompt"]))
+        callback(len(kwargs["prompt"]), len(kwargs["prompt"]))
+        yield "token"
+
+    monkeypatch.setattr(
+        deepseek_v4_vision_runtime,
+        "_prefill_prompt_chunk",
+        lambda _model, _cache, tokens, _kwargs: prefills.append(list(tokens)),
+    )
+    server = SimpleNamespace(
+        ResponseGenerator=ResponseGenerator,
+        stream_generate=stream_generate,
+    )
+    provider = SimpleNamespace(
+        model=Model(),
+        model_key=("model", None, None),
+        is_batchable=True,
+    )
+    prompt = [1, 100, 101, 102, 103, 104, 2, 3, 4]
+    cache = [object()]
+
+    with install_deepseek_v4_vision_runtime(
+        server, provider, config=_config(), rank=0
+    ):
+        provider.model_key = (*provider.model_key, "vision", "digest")
+        output = list(
+            server.stream_generate(
+                model=provider.model,
+                tokenizer=object(),
+                prompt=prompt,
+                prompt_cache=cache,
+                prefill_step_size=4,
+                prompt_progress_callback=lambda done, total: progress.append(
+                    (done, total)
+                ),
+            )
+        )
+
+    assert output == ["token"]
+    assert prefills == [[1], [100, 101, 102, 103, 104], [2, 3]]
+    assert seen["prompt"] == [4]
+    assert seen["prompt_cache"] is cache
+    assert progress[-1] == (len(prompt), len(prompt))
 
 
 @pytest.mark.parametrize("preprocessing_error", [False, True])

--- a/tests/test_deepseek_v4_vision.py
+++ b/tests/test_deepseek_v4_vision.py
@@ -14,6 +14,7 @@ from PIL import Image
 from omlx.cluster.deepseek_v4_vision_runtime import (
     install_deepseek_v4_vision_runtime,
     vision_prefill_chunks,
+    vision_token_spans,
 )
 from omlx.deepseek_v4_vision import (
     IMAGE,
@@ -23,6 +24,7 @@ from omlx.deepseek_v4_vision import (
     is_deepseek_v4_vision_config,
 )
 from omlx.patches.deepseek_v4.vision_inputs import (
+    _image_bytes,
     build_image_block,
     prepare_token_ids,
 )
@@ -97,6 +99,47 @@ def test_one_and_multiple_images_expand_in_prompt_order():
     assert IMAGE_PLACEHOLDER.startswith("<")
 
 
+def test_image_count_is_bounded_before_preprocessing():
+    with pytest.raises(ValueError, match="at most 16 images"):
+        prepare_token_ids(
+            [99] * 17,
+            [{"data": "not decoded"}] * 17,
+            image_token_id=99,
+            config=_config(),
+        )
+
+
+def test_base64_size_is_rejected_before_decode_allocation(monkeypatch):
+    from omlx.patches.deepseek_v4 import vision_inputs
+
+    monkeypatch.setattr(vision_inputs, "_MAX_IMAGE_BYTES", 3)
+    with pytest.raises(ValueError, match="exceeds 50 MiB"):
+        _image_bytes({"data": "A" * 8})
+
+
+def test_decoded_image_and_encoder_patch_counts_are_bounded(monkeypatch):
+    from omlx.patches.deepseek_v4 import vision_inputs
+
+    monkeypatch.setattr(vision_inputs, "_MAX_SOURCE_PIXELS", 15)
+    with pytest.raises(ValueError, match="64 Mi-pixel"):
+        prepare_token_ids(
+            [99],
+            [{"url": _data_url("red")}],
+            image_token_id=99,
+            config=_config(),
+        )
+
+    monkeypatch.setattr(vision_inputs, "_MAX_SOURCE_PIXELS", 64 * 1024 * 1024)
+    monkeypatch.setattr(vision_inputs, "_MAX_VISION_PATCHES", 3)
+    with pytest.raises(ValueError, match="8192-patch"):
+        prepare_token_ids(
+            [99],
+            [{"url": _data_url("red")}],
+            image_token_id=99,
+            config=_config(),
+        )
+
+
 def test_vision_prefill_chunks_never_split_an_image_block():
     prompt = [1, 100, 101, 102, 103, 104, 2, 3, 4]
 
@@ -145,6 +188,11 @@ def test_vision_prefill_chunks_accept_an_image_at_prompt_start():
         vocab_size=100,
         max_chunk_tokens=3,
     ) == ((0, 5), (5, 6))
+
+
+def test_vision_token_spans_reject_unknown_out_of_vocab_token():
+    with pytest.raises(ValueError, match="sentinel kind 5"):
+        vision_token_spans([100, 105, 104], vocab_size=100)
 
 
 @pytest.mark.parametrize(
@@ -217,8 +265,9 @@ def test_rank_zero_runtime_dispatches_image_prefill_and_streaming():
         messages: list
 
     class Model:
-        def set_vision_inputs(self, images):
+        def set_vision_inputs(self, images, *, spans=()):
             self.images = images
+            self.spans = spans
 
     class ResponseGenerator:
         def __init__(self, provider):
@@ -272,6 +321,7 @@ def test_rank_zero_runtime_dispatches_image_prefill_and_streaming():
             tokenizer, shared_request, shared_args
         )
         assert len(provider.model.images) == 1
+        assert provider.model.spans == vision_token_spans(prompt, vocab_size=100)
         assert request.messages[0]["content"][0]["type"] == "image_url"
         assert shared_request.messages[0]["content"][0] == {
             "type": "text",
@@ -295,8 +345,9 @@ def test_runtime_prefills_variable_image_safe_chunks(monkeypatch):
     seen = {}
 
     class Model:
-        def set_vision_inputs(self, images):
+        def set_vision_inputs(self, images, *, spans=()):
             self.images = images
+            self.spans = spans
 
     class ResponseGenerator:
         def _tokenize(self, *_args):
@@ -378,8 +429,9 @@ def test_runtime_uses_one_request_broadcast_for_both_ranks(
         calls = []
 
     class Model:
-        def set_vision_inputs(self, images):
+        def set_vision_inputs(self, images, *, spans=()):
             self.images = images
+            self.spans = spans
 
     class ResponseGenerator:
         def __init__(self, provider):

--- a/tests/test_deepseek_v4_vision.py
+++ b/tests/test_deepseek_v4_vision.py
@@ -115,6 +115,20 @@ def test_vision_prefill_chunks_never_split_an_image_block():
     ]
 
 
+def test_vision_prefill_chunks_isolate_image_from_surrounding_text():
+    prompt = [1, 2, 101, 100, 102, 103, 104, 3, 4]
+
+    chunks = vision_prefill_chunks(
+        prompt,
+        vocab_size=100,
+        max_chunk_tokens=16,
+    )
+
+    # The leading IMAGE_PAD belongs to the image block. Keeping text out of
+    # this model call bounds the non-standard image-visibility attention path.
+    assert chunks == ((0, 2), (2, 7), (7, 9))
+
+
 def test_vision_prefill_chunks_accept_a_cache_suffix_inside_an_image():
     chunks = vision_prefill_chunks(
         [101, 102, 103, 104, 7, 8],

--- a/tests/test_deepseek_v4_vision.py
+++ b/tests/test_deepseek_v4_vision.py
@@ -23,7 +23,7 @@ from omlx.patches.deepseek_v4.vision_inputs import (
     build_image_block,
     prepare_token_ids,
 )
-from omlx.patches.deepseek_v4.vision_model import Aligner, ViT
+from omlx.patches.deepseek_v4.vision_model import Aligner, Attention, ViT
 
 
 def _config():
@@ -117,6 +117,34 @@ def test_tiny_vision_encoder_and_aligner_produce_language_embeddings():
     assert embeddings.dtype == mx.float32
 
 
+def test_vision_attention_splits_fused_qkv_before_head_reshape():
+    config = SimpleNamespace(vision_dim=4, vision_n_heads=2)
+    attention = Attention(config)
+    projection = mx.arange(12).reshape(1, 12)
+    attention.wqkv = lambda _x: projection
+    seen = {}
+
+    def capture(q, k, v, *, scale):
+        seen.update(q=q, k=k, v=v, scale=scale)
+        return v
+
+    original = mx.fast.scaled_dot_product_attention
+    mx.fast.scaled_dot_product_attention = capture
+    try:
+        attention.wo = lambda value: value
+        attention(
+            mx.zeros((1, 4)),
+            mx.ones((1, 1, 1)),
+            mx.zeros((1, 1, 1)),
+        )
+    finally:
+        mx.fast.scaled_dot_product_attention = original
+
+    assert seen["q"].reshape(-1).tolist() == [0, 1, 2, 3]
+    assert seen["k"].reshape(-1).tolist() == [4, 5, 6, 7]
+    assert seen["v"].reshape(-1).tolist() == [8, 9, 10, 11]
+
+
 def test_rank_zero_runtime_dispatches_image_prefill_and_streaming():
     @dataclass
     class Request:
@@ -169,10 +197,11 @@ def test_rank_zero_runtime_dispatches_image_prefill_and_streaming():
         prompt, segments, _types, state = ResponseGenerator(provider)._tokenize(
             tokenizer, request, SimpleNamespace()
         )
+        assert len(provider.model.images) == 1
         streamed = list(server.stream_generate(prompt=prompt))
 
     assert provider.is_batchable is False
-    assert len(provider.model.images) == 1
+    assert provider.model.images is None
     assert segments == [prompt]
     assert state == "normal"
     assert streamed == ["first", "second"]

--- a/tests/test_deepseek_v4_vision.py
+++ b/tests/test_deepseek_v4_vision.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Deterministic tests for the DeepSeek-V4 image token contract."""
+
+import base64
+import io
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import mlx.core as mx
+from PIL import Image
+
+from omlx.cluster.deepseek_v4_vision_runtime import (
+    install_deepseek_v4_vision_runtime,
+)
+from omlx.deepseek_v4_vision import (
+    IMAGE,
+    IMAGE_END,
+    IMAGE_PLACEHOLDER,
+    IMAGE_START,
+    is_deepseek_v4_vision_config,
+)
+from omlx.patches.deepseek_v4.vision_inputs import (
+    build_image_block,
+    prepare_token_ids,
+)
+from omlx.patches.deepseek_v4.vision_model import Aligner, ViT
+
+
+def _config():
+    return {
+        "model_type": "deepseek_v4",
+        "vocab_size": 100,
+        "vision_n_layers": 2,
+        "vision_dim": 8,
+        "vision_n_heads": 2,
+        "vision_inter_dim": 16,
+        "vision_patch_size": 2,
+        "vision_rope_theta": 10_000.0,
+        "vision_downsample_ratio": 2,
+        "vision_max_n_token": 32,
+        "vision_min_pixels": 16,
+        "vision_max_wh_ratio": 8,
+    }
+
+
+def _data_url(color):
+    image = Image.new("RGB", (4, 4), color=color)
+    output = io.BytesIO()
+    image.save(output, format="PNG")
+    return "data:image/png;base64," + base64.b64encode(output.getvalue()).decode()
+
+
+def test_capability_requires_complete_flat_vision_contract():
+    config = _config()
+    assert is_deepseek_v4_vision_config(config)
+    assert not is_deepseek_v4_vision_config(
+        {key: value for key, value in config.items() if key != "vision_n_layers"}
+    )
+    assert not is_deepseek_v4_vision_config({"model_type": "deepseek_v4"})
+
+
+def test_image_block_is_deterministic_and_aligned():
+    first = build_image_block(3, 2, 5)
+    second = build_image_block(3, 2, 5)
+    types, permutation = first
+
+    assert first == second
+    assert types.count(IMAGE_START) == 1
+    assert types.count(IMAGE_END) == 1
+    assert types.count(IMAGE) == len(permutation) == 6
+    assert (5 + types.index(IMAGE_START)) % 4 == 3
+
+
+def test_text_only_prefill_preserves_tokens():
+    tokens, images = prepare_token_ids(
+        [1, 2, 3], [], image_token_id=99, config=_config()
+    )
+    assert tokens == [1, 2, 3]
+    assert images == ()
+
+
+def test_one_and_multiple_images_expand_in_prompt_order():
+    tokens, images = prepare_token_ids(
+        [1, 99, 2, 99, 3],
+        [{"url": _data_url("red")}, {"url": _data_url("blue")}],
+        image_token_id=99,
+        config=_config(),
+    )
+
+    assert len(images) == 2
+    assert images[0].start < images[1].start
+    assert len(tokens) == 3 + sum(len(image.types) for image in images)
+    assert all(token >= 100 for token in tokens if token not in {1, 2, 3})
+    assert IMAGE_PLACEHOLDER.startswith("<")
+
+
+def test_tiny_vision_encoder_and_aligner_produce_language_embeddings():
+    config = SimpleNamespace(
+        vision_patch_size=2,
+        vision_dim=8,
+        vision_n_heads=2,
+        vision_inter_dim=16,
+        vision_n_layers=1,
+        vision_rope_theta=10_000.0,
+        vision_downsample_ratio=2,
+        hidden_size=12,
+    )
+    vision = ViT(config)
+    aligner = Aligner(config)
+
+    features = vision(mx.ones((16, 3, 2, 2)), 4, 4)
+    embeddings = aligner(features, 4, 4)
+    mx.eval(embeddings)
+
+    assert features.shape == (16, 8)
+    assert embeddings.shape == (4, 12)
+    assert embeddings.dtype == mx.float32
+
+
+def test_rank_zero_runtime_dispatches_image_prefill_and_streaming():
+    @dataclass
+    class Request:
+        messages: list
+
+    class Model:
+        def set_vision_inputs(self, images):
+            self.images = images
+
+    class ResponseGenerator:
+        def __init__(self, provider):
+            self.model_provider = provider
+
+        def _share_object(self, payload):
+            return payload
+
+        def _tokenize(self, _tokenizer, _request, _args):
+            return [1, 99, 2], [[1, 99, 2]], ["assistant"], "normal"
+
+    seen = {}
+
+    def stream_generate(*_args, **kwargs):
+        seen.update(kwargs)
+        yield "first"
+        yield "second"
+
+    server = SimpleNamespace(
+        ResponseGenerator=ResponseGenerator, stream_generate=stream_generate
+    )
+    provider = SimpleNamespace(
+        model=Model(), model_key=("model", None, None), is_batchable=True
+    )
+    tokenizer = SimpleNamespace(
+        convert_tokens_to_ids=lambda token: 99 if token == IMAGE_PLACEHOLDER else None,
+        unk_token_id=-1,
+    )
+    request = Request(
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": _data_url("red")}},
+                    {"type": "text", "text": "describe"},
+                ],
+            }
+        ]
+    )
+
+    with install_deepseek_v4_vision_runtime(server, provider, config=_config(), rank=0):
+        prompt, segments, _types, state = ResponseGenerator(provider)._tokenize(
+            tokenizer, request, SimpleNamespace()
+        )
+        streamed = list(server.stream_generate(prompt=prompt))
+
+    assert provider.is_batchable is False
+    assert len(provider.model.images) == 1
+    assert segments == [prompt]
+    assert state == "normal"
+    assert streamed == ["first", "second"]
+    assert seen["prefill_step_size"] == len(prompt)

--- a/tests/test_deepseek_v4_vision.py
+++ b/tests/test_deepseek_v4_vision.py
@@ -3,10 +3,12 @@
 
 import base64
 import io
+import pickle
 from dataclasses import dataclass
 from types import SimpleNamespace
 
 import mlx.core as mx
+import pytest
 from PIL import Image
 
 from omlx.cluster.deepseek_v4_vision_runtime import (
@@ -158,8 +160,8 @@ def test_rank_zero_runtime_dispatches_image_prefill_and_streaming():
         def __init__(self, provider):
             self.model_provider = provider
 
-        def _share_object(self, payload):
-            return payload
+        def _share_request(self, request):
+            return request
 
         def _tokenize(self, _tokenizer, _request, _args):
             return [1, 99, 2], [[1, 99, 2]], ["assistant"], "normal"
@@ -174,12 +176,15 @@ def test_rank_zero_runtime_dispatches_image_prefill_and_streaming():
     server = SimpleNamespace(
         ResponseGenerator=ResponseGenerator, stream_generate=stream_generate
     )
-    provider = SimpleNamespace(
-        model=Model(), model_key=("model", None, None), is_batchable=True
-    )
     tokenizer = SimpleNamespace(
         convert_tokens_to_ids=lambda token: 99 if token == IMAGE_PLACEHOLDER else None,
         unk_token_id=-1,
+    )
+    provider = SimpleNamespace(
+        model=Model(),
+        model_key=("model", None, None),
+        tokenizer=tokenizer,
+        is_batchable=True,
     )
     request = Request(
         messages=[
@@ -194,10 +199,20 @@ def test_rank_zero_runtime_dispatches_image_prefill_and_streaming():
     )
 
     with install_deepseek_v4_vision_runtime(server, provider, config=_config(), rank=0):
-        prompt, segments, _types, state = ResponseGenerator(provider)._tokenize(
-            tokenizer, request, SimpleNamespace()
+        generator = ResponseGenerator(provider)
+        args = SimpleNamespace()
+        _queue, shared_request, shared_args = generator._share_request(
+            (object(), request, args)
+        )
+        prompt, segments, _types, state = generator._tokenize(
+            tokenizer, shared_request, shared_args
         )
         assert len(provider.model.images) == 1
+        assert request.messages[0]["content"][0]["type"] == "image_url"
+        assert shared_request.messages[0]["content"][0] == {
+            "type": "text",
+            "text": IMAGE_PLACEHOLDER,
+        }
         streamed = list(server.stream_generate(prompt=prompt))
 
     assert provider.is_batchable is False
@@ -206,3 +221,119 @@ def test_rank_zero_runtime_dispatches_image_prefill_and_streaming():
     assert state == "normal"
     assert streamed == ["first", "second"]
     assert seen["prefill_step_size"] == len(prompt)
+
+
+@pytest.mark.parametrize("preprocessing_error", [False, True])
+def test_runtime_uses_one_request_broadcast_for_both_ranks(
+    monkeypatch,
+    preprocessing_error,
+):
+    from mlx_lm.server import CompletionRequest
+
+    from omlx.cluster import deepseek_v4_vision_runtime
+
+    prepared = SimpleNamespace(
+        patches=b"pixels",
+        n_vit_h=2,
+        n_vit_w=2,
+        types=(0, 1, 2),
+    )
+
+    def prepare(*_args, **_kwargs):
+        if preprocessing_error:
+            raise ValueError("invalid image")
+        return [1, 2, 3, 4], (prepared,)
+
+    monkeypatch.setattr(deepseek_v4_vision_runtime, "prepare_token_ids", prepare)
+
+    class Bus:
+        payload = None
+        calls = []
+
+    class Model:
+        def set_vision_inputs(self, images):
+            self.images = images
+
+    class ResponseGenerator:
+        def __init__(self, provider):
+            self.model_provider = provider
+
+        def _share_object(self, payload):
+            Bus.calls.append(payload is not None)
+            if payload is not None:
+                Bus.payload = pickle.loads(pickle.dumps(payload))
+            if Bus.payload is None:
+                return None
+            return pickle.loads(pickle.dumps(Bus.payload))
+
+        def _share_request(self, request):
+            shareable = request[1:] if request is not None else None
+            shareable = self._share_object(shareable)
+            if shareable is None:
+                return None
+            queue = request[0] if request is not None else object()
+            return queue, *shareable
+
+        def _tokenize(self, _tokenizer, _request, _args):
+            return [1, 99, 2], [[1, 99, 2]], ["assistant"], "normal"
+
+    server = SimpleNamespace(
+        ResponseGenerator=ResponseGenerator,
+        stream_generate=lambda *_args, **_kwargs: iter(()),
+    )
+    tokenizer = SimpleNamespace(
+        convert_tokens_to_ids=lambda _token: 99,
+        unk_token_id=-1,
+    )
+    providers = [
+        SimpleNamespace(
+            model=Model(),
+            model_key=("model", None, None),
+            tokenizer=tokenizer,
+            is_batchable=True,
+        )
+        for _rank in range(2)
+    ]
+    request = CompletionRequest(
+        request_type="chat",
+        prompt="",
+        messages=[
+            {
+                "role": "user",
+                "content": [{"type": "image_url", "image_url": {"url": "image"}}],
+            }
+        ],
+        tools=None,
+        role_mapping=None,
+    )
+    args = SimpleNamespace()
+
+    with install_deepseek_v4_vision_runtime(server, providers[0], config={}, rank=0):
+        rank_zero = ResponseGenerator(providers[0])
+        shared = rank_zero._share_request((object(), request, args))
+        if preprocessing_error:
+            with pytest.raises(RuntimeError, match="invalid image") as rank_zero_error:
+                rank_zero._tokenize(tokenizer, shared[1], shared[2])
+        else:
+            rank_zero_result = rank_zero._tokenize(tokenizer, shared[1], shared[2])
+            rank_zero_key = providers[0].model_key
+            assert providers[0].model.images == (prepared,)
+
+    with install_deepseek_v4_vision_runtime(server, providers[1], config={}, rank=1):
+        rank_one = ResponseGenerator(providers[1])
+        shared = rank_one._share_request(None)
+        if preprocessing_error:
+            with pytest.raises(RuntimeError, match="invalid image") as rank_one_error:
+                rank_one._tokenize(tokenizer, shared[1], shared[2])
+        else:
+            rank_one_result = rank_one._tokenize(tokenizer, shared[1], shared[2])
+            rank_one_key = providers[1].model_key
+            assert providers[1].model.images is None
+
+    assert Bus.calls == [True, False]
+    if preprocessing_error:
+        assert str(rank_zero_error.value) == str(rank_one_error.value)
+    else:
+        assert rank_zero_result == rank_one_result
+        assert rank_zero_key == rank_one_key
+    assert request.messages[0]["content"][0]["type"] == "image_url"

--- a/tests/test_distributed_engine.py
+++ b/tests/test_distributed_engine.py
@@ -40,6 +40,10 @@ class _Tokenizer:
     def encode(text):
         return list(text.encode())
 
+    @staticmethod
+    def apply_chat_template(messages, **_kwargs):
+        return "\n".join(str(message["content"]) for message in messages)
+
 
 def _ready_engine(handler) -> DistributedBatchedEngine:
     engine = DistributedBatchedEngine(_deployment())
@@ -133,6 +137,33 @@ def test_backend_chat_messages_serialize_native_tool_history_once():
     )
     assert messages[0]["tool_calls"][0]["function"]["arguments"] == {"city": "Paris"}
     assert prepared[1] == messages[1]
+
+
+def test_distributed_vision_counts_only_text_message_parts(monkeypatch):
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64"}},
+                {"type": "text", "text": "describe this image"},
+            ],
+        }
+    ]
+    cleaned = [{"role": "user", "content": "describe this image"}]
+
+    def extract(received):
+        assert received is messages
+        return cleaned, [object()], []
+
+    monkeypatch.setattr("omlx.utils.image.extract_images_from_messages", extract)
+    engine = DistributedBatchedEngine(_deployment())
+    engine._tokenizer = _Tokenizer()
+    engine._supports_multimodal_fallback = True
+
+    count = engine.count_chat_tokens(messages)
+
+    assert count == len("describe this image")
+    assert isinstance(messages[0]["content"], list)
 
 
 @pytest.mark.asyncio

--- a/tests/test_distributed_engine.py
+++ b/tests/test_distributed_engine.py
@@ -52,6 +52,57 @@ def _ready_engine(handler) -> DistributedBatchedEngine:
     return engine
 
 
+def _deepseek_v4_vision_config() -> dict:
+    return {
+        "model_type": "deepseek_v4",
+        "vision_n_layers": 2,
+        "vision_dim": 8,
+        "vision_n_heads": 2,
+        "vision_inter_dim": 16,
+        "vision_patch_size": 2,
+        "vision_rope_theta": 10_000.0,
+        "vision_downsample_ratio": 2,
+        "vision_max_n_token": 32,
+        "vision_min_pixels": 16,
+        "vision_max_wh_ratio": 8,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        (_deepseek_v4_vision_config(), True),
+        ({"model_type": "deepseek_v4"}, False),
+        ({"model_type": "llama", "vision_config": None}, False),
+    ],
+)
+async def test_multimodal_api_capability_requires_recognized_distributed_vision(
+    monkeypatch,
+    config,
+    expected,
+):
+    import mlx_lm.utils as mlx_utils
+
+    monkeypatch.setattr(mlx_utils, "_download", lambda *_args, **_kwargs: "/model")
+    monkeypatch.setattr(mlx_utils, "load_config", lambda _path: config)
+    monkeypatch.setattr(
+        mlx_utils, "load_tokenizer", lambda *_args, **_kwargs: _Tokenizer()
+    )
+    engine = DistributedBatchedEngine(_deployment())
+    monkeypatch.setattr(engine._supervisor, "start", lambda: None)
+    monkeypatch.setattr(engine._supervisor, "stop", lambda: None)
+    engine._supervisor.port = 32000
+
+    assert engine.supports_multimodal_fallback is False
+    await engine.start()
+    try:
+        assert engine.supports_multimodal_fallback is expected
+    finally:
+        await engine.stop()
+    assert engine.supports_multimodal_fallback is False
+
+
 def test_backend_chat_messages_serialize_native_tool_history_once():
     messages = [
         {

--- a/tests/test_distributed_engine.py
+++ b/tests/test_distributed_engine.py
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import json
+import threading
 from dataclasses import replace
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import httpx
 import pytest
@@ -238,37 +241,307 @@ def _stalled_engine():
         )
 
     engine._supervisor.status = status
-    return engine, status_calls
+    stop_calls = []
+    engine._supervisor.stop = lambda: stop_calls.append(True)
+    return engine, status_calls, stop_calls, engine._client
 
 
 @pytest.mark.asyncio
 async def test_distributed_generate_bounds_rank_zero_read_stalls():
-    engine, status_calls = _stalled_engine()
-    try:
-        with pytest.raises(
-            DistributedInferenceError,
-            match="request timed out.*no rank-zero data.*cluster was ready",
-        ):
-            await engine.generate("hello")
-    finally:
-        await engine._client.aclose()
+    engine, status_calls, stop_calls, client = _stalled_engine()
+    with pytest.raises(
+        DistributedInferenceError,
+        match="request timed out.*no rank-zero data.*cluster was ready",
+    ):
+        await engine.generate("hello")
 
     assert len(status_calls) == 2, "availability must be rechecked after timeout"
+    assert stop_calls == [True]
+    assert client.is_closed
+    assert engine._client is None
+    assert engine._loaded is False
+    assert engine.has_active_requests() is False
 
 
 @pytest.mark.asyncio
 async def test_distributed_stream_bounds_rank_zero_read_stalls():
-    engine, status_calls = _stalled_engine()
-    try:
-        with pytest.raises(
-            DistributedInferenceError,
-            match="stream timed out.*no rank-zero data.*cluster was ready",
-        ):
-            [output async for output in engine.stream_generate("hello")]
-    finally:
-        await engine._client.aclose()
+    engine, status_calls, stop_calls, client = _stalled_engine()
+    with pytest.raises(
+        DistributedInferenceError,
+        match="stream timed out.*no rank-zero data.*cluster was ready",
+    ):
+        [output async for output in engine.stream_generate("hello")]
 
     assert len(status_calls) == 2, "availability must be rechecked after timeout"
+    assert stop_calls == [True]
+    assert client.is_closed
+    assert engine._client is None
+    assert engine._loaded is False
+    assert engine.has_active_requests() is False
+
+
+@pytest.mark.asyncio
+async def test_cancelled_distributed_request_stops_every_rank():
+    started = asyncio.Event()
+
+    async def handler(_request):
+        started.set()
+        await asyncio.Event().wait()
+
+    engine = _ready_engine(handler)
+    client = engine._client
+    stop_calls = []
+    engine._supervisor.stop = lambda: stop_calls.append(True)
+
+    request = asyncio.create_task(engine.generate("hello"))
+    await started.wait()
+    request.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await request
+
+    assert stop_calls == [True]
+    assert client.is_closed
+    assert engine._client is None
+    assert engine._loaded is False
+    assert engine.has_active_requests() is False
+
+
+class _PartialSSEStream(httpx.AsyncByteStream):
+    async def __aiter__(self):
+        yield (
+            b'data: {"choices":[{"text":"one","finish_reason":null}]}'
+            b"\n\n"
+        )
+        await asyncio.Event().wait()
+
+
+@pytest.mark.asyncio
+async def test_closing_partial_distributed_stream_stops_every_rank():
+    def handler(_request):
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=_PartialSSEStream(),
+        )
+
+    engine = _ready_engine(handler)
+    client = engine._client
+    stop_calls = []
+    engine._supervisor.stop = lambda: stop_calls.append(True)
+    stream = engine.stream_generate("hello")
+
+    output = await anext(stream)
+    assert output.new_text == "one"
+    await stream.aclose()
+
+    assert stop_calls == [True]
+    assert client.is_closed
+    assert engine._client is None
+    assert engine._loaded is False
+    assert engine.has_active_requests() is False
+
+
+@pytest.mark.asyncio
+async def test_successful_distributed_stream_keeps_cluster_loaded():
+    def handler(_request):
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=(
+                'data: {"choices":[{"text":"ok","finish_reason":null}]}\n\n'
+                'data: {"choices":[{"text":"","finish_reason":"stop"}]}\n\n'
+                "data: [DONE]\n\n"
+            ),
+        )
+
+    engine = _ready_engine(handler)
+    client = engine._client
+    stop_calls = []
+    engine._supervisor.stop = lambda: stop_calls.append(True)
+    try:
+        outputs = [output async for output in engine.stream_generate("hello")]
+    finally:
+        await client.aclose()
+
+    assert "".join(output.new_text for output in outputs) == "ok"
+    assert stop_calls == []
+    assert engine._client is client
+    assert engine._loaded is True
+
+
+@pytest.mark.asyncio
+async def test_fail_closed_engine_retains_metadata_and_preflight_restarts():
+    engine = _ready_engine(lambda _request: httpx.Response(200))
+    client = engine._client
+    tokenizer = engine._tokenizer
+    engine._model_type = "llama"
+    engine._supports_multimodal_fallback = True
+    engine._supervisor.stop = lambda: None
+
+    await engine._teardown_failed_request(client, reason="test failure")
+
+    assert engine._tokenizer is tokenizer
+    assert engine._model_type == "llama"
+    assert engine._supports_multimodal_fallback is True
+    engine.start = AsyncMock()
+    engine._require_healthy_cluster = AsyncMock()
+
+    await engine.preflight_completion("hello")
+
+    engine.start.assert_awaited_once_with()
+    engine._require_healthy_cluster.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_failed_restart_preserves_retained_engine_metadata(monkeypatch):
+    import mlx_lm.utils as mlx_utils
+
+    engine = _ready_engine(lambda _request: httpx.Response(200))
+    client = engine._client
+    tokenizer = engine._tokenizer
+    engine._model_type = "llama"
+    engine._supports_multimodal_fallback = True
+    engine._supervisor.stop = lambda: None
+    await engine._teardown_failed_request(client, reason="test failure")
+
+    monkeypatch.setattr(mlx_utils, "_download", lambda *_args, **_kwargs: "/model")
+    monkeypatch.setattr(
+        mlx_utils,
+        "load_config",
+        lambda _path: {"model_type": "replacement"},
+    )
+    def fail_start():
+        raise RuntimeError("launch failed")
+
+    # Reach the supervisor failure after loading replacement metadata, then
+    # ensure that metadata is not published over the last pool-valid state.
+    monkeypatch.setattr(mlx_utils, "load_tokenizer", lambda *_args, **_kwargs: object())
+    engine._supervisor.start = fail_start
+
+    with pytest.raises(RuntimeError, match="launch failed"):
+        await engine.start()
+
+    assert engine._tokenizer is tokenizer
+    assert engine._model_type == "llama"
+    assert engine._supports_multimodal_fallback is True
+
+
+@pytest.mark.asyncio
+async def test_cancelled_supervisor_start_finishes_and_stops_before_unlock(monkeypatch):
+    import mlx_lm.utils as mlx_utils
+
+    monkeypatch.setattr(mlx_utils, "_download", lambda *_args, **_kwargs: "/model")
+    monkeypatch.setattr(mlx_utils, "load_config", lambda _path: {"model_type": "llama"})
+    monkeypatch.setattr(
+        mlx_utils, "load_tokenizer", lambda *_args, **_kwargs: _Tokenizer()
+    )
+    engine = DistributedBatchedEngine(_deployment())
+    started = threading.Event()
+    release = threading.Event()
+    stop_calls = []
+
+    def blocking_start():
+        started.set()
+        release.wait()
+
+    engine._supervisor.start = blocking_start
+    engine._supervisor.stop = lambda: stop_calls.append(True)
+    task = asyncio.create_task(engine.start())
+    assert await asyncio.to_thread(started.wait, 1)
+
+    task.cancel()
+    await asyncio.sleep(0)
+    assert engine._lifecycle_lock.locked()
+    assert task.done() is False
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, 1)
+
+    assert stop_calls == [True]
+    assert engine._lifecycle_lock.locked() is False
+    assert engine._loaded is False
+    assert engine._tokenizer is None
+
+
+@pytest.mark.asyncio
+async def test_cancelled_supervisor_stop_finishes_before_unlock():
+    engine = _ready_engine(lambda _request: httpx.Response(200))
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_stop():
+        started.set()
+        release.wait()
+
+    engine._supervisor.stop = blocking_stop
+    task = asyncio.create_task(engine.stop())
+    assert await asyncio.to_thread(started.wait, 1)
+
+    task.cancel()
+    await asyncio.sleep(0)
+    assert engine._lifecycle_lock.locked()
+    assert task.done() is False
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, 1)
+
+    assert engine._lifecycle_lock.locked() is False
+    assert engine._loaded is False
+    assert engine._tokenizer is None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_distributed_failures_stop_supervisor_once():
+    engine = _ready_engine(lambda _request: httpx.Response(200))
+    client = engine._client
+    stop_calls = []
+    engine._supervisor.stop = lambda: stop_calls.append(True)
+
+    await asyncio.gather(
+        engine._teardown_failed_request(client, reason="first failure"),
+        engine._teardown_failed_request(client, reason="second failure"),
+    )
+
+    assert stop_calls == [True]
+    assert engine._client is None
+    assert engine._loaded is False
+
+
+@pytest.mark.asyncio
+async def test_stale_distributed_request_cannot_stop_replacement_job():
+    engine = _ready_engine(lambda _request: httpx.Response(200))
+    stale_client = engine._client
+    replacement_client = httpx.AsyncClient(base_url="http://127.0.0.1:2")
+    engine._client = replacement_client
+    stop_calls = []
+    engine._supervisor.stop = lambda: stop_calls.append(True)
+    try:
+        await engine._teardown_failed_request(stale_client, reason="stale failure")
+        assert stop_calls == []
+        assert engine._client is replacement_client
+        assert engine._loaded is True
+    finally:
+        await stale_client.aclose()
+        await replacement_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_abort_all_distributed_requests_hard_stops_cluster():
+    engine = _ready_engine(lambda _request: httpx.Response(200))
+    client = engine._client
+    engine._active_requests = 3
+    stop_calls = []
+    engine._supervisor.stop = lambda: stop_calls.append(True)
+
+    aborted = await engine.abort_all_requests(reason="memory pressure")
+
+    assert aborted == 3
+    assert stop_calls == [True]
+    assert client.is_closed
+    assert engine._client is None
+    assert engine._loaded is False
 
 
 def test_chat_payload_folds_thinking_budget_into_chat_template_kwargs():
@@ -776,14 +1049,19 @@ async def test_distributed_stream_rejects_malformed_usage():
         )
 
     engine = _ready_engine(handler)
-    try:
-        with pytest.raises(
-            DistributedInferenceError,
-            match="invalid token details",
-        ):
-            [output async for output in engine.stream_generate("test")]
-    finally:
-        await engine._client.aclose()
+    client = engine._client
+    stop_calls = []
+    engine._supervisor.stop = lambda: stop_calls.append(True)
+    with pytest.raises(
+        DistributedInferenceError,
+        match="invalid token details",
+    ):
+        [output async for output in engine.stream_generate("test")]
+
+    assert stop_calls == [True]
+    assert client.is_closed
+    assert engine._client is None
+    assert engine._loaded is False
 
 
 @pytest.mark.asyncio
@@ -792,11 +1070,98 @@ async def test_distributed_engine_surfaces_bounded_backend_error():
         return httpx.Response(503, json={"error": "rank 1 failed"})
 
     engine = _ready_engine(handler)
+    client = engine._client
+    stop_calls = []
+    engine._supervisor.stop = lambda: stop_calls.append(True)
     try:
         with pytest.raises(DistributedInferenceError, match="HTTP 503.*rank 1"):
             await engine.generate("hello")
     finally:
-        await engine._client.aclose()
+        await client.aclose()
+
+    assert stop_calls == []
+    assert engine._client is client
+    assert engine._loaded is True
+
+
+@pytest.mark.asyncio
+async def test_distributed_stream_backend_error_keeps_cluster_loaded():
+    engine = _ready_engine(
+        lambda _request: httpx.Response(503, json={"error": "rank 1 busy"})
+    )
+    client = engine._client
+    stop_calls = []
+    engine._supervisor.stop = lambda: stop_calls.append(True)
+    try:
+        with pytest.raises(DistributedInferenceError, match="HTTP 503.*rank 1 busy"):
+            [output async for output in engine.stream_generate("hello")]
+    finally:
+        await client.aclose()
+
+    assert stop_calls == []
+    assert engine._client is client
+    assert engine._loaded is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["completion", "chat"])
+async def test_distributed_stream_early_eof_stops_every_rank(kind):
+    if kind == "chat":
+        event = {"choices": [{"delta": {"content": "one"}}]}
+    else:
+        event = {"choices": [{"text": "one", "finish_reason": None}]}
+
+    engine = _ready_engine(
+        lambda _request: httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            text=f"data: {json.dumps(event)}\n\n",
+        )
+    )
+    client = engine._client
+    stop_calls = []
+    engine._supervisor.stop = lambda: stop_calls.append(True)
+
+    stream = (
+        engine.stream_chat([{"role": "user", "content": "hello"}])
+        if kind == "chat"
+        else engine.stream_generate("hello")
+    )
+    with pytest.raises(DistributedInferenceError, match=r"ended before \[DONE\]"):
+        [output async for output in stream]
+
+    assert stop_calls == [True]
+    assert client.is_closed
+    assert engine._client is None
+    assert engine._loaded is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["completion", "chat"])
+async def test_distributed_stream_done_without_terminal_event_stops_every_rank(kind):
+    engine = _ready_engine(
+        lambda _request: httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            text="data: [DONE]\n\n",
+        )
+    )
+    client = engine._client
+    stop_calls = []
+    engine._supervisor.stop = lambda: stop_calls.append(True)
+
+    stream = (
+        engine.stream_chat([{"role": "user", "content": "hello"}])
+        if kind == "chat"
+        else engine.stream_generate("hello")
+    )
+    with pytest.raises(DistributedInferenceError, match="before a terminal event"):
+        [output async for output in stream]
+
+    assert stop_calls == [True]
+    assert client.is_closed
+    assert engine._client is None
+    assert engine._loaded is False
 
 
 @pytest.mark.asyncio
@@ -808,23 +1173,34 @@ async def test_distributed_transport_error_surfaces_peer_failure_reason():
         )
 
     engine = _ready_engine(handler)
-    engine._supervisor.status = lambda: SimpleNamespace(
-        returncode=1,
-        failure_reason=(
-            "Studio stopped publishing its runtime heartbeat. "
-            "Check oMLX is running on that Mac."
-        ),
-        phase="failed",
-        stderr_tail=(),
+    client = engine._client
+    stop_calls = []
+    engine._supervisor.stop = lambda: stop_calls.append(True)
+    statuses = iter(
+        (
+            SimpleNamespace(returncode=None, failure_reason=None, phase="ready"),
+            SimpleNamespace(
+                returncode=1,
+                failure_reason=(
+                    "Studio stopped publishing its runtime heartbeat. "
+                    "Check oMLX is running on that Mac."
+                ),
+                phase="failed",
+                stderr_tail=(),
+            ),
+        )
     )
-    try:
-        with pytest.raises(
-            DistributedInferenceError,
-            match="Studio stopped publishing its runtime heartbeat",
-        ):
-            await engine.generate("hello")
-    finally:
-        await engine._client.aclose()
+    engine._supervisor.status = lambda: next(statuses)
+    with pytest.raises(
+        DistributedInferenceError,
+        match="Studio stopped publishing its runtime heartbeat",
+    ):
+        await engine.generate("hello")
+
+    assert stop_calls == [True]
+    assert client.is_closed
+    assert engine._client is None
+    assert engine._loaded is False
 
 
 @pytest.mark.asyncio
@@ -836,20 +1212,89 @@ async def test_distributed_transport_error_reports_bounded_launcher_exit():
         )
 
     engine = _ready_engine(handler)
-    engine._supervisor.status = lambda: SimpleNamespace(
-        returncode=1,
-        failure_reason=None,
-        phase="failed",
-        stderr_tail=("rank 1 out of memory",),
+    client = engine._client
+    stop_calls = []
+    engine._supervisor.stop = lambda: stop_calls.append(True)
+    statuses = iter(
+        (
+            SimpleNamespace(returncode=None, failure_reason=None, phase="ready"),
+            SimpleNamespace(
+                returncode=1,
+                failure_reason=None,
+                phase="failed",
+                stderr_tail=("rank 1 out of memory",),
+            ),
+        )
     )
-    try:
-        with pytest.raises(
-            DistributedInferenceError,
-            match="exited with code 1.*rank 1 out of memory",
-        ):
-            await engine.generate("hello")
-    finally:
-        await engine._client.aclose()
+    engine._supervisor.status = lambda: next(statuses)
+    with pytest.raises(
+        DistributedInferenceError,
+        match="exited with code 1.*rank 1 out of memory",
+    ):
+        await engine.generate("hello")
+
+    assert stop_calls == [True]
+    assert client.is_closed
+    assert engine._client is None
+    assert engine._loaded is False
+
+
+@pytest.mark.asyncio
+async def test_distributed_stream_transport_error_stops_every_rank():
+    def handler(request):
+        raise httpx.ConnectError("connection reset", request=request)
+
+    engine = _ready_engine(handler)
+    client = engine._client
+    stop_calls = []
+    engine._supervisor.stop = lambda: stop_calls.append(True)
+    engine._supervisor.status = lambda: SimpleNamespace(
+        returncode=None,
+        failure_reason=None,
+        phase="ready",
+        stderr_tail=(),
+    )
+
+    with pytest.raises(
+        DistributedInferenceError,
+        match="stream failed.*ConnectError",
+    ):
+        [output async for output in engine.stream_generate("hello")]
+
+    assert stop_calls == [True]
+    assert client.is_closed
+    assert engine._client is None
+    assert engine._loaded is False
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_transport_diagnosis_still_stops_every_rank():
+    def handler(request):
+        raise httpx.ConnectError("connection reset", request=request)
+
+    engine = _ready_engine(handler)
+    client = engine._client
+    diagnosis_started = asyncio.Event()
+    stop_calls = []
+    engine._supervisor.stop = lambda: stop_calls.append(True)
+
+    async def blocked_diagnosis(_exc, *, stream):
+        assert stream is False
+        diagnosis_started.set()
+        await asyncio.Event().wait()
+
+    engine._transport_failure_error = blocked_diagnosis
+    task = asyncio.create_task(engine.generate("hello"))
+    await diagnosis_started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert stop_calls == [True]
+    assert client.is_closed
+    assert engine._client is None
+    assert engine._loaded is False
 
 
 @pytest.mark.asyncio
@@ -1173,6 +1618,9 @@ async def test_preflight_rejects_an_unhealthy_rank_before_streaming(monkeypatch)
     # The 200 commits before a streaming body runs, so preflight is the last
     # point a half-dead cluster can still become a clean HTTP error (#2708).
     engine = _ready_engine(lambda request: httpx.Response(200))
+    client = engine._client
+    stop_calls = []
+    monkeypatch.setattr(engine._supervisor, "stop", lambda: stop_calls.append(True))
     monkeypatch.setattr(engine._supervisor, "status", _healthy_supervisor_status)
     monkeypatch.setattr(
         distributed,
@@ -1187,11 +1635,13 @@ async def test_preflight_rejects_an_unhealthy_rank_before_streaming(monkeypatch)
         "describe_failure",
         lambda health: "rank 1 (peer) stopped heartbeating",
     )
-    try:
-        with pytest.raises(DistributedInferenceError, match="not serving"):
-            await engine.preflight_chat([{"role": "user", "content": "hi"}])
-    finally:
-        await engine._client.aclose()
+    with pytest.raises(DistributedInferenceError, match="not serving"):
+        await engine.preflight_chat([{"role": "user", "content": "hi"}])
+
+    assert stop_calls == [True]
+    assert client.is_closed
+    assert engine._client is None
+    assert engine._loaded is False
 
 
 @pytest.mark.asyncio
@@ -1217,23 +1667,30 @@ async def test_preflight_caches_the_peer_health_read(monkeypatch):
 @pytest.mark.asyncio
 async def test_preflight_rejects_a_reported_failure_without_probing(monkeypatch):
     engine = _ready_engine(lambda request: httpx.Response(200))
+    client = engine._client
+    stop_calls = []
+    monkeypatch.setattr(engine._supervisor, "stop", lambda: stop_calls.append(True))
     monkeypatch.setattr(
         engine._supervisor,
         "status",
         lambda: SimpleNamespace(
-            returncode=None, failure_reason="rank 1 connection closed"
+            returncode=None,
+            failure_reason="rank 1 connection closed",
+            stderr_tail=(),
         ),
     )
     probed = []
     monkeypatch.setattr(
         distributed, "check_peers", lambda *a, **k: probed.append(1) or ()
     )
-    try:
-        with pytest.raises(DistributedInferenceError, match="rank 1 connection"):
-            await engine.preflight_chat([{"role": "user", "content": "hi"}])
-        assert probed == []
-    finally:
-        await engine._client.aclose()
+    with pytest.raises(DistributedInferenceError, match="rank 1 connection"):
+        await engine.preflight_chat([{"role": "user", "content": "hi"}])
+
+    assert probed == []
+    assert stop_calls == [True]
+    assert client.is_closed
+    assert engine._client is None
+    assert engine._loaded is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_distributed_engine.py
+++ b/tests/test_distributed_engine.py
@@ -48,6 +48,26 @@ class _Tokenizer:
         return "\n".join(str(message["content"]) for message in messages)
 
 
+def _sse_response(*, json):
+    import json as json_module
+
+    choices = []
+    for original in json["choices"]:
+        choice = dict(original)
+        if "message" in choice:
+            choice["delta"] = choice.pop("message")
+        choices.append(choice)
+    events = [{"choices": choices}, {"choices": [], "usage": json.get("usage", {})}]
+    content = (
+        ": keepalive 1/1\n\n"
+        + "".join(f"data: {json_module.dumps(event)}\n\n" for event in events)
+        + "data: [DONE]\n\n"
+    )
+    return httpx.Response(
+        200, headers={"content-type": "text/event-stream"}, content=content
+    )
+
+
 def _ready_engine(handler) -> DistributedBatchedEngine:
     engine = DistributedBatchedEngine(_deployment())
     engine._loaded = True
@@ -251,7 +271,7 @@ async def test_distributed_generate_bounds_rank_zero_read_stalls():
     engine, status_calls, stop_calls, client = _stalled_engine()
     with pytest.raises(
         DistributedInferenceError,
-        match="request timed out.*no rank-zero data.*cluster was ready",
+        match="stream timed out.*no rank-zero data.*cluster was ready",
     ):
         await engine.generate("hello")
 
@@ -493,6 +513,240 @@ async def test_cancelled_supervisor_stop_finishes_before_unlock():
 
 
 @pytest.mark.asyncio
+async def test_cancelled_supervisor_operation_preserves_cancellation_on_failure():
+    started = threading.Event()
+    release = threading.Event()
+
+    def failing_operation():
+        started.set()
+        release.wait(timeout=2)
+        raise RuntimeError("teardown failed")
+
+    task = asyncio.create_task(
+        DistributedBatchedEngine._run_supervisor_operation(failing_operation)
+    )
+    try:
+        assert await asyncio.to_thread(started.wait, 1)
+        task.cancel()
+        await asyncio.sleep(0)
+    finally:
+        release.set()
+    with pytest.raises(asyncio.CancelledError) as caught:
+        await asyncio.wait_for(task, 1)
+    assert isinstance(caught.value.__cause__, RuntimeError)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("chat", [False, True])
+async def test_repeated_stream_cancellation_drains_activity_during_teardown(chat):
+    started = asyncio.Event()
+    stopping = asyncio.Event()
+    release = asyncio.Event()
+
+    async def handler(_request):
+        started.set()
+        await asyncio.Event().wait()
+
+    engine = _ready_engine(handler)
+    client = engine._client
+
+    async def stop_operation(_operation):
+        stopping.set()
+        await release.wait()
+
+    engine._run_supervisor_operation = stop_operation
+
+    async def consume():
+        stream = (
+            engine.stream_chat([{"role": "user", "content": "hello"}])
+            if chat
+            else engine.stream_generate("hello")
+        )
+        async for _output in stream:
+            pass
+
+    task = asyncio.create_task(consume())
+    try:
+        await asyncio.wait_for(started.wait(), 1)
+        task.cancel()
+        await asyncio.wait_for(stopping.wait(), 1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, 1)
+        assert engine.has_active_requests() is False
+        assert engine._lifecycle_lock.locked()
+        assert engine._teardown_tasks
+    finally:
+        release.set()
+        await asyncio.gather(*engine._teardown_tasks)
+        await client.aclose()
+    assert not engine._lifecycle_lock.locked()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("chat", [False, True])
+@pytest.mark.parametrize("streaming", [False, True])
+async def test_cancelled_queued_vision_request_keeps_running_rank_work(chat, streaming):
+    started = asyncio.Event()
+    release = asyncio.Event()
+    requests = []
+
+    async def handler(request):
+        requests.append(request)
+        started.set()
+        await release.wait()
+        if json.loads(request.content)["stream"]:
+            field = '"delta":{"content":"ok"}' if chat else '"text":"ok"'
+            return httpx.Response(
+                200,
+                content=(
+                    f'data: {{"choices":[{{{field},"finish_reason":"stop"}}]}}\n\n'
+                    "data: [DONE]\n\n"
+                ),
+            )
+        return _sse_response(
+            json={
+                "choices": [
+                    {
+                        "text": "ok",
+                        "message": {"content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+            },
+        )
+
+    engine = _ready_engine(handler)
+    engine._supports_multimodal_fallback = True
+    client = engine._client
+    stop_calls = []
+    engine._supervisor.stop = lambda: stop_calls.append(True)
+
+    async def invoke():
+        prompt = [{"role": "user", "content": "hello"}] if chat else "hello"
+        if streaming:
+            method = engine.stream_chat if chat else engine.stream_generate
+            return [output async for output in method(prompt)]
+        method = engine.chat if chat else engine.generate
+        return await method(prompt)
+
+    running = asyncio.create_task(invoke())
+    queued = None
+    try:
+        await asyncio.wait_for(started.wait(), 1)
+        queued = asyncio.create_task(invoke())
+        await asyncio.sleep(0)
+        assert engine._active_requests == 2
+        assert len(requests) == 1, "queued work must not open a backend socket"
+        queued.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await queued
+        assert engine._active_requests == 1
+        assert stop_calls == []
+        assert engine._client is client
+        release.set()
+        await asyncio.wait_for(running, 1)
+        assert not engine.has_active_requests()
+        assert not engine._vision_request_lock.locked()
+        assert stop_calls == []
+    finally:
+        release.set()
+        await asyncio.gather(
+            running, *([queued] if queued else []), return_exceptions=True
+        )
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_queued_vision_request_cannot_use_replaced_deployment():
+    engine = _ready_engine(lambda _request: httpx.Response(200))
+    engine._supports_multimodal_fallback = True
+    client = engine._client
+    await engine._vision_request_lock.acquire()
+    queued = asyncio.create_task(engine.generate("hello"))
+    replacement = httpx.AsyncClient(base_url="http://127.0.0.1:2")
+    try:
+        await asyncio.sleep(0)
+        assert engine._active_requests == 1
+        engine._client = replacement
+        engine._vision_request_lock.release()
+        with pytest.raises(DistributedInferenceError, match="changed while.*queued"):
+            await queued
+        assert not engine.has_active_requests()
+        assert not engine._vision_request_lock.locked()
+        assert engine._client is replacement
+        assert not replacement.is_closed
+    finally:
+        await client.aclose()
+        await replacement.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("chat", [False, True])
+async def test_nonstream_request_uses_progress_to_outlive_read_timeout(chat):
+    completed = asyncio.Event()
+    seen = []
+
+    async def serve(reader, writer):
+        try:
+            headers = await reader.readuntil(b"\r\n\r\n")
+            length = next(
+                int(line.split(b":", 1)[1])
+                for line in headers.split(b"\r\n")
+                if line.lower().startswith(b"content-length:")
+            )
+            seen.append(json.loads(await reader.readexactly(length)))
+            writer.write(b"HTTP/1.0 200 OK\r\nContent-Type: text/event-stream\r\n\r\n")
+            # Total request time exceeds the real HTTP client's inactivity
+            # limit, but regular backend progress makes the request healthy.
+            for _ in range(6):
+                writer.write(b": keepalive 1/2\n\n")
+                await writer.drain()
+                await asyncio.sleep(0.05)
+            choice = {"finish_reason": "stop"}
+            choice.update({"message": {"content": "ok"}} if chat else {"text": "ok"})
+            writer.write(
+                _sse_response(
+                    json={
+                        "choices": [choice],
+                        "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                    }
+                ).content
+            )
+            await writer.drain()
+        finally:
+            writer.close()
+            await writer.wait_closed()
+            completed.set()
+
+    async with await asyncio.start_server(serve, "127.0.0.1", 0) as server:
+        port = server.sockets[0].getsockname()[1]
+        engine = DistributedBatchedEngine(_deployment(), request_read_timeout=0.2)
+        engine._loaded = True
+        engine._tokenizer = _Tokenizer()
+        engine._client = engine._new_client(f"http://127.0.0.1:{port}")
+        client = engine._client
+        stop_calls = []
+        engine._supervisor.stop = lambda: stop_calls.append(True)
+        try:
+            call = (
+                engine.chat([{"role": "user", "content": "hi"}])
+                if chat
+                else engine.generate("hi")
+            )
+            output = await asyncio.wait_for(call, 2)
+            assert output.text == output.new_text == "ok"
+            assert output.completion_tokens == 1
+            assert seen[0]["stream"] is True
+            assert stop_calls == []
+            assert engine._loaded
+        finally:
+            await client.aclose()
+            await asyncio.wait_for(completed.wait(), 1)
+
+
+@pytest.mark.asyncio
 async def test_concurrent_distributed_failures_stop_supervisor_once():
     engine = _ready_engine(lambda _request: httpx.Response(200))
     client = engine._client
@@ -689,9 +943,8 @@ async def test_distributed_generate_translates_backend_completion():
     def handler(request):
         body = json.loads(request.content)
         assert body["prompt"] == "Hello"
-        assert body["stream"] is False
-        return httpx.Response(
-            200,
+        assert body["stream"] is True
+        return _sse_response(
             json={
                 "choices": [{"text": " world", "finish_reason": "stop"}],
                 "usage": {
@@ -737,9 +990,8 @@ async def test_distributed_chat_preserves_rank_zero_tool_calls_and_reasoning():
         assert request.url.path == "/v1/chat/completions"
         assert body["messages"] == [{"role": "user", "content": "Weather?"}]
         assert body["tools"] == tools
-        assert body["stream"] is False
-        return httpx.Response(
-            200,
+        assert body["stream"] is True
+        return _sse_response(
             json={
                 "choices": [
                     {
@@ -1279,7 +1531,7 @@ async def test_cancel_during_transport_diagnosis_still_stops_every_rank():
     engine._supervisor.stop = lambda: stop_calls.append(True)
 
     async def blocked_diagnosis(_exc, *, stream):
-        assert stream is False
+        assert stream is True
         diagnosis_started.set()
         await asyncio.Event().wait()
 
@@ -1423,11 +1675,13 @@ async def test_distributed_chat_retries_unsupported_reasoning_effort():
                 },
             )
         assert effort == "xhigh"
-        return httpx.Response(
-            200,
+        return _sse_response(
             json={
                 "choices": [
-                    {"message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}
+                    {
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
                 ],
                 "usage": {"prompt_tokens": 1, "completion_tokens": 1},
             },
@@ -1458,8 +1712,7 @@ async def test_distributed_chat_tries_the_normalized_value_first():
         effort = body.get("chat_template_kwargs", {}).get("reasoning_effort")
         calls.append(effort)
         if effort == "high":
-            return httpx.Response(
-                200,
+            return _sse_response(
                 json={
                     "choices": [
                         {
@@ -1502,8 +1755,7 @@ async def test_distributed_generate_retries_unsupported_reasoning_effort():
                 json={"error": "Unexpected reasoning effort minimal."},
             )
         assert effort == "low"
-        return httpx.Response(
-            200,
+        return _sse_response(
             json={
                 "choices": [{"text": "ok", "finish_reason": "stop"}],
                 "usage": {"prompt_tokens": 1, "completion_tokens": 1},

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -52,6 +52,39 @@ def _write_safetensors(path, tensors):
         f.write(b"\x00" * offset)
 
 
+def test_detects_deepseek_v4_flat_vision_config(tmp_path):
+    config = {
+        "model_type": "deepseek_v4",
+        "architectures": ["DeepseekV4ForCausalLM"],
+        "vision_n_layers": 32,
+        "vision_dim": 1024,
+        "vision_n_heads": 16,
+        "vision_inter_dim": 2816,
+        "vision_patch_size": 14,
+        "vision_rope_theta": 10000.0,
+        "vision_downsample_ratio": 3,
+        "vision_max_n_token": 384,
+        "vision_min_pixels": 147456,
+        "vision_max_wh_ratio": 8,
+    }
+    (tmp_path / "config.json").write_text(json.dumps(config))
+
+    assert detect_model_type(tmp_path) == "vlm"
+
+
+def test_deepseek_v4_text_is_not_misclassified(tmp_path):
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "deepseek_v4",
+                "architectures": ["DeepseekV4ForCausalLM"],
+            }
+        )
+    )
+
+    assert detect_model_type(tmp_path) == "llm"
+
+
 class TestIsHelperConfigModelType:
     """Tests for helper (dFlash / Assistant / Draft) model_type detection."""
 
@@ -1209,7 +1242,7 @@ class TestDiscoverModels:
         reranker_dir.mkdir()
         (reranker_dir / "config.json").write_text(
             json.dumps({
-                "model_type": "modernbert",
+                    "model_type": "modernbert",
                 "architectures": ["ModernBertForSequenceClassification"]
             })
         )
@@ -1483,8 +1516,8 @@ class TestReadModelContextLength:
 
     def test_top_level_takes_precedence_over_nested(self, tmp_path):
         self._write(tmp_path, config={
-            "max_position_embeddings": 200000,
-            "text_config": {"max_position_embeddings": 32768},
+                "max_position_embeddings": 200000,
+                "text_config": {"max_position_embeddings": 32768},
         })
         assert _read_model_context_length(tmp_path) == 200000
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -67,6 +67,171 @@ class TestBoundarySnapshotLifecycle:
         assert stale_dir.exists()
 
 
+class TestDistributedMultimodalRouting:
+    """Public API routing tests with no model weights or worker processes."""
+
+    @staticmethod
+    def _patch_engine(monkeypatch, server_module):
+        from types import SimpleNamespace
+
+        engine = SimpleNamespace(
+            supports_multimodal_fallback=True,
+            model_type="deepseek_v4",
+            tokenizer=None,
+        )
+        monkeypatch.setattr(
+            server_module,
+            "get_engine_for_model",
+            AsyncMock(return_value=engine),
+        )
+        monkeypatch.setattr(
+            server_module,
+            "_serving_model_id",
+            lambda _lease, requested: requested,
+        )
+        monkeypatch.setattr(
+            server_module,
+            "get_model_settings_for_request",
+            lambda _model: None,
+        )
+        monkeypatch.setattr(
+            server_module,
+            "get_engine_pool",
+            lambda: SimpleNamespace(get_entry=lambda _model: None),
+        )
+        return engine
+
+    @pytest.mark.asyncio
+    async def test_chat_completion_routes_images_to_multimodal_extractor(
+        self, monkeypatch
+    ):
+        import omlx.server as server_module
+        from omlx.api.openai_models import ChatCompletionRequest
+
+        class RoutedError(Exception):
+            pass
+
+        self._patch_engine(monkeypatch, server_module)
+        request = ChatCompletionRequest(
+            model="vision",
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/png;base64,a"},
+                        }
+                    ],
+                }
+            ],
+        )
+        monkeypatch.setattr(
+            server_module,
+            "_preprocess_markitdown_files_for_llm",
+            AsyncMock(return_value=request),
+        )
+        monkeypatch.setattr(
+            server_module,
+            "extract_multimodal_content",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(RoutedError()),
+        )
+
+        with pytest.raises(RoutedError):
+            await server_module.create_chat_completion(
+                request,
+                MagicMock(headers={}),
+                True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_anthropic_messages_preserves_images_for_distributed_vision(
+        self, monkeypatch
+    ):
+        import omlx.server as server_module
+        from omlx.api.anthropic_models import MessagesRequest
+
+        class RoutedError(Exception):
+            pass
+
+        self._patch_engine(monkeypatch, server_module)
+        observed = []
+
+        def convert(*_args, **kwargs):
+            observed.append(kwargs["preserve_images"])
+            raise RoutedError
+
+        monkeypatch.setattr(server_module, "convert_anthropic_to_internal", convert)
+        request = MessagesRequest(
+            model="vision",
+            max_tokens=8,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/png",
+                                "data": "a",
+                            },
+                        }
+                    ],
+                }
+            ],
+        )
+
+        with pytest.raises(RoutedError):
+            await server_module.create_anthropic_message(
+                request,
+                MagicMock(headers={}),
+                True,
+            )
+        assert observed == [True]
+
+    @pytest.mark.asyncio
+    async def test_responses_preserves_images_for_distributed_vision(self, monkeypatch):
+        import omlx.server as server_module
+        from omlx.api.responses_models import ResponsesRequest
+
+        class RoutedError(Exception):
+            pass
+
+        self._patch_engine(monkeypatch, server_module)
+        observed = []
+
+        def convert(*_args, **kwargs):
+            observed.append(kwargs["preserve_images"])
+            raise RoutedError
+
+        monkeypatch.setattr(
+            server_module, "convert_responses_input_to_messages", convert
+        )
+        request = ResponsesRequest(
+            model="vision",
+            input=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "input_image",
+                            "image_url": "data:image/png;base64,a",
+                        }
+                    ],
+                }
+            ],
+        )
+
+        with pytest.raises(RoutedError):
+            await server_module.create_response(
+                request,
+                MagicMock(headers={}),
+                True,
+            )
+        assert observed == [True]
+
+
 class TestDiffusionStructuredOutputGuard:
     class _DiffusionEngine:
         is_diffusion_model = True

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -648,6 +648,31 @@ class TestExceptionHandlers:
         data = response.json()
         assert "detail" in data
 
+    @pytest.mark.parametrize("quarantined", [False, True])
+    def test_distributed_launch_failure_returns_unavailable(self, quarantined):
+        from fastapi import FastAPI
+
+        from omlx.cluster.launch import (
+            DistributedLaunchError,
+            DistributedMemoryRecoveryError,
+        )
+
+        # Exercise Starlette's exception lookup, including the recovery subclass,
+        # without starting the real application or touching a cluster.
+        test_app = FastAPI(exception_handlers=app.exception_handlers)
+        error_type = (
+            DistributedMemoryRecoveryError if quarantined else DistributedLaunchError
+        )
+
+        @test_app.post("/v1/chat/completions")
+        async def unavailable():
+            raise error_type("rank memory is not reusable")
+
+        with TestClient(test_app, raise_server_exceptions=False) as client:
+            response = client.post("/v1/chat/completions")
+        assert response.status_code == 503
+        assert response.json()["error"]["message"] == "rank memory is not reusable"
+
 
 class TestModelFallback:
     """Tests for model fallback to default when requested model not found."""


### PR DESCRIPTION
## Summary

Adds a deliberately narrow distributed VLM path for `deepseek-ai/DeepSeek-V4-Flash-Vision-Exp` while preserving the existing DeepSeek-V4 language backbone and fail-closed behavior for other VLMs.

- Detects the published flat DeepSeek-V4 vision configuration without misclassifying text checkpoints.
- Ports the public ViT, aligner, image preprocessing, N-layout sentinel expansion, 2-D vision RoPE, vision-specific MoE routing bias, and image-span visibility mask to MLX.
- Keeps preprocessing and vision weights on rank 0, then broadcasts merged prompt embeddings with an MLX collective into the existing pipeline-parallel language prefill/decode path.
- Accounts for coordinator-only weights in planning, staging, deployment serialization, measured-memory validation, and per-rank layer allocation. Tensor parallelism remains rejected for this path.
- Preserves text-only requests, OpenAI-compatible image parts, streaming/non-streaming generation, content-keyed prompt caches, and propagates rank-zero preprocessing/encode failures before peer collectives.
- Isolates complete image sentinel spans during prefill so surrounding text remains on standard optimized attention kernels, bounding the long-context Metal transient that can otherwise stall rank zero.
- Hardens crash recovery by confirming every local and remote rank has exited, comparing post-teardown admission capacity with its pre-launch baseline, and quarantining reloads when Metal memory remains retained.
- Fails closed on abandoned distributed requests: engine start/stop is serialized under a lifecycle lock and blocking supervisor operations are shielded so a second start or stop cannot race a still-running operation (cherry-picked from the validated production line).
- Adds stage/timing/shape diagnostics and a repeatable two-Mac validation runbook.

## Model investigation

The implementation was derived from the public checkpoint config, safetensors index, and reference inference code. The checkpoint uses `model_type=deepseek_v4`, `DeepseekV4ForCausalLM`, flat `vision_*` fields, `vision.*`, `aligner.*`, four image sentinel parameters, and bare DeepSeek language tensor names. Image placeholders expand to the checkpoint N-layout; the language model keeps one-dimensional positions with image-span visibility added to its attention mask.

## Validation

- Physical 2× M5 Max / 128 GiB validation completed 2026-09-04 on **both Ring and JACCL** at `cc113f9d` (oMLX 0.6.4 / MLX 0.32.2 / mlx-lm 0.31.3 / macOS 26.6.2 / Python 3.13.15):
  - Ring: hardware canary pass on both Macs; planner gate (TP=1, rank 0 layers 22–43 with coordinator bytes, rank 1 layers 0–22 with zero, positive headroom); two-rank load (measured 78.3/80.9 GiB, headroom 11.0/8.8 GiB); text-only, one-image (119 prompt tokens), streaming (22 SSE chunks), second-image cache isolation, ~10k-token text+image in 18.2 s, ~23k-token tool-heavy request in 24.4 s with prefix-cache reuse, no Metal stall; 1,048,576-token catalogue (no 128k fallback); graceful unload reaped every rank process on both Macs; reload with repeats clean.
  - JACCL (over freshly repaired `10.0.1.1/24 ↔ 10.0.1.2/24`, `rdma_en1` both Macs): two-rank load with identical layer plan; text, one-image (119 prompt tokens, correct description), streaming (22 chunks), second-image isolation ("I see a blue circle." / "I see a red square."), ~10k-token text+image in 18.1 s with no stall; 7 requests, 0 failed; unload reaped all ranks on both Macs; reload with repeated text/image clean. A JACCL probe without RDMA fabric fails closed with `[jaccl] No IPv4-mapped GID for this device...` and quarantines reloads for that deployment only.
- Two fixes were added during hardware testing and are included: `4cd08e33` stops `read_runtime_markers` from warning on `-memory-recovery.json` quarantine records (separate schema enforced by the launcher; new test in `tests/test_cluster_runtime.py`); `cc113f9d` cherry-picks the production line's fail-closed abandoned-request hardening so this branch supersedes rather than regresses the previous production runtime.
- `.venv/bin/python -m pytest -q tests/test_cluster_*.py tests/test_distributed_engine.py tests/test_deepseek_v4_vision.py` — **1,047 passed, 58 skipped** on the current head.
- Ruff checks for the modified source and test paths — passed (`omlx/cli.py` shows only pre-existing findings outside this PR's diff).
- `python -m compileall -q omlx tests` — passed.
- Public checkpoint config parsed through the patched `ModelArgs`; tiny MLX ViT/aligner shape and dtype smoke passed.
- The final revision was adopted as the cluster production runtime: both Macs pinned to `cc113f9d`, production JACCL deployment `deepseek-v4-vision-cc113f9d-jaccl-1m` ready/live via the production launcher, text+image verified through the production API, plus a full unload/teardown/reload cycle through the production scripts (which also caught and fixed a launcher `cleanup()` scoping bug — see below).

The repository-wide Ruff baseline still reports unrelated pre-existing findings outside these modified paths.

## Known limitations

- Physical validation currently covers only the 2× M5 Max topology and access to that cluster is intermittent. Other hardware and cluster sizes remain unverified.
- The new model-specific runtime is wired through distributed MLX-LM. A separate standalone `VLMBatchedEngine` implementation is not included.
- Image-bearing prefill isolates each complete image sentinel span into its own model call while surrounding text retains the configured chunk cadence. An image block larger than the configured prefill step still sets the minimum safe chunk size.
- The recovery quarantine prevents unsafe automatic reloads but cannot forcibly reclaim IOGPU driver-retained wired memory; if capacity does not return, the affected Mac still requires a reboot.
- Local ops fix (outside this repo, in the cluster setup): the production launcher's `cleanup()` used a function-`local` server PID, so its own health-failure path aborted on an unbound variable under `set -u` and left the server orphaned on port 18000. Fixed by keeping the PID global to the script; verified by a full unload/teardown/restart cycle.
- MTP/DFlash/speculative combinations and tensor parallelism remain rejected by existing capability gates.
- Arbitrary distributed VLM families remain unsupported.

## Hardware validation runbook

See `docs/experimental/deepseek_v4_flash_vision_cluster.md` for the repeatable connectivity, dry-plan, load, text, one-image, streaming, cache-reuse, long-prompt, memory, unload/reload procedure, success markers, failure diagnostics, and benchmark checklist.
