### PR TITLE
fix(qwen4): preserve gathered prefill across mRoPE rebinds

### DIFF
--- a/omlx/models/vlm.py
+++ b/omlx/models/vlm.py
@@ -67,6 +67,14 @@ class VLMModelAdapter(nn.Module):
         # from this dict + current batch UIDs before each step.
         self._uid_rope_deltas: Dict[int, float] = {}
         self._batch_rope_deltas: Optional[mx.array] = None
+        # External/chunked text prefill owns a stronger position-shape proof
+        # than the generic decode binder: the scheduler has already excluded
+        # media embeddings and is advancing one request's scalar cache. Qwen4
+        # uses that proof to keep its position ids rank two, which is exactly
+        # equivalent to three broadcast-identical mRoPE planes and preserves
+        # the qualified gathered-QSA path. Generic/media/batched binds reset
+        # the proof and retain the ordinary rank-three fail-closed path.
+        self._qwen4_text_prefill_positions = False
 
     def release_resources(self) -> None:
         """Drop references to VLM-owned MLX arrays before engine teardown reclaim."""
@@ -77,6 +85,7 @@ class VLMModelAdapter(nn.Module):
         self._pending_kwargs = {}
         self._uid_rope_deltas.clear()
         self._batch_rope_deltas = None
+        self._qwen4_text_prefill_positions = False
         self._language_model = None
         self._vlm_model = None
 
@@ -253,6 +262,7 @@ class VLMModelAdapter(nn.Module):
         self._language_model._position_ids = None
         self._language_model._rope_deltas = None
         self._batch_rope_deltas = None
+        self._qwen4_text_prefill_positions = False
 
     def register_rope_delta(self, uid: int, delta: float) -> None:
         """Register rope_delta for a UID after VLM prefill."""
@@ -269,6 +279,18 @@ class VLMModelAdapter(nn.Module):
         an array of rope_deltas aligned to the batch slot order.
         """
         self._batch_rope_deltas = deltas
+        self._qwen4_text_prefill_positions = False
+
+    def set_text_prefill_rope_delta(self, delta: float) -> None:
+        """Bind one scheduler-proven text row for an imminent prefill call.
+
+        This seam is intentionally separate from ``set_batch_rope_deltas``.
+        Only the scheduler's external/chunked non-media prefill paths may call
+        it. A later generic decode, media, or batched bind clears the proof.
+        """
+
+        self._batch_rope_deltas = mx.array([delta])
+        self._qwen4_text_prefill_positions = True
 
     def _batch_rope_deltas_for_size(self, batch_size: int) -> Optional[mx.array]:
         """Return rope deltas aligned to the current model input batch size."""
@@ -300,7 +322,12 @@ class VLMModelAdapter(nn.Module):
         return mx.concatenate([deltas, pad], axis=0)
 
     def _position_ids_from_starts(
-        self, starts: mx.array, batch_size: int, seq_len: int
+        self,
+        starts: mx.array,
+        batch_size: int,
+        seq_len: int,
+        *,
+        qwen4_text_prefill_positions: bool = False,
     ) -> mx.array:
         """Build model-specific decode position_ids from per-row start offsets.
 
@@ -318,6 +345,18 @@ class VLMModelAdapter(nn.Module):
         steps = mx.arange(seq_len, dtype=starts.dtype)
         seq_positions = starts[:, None] + steps[None, :]
         if self._uses_minimax_m3_positions:
+            return seq_positions
+        if (
+            self.model_type == "qwen4_exp"
+            and qwen4_text_prefill_positions
+            and batch_size == 1
+        ):
+            # Qwen4's gathered-QSA qualification accepts canonical B1 text
+            # positions as (1, T), never general multimodal (3, B, T) mRoPE.
+            # The generic form constructed below is a broadcast of this exact
+            # row across all three planes, so avoiding that broadcast changes
+            # neither rotary values nor logits; it only preserves the proven
+            # text-only fast-path contract.
             return seq_positions
         return mx.broadcast_to(seq_positions[None, :, :], (3, batch_size, seq_len))
 
@@ -366,6 +405,12 @@ class VLMModelAdapter(nn.Module):
         Returns:
             Model output (logits as mx.array)
         """
+        # Consume the scheduler proof before doing any work. A failed/cancelled
+        # call therefore cannot leave a text-only capability armed for a later
+        # media or generic request. Each external prefill chunk explicitly
+        # re-arms it at its own model-call boundary.
+        qwen4_text_prefill_positions = self._qwen4_text_prefill_positions
+        self._qwen4_text_prefill_positions = False
         return_hidden = bool(kwargs.get("return_hidden", False))
         if skip_lm_head:
             # Scheduler prefill chunks discard their logits. Translate the
@@ -408,7 +453,10 @@ class VLMModelAdapter(nn.Module):
                 if base_offsets is not None and deltas is not None:
                     positions = base_offsets + deltas.astype(base_offsets.dtype)
                     position_ids = self._position_ids_from_starts(
-                        positions, batch_size, seq_len
+                        positions,
+                        batch_size,
+                        seq_len,
+                        qwen4_text_prefill_positions=(qwen4_text_prefill_positions),
                     )
                     result = self._language_model(
                         input_ids, cache=cache, position_ids=position_ids, **kwargs
@@ -428,7 +476,10 @@ class VLMModelAdapter(nn.Module):
                 if offsets is not None:
                     batch_size, seq_len = input_ids.shape
                     position_ids = self._position_ids_from_starts(
-                        offsets, batch_size, seq_len
+                        offsets,
+                        batch_size,
+                        seq_len,
+                        qwen4_text_prefill_positions=(qwen4_text_prefill_positions),
                     )
                     result = self._language_model(
                         input_ids, cache=cache, position_ids=position_ids, **kwargs

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1398,6 +1398,24 @@ def _seed_text_only_mrope_delta_for_cached_prefill(model: Any, request: Any) -> 
     mx.eval(lm._rope_deltas)
 
 
+def _bind_text_prefill_rope_delta(model: Any, delta: float) -> None:
+    """Rebind one non-media prefill row without widening Qwen4 positions.
+
+    ``VLMModelAdapter`` exposes a dedicated seam that records the scheduler's
+    text-only proof. Other model wrappers retain the original generic mRoPE
+    binder. Looking up the dedicated method on the class avoids treating an
+    auto-created ``MagicMock`` instance attribute as a production capability.
+    """
+
+    text_setter = getattr(type(model), "set_text_prefill_rope_delta", None)
+    if callable(text_setter):
+        text_setter(model, delta)
+        return
+    generic_setter = getattr(model, "set_batch_rope_deltas", None)
+    if callable(generic_setter):
+        generic_setter(mx.array([delta]))
+
+
 def _vlm_extra_seq_slice(val: mx.array, s: slice) -> mx.array:
     """Slice a VLM extra tensor along its seq dimension.
 
@@ -3598,6 +3616,18 @@ class Scheduler:
             _trace_model_start = time.perf_counter()
             with mx.stream(self._stream):
                 model_kwargs: dict[str, Any] = {}
+                if embeds_array is None:
+                    # External text prefill is interleaved chunk-by-chunk with
+                    # active decode. A finishing VLM row clears the adapter's
+                    # process-local position state, and a decode step may leave
+                    # a differently shaped batch delta behind. Rebind this
+                    # request immediately before every forward so neither
+                    # event can make a singleton Qwen mRoPE chunk restart at
+                    # local position zero inside an absolute QSA timeline.
+                    _bind_text_prefill_rope_delta(
+                        self.model,
+                        getattr(request, "rope_deltas", 0.0),
+                    )
                 if embeds_array is not None and embeds_array.shape[1] > 0:
                     model_kwargs["inputs_embeds"] = embeds_array[:, :n_to_process]
                     if extra_kwargs:
@@ -5174,6 +5204,16 @@ class Scheduler:
         with mx.stream(self._stream):
             chunk = state.tokens_remaining[:, :n]
             state.tokens_remaining = state.tokens_remaining[:, n:]
+            # A chunked text prefill can yield to active decode between
+            # forwards. Completion cleanup or the intervening decode batch may
+            # replace the VLM adapter's process-local mRoPE state. Rebind this
+            # request at the model-call boundary so the next scalar-cache chunk
+            # continues from its absolute cache offset instead of restarting at
+            # local position zero.
+            _bind_text_prefill_rope_delta(
+                self.model,
+                getattr(state.request, "rope_deltas", 0.0),
+            )
             if self._supports_skip_lm_head():
                 self.model(chunk, cache=state.cache, skip_lm_head=True)
             else:

--- a/tests/test_mlx_vlm_qwen4_exp_compat.py
+++ b/tests/test_mlx_vlm_qwen4_exp_compat.py
@@ -653,6 +653,102 @@ def test_qwen4_gathered_qsa_prefill_matches_official_mask_path(monkeypatch):
     ).item()
 
 
+def test_qwen4_rank_two_text_positions_match_identical_mrope_plane_logits(
+    monkeypatch,
+):
+    """Canonical text positions preserve exact values and unlock gathered QSA."""
+    config = _tiny_config()
+    import mlx_vlm.models.qwen4_exp.language as language
+    from mlx_vlm.models.qwen4_exp.language import QSAKVCache, Qwen4ExpAttention
+
+    mx.random.seed(831)
+    attention = Qwen4ExpAttention(config.text_config)
+    projection = mx.random.normal((config.text_config.hidden_size, 17))
+    hidden = mx.random.normal((1, 20, config.text_config.hidden_size))
+    text_positions = mx.arange(20, dtype=mx.int32)[None]
+    identical_mrope = mx.broadcast_to(text_positions[None], (3, 1, 20))
+    mx.eval(attention.parameters(), projection, hidden)
+
+    assert attention._gathered_text_prefill_eligible(
+        hidden,
+        "causal",
+        QSAKVCache(),
+        text_positions,
+        None,
+        False,
+    )
+    assert not attention._gathered_text_prefill_eligible(
+        hidden,
+        "causal",
+        QSAKVCache(),
+        identical_mrope,
+        None,
+        False,
+    )
+
+    gathered_calls = []
+    original_gathered = language.contiguous_causal_gathered_qsa
+
+    def tracked_gathered(*args, **kwargs):
+        gathered_calls.append(True)
+        return original_gathered(*args, **kwargs)
+
+    monkeypatch.setattr(
+        language,
+        "contiguous_causal_gathered_qsa",
+        tracked_gathered,
+    )
+    fast_cache = QSAKVCache()
+    reference_cache = QSAKVCache()
+    actual = attention(
+        hidden,
+        mask="causal",
+        cache=fast_cache,
+        position_ids=text_positions,
+    )
+    expected = attention(
+        hidden,
+        mask="causal",
+        cache=reference_cache,
+        position_ids=identical_mrope,
+    )
+    actual_logits = actual @ projection
+    expected_logits = expected @ projection
+    mx.eval(actual_logits, expected_logits)
+
+    assert gathered_calls == [True]
+    assert mx.allclose(actual, expected, rtol=2e-5, atol=2e-5).item()
+    assert mx.allclose(
+        actual_logits,
+        expected_logits,
+        rtol=2e-5,
+        atol=2e-5,
+    ).item()
+    assert mx.array_equal(
+        mx.argmax(actual_logits, axis=-1),
+        mx.argmax(expected_logits, axis=-1),
+    ).item()
+    assert fast_cache.offset == reference_cache.offset == 20
+    fast_keys, fast_values, fast_index_keys, _ = fast_cache.state
+    reference_keys, reference_values, reference_index_keys, _ = reference_cache.state
+    for fast_value, reference_value in (
+        (fast_keys, reference_keys),
+        (fast_values, reference_values),
+    ):
+        assert mx.allclose(
+            fast_value,
+            reference_value,
+            rtol=2e-5,
+            atol=2e-5,
+        ).item()
+    assert mx.allclose(
+        fast_index_keys,
+        reference_index_keys,
+        rtol=2e-5,
+        atol=2e-5,
+    ).item()
+
+
 def test_qwen4_gathered_qsa_fails_closed_for_multimodal_positions(monkeypatch):
     config = _tiny_config()
     import mlx_vlm.models.qwen4_exp.language as language

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -5849,10 +5849,12 @@ class TestVLMPositionStateClearing:
                 "clear_vlm_position_state",
                 "parameters",
                 "make_cache",
+                "set_batch_rope_deltas",
             ]
         )
         model.clear_vlm_position_state = MagicMock()
         model.make_cache.return_value = []
+        model.set_batch_rope_deltas = MagicMock()
         return model
 
     def test_schedule_waiting_preserves_vlm_position_state(self, mock_tokenizer):
@@ -5943,6 +5945,39 @@ class TestVLMPositionStateClearing:
         scheduler._schedule_waiting()
 
         model.clear_vlm_position_state.assert_called_once()
+
+    def test_external_text_prefill_rebinds_mrope_before_every_chunk(
+        self, mock_tokenizer
+    ):
+        """Concurrent decode or cleanup cannot leak adapter position state."""
+        model = self._make_vlm_model()
+        scheduler = Scheduler(
+            model=model,
+            tokenizer=mock_tokenizer,
+            config=SchedulerConfig(prefill_step_size=512),
+        )
+        request = Request(
+            request_id="text-mrope-chunks",
+            prompt="chunked",
+            sampling_params=SamplingParams(max_tokens=1),
+        )
+        request.prompt_token_ids = list(range(1025))
+        request.num_prompt_tokens = len(request.prompt_token_ids)
+        request.rope_deltas = 7.0
+
+        scheduler._do_external_prefill(
+            request,
+            tokens=request.prompt_token_ids,
+            existing_cache=[],
+            vlm_embeds=None,
+        )
+
+        assert model.call_count == 2
+        assert model.set_batch_rope_deltas.call_count == 2
+        for mock_call in model.set_batch_rope_deltas.call_args_list:
+            delta = mock_call.args[0]
+            assert delta.shape == (1,)
+            assert delta.item() == 7.0
 
     def test_cached_text_only_prefill_seeds_zero_mrope_delta(self, mock_tokenizer):
         """Cached text-only mRoPE suffixes must start at the restored offset."""

--- a/tests/test_scheduler_chunked_prefill.py
+++ b/tests/test_scheduler_chunked_prefill.py
@@ -238,6 +238,103 @@ class TestHasRequests:
 
 
 # ---------------------------------------------------------------------------
+# Chunk-local mRoPE ownership
+# ---------------------------------------------------------------------------
+
+
+class TestChunkedPrefillMRoPE:
+    def test_text_prefill_rebinds_delta_after_interleaved_cleanup(self):
+        class MRoPERecordingModel(_RecordingModel):
+            _uses_mrope = True
+
+            def __init__(self):
+                super().__init__("vlm")
+                self.batch_deltas = None
+                self.delta_history = []
+
+            def set_text_prefill_rope_delta(self, delta):
+                self.batch_deltas = mx.array([delta])
+                self.delta_history.append([delta])
+
+            def set_batch_rope_deltas(self, deltas):
+                raise AssertionError("text prefill must use the bounded binder")
+
+            def __call__(self, tokens, cache=None):
+                assert self.batch_deltas is not None
+                super().__call__(tokens, cache=cache)
+
+        model = MRoPERecordingModel()
+        tokenizer = MagicMock()
+        tokenizer.eos_token_id = 2
+        scheduler = Scheduler(
+            model=model,
+            tokenizer=tokenizer,
+            config=SchedulerConfig(
+                prefill_step_size=4,
+                chunked_prefill=True,
+                paged_cache_block_size=0,
+            ),
+        )
+        request = _make_request("mrope-interleaved", n_tokens=9)
+        request.rope_deltas = 7.0
+        state = _make_prefill_state(scheduler, request, n_remaining=8)
+
+        with patch("omlx.scheduler._sync_and_clear_cache"):
+            assert not scheduler._step_prefill_chunk(state)
+            # Reproduce a concurrent request's completion cleanup.
+            model.batch_deltas = None
+            assert scheduler._step_prefill_chunk(state)
+
+        assert model.chunk_lengths == [4, 4]
+        assert model.delta_history == [[7.0], [7.0]]
+
+    def test_mock_request_without_rope_delta_uses_text_default(self):
+        """Legacy/minimal request doubles retain the canonical text delta."""
+
+        class MRoPERecordingModel(_RecordingModel):
+            _uses_mrope = True
+
+            def __init__(self):
+                super().__init__("vlm")
+                self.delta_history = []
+
+            def set_text_prefill_rope_delta(self, delta):
+                self.delta_history.append([delta])
+
+        model = MRoPERecordingModel()
+        tokenizer = MagicMock()
+        tokenizer.eos_token_id = 2
+        scheduler = Scheduler(
+            model=model,
+            tokenizer=tokenizer,
+            config=SchedulerConfig(
+                prefill_step_size=4,
+                chunked_prefill=True,
+                paged_cache_block_size=0,
+            ),
+        )
+        request = SimpleNamespace(request_id="mock-without-rope-delta")
+        state = _PrefillState(
+            request=request,
+            cache=[],
+            tokens_remaining=mx.zeros((1, 4), dtype=mx.int32),
+            last_token=[99],
+            tokens_processed=0,
+            base_size=0,
+            emitted_boundaries={},
+            boundary_enabled=False,
+            block_size=0,
+            total_length=5,
+        )
+
+        with patch("omlx.scheduler._sync_and_clear_cache"):
+            assert scheduler._step_prefill_chunk(state)
+
+        assert model.chunk_lengths == [4]
+        assert model.delta_history == [[0.0]]
+
+
+# ---------------------------------------------------------------------------
 # get_stats includes num_prefilling
 # ---------------------------------------------------------------------------
 

--- a/tests/test_vlm_model_adapter.py
+++ b/tests/test_vlm_model_adapter.py
@@ -392,6 +392,13 @@ class TestPerRequestMRoPEDecode:
         vlm.config.text_config.rope_parameters = None
         return vlm
 
+    def _make_qwen4_mrope_vlm_model(self):
+        """Create the exact root/text model types shipped by Flash Next."""
+        vlm = self._make_mrope_vlm_model()
+        vlm.config.model_type = "qwen4_exp"
+        vlm.config.text_config.model_type = "qwen4_exp_text"
+        return vlm
+
     def test_mrope_decode_uses_language_model_with_position_ids(self):
         """mRoPE decode with batch_rope_deltas should use language_model with position_ids."""
         import mlx.core as mx
@@ -484,6 +491,95 @@ class TestPerRequestMRoPEDecode:
         pos_ids = call_kwargs["position_ids"]
         assert pos_ids.shape == (3, 1, 1)
         assert pos_ids[0, 0, 0].item() == 16384.0
+
+    def test_qwen4_b1_text_prefill_uses_canonical_rank_two_positions(self):
+        """Three broadcast-identical text planes stay in QSA's proven shape."""
+        import mlx.core as mx
+
+        from omlx.models.vlm import VLMModelAdapter
+
+        vlm = self._make_qwen4_mrope_vlm_model()
+        adapter = VLMModelAdapter(vlm)
+        assert adapter.model_type == "qwen4_exp"
+
+        adapter.set_text_prefill_rope_delta(0.0)
+        cache_layer = MagicMock()
+        cache_layer.offset = 16384
+        adapter(mx.zeros((1, 4), dtype=mx.int32), cache=[cache_layer])
+
+        position_ids = vlm.language_model.call_args.kwargs["position_ids"]
+        assert position_ids.shape == (1, 4)
+        assert position_ids.tolist() == [[16384, 16385, 16386, 16387]]
+
+    def test_qwen4_text_prefill_proof_is_one_shot_after_failed_call(self):
+        """An exception cannot leak the text-only proof into the next call."""
+        import mlx.core as mx
+        import pytest
+
+        from omlx.models.vlm import VLMModelAdapter
+
+        vlm = self._make_qwen4_mrope_vlm_model()
+        adapter = VLMModelAdapter(vlm)
+        cache_layer = MagicMock()
+        cache_layer.offset = 64
+        vlm.language_model.side_effect = [RuntimeError("cancelled"), MagicMock()]
+
+        adapter.set_text_prefill_rope_delta(0.0)
+        with pytest.raises(RuntimeError, match="cancelled"):
+            adapter(mx.zeros((1, 2), dtype=mx.int32), cache=[cache_layer])
+
+        # No rebind at all: the old delta array is still present, but the
+        # stronger text-only capability must have been consumed by the failed
+        # call and therefore cannot affect this later generic request.
+        adapter(mx.zeros((1, 2), dtype=mx.int32), cache=[cache_layer])
+        position_ids = vlm.language_model.call_args.kwargs["position_ids"]
+        assert position_ids.shape == (3, 1, 2)
+
+    def test_qwen4_text_prefill_b2_remains_rank_three(self):
+        """The text proof is not widened to an unqualified batched QSA path."""
+        import mlx.core as mx
+
+        from omlx.models.vlm import VLMModelAdapter
+
+        vlm = self._make_qwen4_mrope_vlm_model()
+        adapter = VLMModelAdapter(vlm)
+        adapter.set_text_prefill_rope_delta(0.0)
+        # A synthetic second delta demonstrates that the adapter refuses to
+        # reinterpret the one-row proof when the model call is batched.
+        adapter._batch_rope_deltas = mx.array([0.0, 0.0])
+        cache_layer = MagicMock()
+        cache_layer.offset = mx.array([128, 96])
+        adapter(mx.zeros((2, 2), dtype=mx.int32), cache=[cache_layer])
+
+        position_ids = vlm.language_model.call_args.kwargs["position_ids"]
+        assert position_ids.shape == (3, 2, 2)
+
+    def test_qwen4_media_positions_remain_divergent_rank_three(self):
+        """True mRoPE media planes bypass text canonicalization unchanged."""
+        import mlx.core as mx
+
+        from omlx.models.vlm import VLMModelAdapter
+
+        vlm = self._make_qwen4_mrope_vlm_model()
+        adapter = VLMModelAdapter(vlm)
+        divergent = mx.array(
+            [
+                [[10, 11, 12]],
+                [[10, 10, 11]],
+                [[7, 8, 8]],
+            ],
+            dtype=mx.int32,
+        )
+        adapter(
+            mx.zeros((1, 3), dtype=mx.int32),
+            cache=[MagicMock()],
+            inputs_embeds=mx.zeros((1, 3, 8)),
+            vlm_extra_kwargs={"position_ids": divergent},
+        )
+
+        position_ids = vlm.language_model.call_args.kwargs["position_ids"]
+        assert position_ids.shape == (3, 1, 3)
+        assert mx.array_equal(position_ids, divergent).item()
 
     def test_non_minimax_mrope_mismatched_delta_size_keeps_existing_path(self):
         """Non-MiniMax mRoPE models keep prior no-position_ids mismatch behavior."""


### PR DESCRIPTION
## Summary

Preserve both sides of Qwen4 text prefill correctness:

- rebind each request’s mRoPE delta immediately before every external/interleaved prefill forward, so concurrent decode or VLM cleanup cannot restart a later chunk at local position zero;
- keep scheduler-proven B1 text positions in canonical rank-two form so the already-qualified gathered-QSA prefill path remains eligible.

## Root cause

The correctness rebind caused ordinary text positions to be presented as `(3, 1, T)`: three broadcast-identical mRoPE planes. Qwen4’s gathered text-prefill gate deliberately accepts canonical `(1, T)` positions and rejects general rank-three multimodal state, so every QSA layer silently fell back to the slower official/dense route.

Real agent traffic exposed the resulting taper: roughly 862 tok/s near 4–8K fell to about 510 tok/s around 40K and 479 tok/s near 49K. The machine had one server, no memory pressure, and no thermal warning; pure model chunk timings confirmed this was not dashboard or network latency.

## Lossless behavior

`VLMModelAdapter` exposes a dedicated one-shot text-prefill binder. Only the scheduler’s non-media external/chunked prefill paths can arm it. For Qwen4 B1, `(1,T)` is exactly one plane of the former three identical planes, so rotary values are unchanged.

The capability is consumed at model-call entry, including exceptions/cancellation. Media, B2, generic models, and unproved shapes retain rank-three positions and fail closed. No weights, logits policy, sampling, token IDs, attention budget, or cache acceptance rule changes.

## Physical M3 Ultra validation

Fresh unique-salt public-API B1 runs, temperature zero, thinking disabled:

- 19,992 uncached tokens: **892.56 tok/s**.
- 219,994 uncached tokens: **885.27 tok/s overall**.
- Windowed pure model throughput: **944.69** at 0–8K, **907.60** at 40–49K, **891.63** at 98–106K, **880.05** at 147–155K, **866.86** at 196–205K, and **851.68 tok/s** at 213–220K.
- Exact cached repeat: 19,991/19,992 tokens reused, **0.15 s model TTFT**, **0.47 s visible TTFT**, identical output SHA-256.

The repaired curve matches or beats the prior qualified aggregate curve (883.06 at 50K down to 851.46 at 220K) and replaces the bad ~40% loss by 40K with about 9.8% taper across the full 220K.

## Validation

- focused regression tests: **7/7**;
- complete touched suites: **440/440** on Python 3.12 after the final CI hardening;
- wider Python 3.13 run reached **4,641 passed / 115 skipped / 77 deselected** with no failure before it was intentionally stopped;
- `git diff --check` clean;
- SSH-signed and DCO-signed-off commit;
- Python 3.11, 3.12, and 3.13 CI all green at exact head `b7e2705a`.

This PR is intentionally bounded to the adapter, scheduler rebind seams, and required tests. It contains no Cluster, cache-provider, kernel, vendor, release, or packaging work. It is ready for review: exact-head Python 3.11–3.13 CI and the final OpenCode owner-harness validation are green.