### PR TITLE
perf(qwen4_exp): batch the PLE sharded-embedding gather

### DIFF
--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gc
 import json
 import math
 import mmap
@@ -7,6 +8,8 @@ import os
 import struct
 import weakref
 from bisect import bisect_right
+from collections import OrderedDict
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, replace
 from pathlib import Path
 from types import SimpleNamespace
@@ -1684,6 +1687,21 @@ class _SafeTensorMMap:
             self._file = None
 
 
+_PLE_DTYPES = {
+    "BF16": (np.dtype("<u2"), mx.bfloat16),
+    "F16": (np.dtype("<f2"), mx.float16),
+    "F32": (np.dtype("<f4"), mx.float32),
+    "U32": (np.dtype("<u4"), mx.uint32),
+    "F8_E4M3": (np.dtype("u1"), None),
+}
+
+
+def _ple_batched_gather() -> bool:
+    return os.environ.get("OMLX_QWEN4_PLE_GATHER", "").strip().lower() not in (
+        "0", "false", "no", "off"
+    )
+
+
 class DiskBackedShardedEmbedding(nn.Module):
     """The 128-way dense or oQ-affine PLE table, gathered from SSD mmap."""
 
@@ -1837,7 +1855,145 @@ class DiskBackedShardedEmbedding(nn.Module):
                 group_size,
             )
 
+    # ---- fast sharded gather ------------------------------------------------
+    # The stock __call__ below evaluates the id tensor and reads it back with
+    # .tolist(), draining the GPU mid-forward, then walks one Python loop per id
+    # Bucket ids by shard with searchsorted, warm every shard in one threaded
+    # pread, dequantize once, and keep a bounded hot-row LRU.
+    # OMLX_QWEN4_PLE_GATHER=0 restores the upstream row-at-a-time path.
+    def _fast_state(self):
+        st = getattr(self, "_omlx_ple_fast", None)
+        if st is not None:
+            return st
+        io, views = [], []
+        for i in range(len(self.shard_sizes)):
+            wk, sk, bk, _bits, _group = self._shard_specs[i]
+            tio, tv = [], []
+            for key in (wk, sk, bk):
+                if key is None:
+                    tio.append(None)
+                    tv.append(None)
+                    continue
+                rd = self._tensor_readers[key]
+                entry = rd._header[key]
+                npdt, view_dt = _PLE_DTYPES.get(str(entry["dtype"]), (None, None))
+                if npdt is None:
+                    raise TypeError(
+                        f"SSD-backed Qwen4 PLE does not support {entry['dtype']}"
+                    )
+                shp = tuple(entry["shape"])
+                off = rd._data_start + entry["data_offsets"][0]
+                tv.append((np.frombuffer(rd._mapping, dtype=npdt,
+                                         count=shp[0] * shp[1],
+                                         offset=off).reshape(shp), view_dt))
+                tio.append((rd._file.fileno(), off,
+                            shp[1] * np.dtype(npdt).itemsize))
+            io.append(tio)
+            views.append(tv)
+        try:
+            hot_mb = int(os.environ.get("OMLX_QWEN4_PLE_HOT_MB", "1024"))
+        except ValueError:
+            hot_mb = 1024
+        row_bytes = max(1, sum(rb for spec in io[0] if spec for _, _, rb in [spec]))
+        st = {
+            "io": io,
+            "views": views,
+            "hot": OrderedDict(),
+            "cap": (max(0, hot_mb) * 2 ** 20) // row_bytes,
+            "pool": ThreadPoolExecutor(max_workers=16,
+                                       thread_name_prefix="ple-warm"),
+        }
+        self._omlx_ple_fast = st
+        return st
+
+    def _gather_host(self, host, shape):
+        offsets = np.asarray(self.shard_offsets, dtype=np.int64)
+        if host.size and (host.min() < 0 or host.max() >= offsets[-1]):
+            raise IndexError("embedding index is outside the sharded vocabulary")
+        uniq, inverse = np.unique(host, return_inverse=True)
+        st = self._fast_state()
+        io, views, hot, cap = st["io"], st["views"], st["hot"], st["cap"]
+
+        miss = (np.array([r for r in uniq if int(r) not in hot], dtype=np.int64)
+                if cap else uniq)
+        if miss.size:
+            shard = np.searchsorted(offsets, miss, side="right") - 1
+            local = miss - offsets[shard]
+            order = np.argsort(shard, kind="stable")
+            shard_s, local_s, miss_s = shard[order], local[order], miss[order]
+            work = []
+            for si, lr in zip(shard_s, local_s):
+                for spec in io[int(si)]:
+                    if spec is not None:
+                        fd, base, rb = spec
+                        work.append((fd, base + int(lr) * rb, rb))
+            if work:
+                step = max(1, (len(work) + 15) // 16)
+
+                def _touch(chunk):
+                    for fd, off, rb in chunk:
+                        os.pread(fd, rb, off)
+
+                list(st["pool"].map(
+                    _touch,
+                    [work[k:k + step] for k in range(0, len(work), step)]))
+            bounds = np.searchsorted(shard_s, np.arange(len(self.shard_sizes) + 1))
+            for si in np.unique(shard_s):
+                lo, hi = bounds[si], bounds[si + 1]
+                rows_l = local_s[lo:hi]
+                (wv, _wd), sv_p, bv_p = views[int(si)]
+                sv = sv_p[0] if sv_p else None
+                bv = bv_p[0] if bv_p else None
+                w = np.ascontiguousarray(wv[rows_l])
+                sc = np.ascontiguousarray(sv[rows_l]) if sv is not None else None
+                bi = np.ascontiguousarray(bv[rows_l]) if bv is not None else None
+                for j, gid in enumerate(miss_s[lo:hi]):
+                    # .copy() so a cached row owns its bytes; a view would pin
+                    # the whole fetched block and unbound OMLX_QWEN4_PLE_HOT_MB.
+                    hot[int(gid)] = (w[j].copy(),
+                                     None if sc is None else sc[j].copy(),
+                                     None if bi is None else bi[j].copy())
+        self.last_touched_shards = tuple(
+            int(x) for x in np.unique(
+                np.searchsorted(offsets, uniq, side="right") - 1)
+        )
+        rows = []
+        for r in uniq:
+            k = int(r)
+            rows.append(hot[k])
+            if cap:
+                hot.move_to_end(k)
+        while cap and len(hot) > cap:
+            hot.popitem(last=False)
+        if not cap:
+            hot.clear()
+
+        _, _, _, bits, group_size = self._shard_specs[0]
+        (_, w_view), sp, bp = views[0]
+        w = mx.array(np.stack([r[0] for r in rows]))
+        if bits is not None:
+            sc = mx.array(np.stack([r[1] for r in rows])).view(sp[1])
+            bi = mx.array(np.stack([r[2] for r in rows])).view(bp[1])
+            values = mx.dequantize(w, sc, bi, group_size=group_size, bits=bits,
+                                   mode="affine")
+        elif w_view is None:
+            values = mx.from_fp8(w, dtype=mx.bfloat16)
+        else:
+            values = w.view(w_view)
+        values = values.astype(mx.bfloat16) * self.weight_scale
+        self.rows_read = int(uniq.size)
+        out = values[mx.array(inverse.astype(np.int32))]
+        return out.reshape(*shape, self.dims)
+
+    def _call_fast(self, indices: mx.array) -> mx.array:
+        shape = indices.shape
+        flat = indices.reshape(-1)
+        mx.eval(flat)
+        return self._gather_host(np.asarray(flat, dtype=np.int64), shape)
+
     def __call__(self, indices: mx.array) -> mx.array:
+        if _ple_batched_gather():
+            return self._call_fast(indices)
         shape = indices.shape
         flat = indices.reshape(-1)
         mx.eval(flat)
@@ -1884,6 +2040,20 @@ class DiskBackedShardedEmbedding(nn.Module):
         return result.reshape(*shape, self.dims)
 
     def close(self):
+        # The fast path keeps numpy views into each mmap; they must be dropped
+        # before the readers close or the buffer stays exported.
+        state = getattr(self, "_omlx_ple_fast", None)
+        if state is not None:
+            state["views"].clear()
+            state["io"].clear()
+            state["hot"].clear()
+            state["pool"].shutdown(wait=False)
+            try:
+                delattr(self, "_omlx_ple_fast")
+            except AttributeError:
+                self.__dict__.pop("_omlx_ple_fast", None)
+            del state
+            gc.collect()
         for reader in self._readers.values():
             reader.close()
         self._readers.clear()

--- a/tests/test_mlx_vlm_qwen4_exp_compat.py
+++ b/tests/test_mlx_vlm_qwen4_exp_compat.py
@@ -1423,3 +1423,52 @@ def test_qwen4_lightning_mtp_isolated_from_dense_qwen35_runtime_patch():
 
     assert resident_owner.mtp is not None
     assert later_owner.mtp is not None
+
+
+def _write_fp8_ple_shard(model_path, key, rows, dims):
+    """Emit a one-shard safetensors file holding a dense F8_E4M3 PLE table."""
+
+    payload = bytes((index * 7 + 3) % 256 for index in range(rows * dims))
+    header = json.dumps(
+        {
+            key: {
+                "dtype": "F8_E4M3",
+                "shape": [rows, dims],
+                "data_offsets": [0, len(payload)],
+            }
+        }
+    ).encode()
+    shard = model_path / "model-00001.safetensors"
+    shard.write_bytes(
+        len(header).to_bytes(8, "little") + header + payload
+    )
+    (model_path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {key: shard.name}})
+    )
+
+
+def test_qwen4_ssd_ple_gathers_fp8_shards(tmp_path, monkeypatch):
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    import mlx_vlm.models.qwen4_exp.language as language
+
+    rows, dims = 8, 4
+    _write_fp8_ple_shard(tmp_path, "ple.shard_0.weight", rows, dims)
+    indices = mx.array([0, 3, 5, 3], dtype=mx.int32)
+
+    def gather():
+        embedding = language.DiskBackedShardedEmbedding(
+            tmp_path, "ple", rows, dims, 1
+        )
+        try:
+            return embedding(indices)
+        finally:
+            embedding.close()
+
+    monkeypatch.delenv("OMLX_QWEN4_PLE_GATHER", raising=False)
+    batched = gather()
+    monkeypatch.setenv("OMLX_QWEN4_PLE_GATHER", "0")
+    upstream = gather()
+    mx.eval(batched, upstream)
+
+    assert batched.shape == (4, dims)
+    assert mx.array_equal(batched, upstream).item()


### PR DESCRIPTION
Qwen3.8-Flash-Next's SSD-backed PLE embedding gather stalled the GPU once per forward. This batches it.

**Decode: 35.4 → 37.3 tok/s at 92k (+5.4%, 95% CI [+0.13, +3.78] tok/s), paired, on `main`.**

### What was slow

The gather evaluated the id tensor and read it back with `.tolist()` — draining the GPU mid-forward — then looped per id and rescanned every shard. Ids scatter across 50–90 shards holding 1–2 rows each, so the cold mmap faults that dominate were never overlapped.

### Change

Bucket ids by shard with `searchsorted`, warm every shard in one threaded pread, dequantize once, and keep a bounded hot-row LRU. Dtype coverage matches the upstream reader, including `F8_E4M3` via `mx.from_fp8`.

Output is bitwise equal to the upstream row reader: `test_qwen4_ssd_ple_gathers_fp8_shards` compares both paths on an FP8 shard, and the existing gather tests are unchanged.

### Measurement

Paired runs on `upstream/main` + this commit, arms interleaved in one process and toggled live, 92k warm-prefix context, 600 generated tokens, M5 Max 128 GB.

| | n | off | on | diff | | 95% CI |
|---|---|---|---|---|---|---|
| PLE gather | 8 | 35.42 | 37.32 | +1.90 | **+5.4%** | [+0.13, +3.78] |

The saving is a fixed few milliseconds of host time per forward, so its share grows as the rest of the forward gets faster; on top of #3320 the same change measures +5.9%.

### Switches

`OMLX_QWEN4_PLE_GATHER=0` restores the upstream row-at-a-time path without a rebuild; `OMLX_QWEN4_PLE_HOT_MB` bounds the hot-row cache (default 1024).

Tests: same 5 pre-existing failures as `main`, none added.

Split off from the earlier version of this PR: the split-K sparse-GQA change now lives in a PR against #3320, whose verify routing is what gives it a decode effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
