### PR TITLE
fix: pass a portable count to macOS host_statistics64

### DIFF
--- a/omlx/utils/psutil_compat.py
+++ b/omlx/utils/psutil_compat.py
@@ -29,6 +29,11 @@ _VM_STATS_MIN_COUNT = 4
 # against `vm_stat` output on Apple Silicon.
 _VM_SPECULATIVE_INDEX = 23
 _VM_COMPRESSOR_INDEX = 32
+# Keep the initial request within both the 40-entry and 62-entry SDK layouts;
+# newer kernels can report a larger required count and trigger a safe retry.
+_HOST_INFO64_INITIAL_COUNT = _VM_COMPRESSOR_INDEX + 1
+# mach_vm.h's MIG_ARRAY_TOO_LARGE return value (KERN_INVALID_ARGUMENT - 307).
+_MIG_ARRAY_TOO_LARGE = -307
 _VM_PAGE_SIZE = 16384
 _SYSCTL = "/usr/sbin/sysctl"
 _VM_STAT = "/usr/bin/vm_stat"
@@ -104,19 +109,29 @@ def get_macos_vm_stats() -> dict[str, int] | None:
     """Return macOS vm_statistics64 page counters in bytes.
 
     The first four counters are stable across SDK versions. The oversized
-    host_info64_t buffer avoids binding oMLX to an SDK-specific struct tail.
-    "speculative" and "compressed" sit further into the struct and are only
-    reported when the kernel filled that far, so callers must treat them as
-    optional.
+    host_info64_t buffer avoids binding oMLX to an SDK-specific struct tail,
+    while the initial count covers every field oMLX reads in both known SDK
+    layouts. If a newer kernel reports that it needs more entries, the call is
+    retried with that count when it still fits the allocation. "speculative"
+    and "compressed" sit further into the struct and are only reported when
+    the kernel filled that far, so callers must treat them as optional.
     """
     if _libc is None or _MACH_HOST is None:
         return None
     try:
         stats = (ctypes.c_int * _HOST_INFO64_MAX_COUNT)()
-        count = ctypes.c_uint(_HOST_INFO64_MAX_COUNT)
+        count = ctypes.c_uint(_HOST_INFO64_INITIAL_COUNT)
         rc = _libc.host_statistics64(
             _MACH_HOST, _HOST_VM_INFO64, stats, ctypes.byref(count)
         )
+        if rc == _MIG_ARRAY_TOO_LARGE:
+            required_count = int(count.value)
+            if not (_VM_STATS_MIN_COUNT <= required_count <= _HOST_INFO64_MAX_COUNT):
+                return None
+            count = ctypes.c_uint(required_count)
+            rc = _libc.host_statistics64(
+                _MACH_HOST, _HOST_VM_INFO64, stats, ctypes.byref(count)
+            )
         if rc != 0 or count.value < _VM_STATS_MIN_COUNT:
             return None
         ps = _VM_PAGE_SIZE

--- a/tests/test_process_memory_enforcer.py
+++ b/tests/test_process_memory_enforcer.py
@@ -108,14 +108,14 @@ def _close_coro(coro):
 class TestMacOSVMStats:
     """Tests for the host_statistics64 telemetry adapter."""
 
-    def test_uses_max_sized_host_info64_buffer(self):
-        """Newer macOS kernels can require a larger vm_statistics64 tail."""
+    def test_uses_layout_compatible_host_info64_count(self):
+        """Request only the fields needed across SDK-specific layouts."""
 
         class FakeLibc:
             def host_statistics64(self, host, flavor, stats, count):
                 assert host == 123
                 assert flavor == psutil_compat._HOST_VM_INFO64
-                assert count._obj.value == psutil_compat._HOST_INFO64_MAX_COUNT
+                assert count._obj.value == psutil_compat._HOST_INFO64_INITIAL_COUNT
                 stats[0] = 10
                 stats[1] = 20
                 stats[2] = 30

--- a/tests/test_psutil_compat.py
+++ b/tests/test_psutil_compat.py
@@ -80,3 +80,49 @@ def test_vm_stats_omits_tail_counters_on_short_reply(monkeypatch):
     assert "speculative" not in stats
     # The stable four must still be there — _build_svmem depends on them.
     assert {"free", "active", "inactive", "wired"} <= set(stats)
+
+
+def test_vm_stats_retries_with_kernel_requested_count():
+    calls = []
+
+    class FakeLibc:
+        def host_statistics64(self, host, flavor, stats, count):
+            calls.append(count._obj.value)
+            if len(calls) == 1:
+                count._obj.value = 104
+                return psutil_compat._MIG_ARRAY_TOO_LARGE
+            assert count._obj.value == 104
+            for index, value in enumerate((10, 20, 30, 40)):
+                stats[index] = value
+            count._obj.value = 104
+            return 0
+
+    with (
+        patch.object(psutil_compat, "_libc", FakeLibc()),
+        patch.object(psutil_compat, "_MACH_HOST", 123),
+        patch.object(psutil_compat, "_VM_PAGE_SIZE", 4096),
+    ):
+        stats = psutil_compat.get_macos_vm_stats()
+
+    assert calls == [psutil_compat._HOST_INFO64_INITIAL_COUNT, 104]
+    assert stats == {
+        "free": 10 * 4096,
+        "active": 20 * 4096,
+        "inactive": 30 * 4096,
+        "wired": 40 * 4096,
+        "speculative": 0,
+        "compressed": 0,
+    }
+
+
+def test_vm_stats_rejects_oversized_kernel_requirement():
+    class FakeLibc:
+        def host_statistics64(self, host, flavor, stats, count):
+            count._obj.value = psutil_compat._HOST_INFO64_MAX_COUNT + 1
+            return psutil_compat._MIG_ARRAY_TOO_LARGE
+
+    with (
+        patch.object(psutil_compat, "_libc", FakeLibc()),
+        patch.object(psutil_compat, "_MACH_HOST", 123),
+    ):
+        assert psutil_compat.get_macos_vm_stats() is None


### PR DESCRIPTION
## Summary

Fixes #2983.

`get_macos_vm_stats()` allocates room for future `vm_statistics64` fields, but
previously passed that allocation capacity (`256`) as the Mach API's in/out
count. macOS validates the count against the structure layout exposed by the
interpreter's SDK, which produces warnings for both current 40-entry and
62-entry layouts.

This change:

- starts with a portable count that includes every field oMLX reads;
- keeps the larger allocation for forward-compatible tails;
- retries with the kernel-reported count for `MIG_ARRAY_TOO_LARGE` when it fits;
- falls back safely when the kernel reports an invalid or oversized requirement.

## Validation

- `pytest tests/test_psutil_compat.py -q` (6 passed)
- Ruff check and formatting checks for the changed compatibility module/tests
- Python bytecode compilation for the changed module/tests
- `git diff --check`

The full process-enforcer module could not be completed in this environment
because its optional PyTorch/transformers imports are unavailable; its focused
Mach-statistics behavior is covered by the isolated tests above.
