### PR TITLE
fix(stream): keep unfinished reasoning private

### DIFF
--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -152,15 +152,13 @@ def extract_thinking(text: str) -> Tuple[str, str]:
     - Empty think: ``<think></think>answer`` → ``("", "answer")``
     - Think only: ``<think>reasoning</think>`` → ``("reasoning", "")``
     - Malformed (open with no close): ``<think>everything…`` →
-      ``("", "everything…")`` — recovery for V4-style models that
-      occasionally skip the ``</think>`` boundary token. Without this
-      fallback the entire body would be classified as thinking and the
-      visible answer would be empty.
+      ``("everything…", "")`` — unfinished private reasoning is never
+      reclassified as a visible answer.
 
-    Tag-free text is always classified as content. Mirrors
-    ``ThinkingParser.finish()`` recovery semantics (`_content_emitted`
-    fallback): when the model emits no thinking markers, surface the body
-    as the answer so the response is never empty.
+    Tag-free text is always classified as content because this non-streaming
+    helper has no prompt-open-state information. Streaming callers use
+    :class:`ThinkingParser`, which preserves unfinished prompt-opened text as
+    reasoning and reports the response as incomplete.
 
     Args:
         text: Complete model output text.
@@ -201,13 +199,13 @@ def extract_thinking(text: str) -> Tuple[str, str]:
             remaining = text[match.end():].strip()
             return (thinking, remaining)
 
-    # Malformed: <think> opened but never closed. Drop the open tag and
-    # treat the remainder as content so the answer body is not empty.
+    # Malformed: <think> opened but never closed. Keep the remainder private;
+    # surfacing chain-of-thought as an answer is a protocol/privacy failure.
     if '<think>' in text and '</think>' not in text:
         idx = text.index('<think>')
         before = text[:idx]
         after = text[idx + _OPEN_LEN:]
-        return ("", (before + after).strip())
+        return (after.strip(), before.strip())
 
     return ("", text)
 
@@ -237,12 +235,8 @@ class ThinkingParser:
     def __init__(self, start_in_thinking: bool = False):
         self._in_thinking: bool = start_in_thinking
         self._buffer: str = ""  # Buffer for potential partial tags
-        # Recovery state for malformed thinking: when the prompt prepends
-        # ``<think>`` and the model never emits ``</think>`` before EOS,
-        # everything we streamed went out as thinking. The streamed events
-        # cannot be retracted, so finish() emits the accumulated thinking
-        # text once more as content — the client will show both panels but
-        # the answer body is no longer empty.
+        # State retained for protocol validation and observability. Unfinished
+        # thinking is never copied into visible answer content.
         self._close_seen: bool = False
         self._thinking_accumulated: List[str] = []
         self._content_emitted: bool = False
@@ -328,34 +322,16 @@ class ThinkingParser:
 
         Should be called when the stream is complete to emit any
         buffered characters that were waiting for potential tag completion.
-        Also recovers from malformed thinking — when the model never
-        emitted ``</think>`` and no content was ever produced, returns
-        the accumulated thinking text as content so the client surfaces
-        a non-empty answer body.
+        Unfinished reasoning remains reasoning. Callers can inspect
+        :attr:`unfinished_thinking` and surface an incomplete finish reason;
+        they must not leak accumulated chain-of-thought into answer content.
 
         Returns:
             Tuple of (thinking_text, content_text) from remaining buffer
-            (plus recovered content if applicable).
+            from the remaining buffer.
         """
         partial = self._buffer
         self._buffer = ""
-
-        # Recovery: prompt opened a thinking block (or model echoed
-        # ``<think>`` itself), the close tag never arrived, and nothing
-        # ever streamed as content. Re-emit the accumulated thinking text
-        # as content so the answer body is not empty. The thinking events
-        # already streamed live cannot be retracted, so the client sees
-        # the same text twice — once in the thinking panel, once as the
-        # answer. UX trade-off documented in the chat template plan.
-        if (
-            self._in_thinking
-            and not self._close_seen
-            and not self._content_emitted
-            and self._thinking_accumulated
-        ):
-            recovered = "".join(self._thinking_accumulated) + partial
-            self._content_emitted = True
-            return ("", recovered)
 
         if not partial:
             return ("", "")
@@ -367,6 +343,12 @@ class ThinkingParser:
         else:
             self._content_emitted = True
             return ("", partial)
+
+    @property
+    def unfinished_thinking(self) -> bool:
+        """Whether the stream ended while a reasoning block was still open."""
+
+        return self._in_thinking
 
     @staticmethod
     def _could_be_tag(text: str) -> bool:
@@ -389,29 +371,33 @@ class ThinkingParser:
 
 
 class ThinkingBudgetProcessor:
-    """Logits processor that enforces a thinking token budget.
+    """Logits processor that keeps an opened thinking protocol well formed.
 
-    Counts tokens generated while in thinking mode.  When the budget is
-    exceeded, forces the close-think token(s) one at a time, then becomes
-    a no-op for the rest of generation.
+    While the prompt-opened thinking block is active, terminal stop tokens can
+    be suppressed so a sampled EOS cannot strand the response inside
+    ``<think>``.  When a budget is configured, the processor additionally
+    counts thinking tokens and forces the close-think sequence once the budget
+    is reached.  After the close marker it becomes a no-op.
 
     Handles both single-token and multi-token close-think sequences, and
     supports alternative think markers (e.g. ``<longcat_think>``).
 
     Args:
         think_end_token_ids: Token ID(s) for the close-think tag.
-        budget: Maximum number of thinking tokens before forcing close.
+        budget: Optional maximum thinking tokens before forcing close.
         think_start_token_id: Token ID for the open-think tag (re-entry detection).
+        stop_token_ids: Terminal token IDs forbidden until thinking closes.
     """
 
     def __init__(
         self,
         think_end_token_ids: List[int],
-        budget: int,
+        budget: Optional[int],
         think_start_token_id: Optional[int] = None,
         leading_token_ids: Optional[List[int]] = None,
         trailing_token_ids: Optional[List[int]] = None,
         token_to_piece: Optional[Callable[[int], str | bytes | None]] = None,
+        stop_token_ids: Optional[Sequence[int]] = None,
     ):
         self._think_end_ids = think_end_token_ids
         # Full force sequence: \n + </think> + \n\n (matches training pattern)
@@ -420,9 +406,12 @@ class ThinkingBudgetProcessor:
             + list(think_end_token_ids)
             + (trailing_token_ids or [])
         )
-        self._budget = budget
+        self._budget = None if budget is None else max(1, int(budget))
         self._think_start_id = think_start_token_id
         self._token_to_piece = token_to_piece
+        self._stop_token_ids = tuple(
+            sorted({int(token_id) for token_id in (stop_token_ids or ())})
+        )
 
         # State
         self._thinking_tokens: int = 0
@@ -458,10 +447,22 @@ class ThinkingBudgetProcessor:
         if self._forcing:
             return self._force_next_token(logits, mx)
 
+        # A prompt-opened reasoning block is a protocol region, not a complete
+        # assistant response.  Sampling EOS here used to terminate the request
+        # before ``</think>``; the streaming fallback then had no choice but to
+        # duplicate the unfinished reasoning into visible content.  Mask only
+        # terminal tokens while the block is open.  Every replacement remains
+        # sampled and target-verified; natural ``</think>`` immediately removes
+        # the constraint.
+        if self._in_thinking and self._stop_token_ids:
+            logits[..., list(self._stop_token_ids)] = mx.array(float("-inf"))
+
         if self._waiting_utf8:
             return logits
 
         if self._in_thinking:
+            if self._budget is None:
+                return logits
             self._thinking_tokens += 1
             if self._thinking_tokens >= self._budget:
                 if self._last_token_utf8_complete:

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -5800,15 +5800,22 @@ class Scheduler:
         if suppress_processor is not None:
             logits_processors.append(suppress_processor)
 
-        # Add thinking budget processor for reasoning models
-        if (
+        # Keep prompt-opened reasoning structurally complete even when no
+        # explicit thinking budget is configured.  Previously a target-sampled
+        # EOS inside ``<think>`` produced a successful three-token ``stop`` and
+        # forced the streaming parser to surface internal reasoning as the
+        # answer body.  The processor masks terminal tokens only until the
+        # natural close marker; an explicit budget retains its existing forced
+        # close behavior.
+        needs_think_protocol = bool(
+            request is not None and getattr(request, "needs_think_prefix", False)
+        )
+        parser_budget_protocol = bool(
             sampling_params.thinking_budget is not None
             and request is not None
-            and (
-                getattr(request, "needs_think_prefix", False)
-                or self._get_output_parser_thinking_end_text() is not None
-            )
-        ):
+            and self._get_output_parser_thinking_end_text() is not None
+        )
+        if needs_think_protocol or parser_budget_protocol:
             think_end_ids = self._resolve_think_end_token_ids()
             if think_end_ids:
                 from .api.thinking import ThinkingBudgetProcessor
@@ -5829,6 +5836,11 @@ class Scheduler:
                     leading_token_ids=leading_ids,
                     trailing_token_ids=trailing_ids,
                     token_to_piece=self._thinking_budget_token_to_piece,
+                    stop_token_ids=(
+                        sorted(self._get_stop_tokens() - set(think_end_ids))
+                        if needs_think_protocol
+                        else None
+                    ),
                 )
                 logits_processors.append(processor)
 

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -5054,6 +5054,20 @@ async def stream_chat_completion(
         if tool_calls
         else (last_output.finish_reason if last_output else "stop")
     )
+    if (
+        not tool_calls
+        and thinking_parser.unfinished_thinking
+        and finish_reason == "stop"
+    ):
+        # The target terminated inside a prompt-opened reasoning block. Treat
+        # this as an incomplete response rather than a successful answer; the
+        # private reasoning has already streamed on reasoning_content and must
+        # never be promoted into delta.content.
+        finish_reason = "length"
+        logger.warning(
+            "Chat stream ended before the thinking protocol closed; "
+            "reporting an incomplete response"
+        )
     final_chunk = ChatCompletionChunk(
         id=response_id,
         model=request.model,
@@ -5348,6 +5362,7 @@ async def stream_anthropic_messages(
 
     # Flush remaining buffered content from thinking parser
     thinking_delta, content_delta = thinking_parser.finish()
+    unfinished_thinking = thinking_parser.unfinished_thinking
     if thinking_delta:
         if thinking_filter:
             thinking_delta = thinking_filter.feed(thinking_delta)
@@ -5519,8 +5534,16 @@ async def stream_anthropic_messages(
             yield create_content_block_stop_event(index=i)
 
     # 6. Send message_delta with stop_reason and actual token counts
+    anthropic_finish_reason = output.finish_reason if output else "stop"
+    if not tool_calls and unfinished_thinking and anthropic_finish_reason == "stop":
+        anthropic_finish_reason = "length"
+        logger.warning(
+            "Anthropic stream ended before the thinking protocol closed; "
+            "reporting max_tokens"
+        )
     stop_reason = map_finish_reason_to_stop_reason(
-        output.finish_reason if output else "stop", bool(tool_calls)
+        anthropic_finish_reason,
+        bool(tool_calls),
     )
     # Use actual token counts from the last output
     actual_input_tokens = last_output.prompt_tokens if last_output else 0
@@ -6881,8 +6904,10 @@ async def stream_responses_api(
         return
 
     # Flush remaining content from parsers
+    unfinished_thinking = False
     if stream_content:
         thinking_delta, content_delta = thinking_parser.finish()
+        unfinished_thinking = thinking_parser.unfinished_thinking
         if thinking_delta:
             if thinking_filter:
                 thinking_delta = thinking_filter.feed(thinking_delta)
@@ -7231,7 +7256,10 @@ async def stream_responses_api(
         }
 
     # 13. Emit the terminal event matching the final response status.
-    truncated = getattr(last_output, "finish_reason", None) == "length"
+    truncated = bool(
+        getattr(last_output, "finish_reason", None) == "length"
+        or (not tool_calls and unfinished_thinking)
+    )
     terminal_event = "response.incomplete" if truncated else "response.completed"
     final_response = {
         "id": response_id,

--- a/tests/test_chat_stream_unfinished_thinking.py
+++ b/tests/test_chat_stream_unfinished_thinking.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression contract for EOS inside a prompt-opened thinking block."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from omlx import server
+from omlx.api.openai_models import ChatCompletionRequest, Message
+
+
+class _ThinkingTokenizer:
+    think_start_id = 41
+    think_end_id = 42
+    eos_token_id = 2
+
+    def apply_chat_template(self, _messages, **_kwargs):
+        return "<think>"
+
+    def encode(self, _text, add_special_tokens=False):
+        return [self.think_start_id]
+
+
+class _ReasoningOnlyEngine:
+    tokenizer = _ThinkingTokenizer()
+    model_type = "qwen4_exp"
+    is_diffusion_model = False
+
+    async def stream_chat(self, **_kwargs):
+        yield SimpleNamespace(
+            new_text='The user just said "Right!"',
+            text='The user just said "Right!"',
+            tool_calls=None,
+            finish_reason="stop",
+            finished=True,
+            prompt_tokens=20,
+            completion_tokens=7,
+            cached_tokens=19,
+        )
+
+
+def _sse_payload(event: str) -> dict | None:
+    if not event.startswith("data: ") or event == "data: [DONE]\n\n":
+        return None
+    return json.loads(event[6:])
+
+
+@pytest.mark.asyncio
+async def test_unfinished_reasoning_never_becomes_content_and_is_incomplete():
+    request = ChatCompletionRequest(
+        model="qwen4-exp-test",
+        messages=[Message(role="user", content="Right!")],
+        stream=True,
+    )
+    events = [
+        event
+        async for event in server.stream_chat_completion(
+            _ReasoningOnlyEngine(),
+            [{"role": "user", "content": "Right!"}],
+            request,
+        )
+    ]
+    payloads = [payload for event in events if (payload := _sse_payload(event))]
+
+    deltas = [choice["delta"] for payload in payloads for choice in payload["choices"]]
+    reasoning = "".join(delta.get("reasoning_content", "") for delta in deltas)
+    content = "".join(delta.get("content", "") for delta in deltas)
+    finish_reasons = [
+        choice.get("finish_reason")
+        for payload in payloads
+        for choice in payload["choices"]
+        if choice.get("finish_reason") is not None
+    ]
+
+    assert reasoning == 'The user just said "Right!"'
+    assert content == ""
+    assert finish_reasons == ["length"]

--- a/tests/test_thinking.py
+++ b/tests/test_thinking.py
@@ -52,14 +52,12 @@ class TestExtractThinking:
         assert "Step 1" in thinking
         assert content == "Final answer"
 
-    def test_open_tag_no_close_recovers_as_content(self):
-        """Model opened ``<think>`` but never closed it — non-streaming
-        path treats the body as content (matching the streaming
-        recovery in ThinkingParser.finish())."""
+    def test_open_tag_no_close_remains_private_reasoning(self):
+        """Unclosed reasoning is never promoted into answer content."""
         from omlx.api.thinking import extract_thinking
         thinking, content = extract_thinking("<think>\nthe whole answer body")
-        assert thinking == ""
-        assert content == "the whole answer body"
+        assert thinking == "the whole answer body"
+        assert content == ""
 
     def test_partial_no_open_tag(self):
         """Content before </think> without <think> tag (scheduler prefix case)."""
@@ -98,7 +96,8 @@ class TestExtractThinking:
         issue #1348: in 0.3.9 the Responses API passed
         ``start_in_thinking=True`` here, which misclassified short tool-turn
         answers (no ``</think>``) as thinking and left ``output_text`` empty.
-        Mirrors ``ThinkingParser.finish()`` recovery semantics."""
+        Prompt-open state belongs to ``ThinkingParser``; this standalone helper
+        cannot infer it from tag-free text."""
         thinking, content = extract_thinking("just the reasoning")
         assert thinking == ""
         assert content == "just the reasoning"
@@ -237,17 +236,8 @@ class TestThinkingParser:
         # The > and < characters should pass through since they don't form valid tags
         assert "x > 0" in t1 or "x > 0" in (t1 + parser._buffer)
 
-    def test_recovery_when_no_close_tag_streams_as_content(self):
-        """Model opened ``<think>`` but never emitted ``</think>``.
-
-        For V4-Flash and similar models, the thinking close tag is
-        sometimes skipped — the entire response streams as thinking
-        and the visible answer body ends up empty. ``finish()`` recovers
-        by re-emitting the accumulated thinking text as content so the
-        client can render the body. The thinking deltas already streamed
-        cannot be retracted, so the same text shows in both panels —
-        documented UX trade-off.
-        """
+    def test_unclosed_thinking_stays_private(self):
+        """Model-opened unfinished reasoning never becomes answer content."""
         parser = ThinkingParser()
 
         # Streamed chunks: open tag + free-form text, no close tag.
@@ -273,9 +263,10 @@ class TestThinkingParser:
         # Live thinking deltas streamed normally during the response.
         assert "Hello world" in thinking
         assert "body of the response" in thinking
-        # Recovery: same text re-emitted as content at finish().
-        assert "Hello world" in content
-        assert "body of the response" in content
+        # Fail closed: unfinished private reasoning is not promoted into the
+        # visible answer body. The transport reports this response incomplete.
+        assert content == ""
+        assert parser.unfinished_thinking is True
         # No tag literals leaked into either panel.
         assert "<think>" not in thinking and "<think>" not in content
         assert "</think>" not in thinking and "</think>" not in content
@@ -360,28 +351,26 @@ class TestThinkingParser:
         assert t1 == "body"
         assert c1 == "answer"
 
-    def test_start_in_thinking_recovery_emits_thinking_as_content(self):
-        """Recovery is intentional UX fallback: if start_in_thinking=True
-        and no </think> ever arrives, finish() re-emits the accumulated
-        thinking as content so the message body is not empty. The client
-        ends up showing the same text in both panels — documented
-        trade-off, not a bug. Guard against accidental regression."""
+    def test_start_in_thinking_unfinished_reasoning_stays_private(self):
+        """Prompt-opened reasoning never leaks into visible content."""
         parser = ThinkingParser(start_in_thinking=True)
         parser.feed("the whole answer ")
         parser.feed("never closed")
         t, c = parser.finish()
         assert t == ""
-        assert c == "the whole answer never closed"
+        assert c == ""
+        assert parser.unfinished_thinking is True
 
-    def test_default_recovery_still_works(self):
-        """Regression guard for the legacy recovery branch — default
-        ThinkingParser (no start_in_thinking) with `<think>...` body and
-        no closing tag still re-emits thinking as content."""
+    def test_default_unfinished_reasoning_stays_private(self):
+        """An explicitly opened but unfinished block remains reasoning."""
         parser = ThinkingParser()
-        parser.feed("<think>open but never closed")
+        t1, c1 = parser.feed("<think>open but never closed")
         t, c = parser.finish()
+        assert t1 == "open but never closed"
+        assert c1 == ""
         assert t == ""
-        assert c == "open but never closed"
+        assert c == ""
+        assert parser.unfinished_thinking is True
 
 
 class TestCleanSpecialTokens:

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -49,12 +49,19 @@ class TestThinkingBudgetProcessor:
 
     NEWLINE_ID = 99  # Dummy \n token ID
 
-    def _make_processor(self, budget: int = 5, end_ids=None, trailing_ids=None):
+    def _make_processor(
+        self,
+        budget: int | None = 5,
+        end_ids=None,
+        trailing_ids=None,
+        stop_ids=None,
+    ):
         return ThinkingBudgetProcessor(
             think_end_token_ids=end_ids or [self.THINK_END_ID],
             budget=budget,
             think_start_token_id=self.THINK_START_ID,
             trailing_token_ids=trailing_ids,
+            stop_token_ids=stop_ids,
         )
 
     # --- Budget enforcement ---
@@ -131,6 +138,40 @@ class TestThinkingBudgetProcessor:
         original = _make_logits()
         result = proc(_make_tokens(10, self.THINK_END_ID, 50), original)
         assert mx.array_equal(result, original)
+
+    def test_masks_eos_until_natural_thinking_close_without_budget(self):
+        """Prompt-opened thinking cannot terminate before ``</think>``."""
+        eos_id = 2
+        proc = self._make_processor(budget=None, stop_ids=[eos_id])
+
+        masked = proc(_make_tokens(10), _make_logits())
+        assert masked[0, eos_id].item() == float("-inf")
+        assert masked[0, 0].item() == 0.0
+        assert not proc._forcing
+
+        # Once the target naturally emits the close marker, ordinary EOS is
+        # immediately available for the answer phase.
+        unmasked = proc(
+            _make_tokens(10, self.THINK_END_ID),
+            _make_logits(),
+        )
+        assert proc._done
+        assert unmasked[0, eos_id].item() == 0.0
+
+    def test_eos_mask_survives_snapshot_restore(self):
+        """Speculative rollback preserves the open-thinking EOS guard."""
+        eos_id = 2
+        proc = self._make_processor(budget=None, stop_ids=[eos_id])
+        proc(_make_tokens(10), _make_logits())
+        snapshot = proc.snapshot_state()
+
+        proc(_make_tokens(10, self.THINK_END_ID), _make_logits())
+        assert proc._done
+        proc.restore_state(snapshot)
+
+        masked = proc(_make_tokens(10), _make_logits())
+        assert not proc._done
+        assert masked[0, eos_id].item() == float("-inf")
 
     def test_first_call_skips_state_update(self):
         """First call should not check tokens[-1] for state transitions."""
@@ -338,6 +379,47 @@ class TestParserBackedThinkingBudgetWiring:
         ]
         assert len(budget_processors) == 1
         assert budget_processors[0]._think_end_ids == [101]
+
+    def test_prompt_opened_thinking_gets_eos_guard_without_budget(self):
+        scheduler = self._make_scheduler(None, {})
+        scheduler._resolve_think_end_token_ids = MagicMock(return_value=[42])
+        # A close marker can also appear in a model's terminal-token set. It
+        # must remain sampleable or the protocol could never close.
+        scheduler._get_stop_tokens = MagicMock(return_value={2, 3, 42})
+        request = self._make_request()
+        request.sampling_params.thinking_budget = None
+        # Caller-owned stops remain authoritative and are not folded into the
+        # protocol guard. Only scheduler/model terminal EOS IDs are masked.
+        request.sampling_params.stop_token_ids = [77]
+        request.needs_think_prefix = True
+
+        _, processors = scheduler._build_sampler_and_processors(
+            request.sampling_params,
+            request,
+        )
+
+        protocol_processors = [
+            p for p in processors if isinstance(p, ThinkingBudgetProcessor)
+        ]
+        assert len(protocol_processors) == 1
+        assert protocol_processors[0]._budget is None
+        assert protocol_processors[0]._stop_token_ids == (2, 3)
+
+    def test_no_protocol_processor_for_plain_request_without_budget(self):
+        scheduler = self._make_scheduler(None, {})
+        request = self._make_request()
+        request.sampling_params.thinking_budget = None
+        request.needs_think_prefix = False
+
+        _, processors = scheduler._build_sampler_and_processors(
+            request.sampling_params,
+            request,
+        )
+
+        assert not any(
+            isinstance(processor, ThinkingBudgetProcessor)
+            for processor in processors
+        )
 
     def test_parser_marker_ignores_none_tokenizer_think_end(self):
         factory = OutputParserFactory(


### PR DESCRIPTION
## Summary

Reasoning models can occasionally sample a terminal token before emitting their closing reasoning marker. oMLX previously treated that malformed but successful-looking stop as a normal completion and copied the accumulated private reasoning into visible assistant content.

This change makes the protocol fail closed and prevents the malformed stop at its source:

- mask only model-owned terminal tokens while a prompt-opened reasoning block remains active
- immediately restore ordinary EOS behavior after the natural close marker
- preserve explicit caller stop tokens and overlapping close markers
- retain processor state across speculative MTP snapshot/rollback
- never promote unfinished reasoning into visible content
- report malformed OpenAI, Anthropic, and Responses streams as incomplete

The scope is protocol handling only. It does not change cache contents, tool parsing, request-specific stop conditions, model weights, or accepted-token accounting.

## Regression coverage

- EOS blocked before close and available after close
- no-budget and budgeted reasoning paths
- speculative snapshot/restore
- caller stop-token and close-marker isolation
- plain non-reasoning requests remain unchanged
- OpenAI SSE reproduction of the observed unfinished internal monologue
- scheduler, cancellation, MTP, proxy, prompt-priming, and server endpoint suites

Validation on upstream main: **557 passed, 3 deselected**.