### PR TITLE
fix(engine_pool): expose effective MTP state when embedded tensors are missing

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -2024,6 +2024,12 @@ async def list_models(is_admin: bool = Depends(require_admin)):
             "dflash_ssd_cache_available": dflash_ssd_cache_available,
             "mtp_compatible": mtp_compat_ok,
             "mtp_compatibility_reason": mtp_compat_reason,
+            # Load-time resolution from the pool (issue #3342): what the
+            # loaded engine is actually doing, as opposed to the disk
+            # compatibility verdict above. None = not resolved.
+            "mtp_requested": model_info.get("mtp_requested"),
+            "mtp_active": model_info.get("mtp_active"),
+            "mtp_inactive_reason": model_info.get("mtp_inactive_reason"),
             "qwen4_ple_ssd_offload_supported": qwen4_ple_ssd_offload_supported,
             "qwen4_ple_ssd_offload_forced": qwen4_ple_ssd_offload_forced,
             "qwen4_ple_resident_bytes": qwen4_resident_bytes,
@@ -2073,6 +2079,9 @@ async def list_models(is_admin: bool = Depends(require_admin)):
                 "dflash_ssd_cache_available": False,
                 "mtp_compatible": False,
                 "mtp_compatibility_reason": "",
+                "mtp_requested": None,
+                "mtp_active": None,
+                "mtp_inactive_reason": None,
                 "is_paroquant": False,
                 "paroquant_reason": "",
                 "virtual": True,

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import functools
 import gc
 import json
 import logging
@@ -178,6 +179,58 @@ def _qwen35_cpu_share_estimated_bytes(
     return int(extra * _CPU_SHARE_MATERIALIZATION_HEADROOM)
 
 
+MTP_INACTIVE_NO_EMBEDDED_TENSORS = "no_embedded_mtp_tensors"
+
+
+def _checkpoint_mtp_fingerprint(model_path: str) -> tuple | None:
+    """Cheap change-detector for the files ``_checkpoint_has_mtp_weights`` reads.
+
+    The detector answers from ``model.safetensors.index.json`` when it exists
+    (a shard edited without an index update is invisible to it too), so the
+    fingerprint is that file's ``(size, mtime_ns)``. Without an index it scans
+    every shard header, so the fingerprint covers every ``*.safetensors``.
+    ``None`` when neither exists -- the detector returns False there.
+    """
+    root = Path(model_path)
+    index_path = root / "model.safetensors.index.json"
+    try:
+        st = index_path.stat()
+    except OSError:
+        st = None
+    if st is not None:
+        return ("index", st.st_size, st.st_mtime_ns)
+    shards: list[tuple[str, int, int]] = []
+    try:
+        for shard in sorted(root.glob("*.safetensors")):
+            shard_st = shard.stat()
+            shards.append((shard.name, shard_st.st_size, shard_st.st_mtime_ns))
+    except OSError:
+        return None
+    return tuple(shards) or None
+
+
+@functools.lru_cache(maxsize=64)
+def _cached_checkpoint_has_mtp_weights(
+    model_path: str, fingerprint: tuple | None
+) -> bool:
+    from .utils.model_loading import _checkpoint_has_mtp_weights
+
+    return _checkpoint_has_mtp_weights(model_path)
+
+
+def _checkpoint_has_mtp_weights_cached(model_path: str) -> bool:
+    """``_checkpoint_has_mtp_weights`` with one index parse per checkpoint state.
+
+    ``_engine_runtime_signature`` runs on every ``get_engine``; the Flash-Next
+    index alone is ~400 KB, so the parse is cached on the checkpoint
+    fingerprint (one ``stat`` per call) the same way
+    ``qwen4_exp_residency_estimate`` caches its estimate.
+    """
+    return _cached_checkpoint_has_mtp_weights(
+        model_path, _checkpoint_mtp_fingerprint(model_path)
+    )
+
+
 @dataclass
 class EngineEntry:
     """Per-model state in the engine pool."""
@@ -240,6 +293,16 @@ class EngineEntry:
     runtime_settings_signature: tuple[tuple[str, str], ...] | None = None
     load_failed: bool = False  # Sticky until the next discovery refresh
     load_failure_message: str | None = None
+    # Load-time MTP resolution (issue #3342). ``mtp_active`` is what the
+    # pool could verify for the loaded engine, not what settings asked for:
+    # True/False only for families whose activation the pool resolves
+    # (qwen4_exp), None for everything else and whenever no engine is
+    # loaded — so a client can never read None as "disabled".
+    # ``mtp_inactive_reason`` is set iff MTP was requested and could not
+    # activate.
+    mtp_requested: bool | None = None
+    mtp_active: bool | None = None
+    mtp_inactive_reason: str | None = None
     load_failure_at: float | None = None
 
 
@@ -412,14 +475,50 @@ class EnginePool:
         entry: EngineEntry,
         settings: object | None,
     ) -> object | None:
-        """Apply a forced mmap decision without mutating persisted settings."""
+        """Apply forced mmap / resolved MTP decisions without mutating persisted settings."""
 
         enabled, forced, _ = self._qwen4_ple_offload_status(entry, settings)
-        if not enabled or not forced or settings is None:
-            return settings
-        effective = copy.copy(settings)
-        setattr(effective, "qwen4_ple_ssd_offload", True)
+        effective = settings
+        if enabled and forced and settings is not None:
+            effective = copy.copy(settings)
+            setattr(effective, "qwen4_ple_ssd_offload", True)
+        # Same shape for Lightning MTP (issue #3342): a persisted
+        # ``mtp_enabled`` on a checkpoint that lost its embedded ``mtp.*``
+        # tensors must not reach the engine as a request the runtime will
+        # silently ignore. Hand the engine the resolved value on a copy; the
+        # persisted setting stays as the operator wrote it.
+        requested, active, _ = self._resolve_mtp_state(entry, settings)
+        if requested and active is False and settings is not None:
+            if effective is settings:
+                effective = copy.copy(settings)
+            effective.mtp_enabled = False
         return effective
+
+    def _resolve_mtp_state(
+        self,
+        entry: EngineEntry,
+        settings: object | None,
+    ) -> tuple[bool, bool | None, str | None]:
+        """Resolve ``(requested, active, inactive_reason)`` for a load.
+
+        ``active`` is only ever True/False for families whose activation the
+        pool can verify from the checkpoint -- today qwen4_exp, using the same
+        ``_checkpoint_has_mtp_weights`` detector the loader and the admin
+        write gate use, so the three surfaces cannot disagree. Every other
+        family resolves to ``None`` ("not verified"), never to a guess.
+        ``inactive_reason`` is set iff MTP was requested and cannot activate.
+        """
+        requested = bool(
+            settings is not None and getattr(settings, "mtp_enabled", False)
+        )
+        model_type = (entry.config_model_type or "").replace("-", "_").lower()
+        if model_type != "qwen4_exp":
+            return requested, None, None
+        if not requested:
+            return False, False, None
+        if _checkpoint_has_mtp_weights_cached(entry.model_path):
+            return True, True, None
+        return True, False, MTP_INACTIVE_NO_EMBEDDED_TENSORS
 
     @property
     def current_model_memory(self) -> int:
@@ -586,7 +685,16 @@ class EnginePool:
         # Load-time model variants. Dependent fields only matter when their
         # feature is active; stale draft paths or tuning defaults must not
         # force a reload when the corresponding feature is disabled.
+        # Resolved, not requested: the expected signature (get_engine) is
+        # computed from the caller's settings and the recorded one (load
+        # completion) from the effective copy. Reading the raw setting here
+        # would make them disagree whenever the pool resolved mtp_enabled
+        # off, and every request would unload/reload the engine (#2406).
         mtp_active = bool(data.get("mtp_enabled", False))
+        if entry is not None:
+            _, resolved, _ = self._resolve_mtp_state(entry, settings)
+            if resolved is not None:
+                mtp_active = resolved
         add("mtp_enabled", mtp_active)
         # Draft depth is read once at engine construction; it must be in the
         # signature while Lightning MTP is active so a change reloads the
@@ -2305,6 +2413,9 @@ class EnginePool:
         entry.pending_unload_allow_pinned = False
         entry.runtime_settings_signature = None
         entry.runtime_estimated_size = None
+        entry.mtp_requested = None
+        entry.mtp_active = None
+        entry.mtp_inactive_reason = None
 
         if distributed:
             # Cluster weights live in supervised rank processes, not this
@@ -2536,6 +2647,15 @@ class EnginePool:
             model_settings = runtime_settings
             if model_settings is None and self._settings_manager is not None:
                 model_settings = self._settings_manager.get_settings(model_id)
+            mtp_resolution = self._resolve_mtp_state(entry, model_settings)
+            if mtp_resolution[2] is not None:
+                logger.warning(
+                    "Lightning MTP is enabled in settings for %s but cannot "
+                    "activate (%s); the engine will serve target-only "
+                    "completions. Status reports mtp_active=false.",
+                    model_id,
+                    mtp_resolution[2],
+                )
             model_settings = self._effective_qwen4_model_settings(entry, model_settings)
 
             deployment = self._distributed_deployment_for_entry(entry)
@@ -2864,6 +2984,11 @@ class EnginePool:
             entry.last_access = time.time()
             self._current_model_memory += resident_size
             load_completed = True
+            (
+                entry.mtp_requested,
+                entry.mtp_active,
+                entry.mtp_inactive_reason,
+            ) = mtp_resolution
             self._clear_load_failure(entry)
 
             # VLM MTP: load MTP drafter (gemma4_assistant or qwen3_5_mtp) and attach to engine.
@@ -3021,6 +3146,12 @@ class EnginePool:
             entry.abort_loading = False
             if not load_completed:
                 entry.runtime_estimated_size = None
+                # Constructor failure and post-construction abort both land
+                # here; neither leaves an engine, so neither leaves a
+                # resolution to report.
+                entry.mtp_requested = None
+                entry.mtp_active = None
+                entry.mtp_inactive_reason = None
             self._wake_process_memory_enforcer()
 
     async def preload_pinned_models(self) -> None:
@@ -3109,6 +3240,11 @@ class EnginePool:
                     "source_type": e.source_type,
                     "source_repo_id": e.source_repo_id,
                     "last_access": e.last_access if e.last_access > 0 else None,
+                    # Load-time MTP resolution; None = not resolved (engine
+                    # not loaded, or a family the pool does not verify).
+                    "mtp_requested": e.mtp_requested,
+                    "mtp_active": e.mtp_active,
+                    "mtp_inactive_reason": e.mtp_inactive_reason,
                 }
                 for mid, e in sorted(self._entries.items())
             ],

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2988,6 +2988,15 @@ async def list_models_status(_: bool = Depends(verify_api_key)):
     List all available models with detailed status.
 
     Extended endpoint that provides more information than /v1/models.
+
+    Speculative decoding fields per model: ``mtp_requested`` is the
+    ``mtp_enabled`` value the engine was loaded under (the persisted setting,
+    or a runtime override such as ANE tuning's); ``mtp_active`` is the server's
+    load-time resolution of whether Lightning MTP actually engaged;
+    ``mtp_inactive_reason`` names why a requested MTP could not (e.g.
+    ``no_embedded_mtp_tensors``). ``null`` means not resolved -- the model is
+    not loaded, or its family's activation is not verified by the server --
+    never "disabled".
     """
     if _server_state.engine_pool is None:
         raise HTTPException(status_code=503, detail="Server not initialized")

--- a/tests/test_admin_mtp_state.py
+++ b/tests/test_admin_mtp_state.py
@@ -1,0 +1,120 @@
+"""Admin models list passes the pool's load-time MTP resolution through (#3342).
+
+``mtp_compatible`` / ``mtp_compatibility_reason`` are a disk verdict computed
+at list time; ``mtp_requested`` / ``mtp_active`` / ``mtp_inactive_reason`` are
+what the loaded engine is actually doing. Both ride the same row.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from omlx.admin import routes as admin_routes
+
+MTP_KEYS = ("mtp_requested", "mtp_active", "mtp_inactive_reason")
+
+
+def _list_models_with(status_entry: dict) -> dict:
+    pool = MagicMock()
+    pool.get_status.return_value = {"models": [status_entry]}
+    pool._fallback_admission_ceiling.return_value = 0
+    pool._scheduler_config = MagicMock(paged_ssd_cache_dir=None)
+    manager = MagicMock()
+    manager.get_all_settings.return_value = {}
+    state = MagicMock(default_model=None)
+
+    with (
+        patch.object(admin_routes, "_get_engine_pool", return_value=pool),
+        patch.object(admin_routes, "_get_settings_manager", return_value=manager),
+        patch.object(admin_routes, "_get_server_state", return_value=state),
+        patch.object(admin_routes, "_get_global_settings", return_value=None),
+        patch.object(
+            admin_routes, "_dflash_compat_for_model", return_value=(False, "")
+        ),
+        patch.object(
+            admin_routes,
+            "_mtp_compat_for_model",
+            return_value=(
+                False,
+                "Qwen4-Exp Lightning MTP requires embedded mtp.* tensors",
+            ),
+        ),
+        patch.object(
+            admin_routes, "_paroquant_compat_for_model", return_value=(False, "")
+        ),
+    ):
+        return asyncio.run(admin_routes.list_models(is_admin=True))
+
+
+def _status_entry(tmp_path, **mtp_fields) -> dict:
+    model_path = tmp_path / "qwen4"
+    model_path.mkdir(exist_ok=True)
+    entry = {
+        "id": "qwen4",
+        "model_path": str(model_path),
+        "config_model_type": "llama",
+        "estimated_size": 1000,
+        "loaded": True,
+    }
+    entry.update(mtp_fields)
+    return entry
+
+
+@pytest.mark.parametrize(
+    "resolution",
+    [
+        (True, False, "no_embedded_mtp_tensors"),
+        (True, True, None),
+        (False, False, None),
+        (True, None, None),
+        (None, None, None),
+    ],
+)
+def test_list_models_passes_pool_resolution_through(tmp_path, resolution):
+    requested, active, reason = resolution
+    result = _list_models_with(
+        _status_entry(
+            tmp_path,
+            mtp_requested=requested,
+            mtp_active=active,
+            mtp_inactive_reason=reason,
+        )
+    )
+
+    model = result["models"][0]
+    assert (
+        model["mtp_requested"],
+        model["mtp_active"],
+        model["mtp_inactive_reason"],
+    ) == resolution
+    # The disk verdict is unchanged and still rides alongside.
+    assert model["mtp_compatible"] is False
+    assert "embedded mtp.*" in model["mtp_compatibility_reason"]
+
+
+def test_list_models_omits_nothing_when_pool_predates_the_fields(tmp_path):
+    # A status entry without the keys (older pool, stubbed pool) still yields
+    # the keys as None rather than KeyError -- "not resolved".
+    result = _list_models_with(_status_entry(tmp_path))
+    model = result["models"][0]
+    assert all(model[key] is None for key in MTP_KEYS)
+
+
+def test_markitdown_builtin_row_carries_the_keys_as_none(tmp_path):
+    result = _list_models_with(_status_entry(tmp_path))
+    builtin = [
+        m for m in result["models"] if m["id"] == admin_routes.MARKITDOWN_MODEL_ID
+    ]
+    if not builtin:
+        pytest.skip("markitdown builtin row not present in this build")
+    assert all(builtin[0][key] is None for key in MTP_KEYS)
+
+
+def test_models_status_docstring_states_the_null_contract():
+    from omlx.server import list_models_status
+
+    doc = list_models_status.__doc__ or ""
+    assert "mtp_active" in doc
+    assert "null" in doc
+    assert "not resolved" in doc

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -3989,3 +3989,395 @@ class TestLoadRefusalNamesBindingCeiling:
         assert "dynamic memory ceiling" in message
         assert "close other apps" in message.lower()
         assert "lower memory_guard_tier" not in message
+
+
+class TestMTPEffectiveState:
+    """Load-time MTP resolution (issue #3342).
+
+    A persisted ``mtp_enabled`` on a Qwen4-Exp checkpoint without embedded
+    ``mtp.*`` tensors used to reach the engine unchanged and serve target-only
+    completions with nothing observable. The pool now resolves the effective
+    state before construction, records it on the entry, and exposes it on
+    status -- without touching the persisted setting.
+    """
+
+    @staticmethod
+    def _qwen4_checkpoint(tmp_path, *, with_mtp: bool, name: str = "qwen4"):
+        model = tmp_path / name
+        model.mkdir()
+        (model / "config.json").write_text(json.dumps({"model_type": "qwen4_exp"}))
+        weight_map = {
+            "language_model.model.embed_tokens.weight": "model-00001.safetensors"
+        }
+        if with_mtp:
+            weight_map["mtp.layers.0.mlp.gate.weight"] = "model-00002.safetensors"
+        (model / "model.safetensors.index.json").write_text(
+            json.dumps({"weight_map": weight_map})
+        )
+        return model
+
+    @staticmethod
+    def _entry(model, *, config_model_type="qwen4_exp", engine_type="vlm"):
+        return EngineEntry(
+            model_id=model.name,
+            model_path=str(model),
+            model_type="vlm" if engine_type == "vlm" else "llm",
+            engine_type=engine_type,
+            config_model_type=config_model_type,
+            estimated_size=1000,
+        )
+
+    @staticmethod
+    def _pool_with(entry):
+        pool = _make_pool(ceiling=10 * 1024**3)
+        pool._entries[entry.model_id] = entry
+        return pool
+
+    # -- resolution (AC1) ---------------------------------------------------
+
+    def test_missing_tensors_resolve_off_on_a_copy(self, tmp_path):
+        from omlx.model_settings import ModelSettings
+
+        entry = self._entry(self._qwen4_checkpoint(tmp_path, with_mtp=False))
+        pool = self._pool_with(entry)
+        requested = ModelSettings(mtp_enabled=True)
+
+        effective = pool._effective_qwen4_model_settings(entry, requested)
+
+        assert effective is not requested
+        assert effective.mtp_enabled is False
+        assert requested.mtp_enabled is True
+        assert pool._resolve_mtp_state(entry, requested) == (
+            True,
+            False,
+            "no_embedded_mtp_tensors",
+        )
+
+    def test_present_tensors_pass_settings_through(self, tmp_path):
+        from omlx.model_settings import ModelSettings
+
+        entry = self._entry(self._qwen4_checkpoint(tmp_path, with_mtp=True))
+        pool = self._pool_with(entry)
+        requested = ModelSettings(mtp_enabled=True)
+
+        effective = pool._effective_qwen4_model_settings(entry, requested)
+
+        assert effective is requested
+        assert effective.mtp_enabled is True
+        assert pool._resolve_mtp_state(entry, requested) == (True, True, None)
+
+    def test_not_requested_has_no_reason(self, tmp_path):
+        from omlx.model_settings import ModelSettings
+
+        entry = self._entry(self._qwen4_checkpoint(tmp_path, with_mtp=False))
+        pool = self._pool_with(entry)
+
+        assert pool._resolve_mtp_state(entry, ModelSettings(mtp_enabled=False)) == (
+            False,
+            False,
+            None,
+        )
+        assert pool._resolve_mtp_state(entry, None) == (False, False, None)
+
+    # -- non-qwen4 untouched (AC6) -------------------------------------------
+
+    def test_generic_family_is_not_resolved(self, tmp_path):
+        from omlx.model_settings import ModelSettings
+
+        model = tmp_path / "qwen35"
+        model.mkdir()
+        (model / "config.json").write_text(json.dumps({"model_type": "qwen3_5"}))
+        entry = self._entry(model, config_model_type="qwen3_5", engine_type="batched")
+        pool = self._pool_with(entry)
+        requested = ModelSettings(mtp_enabled=True)
+
+        assert pool._effective_qwen4_model_settings(entry, requested) is requested
+        assert pool._resolve_mtp_state(entry, requested) == (True, None, None)
+
+    # -- record + status + reason invariant (AC2, AC2b, AC3) -----------------
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("with_mtp", "mtp_enabled", "expected"),
+        [
+            (False, True, (True, False, "no_embedded_mtp_tensors")),
+            (True, True, (True, True, None)),
+            (False, False, (False, False, None)),
+        ],
+    )
+    async def test_load_records_resolution_and_status_exposes_it(
+        self, tmp_path, with_mtp, mtp_enabled, expected
+    ):
+        from omlx.model_settings import ModelSettings
+
+        entry = self._entry(self._qwen4_checkpoint(tmp_path, with_mtp=with_mtp))
+        pool = self._pool_with(entry)
+        before = pool.get_status()["models"][0]
+        assert (
+            before["mtp_requested"],
+            before["mtp_active"],
+            before["mtp_inactive_reason"],
+        ) == (
+            None,
+            None,
+            None,
+        )
+
+        mock_engine = MagicMock()
+        mock_engine.start = AsyncMock()
+        mock_engine.stop = AsyncMock()
+        with (
+            patch("omlx.engine_pool.VLMBatchedEngine", return_value=mock_engine),
+            patch("omlx.engine_pool.BatchedEngine", return_value=mock_engine),
+        ):
+            await pool._load_engine(
+                entry.model_id, runtime_settings=ModelSettings(mtp_enabled=mtp_enabled)
+            )
+
+        assert (
+            entry.mtp_requested,
+            entry.mtp_active,
+            entry.mtp_inactive_reason,
+        ) == expected
+        assert (entry.mtp_inactive_reason is not None) == (
+            entry.mtp_requested is True and entry.mtp_active is False
+        )
+        after = pool.get_status()["models"][0]
+        assert (
+            after["mtp_requested"],
+            after["mtp_active"],
+            after["mtp_inactive_reason"],
+        ) == expected
+        assert set(before) <= set(after)
+
+        await pool._unload_engine(entry.model_id)
+        assert (entry.mtp_requested, entry.mtp_active, entry.mtp_inactive_reason) == (
+            None,
+            None,
+            None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_generic_family_records_unverified_active(self, tmp_path):
+        from omlx.model_settings import ModelSettings
+
+        model = tmp_path / "qwen35"
+        model.mkdir()
+        (model / "config.json").write_text(json.dumps({"model_type": "qwen3_5"}))
+        entry = self._entry(model, config_model_type="qwen3_5", engine_type="batched")
+        pool = self._pool_with(entry)
+        mock_engine = MagicMock()
+        mock_engine.start = AsyncMock()
+        with patch("omlx.engine_pool.BatchedEngine", return_value=mock_engine):
+            await pool._load_engine(
+                entry.model_id, runtime_settings=ModelSettings(mtp_enabled=True)
+            )
+
+        assert (entry.mtp_requested, entry.mtp_active, entry.mtp_inactive_reason) == (
+            True,
+            None,
+            None,
+        )
+
+    # -- failed / aborted loads reset (AC2) ---------------------------------
+
+    @pytest.mark.asyncio
+    async def test_constructor_failure_leaves_fields_unset(self, tmp_path):
+        from omlx.model_settings import ModelSettings
+
+        entry = self._entry(self._qwen4_checkpoint(tmp_path, with_mtp=False))
+        pool = self._pool_with(entry)
+        with (
+            patch(
+                "omlx.engine_pool.VLMBatchedEngine", side_effect=RuntimeError("boom")
+            ),
+            patch("omlx.engine_pool.BatchedEngine", side_effect=RuntimeError("boom")),
+            pytest.raises(ModelUnavailableError, match="failed to load"),
+        ):
+            await pool._load_engine(
+                entry.model_id, runtime_settings=ModelSettings(mtp_enabled=True)
+            )
+
+        assert (entry.mtp_requested, entry.mtp_active, entry.mtp_inactive_reason) == (
+            None,
+            None,
+            None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_aborted_load_leaves_fields_unset(self, tmp_path):
+        from omlx.model_settings import ModelSettings
+
+        entry = self._entry(self._qwen4_checkpoint(tmp_path, with_mtp=False))
+        pool = self._pool_with(entry)
+        mock_engine = MagicMock()
+
+        async def _start_then_abort():
+            entry.abort_loading = True
+
+        mock_engine.start = AsyncMock(side_effect=_start_then_abort)
+        mock_engine.stop = AsyncMock()
+        with (
+            patch("omlx.engine_pool.VLMBatchedEngine", return_value=mock_engine),
+            patch("omlx.engine_pool.BatchedEngine", return_value=mock_engine),
+            pytest.raises(ModelLoadingError, match="aborted"),
+        ):
+            await pool._load_engine(
+                entry.model_id, runtime_settings=ModelSettings(mtp_enabled=True)
+            )
+
+        assert entry.engine is None
+        assert (entry.mtp_requested, entry.mtp_active, entry.mtp_inactive_reason) == (
+            None,
+            None,
+            None,
+        )
+
+    # -- warning (AC5) --------------------------------------------------------
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("with_mtp", "mtp_enabled", "expect_warning"),
+        [(False, True, True), (True, True, False), (False, False, False)],
+    )
+    async def test_inactive_for_cause_warns_once(
+        self, tmp_path, caplog, with_mtp, mtp_enabled, expect_warning
+    ):
+        from omlx.model_settings import ModelSettings
+
+        entry = self._entry(self._qwen4_checkpoint(tmp_path, with_mtp=with_mtp))
+        pool = self._pool_with(entry)
+        mock_engine = MagicMock()
+        mock_engine.start = AsyncMock()
+        with (
+            caplog.at_level(logging.WARNING, logger="omlx.engine_pool"),
+            patch("omlx.engine_pool.VLMBatchedEngine", return_value=mock_engine),
+            patch("omlx.engine_pool.BatchedEngine", return_value=mock_engine),
+        ):
+            await pool._load_engine(
+                entry.model_id, runtime_settings=ModelSettings(mtp_enabled=mtp_enabled)
+            )
+
+        hits = [
+            r
+            for r in caplog.records
+            if r.name == "omlx.engine_pool"
+            and r.levelno == logging.WARNING
+            and "no_embedded_mtp_tensors" in r.getMessage()
+        ]
+        if expect_warning:
+            assert len(hits) == 1
+            message = hits[0].getMessage()
+            assert entry.model_id in message
+            assert "target-only" in message
+        else:
+            assert hits == []
+
+    # -- reuse-key invariant (AC7) --------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_signature_agrees_and_reuse_does_not_reload(self, tmp_path, caplog):
+        from omlx.model_settings import ModelSettings
+
+        entry = self._entry(self._qwen4_checkpoint(tmp_path, with_mtp=False))
+        pool = self._pool_with(entry)
+        requested = ModelSettings(mtp_enabled=True, mtp_num_draft_tokens=3)
+        mock_engine = MagicMock()
+        mock_engine.start = AsyncMock()
+        mock_engine.stop = AsyncMock()
+        mock_engine.has_active_requests = MagicMock(return_value=False)
+        with (
+            patch("omlx.engine_pool.VLMBatchedEngine", return_value=mock_engine),
+            patch("omlx.engine_pool.BatchedEngine", return_value=mock_engine),
+        ):
+            await pool._load_engine(entry.model_id, runtime_settings=requested)
+            expected = pool._engine_runtime_signature(entry.model_id, requested)
+            assert expected == entry.runtime_settings_signature
+            assert dict(expected)["mtp_enabled"] == "False"
+            assert "mtp_num_draft_tokens" not in dict(expected)
+
+            with caplog.at_level(logging.INFO, logger="omlx.engine_pool"):
+                engine = await pool.get_engine(
+                    entry.model_id, runtime_settings=requested
+                )
+        assert engine is mock_engine
+        assert entry.engine is mock_engine
+        assert not any(
+            "Runtime settings variant changed" in r.getMessage() for r in caplog.records
+        )
+
+    def test_signature_flips_when_tensors_appear(self, tmp_path):
+        from omlx.model_settings import ModelSettings
+
+        model = self._qwen4_checkpoint(tmp_path, with_mtp=False)
+        entry = self._entry(model)
+        pool = self._pool_with(entry)
+        requested = ModelSettings(mtp_enabled=True)
+
+        before = dict(pool._engine_runtime_signature(entry.model_id, requested))
+        assert before["mtp_enabled"] == "False"
+
+        index = model / "model.safetensors.index.json"
+        data = json.loads(index.read_text())
+        data["weight_map"]["mtp.layers.0.mlp.gate.weight"] = "model-00002.safetensors"
+        index.write_text(json.dumps(data))
+        after = dict(pool._engine_runtime_signature(entry.model_id, requested))
+        assert after["mtp_enabled"] == "True"
+
+    # -- no per-request index parse (AC6b, AC2c) ------------------------------
+
+    def test_index_is_parsed_once_per_fingerprint(self, tmp_path):
+        from omlx.model_settings import ModelSettings
+
+        model = self._qwen4_checkpoint(tmp_path, with_mtp=False)
+        entry = self._entry(model)
+        pool = self._pool_with(entry)
+        requested = ModelSettings(mtp_enabled=True)
+
+        with patch(
+            "omlx.utils.model_loading._checkpoint_has_mtp_weights", return_value=False
+        ) as detector:
+            for _ in range(25):
+                pool._engine_runtime_signature(entry.model_id, requested)
+            assert detector.call_count == 1
+
+            # A touched index is a new fingerprint: exactly one more parse.
+            index = model / "model.safetensors.index.json"
+            import os
+
+            st = index.stat()
+            os.utime(index, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000))
+            pool._engine_runtime_signature(entry.model_id, requested)
+            pool._engine_runtime_signature(entry.model_id, requested)
+            assert detector.call_count == 2
+
+    def test_fingerprint_without_index_covers_every_shard(self, tmp_path):
+        from omlx.engine_pool import _checkpoint_mtp_fingerprint
+
+        model = tmp_path / "single"
+        model.mkdir()
+        (model / "config.json").write_text(json.dumps({"model_type": "qwen4_exp"}))
+        (model / "model-00001.safetensors").write_bytes(b"a")
+        (model / "model-00002.safetensors").write_bytes(b"b")
+
+        first = _checkpoint_mtp_fingerprint(str(model))
+        assert first is not None and len(first) == 2
+
+        # Changing the SECOND shard changes the fingerprint (the detector
+        # scans every shard header when there is no index).
+        (model / "model-00002.safetensors").write_bytes(b"bb")
+        second = _checkpoint_mtp_fingerprint(str(model))
+        assert second != first
+
+        # With an index present, the fingerprint tracks the index alone.
+        (model / "model.safetensors.index.json").write_text(
+            json.dumps({"weight_map": {}})
+        )
+        indexed = _checkpoint_mtp_fingerprint(str(model))
+        assert indexed[0] == "index"
+        (model / "model-00002.safetensors").write_bytes(b"bbb")
+        assert _checkpoint_mtp_fingerprint(str(model)) == indexed
+
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        assert _checkpoint_mtp_fingerprint(str(empty)) is None


### PR DESCRIPTION
## Summary

A Qwen4-Exp model whose persisted settings say `mtp_enabled: true` but whose safetensors index has no `mtp.*` tensors loads fine, logs one warning, and serves target-only completions — while `/v1/models/status`, `/admin/api/models` and the settings API all still present MTP as enabled (#3342). The runtime already knows: the qwen4 loader branch computes `mtp_active = requested and has_mtp_weights` and the vendored `configure_mtp_runtime` binds the head disabled. Nothing observable to a client changed, so an operator sees a throughput drop that is indistinguishable from a performance bug. The admin settings *write* path already refuses to enable MTP for such a checkpoint; the gap is every other way the state arises — `settings.json` edited by hand or by an agent, a checkpoint re-converted after the setting was saved, or a settings file carried across machines.

This takes the issue's second remedy rather than the first: expose the effective state, don't refuse the load. Every analogous "requested accelerator unavailable" case here degrades soft and keeps serving (the `#1426` skip-attach path, DFlash falling back to the default engine, the forced PLE mmap decision), and a model that served yesterday should not refuse to load because a setting went stale. The pool now resolves the effective MTP state before construction — on a copy, exactly the way `_effective_qwen4_model_settings` already hands the engine a forced `qwen4_ple_ssd_offload` without touching the persisted settings — records it on the entry, and exposes three fields on `get_status()`, `/v1/models/status` and `/admin/api/models`: `mtp_requested` (the `mtp_enabled` the engine was loaded under), `mtp_active`, and `mtp_inactive_reason` (`no_embedded_mtp_tensors`). `mtp_active` is only ever `true`/`false` for families the pool actually verifies — `qwen4_exp` today, using the same `_checkpoint_has_mtp_weights` detector the loader and the admin write gate use, so the three surfaces can't disagree. For every other family it is `null`, and `null` means "not resolved", never "disabled"; the status endpoint docstring says so.

Two things in the implementation are worth a reviewer's attention. The pool computes the reuse signature twice from different settings objects — the expected one at `get_engine()` from the caller's requested settings, the recorded one at load completion from the effective copy — so `_engine_runtime_signature` reads the *resolved* flag rather than the raw setting; otherwise a resolved-off engine would log "Runtime settings variant changed" and unload/reload on every request (the #2406 class). And because that signature runs on every `get_engine()`, the detector result is cached on a checkpoint fingerprint (index size + mtime, or every shard's when there is no index — exactly the files the detector reads), the same shape `qwen4_exp_residency_estimate` uses; the Flash-Next index is ~400 KB and is now parsed once per checkpoint state, not per request.

## Changes

- `omlx/engine_pool.py`: `_resolve_mtp_state()` (requested / active / reason, qwen4_exp-verified, `None` otherwise); `_effective_qwen4_model_settings` hands the engine a copy with `mtp_enabled=False` when MTP was requested but cannot activate; one WARNING naming the model, the reason and the consequence ("serving target-only completions"); `EngineEntry.mtp_requested/mtp_active/mtp_inactive_reason` written at load completion, reset in the shared `finally` on a failed or aborted load and on unload; exposed on `get_status()`; `_engine_runtime_signature` uses the resolved flag; fingerprint-keyed cache around `_checkpoint_has_mtp_weights`.
- `omlx/admin/routes.py`: the models list passes the three fields through next to the existing `mtp_compatible` / `mtp_compatibility_reason` (a disk verdict; these are what the loaded engine is doing). The markitdown builtin row carries them as `null`.
- `omlx/server.py`: `/v1/models/status` docstring states the `null` = not-resolved contract. The payload flows through unchanged from `get_status()`.
- Tests: 17 in `tests/test_engine_pool.py` (resolution on a copy with identity checks, the three recorded states, reason invariant, status key set, failed-load and aborted-load reset as two distinct paths, exactly-one-warning, the reuse-key invariant with a second `get_engine` that must not reload, signature flipping when tensors appear, index parsed once per fingerprint, no-index fingerprint covering every shard) and 7 in a new `tests/test_admin_mtp_state.py`. All fail on the base and pass after.

Behavior for non-qwen4 families is unchanged: the caller's settings object reaches engine construction by identity and the generic `_is_mtp_compatible` path is untouched. The settings read API still returns what the operator wrote — making it return a value the operator did not write would be a second source of settings drift (#3089).

## Test plan

- `uv run pytest tests/` — 10754 passed, 30 skipped, 0 failed (4m30s, Python 3.12, MLX 0.32.2, M5 Max). Thirteen tests were deselected because they fail identically on stock `upstream/main` `ebf4f1fa` on this machine with zero local changes (`test_deepseek_v4_dspark` ×5 bf16 exact-equality, `test_dflash_laguna`, `test_glm_moe_dsa_patch` affine-block kernels, `test_mlx_vlm_glm5_next_compat`, `test_mlx_vlm_qwen4_exp_compat` ×2, `test_qwen4_qsa_decode_gather`, `test_qwen4_qsa_native_indexer` ×2). That list was 5 at v0.6.4 / MLX 0.32.0 — it's growing with MLX bumps and looks like M5-generation numerics that macos-14 CI can't see; happy to file it separately.
- New tests verified to fail before the change (code stashed, tests kept) and pass after.
- No live server run for this one: the change is in `EnginePool`'s load path and status payload, which the tests drive end-to-end through `_load_engine` / `get_engine` / `_unload_engine` with the engine constructor mocked and a real on-disk index (with and without `mtp.*` keys). The reuse-key test loads, then calls `get_engine` again with the same requested settings and asserts no "Runtime settings variant changed" unload — the failure mode the resolved signature exists to prevent.

Related to #3342 — this implements the "expose it through the API" remedy; the settings read endpoint deliberately keeps returning the persisted value.

— Generated with Marshal · gate: READY · 73b21e4 · tier: full
verify bar: passed at 73b21e4 — 1 check(s) + secrets scan, sha-keyed proof