### PR TITLE
fix(scheduler): do not seed the prefill transient rate from a short chunk's fixed overhead

### DIFF
--- a/omlx/prefill_transient_tracker.py
+++ b/omlx/prefill_transient_tracker.py
@@ -44,6 +44,22 @@ class PrefillTransientTracker:
     # above the largest observed legitimate fluctuation and below the
     # observed outlier.
     _EWMA_OUTLIER_RATIO = 8.0
+    # A chunk's footprint delta is a fixed overhead plus a per-token cost:
+    # MoE gather buffers, expert-streaming scratch banks, MTP verify buffers
+    # and the MLX pool's first-touch allocations are paid once per chunk
+    # regardless of its length. Dividing a short chunk's delta by its token
+    # count attributes that overhead to every token and, when the sample
+    # seeds the EWMA, extrapolates it to full-size chunks with nothing to
+    # compare against. Measured on Qwen3.8 Flash Next with SSD expert
+    # streaming (2026-09-01): a 54-token prompt cost 571 MB, the seeded
+    # 10.8 MB/token predicted 24.6 GB for the next 2048-token chunk, and
+    # every prompt over ~2k tokens was refused; the chunk's real transient
+    # was 3.2 GB. A seed sample shorter than this whose per-token rate is
+    # more than ``_EWMA_OUTLIER_RATIO`` times the caller's static estimate
+    # is therefore treated like any other outlier: counted, kept out of the
+    # rate, and the scheduler stays on its static estimate until a plausible
+    # sample arrives, exactly as it does before the first chunk.
+    _SEED_RATE_MIN_TOKENS = 256
 
     def __init__(self, model_id: str = "") -> None:
         self._model_id = model_id
@@ -78,7 +94,12 @@ class PrefillTransientTracker:
         self._recent_reclaim_bytes = 0
 
     def update(
-        self, n_tokens: int, transient_bytes: int, *, floor_sample: bool = False
+        self,
+        n_tokens: int,
+        transient_bytes: int,
+        *,
+        floor_sample: bool = False,
+        static_per_token: float = 0.0,
     ) -> None:
         """Record one chunk observation.
 
@@ -100,6 +121,14 @@ class PrefillTransientTracker:
         still updates ``last_delta_bytes``/``last_n_tokens`` raw, so a
         genuine regime change remains visible via those fields even while
         the accumulated EWMA is protected from a single noisy reading.
+
+        ``static_per_token`` is the scheduler's formula estimate for this
+        chunk (bytes per token). While no rate has been seeded yet, a chunk
+        shorter than ``_SEED_RATE_MIN_TOKENS`` whose measured rate exceeds
+        that estimate by ``_EWMA_OUTLIER_RATIO`` is rejected from the seed
+        (see the constant's docstring); it is still counted and still feeds
+        the floor-size running max, but does not become the last-delta
+        anchor either.
         """
         if n_tokens <= 0:
             return
@@ -125,7 +154,24 @@ class PrefillTransientTracker:
                 )
 
         per_token = transient_bytes / n_tokens
-        if self._samples == 0:
+        if self._ewma_per_token <= 0.0:
+            if (
+                n_tokens < self._SEED_RATE_MIN_TOKENS
+                and static_per_token > 0.0
+                and per_token > static_per_token * self._EWMA_OUTLIER_RATIO
+            ):
+                logger.debug(
+                    "PrefillTransientTracker(%s): rejected %d-token seed at "
+                    "%.1f bytes/token (static %.1f, ratio limit %.1fx): a "
+                    "short chunk's fixed overhead is not a per-token rate",
+                    self._model_id,
+                    n_tokens,
+                    per_token,
+                    static_per_token,
+                    self._EWMA_OUTLIER_RATIO,
+                )
+                self._samples += 1
+                return
             self._ewma_per_token = per_token
         elif per_token > self._ewma_per_token * self._EWMA_OUTLIER_RATIO:
             # Reject from the EWMA blend: a single sample this far above

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -4721,8 +4721,19 @@ class Scheduler:
                 requested_step,
             )
             return
+        static_per_token = 0.0
+        monitor = getattr(self, "memory_monitor", None)
+        if monitor is not None:
+            static = monitor.estimate_chunk_transient_bytes(
+                n_tokens, kv_len + n_tokens
+            )
+            static += monitor.estimate_prompt_kv_bytes(n_tokens)
+            static_per_token = float(static) / n_tokens
         self._prefill_transient_tracker.update(
-            n_tokens, delta, floor_sample=n_tokens <= min_chunk
+            n_tokens,
+            delta,
+            floor_sample=n_tokens <= min_chunk,
+            static_per_token=static_per_token,
         )
         logger.debug(
             "[throttle:%s] measure rid=%s n=%d kv_len=%d transient=%.2fMB per_token=%.1fKB ewma=%.1fKB observed_max=%.1fMB samples=%d",

--- a/tests/test_prefill_transient_tracker.py
+++ b/tests/test_prefill_transient_tracker.py
@@ -187,3 +187,53 @@ class TestReset:
         assert t.last_delta_bytes == 0
         assert t.predict(2048) == 0
         assert t.observed_max_bytes == 0
+
+
+class TestShortSeedRejection:
+    """A short chunk's fixed overhead must not seed the per-token rate.
+
+    Qwen3.8 Flash Next with SSD expert streaming measured 571 MB for a
+    54-token prompt; seeded as 10.8 MB/token it predicted 24.6 GB for the
+    next 2048-token chunk (real transient 3.2 GB) and refused every long
+    prompt.
+    """
+
+    def test_implausible_short_seed_is_rejected(self):
+        t = PrefillTransientTracker("m")
+        # 54 tokens, 571 MB, static estimate ~20 KB/token.
+        t.update(54, 571 * 1024**2, static_per_token=20 * 1024)
+        assert t.samples == 1, "sample is still counted"
+        assert t.bytes_per_token == 0.0, "must not seed the rate"
+        assert t.last_n_tokens == 0 and t.last_delta_bytes == 0
+        assert t.predict(2048) == 0, "caller falls back to the static estimate"
+
+    def test_plausible_short_seed_still_seeds(self):
+        t = PrefillTransientTracker("m")
+        t.update(54, 54 * 100_000, static_per_token=50_000)  # 2x static
+        assert t.bytes_per_token == 100_000.0
+
+    def test_seed_without_static_hint_is_unchanged(self):
+        t = PrefillTransientTracker("m")
+        t.update(54, 571 * 1024**2)
+        assert t.bytes_per_token == 571 * 1024**2 / 54
+
+    def test_rate_sized_seed_ignores_the_ratio(self):
+        t = PrefillTransientTracker("m")
+        t.update(2048, 2048 * 1_000_000, static_per_token=1_000)  # 1000x static
+        assert t.bytes_per_token == 1_000_000.0
+
+    def test_later_plausible_sample_seeds_after_rejection(self):
+        t = PrefillTransientTracker("m")
+        t.update(54, 571 * 1024**2, static_per_token=20 * 1024)
+        t.update(2048, 2048 * 1_500_000, static_per_token=1_000_000)
+        assert t.samples == 2
+        assert t.bytes_per_token == 1_500_000.0
+        assert t.last_n_tokens == 2048
+
+    def test_rejected_seed_still_feeds_floor_max(self):
+        t = PrefillTransientTracker("m")
+        t.update(1000, 100_000)  # first sample never feeds the max
+        t.reset()
+        t.update(2048, 2048 * 100)  # seeds the rate
+        t.update(32, 300 * 1024**2, floor_sample=True, static_per_token=1_000)
+        assert t.observed_max_bytes == 300 * 1024**2


### PR DESCRIPTION
## Summary

`PrefillTransientTracker` seeds its per-token rate from the first positive chunk sample by dividing the footprint delta by the token count. A prefill chunk's delta is a fixed overhead plus a per-token cost (MoE gather buffers, expert-streaming scratch banks, MTP verify buffers, MLX pool first-touch allocations), so a short first prompt attributes that overhead to every token and the rate is extrapolated to full-size chunks with nothing to compare against.

Observed on Qwen3.8 Flash Next oQ2 with SSD expert streaming (PR #3359 branch) on a 64 GB M5 Pro: a 54-token prompt cost 571 MB, the seeded 10.8 MB/token predicted 24.6 GB for the next 2048-token chunk, and the guard refused every prompt over about 2k tokens ("KV+SDPA 20.6 GB") although the formula terms total 0.6 GiB and the chunk's Metal peak measured with the guard off was 3.2 GB.

## Change

While no rate has been seeded, a sample shorter than 256 tokens whose per-token rate exceeds the scheduler's static estimate by the existing 8x `_EWMA_OUTLIER_RATIO` is rejected as a seed. It still counts toward `samples` and the floor-size running max, and does not become the last-delta anchor. The scheduler stays on its static estimate until a plausible sample arrives, which is the same regime as before the first chunk. Rate-sized seeds, seeds without a static hint, and every later sample are unchanged, so the tracker's existing outlier protection and the OOM-crash guard it was built for are untouched.

`_record_chunk_transient` now passes the static per-token estimate (`estimate_chunk_transient_bytes + estimate_prompt_kv_bytes`) as the hint; it is 0 when no memory monitor is attached.

## Scope note

This removes the short-prompt poisoning, which I verified in the debug log (`rejected 54-token seed at 9900740.0 bytes/token (static 55104.0)`). It does not by itself unblock 4k prompts on the streaming branch: there, a real 2048-token chunk measures a 16.2 GB footprint delta, which the enforcer log attributes to the MLX buffer pool growing to about 13 GB during the streamed prefill. That is a property of the streaming prefill path and belongs in #3359, not here.

## Validation

- `tests/test_prefill_transient_tracker.py` (6 new tests), `tests/test_scheduler_prefill_memory_guard.py`, `tests/test_prefill_oom_graceful.py`, `tests/test_context_benchmark.py`: 144 passed.
- ruff clean on touched files.