### PR TITLE
fix(memory): refresh ANE prefill transient reserve after bank compile

### DIFF
--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -579,6 +579,7 @@ class BatchedEngine(BaseEngine):
         scheduler = self._engine.engine.scheduler
         if ane_prefill_sequence_length:
             from ..patches.qwen35_ane_prefill import (
+                ane_prefill_transient_bytes,
                 configure_qwen35_ane_prefill_scheduler,
             )
 
@@ -586,6 +587,15 @@ class BatchedEngine(BaseEngine):
                 scheduler,
                 ane_prefill_sequence_length,
             )
+            # Price the compiled ANE I/O surfaces explicitly: a later
+            # _set_model_info_for_monitor() defaults the term to zero
+            # unless re-derived, and the monitor must hold the real
+            # reservation while the banks exist.
+            monitor = getattr(scheduler, "memory_monitor", None)
+            if monitor is not None:
+                monitor.set_ane_prefill_transient_bytes(
+                    ane_prefill_transient_bytes(self._model)
+                )
         if self._model_settings is not None:
             tq_enabled = getattr(self._model_settings, "turboquant_kv_enabled", False)
             if tq_enabled:

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -2105,6 +2105,18 @@ class VLMBatchedEngine(BaseEngine):
                         scheduler,
                         requested_ane_sequence_length,
                     )
+                    # The scheduler snapshotted model info before these
+                    # banks existed; price the compiled I/O surfaces now so
+                    # admission charges them while the banks are resident.
+                    from ..patches.qwen35_ane_prefill import (
+                        ane_prefill_transient_bytes,
+                    )
+
+                    monitor = getattr(scheduler, "memory_monitor", None)
+                    if monitor is not None:
+                        monitor.set_ane_prefill_transient_bytes(
+                            ane_prefill_transient_bytes(self._vlm_model)
+                        )
             except Exception:
                 logger.warning("Qwen ANE prefill not enabled", exc_info=True)
 

--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -427,6 +427,18 @@ class MemoryMonitor:
         """
         self._ane_prefill_transient_bytes = 0
 
+    def set_ane_prefill_transient_bytes(self, value: int) -> None:
+        """Refresh the ANE prefill I/O-surface reservation.
+
+        ANE banks compile after the scheduler snapshots model info (the
+        engine builds them once the scheduler exists), so the load-time
+        value can read 0 while banks are being created. Engines call this
+        right after compilation so admission prices the real reservation
+        while banks exist; bank release clears it via
+        clear_ane_prefill_transient.
+        """
+        self._ane_prefill_transient_bytes = max(int(value), 0)
+
     def set_model_info(
         self,
         num_layers: int,

--- a/tests/test_memory_monitor.py
+++ b/tests/test_memory_monitor.py
@@ -1097,3 +1097,30 @@ class TestAnePrefillTransientReserve:
         )
         monitor.clear_ane_prefill_transient()
         assert monitor._ane_prefill_transient_bytes == 0
+
+    def test_setter_refreshes_after_compile_and_clears_after_release(self):
+        # The banks compile after the scheduler snapshots model info, so the
+        # load-time reserve reads 0; engines refresh it post-compile, and the
+        # release rung clears it while the model stays resident.
+        from omlx.memory_monitor import MemoryMonitor
+
+        monitor = MemoryMonitor(max_kv_cache_memory=None, eviction_enabled=False)
+        monitor.set_model_info(
+            num_layers=2,
+            num_kv_heads=2,
+            head_dim=64,
+            dtype_size=2,
+        )
+        assert monitor._ane_prefill_transient_bytes == 0
+        reserve = 12 * 1024**3
+        base_peak = monitor.estimate_prefill_peak_bytes(32768, 2048)
+        monitor.set_ane_prefill_transient_bytes(reserve)
+        assert monitor._ane_prefill_transient_bytes == reserve
+        assert (
+            monitor.estimate_prefill_peak_bytes(32768, 2048) == base_peak + reserve
+        )
+        monitor.clear_ane_prefill_transient()
+        assert monitor._ane_prefill_transient_bytes == 0
+        # Negative input clamps to zero instead of widening headroom.
+        monitor.set_ane_prefill_transient_bytes(-5)
+        assert monitor._ane_prefill_transient_bytes == 0


### PR DESCRIPTION
## Problem

#2841: with ANE prefill enabled, the compiled slices hold fixed-shape fp16 I/O
surfaces that the first long prompt dirties on top of the KV+SDPA peak. `dcb317fe`
priced those surfaces through an `ane_prefill_transient_bytes` term passed to
`set_model_info`. That term is snapshotted **at scheduler init**, but on the VLM
path the ANE banks are compiled **after** the scheduler is initialized —
`VLMBatchedEngine.start()` runs `enable_qwen35_ane_prefill` only after
`engine.start()` has constructed the scheduler. The load-time read therefore
returns 0 and the reserve never engages.

Production capture (v0.6.4, ANE prefill enabled, Qwen3.8-27B-oQ4e-mtp):

```
qwen35_ane_prefill - Warmed 224 ANE procedures in 2.0s at load
engine_pool        - Loaded model: Qwen3.8-27B-oQ4e-mtp (actual: 28.49GB, local estimate: 16.60GB)
scheduler          - [guard:external] admission terms: current=32.41GB predicted_transient=3.87GB observed_max_bytes=0.00GB ane_prefill_transient_bytes=0.00GB
context_benchmark  - ERROR - Not enough memory to prefill even 4,096 tokens on this machine
```

224 procedures are warm and the banks are resident (~11.9 GB over the GPU-only
footprint), yet the admission breakdown prints `ane_prefill_transient_bytes=0.00GB`
and the model cannot prefill even 4,096 tokens. This matches the post-`dcb317fe`
report on #2841 ("still seeing the abort, disabling ANE prefill fixes it"). The LM
path is unaffected (its compile runs before the scheduler is created); the VLM path
is the one that loads Qwen multimodal checkpoints.

## Change

- **`MemoryMonitor.set_ane_prefill_transient_bytes(value)`**: idempotent setter,
  clamps negative to 0.
- **`BatchedEngine.start()` / `VLMBatchedEngine.start()`**: refresh the reserve
  immediately after `enable_qwen35_ane_prefill` compiles the banks, computed from
  the live model dims via the existing `ane_prefill_transient_bytes(model)`. The
  release rung already zeroes it through `clear_ane_prefill_transient()` (#3103),
  so the term is non-zero exactly while the banks are resident.

## Verification

- New unit test: reserve defaults to 0, the setter raises it,
  `estimate_prefill_peak_bytes` includes it, clear drops it, negative input clamps.
  `tests/test_memory_monitor.py` + `tests/test_qwen35_ane_prefill.py`: **216 passed**.
  Broader: `test_scheduler_prefill_memory_guard.py` + `test_memory_monitor_vlm_config.py`
  + `test_batched_engine.py`: **104 passed**.
- ANE compiles and engages on a source build (224 procedures warmed). With ANE
  enabled, the long-context benchmark now reaches the bank-release rung and completes
  65,536 tokens where the v0.6.4 capture above rejected at 4,096 — the full
  before/after ladder trace is in the eviction-escalation PR.
