### PR TITLE
fix(engine_pool): escalate prefill headroom past a no-op first pass

### DIFF
--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -293,8 +293,9 @@ class EnginePool:
         # rung can "succeed" marginally on every pass of a long prompt while
         # the durable rung behind it (ANE bank release) is never reached; a
         # request coming back for more headroom escalates instead of
-        # reclaiming again first. Bounded FIFO — request ids are transient.
-        self._prefill_headroom_recurring: OrderedDict[str, None] = OrderedDict()
+        # reclaiming again first. Values count callback attempts per request
+        # (>1 = recurring). Bounded FIFO — request ids are transient.
+        self._prefill_headroom_recurring: OrderedDict[str, int] = OrderedDict()
         self._load_seconds_per_gb_ema: float | None = None
         self._load_time_observations: int = 0
         self._lease_release_tasks: set[asyncio.Task[None]] = set()
@@ -1915,12 +1916,39 @@ class EnginePool:
             return False
 
         evicted_any = False
+        evicted_count = 0
         reclaim_attempted = False
         ane_release_attempted = False
-        # Snapshot once per call: "a PREVIOUS pass for this request already
-        # got a reclaim". Marking inside this call must not flip it.
-        recurring = request_id in self._prefill_headroom_recurring
+        reason = str(getattr(eviction_request, "reason", "") or "")
         async with self._lock:
+            attempt = self._prefill_headroom_recurring.get(request_id, 0) + 1
+            self._prefill_headroom_recurring[request_id] = attempt
+            while len(self._prefill_headroom_recurring) > 512:
+                self._prefill_headroom_recurring.popitem(last=False)
+            # Snapshot once per call: "a PREVIOUS pass for this request
+            # already ran". Marking at entry must not flip it for THIS call.
+            recurring = attempt > 1
+
+            def _log_decision(action: str, outcome: str) -> None:
+                logger.info(
+                    "[prefill-eviction] request=%s retry=%d reason=%s "
+                    "action=%s outcome=%s recurring=%s mx_active=%.2fGB "
+                    "phys_footprint=%.2fGB model_memory=%.2fGB "
+                    "predicted=%.2fGB target=%.2fGB evicted=%d",
+                    request_id,
+                    attempt,
+                    reason,
+                    action,
+                    outcome,
+                    recurring,
+                    mx.get_active_memory() / 1024**3,
+                    get_phys_footprint() / 1024**3,
+                    self._current_model_memory / 1024**3,
+                    predicted / 1024**3,
+                    target / 1024**3,
+                    evicted_count,
+                )
+
             while True:
                 current = max(
                     mx.get_active_memory(),
@@ -1935,6 +1963,22 @@ class EnginePool:
                     # process-wide and can be masked by concurrent
                     # allocation, but reaching this check with headroom
                     # after an attempt means admission will now succeed.
+                    if ane_release_attempted:
+                        action = "release_ane"
+                    elif reclaim_attempted:
+                        action = "reclaim_pool"
+                    elif evicted_any:
+                        action = "evict_model"
+                    else:
+                        # No rung ran: the pool's own reading already sees
+                        # headroom. The entry mark above keeps this request
+                        # recurring, so when the scheduler's tighter usage
+                        # reading disagrees and sends it back, the ladder
+                        # escalates straight to the ANE-bank release instead
+                        # of spending the remaining retry on the reclaim rung
+                        # a no-op first pass already proved useless.
+                        action = "already_fit"
+                    _log_decision(action, "retry")
                     return evicted_any or reclaim_attempted or ane_release_attempted
 
                 victim = self._find_lru_prefill_eviction_victim(
@@ -1968,9 +2012,6 @@ class EnginePool:
                         # requesting engine's own MLX thread, then let the
                         # loop re-measure.
                         reclaim_attempted = True
-                        self._prefill_headroom_recurring[request_id] = None
-                        while len(self._prefill_headroom_recurring) > 512:
-                            self._prefill_headroom_recurring.popitem(last=False)
                         await self._reclaim_pooled_buffers_for_prefill(
                             exclude_model_id, request_id
                         )
@@ -2008,6 +2049,9 @@ class EnginePool:
                             format_size(predicted),
                             format_size(target),
                         )
+                        _log_decision("evict_model", "retry")
+                    else:
+                        _log_decision("reject", "exhausted")
                     return evicted_any
 
                 logger.info(
@@ -2021,6 +2065,7 @@ class EnginePool:
                 )
                 await self._unload_engine(victim)
                 evicted_any = True
+                evicted_count += 1
 
     @staticmethod
     def _resolve_engine_core_from_engine(engine: object) -> object | None:

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -2371,9 +2371,17 @@ class TestEnginePoolPrefillEviction:
 
         # The helper's before/after reads both see 45GB (another engine
         # allocates while the reclaim frees, masking the delta as 0), but
-        # the loop's next reading sees the real 25GB baseline. Exactly four
-        # reads: loop #1, helper before, helper after, loop #2.
+        # the loop's next reading sees the real 25GB baseline. Four scripted
+        # reads: loop #1, helper before, helper after, loop #2; further
+        # reads (decision logging) stay at the settled 25GB baseline.
         phys = iter([45 * gb, 45 * gb, 45 * gb, 25 * gb])
+
+        def _phys():
+            try:
+                return next(phys)
+            except StopIteration:
+                return 25 * gb
+
         scheduler = self._reclaim_scheduler(lambda: None)
         req = PrefillEvictionRequest(
             request_id="req-1",
@@ -2398,7 +2406,7 @@ class TestEnginePoolPrefillEviction:
                 patch("omlx.engine_pool.mx.get_active_memory", return_value=0),
                 patch(
                     "omlx.engine_pool.get_phys_footprint",
-                    side_effect=lambda: next(phys),
+                    side_effect=_phys,
                 ),
             ):
                 admitted = await pool._evict_idle_lru_for_prefill("target", req)
@@ -2539,6 +2547,71 @@ class TestEnginePoolPrefillEviction:
         scheduler._reclaim_prefill_headroom.assert_called_once()
         pool._unload_engine.assert_not_awaited()
         assert pool._entries["busy"].engine is not None
+
+    @pytest.mark.asyncio
+    async def test_noop_first_pass_escalates_second_pass_to_ane_release(
+        self, caplog
+    ):
+        """The observed admission sequence: the first callback's pool-side
+        re-measurement already sees headroom and runs no rung (the scheduler
+        retries anyway because its own usage reading is tighter); the second
+        callback must escalate straight to the ANE bank release instead of
+        spending the remaining retry on the pooled-buffer reclaim a no-op
+        first pass already proved useless."""
+        gb = 1024**3
+        pool = _make_pool(ceiling=0)
+
+        state = {"pressure": 20 * gb, "released": False}
+
+        def _phys():
+            return 25 * gb if state["released"] else state["pressure"]
+
+        async def _release_ane(model_id, request_id):
+            state["released"] = True
+            return 17 * gb
+
+        req = PrefillEvictionRequest(
+            request_id="req-1",
+            model_id="target",
+            current_bytes=20 * gb,
+            target_cap_bytes=40 * gb,
+            predicted_transient_bytes=10 * gb,
+            requested_tokens=2048,
+            reason="prefill_safety_cap",
+        )
+
+        pool._entries = {"target": self._entry("target", 25 * gb)}
+        pool._current_model_memory = 15 * gb
+        pool._unload_engine = AsyncMock()
+        pool._release_ane_prefill_for_headroom = AsyncMock(side_effect=_release_ane)
+        pool._reclaim_pooled_buffers_for_prefill = AsyncMock(return_value=0)
+
+        with (
+            patch("omlx.engine_pool.mx.get_active_memory", return_value=0),
+            patch("omlx.engine_pool.get_phys_footprint", side_effect=_phys),
+            caplog.at_level(logging.INFO, logger="omlx.engine_pool"),
+        ):
+            first = await pool._evict_idle_lru_for_prefill("target", req)
+            # The scheduler's tighter usage reading still sees pressure on
+            # the retry even though the pool's first reading saw headroom.
+            state["pressure"] = 45 * gb
+            second = await pool._evict_idle_lru_for_prefill("target", req)
+
+        assert first is False
+        assert second is True
+        pool._reclaim_pooled_buffers_for_prefill.assert_not_awaited()
+        pool._release_ane_prefill_for_headroom.assert_awaited_once()
+        pool._unload_engine.assert_not_awaited()
+        decisions = [
+            record.getMessage()
+            for record in caplog.records
+            if "[prefill-eviction]" in record.getMessage()
+        ]
+        assert len(decisions) == 2
+        assert "action=already_fit" in decisions[0]
+        assert "retry=1" in decisions[0]
+        assert "action=release_ane" in decisions[1]
+        assert "retry=2" in decisions[1]
 
 
 class TestEnginePoolStatus:


### PR DESCRIPTION
## Problem

#3103 added an ANE-bank-release rung, made *recurring* pressure escalate
release-before-reclaim, and raised the retry budget to 2. But a request is marked
recurring only when the pooled-buffer reclaim rung actually runs. There is a path
where the first eviction callback runs **no rung at all**: the pool's own
re-measurement — `max(mx.get_active_memory(), phys_footprint, model_memory)` —
reads lower than the scheduler's `_current_usage_bytes()`, sees headroom, and
returns having done nothing and marked nothing.

The scheduler's tighter reading still shows pressure, so it spends its retry. The
second callback is still *not* recurring, so it runs the marginal pooled reclaim —
which prefill continuously refutes by refilling MLX's buffer cache — and the budget
is exhausted. The durable release rung is never reached.

Production capture (v0.6.4, request `4420aa8c`, ANE prefill enabled):

```
scheduler   - Request 4420aa8c needs prefill headroom before throttling (current=32.44GB, predicted=1.36GB, target=33.29GB)
engine_core - No idle model evicted for request 4420aa8c; scheduler will fall back to throttling
scheduler   - Request 4420aa8c needs prefill headroom before throttling (current=32.39GB, predicted=2.23GB, target=34.41GB)
engine_pool - Reclaimed 2.60GB of pooled Metal buffers for prefill request 4420aa8c (no idle model to evict)
```

Pass 1 ran no rung ("No idle model evicted ... fall back to throttling", with no
reclaim line); pass 2 reclaimed; retries exhausted. The request was then rejected at
the 2048-token guard — `Not enough memory to prefill even 4,096 tokens` — while the
~12 GB of bank memory sat untouched.

## Change

- `_evict_idle_lru_for_prefill` marks the request at **entry**, storing a per-request
  callback attempt counter in `_prefill_headroom_recurring` (bounded FIFO).
  `recurring = attempt > 1` is snapshotted so marking inside the current call does
  not flip it mid-call. A no-op first pass now leaves the request recurring, so the
  retry escalates to the release rung instead of reclaiming again. The two-retry
  policy and rung ordering are unchanged.
- Adds one stable `[prefill-eviction]` INFO record per callback decision:
  `request / retry / reason / action / outcome / recurring / mx_active /
  phys_footprint / model_memory / predicted / target / evicted`, where
  `action ∈ {already_fit, evict_model, reclaim_pool, release_ane, reject}`. Within a
  single pass the ladder still runs reclaim→release when reclaim alone is not enough;
  the record reports the highest rung reached. The decision was previously invisible.

## Verification

- New test reproduces the observed sequence exactly: first callback `already_fit`
  no-op → second releases the ANE banks; asserts reclaim is never attempted, no model
  is evicted, and both decision records read `action=already_fit retry=1` then
  `action=release_ane retry=2`. The existing masked-delta test is updated for the
  extra re-measurement taken by decision logging.
  `tests/test_engine_pool.py` + `tests/test_prefill_oom_graceful.py`: **191 passed**.
  Broader: `test_cluster_engine_pool.py` + `test_scheduler_prefill_memory_guard.py`
  + `test_server_prefill_memory_handler.py`: **65 passed**.
- Live (source build, ANE prefill enabled): the decision is now logged and the ladder
  reaches the release rung under pressure:

```
engine_pool - [prefill-eviction] request=e417db5c retry=1 reason=adaptive_prefill_throttle action=release_ane outcome=retry recurring=False mx_active=16.57GB phys_footprint=20.25GB model_memory=16.60GB predicted=3.39GB target=33.70GB evicted=0
engine_pool - Released ANE prefill banks on 'Qwen3.8-27B-oQ4e-mtp' ... freed 10.29GB
```

  With the pressure now recoverable, the 65,536-token context benchmark completes
  (~397 tok/s) where the v0.6.4 capture above rejected at 4,096 tokens.
