### PR TITLE
feat: content-free prefill memory diagnostics

### DIFF
--- a/omlx/admin/context_benchmark.py
+++ b/omlx/admin/context_benchmark.py
@@ -90,6 +90,12 @@ class ContextBenchmarkRequest(BaseModel):
 
     model_id: str
     target_tokens: int = 131072
+    # API-only A/B controls (defaults keep the admin UI behavior).
+    # Load the text-only LM engine even for VLM models to measure the
+    # vision-weight residency difference.
+    force_lm_engine: bool = False
+    # False runs the measurement without writing max_context_window.
+    apply_result: bool = True
 
     @field_validator("target_tokens")
     @classmethod
@@ -296,6 +302,9 @@ async def _run_probe_prefill(engine: Any, prompt: str) -> tuple[Any, float]:
     memory guard refuses or aborts the probe. With max_tokens=1 the wall
     clock is dominated by the prefill, so callers can derive a prefill
     tok/s from it when the engine does not report prompt_tps.
+
+    Probes carry benchmark_trace so every prefill chunk emits the
+    content-free memory diagnostic lines the A/B matrix is built from.
     """
     started = time.perf_counter()
     last_output = None
@@ -305,6 +314,7 @@ async def _run_probe_prefill(engine: Any, prompt: str) -> tuple[Any, float]:
         temperature=0.0,
         top_p=1.0,
         skip_cache_store=True,
+        benchmark_trace=True,
     ):
         last_output = output
     return last_output, time.perf_counter() - started
@@ -425,8 +435,14 @@ async def run_context_benchmark(run: ContextBenchmarkRun, engine_pool: Any) -> N
                     )
 
         await _progress(run, "prepare", 0.4, f"Loading {request.model_id}...")
-        engine = await engine_pool.get_engine(request.model_id)
-        logger.info("Context bench: loaded %s", request.model_id)
+        engine = await engine_pool.get_engine(
+            request.model_id, force_lm=request.force_lm_engine
+        )
+        logger.info(
+            "Context bench: loaded %s (engine_mode=%s)",
+            request.model_id,
+            "lm" if request.force_lm_engine else "default",
+        )
 
         scheduler = _resolve_scheduler(engine)
         if scheduler is None:
@@ -699,7 +715,7 @@ async def run_context_benchmark(run: ContextBenchmarkRun, engine_pool: Any) -> N
 
         applied = False
         sm = getattr(engine_pool, "_settings_manager", None)
-        if sm is not None:
+        if request.apply_result and sm is not None:
             try:
                 settings = sm.get_settings(request.model_id)
                 settings.max_context_window = final
@@ -743,6 +759,10 @@ async def run_context_benchmark(run: ContextBenchmarkRun, engine_pool: Any) -> N
                 if getattr(scheduler, "_prefill_speed_priority", False)
                 else "context"
             ),
+            # A/B mode metadata: which engine served the measurement and
+            # whether it mutated the stored max_context_window.
+            "engine_mode": "lm" if request.force_lm_engine else "default",
+            "apply_result": request.apply_result,
         }
         run.result = result
         await _send_event(run, {"type": "result", "data": result})

--- a/omlx/cache/observability.py
+++ b/omlx/cache/observability.py
@@ -96,6 +96,9 @@ class BoundarySnapshotDiagnostics:
         "override_hits",
         "override_misses",
         "store_skips",
+        "gdn_commit_attempts",
+        "gdn_commit_successes",
+        "gdn_commit_failures",
     )
 
     def __init__(self) -> None:
@@ -124,6 +127,9 @@ class BoundarySnapshotDiagnostics:
             "override_hit": "override_hits",
             "override_miss": "override_misses",
             "store_skip": "store_skips",
+            "gdn_commit_attempt": "gdn_commit_attempts",
+            "gdn_commit_success": "gdn_commit_successes",
+            "gdn_commit_failure": "gdn_commit_failures",
         }.get(event)
 
         with self._lock:

--- a/omlx/patches/sdpa256_attention.py
+++ b/omlx/patches/sdpa256_attention.py
@@ -64,6 +64,46 @@ _FORCE_TILED: bool | None = None
 # INFO; repeats stay silent to keep the hot path quiet.
 _TILED_ROUTE_LOGGED: "set[str]" = set()
 
+# Content-free route counters for benchmark correlation: how often the
+# wrapper served each path and the KV length at the first bounded switch.
+# Opt-in (OMLX_SDPA256_ROUTE_STATS=1): the wrapper runs on every SDPA call of
+# every decode step, so the counters must add nothing to the hot path unless
+# they are actually being collected.
+_ROUTE_STATS_ENABLED: bool = os.environ.get(
+    "OMLX_SDPA256_ROUTE_STATS", ""
+).strip() == "1"
+_ROUTE_STATS = {
+    "stock_calls": 0,
+    "bounded_calls": 0,
+    "first_bounded_kv_len": 0,
+}
+
+
+def get_route_snapshot() -> dict[str, int]:
+    """Cumulative route counters since the patch was applied."""
+    return dict(_ROUTE_STATS)
+
+
+def _set_route_stats_enabled(enabled: bool) -> None:
+    global _ROUTE_STATS_ENABLED
+    _ROUTE_STATS_ENABLED = bool(enabled)
+
+
+def _reset_route_stats() -> None:
+    for key in _ROUTE_STATS:
+        _ROUTE_STATS[key] = 0
+
+
+def _note_route_call(bounded: bool, kv_len: int = 0) -> None:
+    if not _ROUTE_STATS_ENABLED:
+        return
+    if bounded:
+        _ROUTE_STATS["bounded_calls"] += 1
+        if _ROUTE_STATS["first_bounded_kv_len"] == 0 and kv_len > 0:
+            _ROUTE_STATS["first_bounded_kv_len"] = int(kv_len)
+    else:
+        _ROUTE_STATS["stock_calls"] += 1
+
 
 def _note_tiled_route(reason: str, detail: str) -> None:
     if reason in _TILED_ROUTE_LOGGED:
@@ -330,7 +370,9 @@ def apply_sdpa256_attention_patch(min_kv_len: int = _SDPA256_MIN_KV_LEN) -> bool
         sinks: mx.array | None = None,
     ) -> mx.array:
         if _should_route(queries, keys, cache, mask, sinks):
+            _note_route_call(True, keys.shape[-2])
             return _flash_sdpa256(queries, keys, values, scale, mask, sinks)
+        _note_route_call(False)
         return original_sdpa(queries, keys, values, cache, scale, mask, sinks)
 
     mlx_base.scaled_dot_product_attention = patched_sdpa
@@ -375,7 +417,9 @@ def apply_sdpa256_attention_patch(min_kv_len: int = _SDPA256_MIN_KV_LEN) -> bool
                 sinks=None,
             ) -> mx.array:
                 if _should_route(queries, keys, cache, mask, sinks):
+                    _note_route_call(True, keys.shape[-2])
                     return _flash_sdpa256(queries, keys, values, scale, mask, sinks)
+                _note_route_call(False)
                 return original_vlm_sdpa(
                     queries, keys, values, cache, scale, mask, sinks
                 )

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -56,7 +56,10 @@ from .exceptions import (
     describe_ceiling_binding,
     is_cache_corruption_error,
 )
-from .patches.sdpa256_attention import set_unfused_headroom_provider
+from .patches.sdpa256_attention import (
+    get_route_snapshot as sdpa256_route_snapshot,
+    set_unfused_headroom_provider,
+)
 from .decode_activity import get_decode_activity
 from .prefill_progress import get_prefill_tracker
 from .prefill_transient_tracker import PrefillTransientTracker
@@ -1625,12 +1628,14 @@ class _BoundarySnapshotProvider:
         valid_tcs: list[int],
         in_memory_snapshots: dict[int, Any],
         paged_ssd_manager: Any | None = None,
+        diagnostics: Any | None = None,
     ) -> None:
         self._store = store
         self._request_id = request_id
         self._valid_tcs = set(valid_tcs)
         self._in_memory = in_memory_snapshots
         self._paged_ssd_manager = paged_ssd_manager
+        self._diagnostics = diagnostics
 
     def __contains__(self, tc: int) -> bool:
         return tc in self._valid_tcs
@@ -1667,10 +1672,43 @@ class _BoundarySnapshotProvider:
         block_size: int,
     ) -> bool:
         """Promote one request-local boundary snapshot to durable sidecar storage."""
+
+        def _record(reason: str | None, success: bool) -> None:
+            diagnostics = self._diagnostics
+            if diagnostics is None:
+                return
+            try:
+                diagnostics.record(
+                    "gdn_commit_success" if success else "gdn_commit_failure",
+                    reason=reason,
+                    request_id=self._request_id,
+                    token_count=token_count,
+                    block_size=block_size,
+                )
+            except Exception:
+                logger.debug("gdn commit diagnostics record failed", exc_info=True)
+
+        diagnostics = self._diagnostics
+        if diagnostics is not None:
+            try:
+                diagnostics.record(
+                    "gdn_commit_attempt",
+                    request_id=self._request_id,
+                    token_count=token_count,
+                    block_size=block_size,
+                )
+            except Exception:
+                logger.debug("gdn commit diagnostics record failed", exc_info=True)
         if self._store is None or self._paged_ssd_manager is None:
+            # Snapshot lived in memory only — no SSD staging was ever
+            # captured for this request, so there is nothing to promote.
+            _record("in_memory_only", False)
             return False
         staged_path = self._store.take_staged_file(self._request_id, token_count)
         if staged_path is None:
+            # Capture claimed a boundary but the staged sidecar file is
+            # gone — the store never wrote it or it was cleaned up.
+            _record("staged_missing", False)
             return False
         try:
             signature_builder = getattr(
@@ -1695,10 +1733,14 @@ class _BoundarySnapshotProvider:
             if committed is None:
                 with suppress(OSError):
                     staged_path.unlink()
-            return committed is not None
+                _record("promotion_failed", False)
+                return False
+            _record(None, True)
+            return True
         except Exception:
             with suppress(OSError):
                 staged_path.unlink()
+            _record("promotion_failed", False)
             return False
 
 
@@ -3768,7 +3810,7 @@ class Scheduler:
                     "processed=%d->%d kv_before=%d requested_step=%d "
                     "boundary_enabled=%s cache_block_size=%d ane_tile=%d "
                     "ane_full_tiles=%d ane_tail_tokens=%d model_cache_ms=%.3f "
-                    "total_ms=%.3f overhead_ms=%.3f",
+                    "total_ms=%.3f overhead_ms=%.3f %s",
                     request.request_id,
                     n_to_process,
                     _trace_processed_before,
@@ -3783,6 +3825,13 @@ class Scheduler:
                     _trace_model_ms,
                     _trace_total_ms,
                     max(0.0, _trace_total_ms - _trace_model_ms),
+                    self._benchmark_trace_memory_fields(
+                        n_tokens=n_to_process,
+                        kv_len=base_size + _trace_processed_before,
+                        phys_pre=_throttle_pre,
+                        phys_post=_throttle_post,
+                        phys_post_clear=get_phys_footprint(),
+                    ),
                 )
 
         # Emit final boundary snapshot if prompt lands exactly on boundary.
@@ -4638,6 +4687,64 @@ class Scheduler:
             return False
         return current >= self._memory_limit_bytes
 
+    def _benchmark_trace_memory_fields(
+        self,
+        *,
+        n_tokens: int,
+        kv_len: int,
+        phys_pre: int,
+        phys_post: int,
+        phys_post_clear: int,
+    ) -> str:
+        """Content-free memory context for one benchmark-trace chunk line.
+
+        Only called for benchmark_trace requests; normal inference logs
+        never reach this path.
+        """
+        tracker = self._prefill_transient_tracker
+        try:
+            predicted = int(self._predicted_chunk_transient(n_tokens, kv_len))
+        except Exception:
+            predicted = 0
+        guard_cap = 0
+        guard_headroom = 0
+        try:
+            _, guard_cap, _ = self._prefill_abort_description()
+            if guard_cap > 0:
+                guard_headroom = guard_cap - self._current_usage_bytes()
+        except Exception:
+            pass
+        try:
+            mx_active = mx.get_active_memory()
+            mx_peak = mx.get_peak_memory()
+        except Exception:
+            mx_active = 0
+            mx_peak = 0
+        sdpa_stock = sdpa_bounded = sdpa_first_kv = 0
+        try:
+            snapshot = sdpa256_route_snapshot()
+            sdpa_stock = int(snapshot.get("stock_calls", 0))
+            sdpa_bounded = int(snapshot.get("bounded_calls", 0))
+            sdpa_first_kv = int(snapshot.get("first_bounded_kv_len", 0))
+        except Exception:
+            pass
+        return (
+            f"phys_pre={phys_pre / 1024**3:.3f}GB "
+            f"phys_post={phys_post / 1024**3:.3f}GB "
+            f"phys_post_clear={phys_post_clear / 1024**3:.3f}GB "
+            f"mx_active={mx_active / 1024**3:.3f}GB "
+            f"mx_peak={mx_peak / 1024**3:.3f}GB "
+            f"predicted_transient={predicted / 1024**3:.3f}GB "
+            f"measured_delta={(phys_post - phys_pre) / 1024**2:.1f}MB "
+            f"reclaim_recent="
+            f"{(tracker.recent_reclaim_bytes if tracker else 0) / 1024**2:.1f}MB "
+            f"guard_cap={guard_cap / 1024**3:.3f}GB "
+            f"guard_headroom={guard_headroom / 1024**3:.3f}GB "
+            f"priority={'speed' if self._prefill_speed_priority else 'context'} "
+            f"sdpa_stock={sdpa_stock} sdpa_bounded={sdpa_bounded} "
+            f"sdpa_first_switch_kv={sdpa_first_kv}"
+        )
+
     def _record_chunk_transient(
         self,
         n_tokens: int,
@@ -5299,7 +5406,7 @@ class Scheduler:
                 "processed=%d->%d kv_before=%d requested_step=%d "
                 "boundary_enabled=%s cache_block_size=%d ane_tile=%d "
                 "ane_full_tiles=%d ane_tail_tokens=%d model_cache_ms=%.3f "
-                "total_ms=%.3f overhead_ms=%.3f",
+                "total_ms=%.3f overhead_ms=%.3f %s",
                 state.request.request_id,
                 n,
                 _trace_processed_before,
@@ -5314,6 +5421,13 @@ class Scheduler:
                 _trace_model_ms,
                 chunk_dt * 1000.0,
                 max(0.0, chunk_dt * 1000.0 - _trace_model_ms),
+                self._benchmark_trace_memory_fields(
+                    n_tokens=n,
+                    kv_len=state.base_size + _trace_processed_before,
+                    phys_pre=_throttle_pre,
+                    phys_post=_throttle_post,
+                    phys_post_clear=get_phys_footprint(),
+                ),
             )
         # Full-size chunks only: boundary/tail slivers under-measure, and
         # the running max must reflect sustained capability.
@@ -6945,6 +7059,7 @@ class Scheduler:
             valid_tcs=provider_tcs,
             in_memory_snapshots=extracted_in_memory,
             paged_ssd_manager=self.paged_ssd_cache_manager,
+            diagnostics=self._boundary_snapshot_diagnostics,
         )
 
         token_sequence = (

--- a/tests/test_cache_observability.py
+++ b/tests/test_cache_observability.py
@@ -318,3 +318,175 @@ def test_boundary_snapshot_diagnostics_clear_resets_state():
     assert snapshot["capture_attempts"] == 0
     assert snapshot["reasons"] == {}
     assert snapshot["last_event"] is None
+
+
+def test_boundary_snapshot_diagnostics_count_gdn_commit_failures_by_reason():
+    diagnostics = BoundarySnapshotDiagnostics()
+    for reason in ("in_memory_only", "staged_missing", "promotion_failed"):
+        diagnostics.record(
+            "gdn_commit_attempt",
+            request_id="req-a",
+            token_count=4096,
+            block_size=2048,
+        )
+        diagnostics.record(
+            "gdn_commit_failure",
+            reason=reason,
+            request_id="req-a",
+            token_count=4096,
+            block_size=2048,
+        )
+
+    snapshot = diagnostics.snapshot()
+    assert snapshot["gdn_commit_attempts"] == 3
+    assert snapshot["gdn_commit_failures"] == 3
+    assert snapshot["gdn_commit_successes"] == 0
+    assert snapshot["reasons"] == {
+        "in_memory_only": 1,
+        "staged_missing": 1,
+        "promotion_failed": 1,
+    }
+    assert snapshot["last_event"]["reason"] == "promotion_failed"
+
+
+def test_boundary_snapshot_diagnostics_count_successful_promotion_once():
+    diagnostics = BoundarySnapshotDiagnostics()
+    diagnostics.record(
+        "gdn_commit_attempt",
+        request_id="req-a",
+        token_count=4096,
+        block_size=2048,
+    )
+    diagnostics.record(
+        "gdn_commit_success",
+        request_id="req-a",
+        token_count=4096,
+        block_size=2048,
+    )
+
+    snapshot = diagnostics.snapshot()
+    assert snapshot["gdn_commit_attempts"] == 1
+    assert snapshot["gdn_commit_successes"] == 1
+    assert snapshot["gdn_commit_failures"] == 0
+
+
+def test_boundary_provider_commit_records_each_failure_reason():
+    from omlx.scheduler import _BoundarySnapshotProvider
+
+    diagnostics = BoundarySnapshotDiagnostics()
+
+    # No SSD store at all: the snapshot existed in memory only.
+    provider = _BoundarySnapshotProvider(
+        store=None,
+        request_id="req-a",
+        valid_tcs=[2048],
+        in_memory_snapshots={},
+        paged_ssd_manager=None,
+        diagnostics=diagnostics,
+    )
+    assert provider.commit_gdn_checkpoint(
+        2048,
+        b"h1",
+        layer_cache_types=None,
+        layer_meta_states=None,
+        model_name="m",
+        block_size=2048,
+    ) is False
+
+    # Store exists but the staged sidecar file is gone.
+    class _Store:
+        def take_staged_file(self, request_id, token_count):
+            return None
+
+    provider = _BoundarySnapshotProvider(
+        store=_Store(),
+        request_id="req-a",
+        valid_tcs=[2048],
+        in_memory_snapshots={},
+        paged_ssd_manager=object(),
+        diagnostics=diagnostics,
+    )
+    assert provider.commit_gdn_checkpoint(
+        2048,
+        b"h2",
+        layer_cache_types=None,
+        layer_meta_states=None,
+        model_name="m",
+        block_size=2048,
+    ) is False
+
+    snapshot = diagnostics.snapshot()
+    assert snapshot["gdn_commit_attempts"] == 2
+    assert snapshot["gdn_commit_failures"] == 2
+    assert snapshot["reasons"] == {"in_memory_only": 1, "staged_missing": 1}
+
+
+def test_boundary_provider_commit_records_promotion_failure_and_success(tmp_path):
+    from pathlib import Path
+
+    from omlx.scheduler import _BoundarySnapshotProvider
+
+    diagnostics = BoundarySnapshotDiagnostics()
+    staged = tmp_path / "staged.bin"
+    staged.write_bytes(b"x")
+
+    class _Store:
+        def take_staged_file(self, request_id, token_count):
+            return Path(staged)
+
+    class _FailingManager:
+        def gdn_cache_signature_for(self, **kwargs):
+            return b"sig"
+
+        def commit_gdn_checkpoint_file(self, *args, **kwargs):
+            return None
+
+    provider = _BoundarySnapshotProvider(
+        store=_Store(),
+        request_id="req-a",
+        valid_tcs=[2048],
+        in_memory_snapshots={},
+        paged_ssd_manager=_FailingManager(),
+        diagnostics=diagnostics,
+    )
+    assert provider.commit_gdn_checkpoint(
+        2048,
+        b"h3",
+        layer_cache_types=["kv"],
+        layer_meta_states=None,
+        model_name="m",
+        block_size=2048,
+    ) is False
+    assert not staged.exists()  # fail-closed staged-file deletion preserved
+
+    staged.write_bytes(b"x")
+
+    class _OkManager:
+        def gdn_cache_signature_for(self, **kwargs):
+            return b"sig"
+
+        def commit_gdn_checkpoint_file(self, *args, **kwargs):
+            return Path(staged)
+
+    provider = _BoundarySnapshotProvider(
+        store=_Store(),
+        request_id="req-a",
+        valid_tcs=[2048],
+        in_memory_snapshots={},
+        paged_ssd_manager=_OkManager(),
+        diagnostics=diagnostics,
+    )
+    assert provider.commit_gdn_checkpoint(
+        2048,
+        b"h4",
+        layer_cache_types=["kv"],
+        layer_meta_states=None,
+        model_name="m",
+        block_size=2048,
+    ) is True
+
+    snapshot = diagnostics.snapshot()
+    assert snapshot["gdn_commit_attempts"] == 2
+    assert snapshot["gdn_commit_failures"] == 1
+    assert snapshot["gdn_commit_successes"] == 1
+    assert snapshot["reasons"] == {"promotion_failed": 1}

--- a/tests/test_context_benchmark.py
+++ b/tests/test_context_benchmark.py
@@ -223,11 +223,13 @@ class _FakePool:
         self.native = native
         self.loaded = list(loaded or [])
         self.unloaded = []
+        self.get_engine_calls = []
 
     def get_loaded_model_ids(self):
         return list(self.loaded)
 
     async def get_engine(self, model_id, force_lm=False):
+        self.get_engine_calls.append((model_id, force_lm))
         return self._engine
 
     async def _unload_engine(self, model_id):
@@ -237,11 +239,11 @@ class _FakePool:
         return SimpleNamespace(model_context_length=self.native, model_type="llm")
 
 
-def _make_run(target_tokens=131072):
+def _make_run(target_tokens=131072, **request_kwargs):
     return ContextBenchmarkRun(
         bench_id="ctx-test",
         request=ContextBenchmarkRequest(
-            model_id="test-model", target_tokens=target_tokens
+            model_id="test-model", target_tokens=target_tokens, **request_kwargs
         ),
     )
 
@@ -599,3 +601,44 @@ class TestRunContextBenchmark:
         assert run.phase == "apply"
         assert run.progress > 90
         assert run.message
+
+    @pytest.mark.asyncio
+    async def test_force_lm_engine_reaches_pool_and_reports_mode(self):
+        scheduler = _FakeScheduler(boundary=50000)
+        engine = _FakeEngine(scheduler)
+        pool = _FakePool(engine)
+        run = _make_run(force_lm_engine=True)
+
+        await _run_bench(run, pool)
+
+        assert run.status == "completed"
+        assert pool.get_engine_calls == [("test-model", True)]
+        assert run.result["engine_mode"] == "lm"
+
+    @pytest.mark.asyncio
+    async def test_default_run_loads_default_engine_mode(self):
+        scheduler = _FakeScheduler(boundary=50000)
+        engine = _FakeEngine(scheduler)
+        pool = _FakePool(engine)
+        run = _make_run()
+
+        await _run_bench(run, pool)
+
+        assert pool.get_engine_calls == [("test-model", False)]
+        assert run.result["engine_mode"] == "default"
+        assert run.result["apply_result"] is True
+
+    @pytest.mark.asyncio
+    async def test_apply_result_false_never_writes_settings(self):
+        scheduler = _FakeScheduler(boundary=50000)
+        engine = _FakeEngine(scheduler)
+        pool = _FakePool(engine)
+        run = _make_run(apply_result=False)
+
+        await _run_bench(run, pool)
+
+        assert run.status == "completed"
+        assert run.result["applied"] is False
+        assert run.result["apply_result"] is False
+        assert pool._settings_manager.applied == []
+        assert pool._settings_manager.settings.max_context_window is None

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3539,6 +3539,87 @@ class TestSchedulerArraysCacheBlockAlignment:
         finally:
             scheduler.shutdown()
 
+    def test_benchmark_trace_memory_fields_gated_to_benchmark_requests(
+        self, mock_tokenizer, tmp_path, caplog
+    ):
+        """New per-chunk memory fields emit only for benchmark_trace
+        requests; normal inference logs stay unchanged."""
+        import logging as _logging
+
+        model = self._hybrid_model()
+        with (
+            patch("omlx.settings.get_system_memory", return_value=64 * 1024**3),
+            patch("omlx.custom_kernels.nax.is_nax_available", return_value=False),
+        ):
+            scheduler = Scheduler(
+                model=model,
+                tokenizer=mock_tokenizer,
+                config=SchedulerConfig(
+                    paged_ssd_cache_dir=str(tmp_path),
+                    paged_cache_block_size=256,
+                ),
+            )
+
+        def _request(trace: bool) -> Request:
+            request = Request(
+                request_id="trace-gating",
+                prompt=list(range(4097)),
+                sampling_params=SamplingParams(),
+            )
+            request.prompt_token_ids = list(range(4097))
+            request.num_prompt_tokens = 4097
+            request.benchmark_trace = trace
+            return request
+
+        try:
+            with caplog.at_level(_logging.INFO, logger="omlx.scheduler"):
+                with patch.object(scheduler, "_emit_prefill_boundary_snapshot"):
+                    scheduler._do_external_prefill(
+                        _request(trace=True),
+                        list(range(4097)),
+                        model.make_cache(),
+                    )
+            traced = [
+                record.getMessage()
+                for record in caplog.records
+                if "[benchmark-prefill]" in record.getMessage()
+            ]
+            assert traced, "benchmark_trace request must emit chunk records"
+            for line in traced:
+                for field in (
+                    "phys_pre=",
+                    "phys_post=",
+                    "phys_post_clear=",
+                    "mx_active=",
+                    "mx_peak=",
+                    "predicted_transient=",
+                    "measured_delta=",
+                    "reclaim_recent=",
+                    "guard_cap=",
+                    "guard_headroom=",
+                    "priority=",
+                    "sdpa_stock=",
+                    "sdpa_bounded=",
+                    "sdpa_first_switch_kv=",
+                ):
+                    assert field in line
+
+            caplog.clear()
+            with caplog.at_level(_logging.INFO, logger="omlx.scheduler"):
+                with patch.object(scheduler, "_emit_prefill_boundary_snapshot"):
+                    scheduler._do_external_prefill(
+                        _request(trace=False),
+                        list(range(4097)),
+                        model.make_cache(),
+                    )
+            assert not [
+                record.getMessage()
+                for record in caplog.records
+                if "[benchmark-prefill]" in record.getMessage()
+            ], "normal requests must not emit benchmark trace lines"
+        finally:
+            scheduler.shutdown()
+
 
 class TestPeriodicClearGating:
     """Tests for the conditional periodic clear (#978/#1040 mitigation)."""

--- a/tests/test_sdpa256_attention.py
+++ b/tests/test_sdpa256_attention.py
@@ -791,3 +791,46 @@ def test_production_install_order_covers_vlm_language(
         from omlx import memory_monitor as mm
 
         mm._SDPA_TILED_PREFILL_HEAD_DIMS.pop(256, None)
+
+
+# --- opt-in route counters (benchmark correlation) -----------------------
+
+
+def test_route_stats_off_by_default_and_count_nothing(monkeypatch):
+    from omlx.patches import sdpa256_attention as sdpa256
+
+    monkeypatch.setenv("OMLX_SDPA256_ROUTE_STATS", "")
+    monkeypatch.setattr(sdpa256, "_ROUTE_STATS_ENABLED", False, raising=False)
+    sdpa256._reset_route_stats()
+
+    # A bounded and a stock note with stats disabled leave the counters at 0,
+    # so the decode hot path adds no bookkeeping unless explicitly enabled.
+    sdpa256._note_route_call(True, kv_len=16384)
+    sdpa256._note_route_call(False)
+    snap = sdpa256.get_route_snapshot()
+    assert snap == {"stock_calls": 0, "bounded_calls": 0, "first_bounded_kv_len": 0}
+
+
+def test_route_stats_count_and_record_first_switch_when_enabled(monkeypatch):
+    from omlx.patches import sdpa256_attention as sdpa256
+
+    monkeypatch.setattr(sdpa256, "_ROUTE_STATS_ENABLED", True, raising=False)
+    sdpa256._reset_route_stats()
+
+    sdpa256._note_route_call(False)
+    sdpa256._note_route_call(False)
+    sdpa256._note_route_call(True, kv_len=65535)
+    sdpa256._note_route_call(True, kv_len=70000)
+
+    snap = sdpa256.get_route_snapshot()
+    assert snap["stock_calls"] == 2
+    assert snap["bounded_calls"] == 2
+    # Only the FIRST bounded switch is recorded.
+    assert snap["first_bounded_kv_len"] == 65535
+
+    sdpa256._reset_route_stats()
+    assert sdpa256.get_route_snapshot() == {
+        "stock_calls": 0,
+        "bounded_calls": 0,
+        "first_bounded_kv_len": 0,
+    }


### PR DESCRIPTION
## Problem

Prefill memory decisions are opaque. A rejection is one aggregate comparison; the
per-chunk footprint / transient / guard state that led to it is not logged, the SDPA
route switch point is not visible, and a failed GDN checkpoint commit gives no stable
reason. #3082 made the *rejection* diagnosable by breaking the admission bound into
terms; this extends that to the per-chunk measurements and the subsystems around
them. Everything is content-free — sizes, counters, and stable identifiers only, no
prompt data. These are the diagnostics that surfaced the ANE-reserve and
eviction-escalation defects tracked in the companion fixes.

## Change

1. **Chunk trace** (`scheduler.py`): the existing `[benchmark-prefill]` lines gain
   physical footprint before/after/post-clear, MLX active/peak, predicted vs measured
   transient, recent reclaim charge, guard cap/headroom, prefill priority, and SDPA
   route counters. Emitted only for `benchmark_trace` requests; normal inference logs
   are byte-identical.
2. **SDPA route counters** (`sdpa256_attention.py`): stock vs bounded call counts and
   the first-switch KV length, behind `OMLX_SDPA256_ROUTE_STATS=1`. The wrapper runs
   on every SDPA call of every decode step, so the counters add nothing to the hot
   path unless collection is explicitly on (covered by a dedicated test).
3. **GDN checkpoint commit counters** (`cache/observability.py` + `scheduler.py`):
   `gdn_commit_attempts / successes / failures` with stable reasons
   `in_memory_only` / `staged_missing` / `promotion_failed`, recorded by the
   boundary-snapshot provider and surfaced in `/admin/api/stats`. Fail-closed
   staged-file deletion is preserved. This makes the historical "split-GDN checkpoint
   not committed" rejection class diagnosable from one counter read.
4. **Context-benchmark controls** (`admin/context_benchmark.py`): API-only,
   backward-compatible `force_lm_engine` (VLM vs text-only residency A/B) and
   `apply_result` (measure without writing `max_context_window`); both reported in the
   result metadata. UI defaults unchanged.

## Verification

- New-fields gating: emitted for `benchmark_trace` requests only; normal requests
  produce no benchmark lines. Each GDN failure reason increments and appears in the
  snapshot; a successful promotion counts once. `force_lm_engine` reaches the pool,
  `apply_result=false` writes no setting, mode is reported. Route counters are off by
  default and count + record the first switch when enabled.
- `tests/test_scheduler.py` + `test_cache_observability.py` + `test_context_benchmark.py`
  + `test_sdpa256_attention.py`: **338 passed**. Broader cache/benchmark suites
  (`test_benchmark.py`, `test_runtime_cache_observability.py`,
  `test_boundary_snapshot_store.py`, `test_prefix_cache_cachelist_mixed.py`):
  **180 passed**.
- Field output exercised live during long-context A/B runs; a representative chunk:

```
[benchmark-prefill] rid=... path=external chunk_tokens=2048 ... phys_pre=17.629GB phys_post=20.471GB phys_post_clear=20.052GB mx_active=16.835GB mx_peak=19.356GB predicted_transient=3.695GB measured_delta=2910.4MB reclaim_recent=0.0MB guard_cap=33.696GB guard_headroom=13.644GB priority=context sdpa_stock=176 sdpa_bounded=0 sdpa_first_switch_kv=0
```
