### PR TITLE
fix(scheduler): gate cache-freshness deferral on restorable overlap, not prompt length

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -7938,13 +7938,23 @@ class Scheduler:
                 f"{best_p}: stored=...{stored_ctx!r} vs prompt=...{prompt_ctx!r}"
             )
 
-    # A 4K prompt is the smallest standard benchmark/workload where a missed
-    # async store is already a multi-second re-prefill.  DeepSeek V4 boundary
-    # snapshots intentionally retain 3584 of 4096 prompt tokens, and their SSD
-    # write can finish just after the first HTTP response is returned.  Include
-    # this workload class in the non-blocking freshness deferral so an immediate
-    # repeated turn waits for that relevant store instead of racing it.
-    _CACHE_FRESHNESS_WAIT_MIN_PROMPT_TOKENS = 4096
+    # Whether an in-flight store_cache is worth waiting for is decided by the
+    # overlap with it, not by the prompt's length.  What a wait can save is the
+    # re-prefill of the restorable overlap (whole blocks of the effective
+    # paged_cache_block_size -- 256 for KV models, the 2048-token boundary when
+    # the GDN split is active); what it costs is bounded by the store's own
+    # duration, which scales with the tokens THAT store copies (~13-20 us/token
+    # measured on M5 Max, hot cache off) while prefill costs ~0.6-5 ms/token
+    # across current models and machines.  So: never wait when less than one
+    # block is restorable (nothing a wait could make visible), and never wait on
+    # a store more than 16x larger than the overlap (a harness side-request
+    # that shares only the system prompt with a 100K-token turn being stored),
+    # which keeps the worst-case wait well under the prefill it avoids.  A fixed
+    # prompt floor (8192, then 4096 for the DeepSeek V4 3584-of-4096 boundary
+    # snapshot, #2471) reproduced the race one notch lower each time: agent
+    # harnesses firing a 3K follow-up instantly re-prefilled every turn (#3102).
+    # The 4K boundary-snapshot case still waits under the overlap gates.
+    _CACHE_FRESHNESS_WAIT_MAX_STORE_TO_OVERLAP = 16
     _CACHE_FRESHNESS_WAIT_MIN_COMMON_TOKENS = 8192
     _CACHE_FRESHNESS_WAIT_MIN_PROMPT_RATIO = 0.30
     _CACHE_FRESHNESS_WAIT_TIMEOUT_S = 4.0
@@ -7970,8 +7980,7 @@ class Scheduler:
             return None
 
         prompt = request.prompt_token_ids or []
-        if len(prompt) < self._CACHE_FRESHNESS_WAIT_MIN_PROMPT_TOKENS:
-            return None
+        block = max(1, self.config.paged_cache_block_size)
 
         best_rid: str | None = None
         best_future: concurrent.futures.Future | None = None
@@ -7984,6 +7993,18 @@ class Scheduler:
                 continue
 
             common = self._common_prefix_len(prompt, info.tokens)
+            # Per-candidate: only whole blocks can be restored, and a store far
+            # larger than the overlap costs more to wait for than it saves. A
+            # longest-overlap store that fails here must not veto a smaller
+            # store that passes, so filter before ranking.
+            restorable = (common // block) * block
+            if restorable < block:
+                continue
+            if (
+                len(info.tokens)
+                > self._CACHE_FRESHNESS_WAIT_MAX_STORE_TO_OVERLAP * restorable
+            ):
+                continue
             if common > best_common:
                 best_rid = rid
                 best_future = future

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -822,13 +822,14 @@ class TestSchedulerAddRequest:
         assert scheduler._should_defer_for_cache_freshness(request) is False
         assert request.request_id not in scheduler._cache_freshness_waits
 
-    def test_admission_does_not_defer_for_short_prompt_even_with_high_ratio(
+    def test_admission_defers_for_short_prompt_with_restorable_overlap(
         self, mock_model, mock_tokenizer
     ):
-        """Prompts below the freshness minimum should never wait on store_cache."""
+        """A sub-4K follow-up waits when whole blocks of the store are reusable (#3102)."""
         scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
         scheduler.block_aware_cache = MagicMock()
         prompt = list(range(4095))
+        scheduler.block_aware_cache.fetch_cache.return_value = (None, prompt)
 
         future = MagicMock()
         future.done.return_value = False
@@ -848,8 +849,173 @@ class TestSchedulerAddRequest:
 
         future.result.assert_not_called()
         scheduler.block_aware_cache.fetch_cache.assert_not_called()
+        assert scheduler._should_defer_for_cache_freshness(request) is True
+        assert request.request_id in scheduler._cache_freshness_waits
+        wait = scheduler._cache_freshness_waits[request.request_id]
+        assert wait.store_request_id == "req-prev"
+        assert wait.common_prefix == 3584
+
+        future.done.return_value = True
+        assert scheduler._should_defer_for_cache_freshness(request) is False
+        scheduler._prepare_prefix_cache_for_request(request)
+        scheduler.block_aware_cache.fetch_cache.assert_called_once()
+        future.result.assert_not_called()
+
+    def test_admission_defers_for_instant_follow_up_on_gdn_boundary_store(
+        self, mock_model, mock_tokenizer
+    ):
+        """The live #3102 shape: 2875-token turn 2 vs a 2048-token boundary store."""
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        scheduler.block_aware_cache = MagicMock()
+        scheduler.config.paged_cache_block_size = 2048
+        prompt = list(range(2875))
+
+        future = MagicMock()
+        future.done.return_value = False
+        scheduler._inflight_store_futures["req-prev"] = future
+        scheduler._inflight_store_info["req-prev"] = (
+            scheduler_module._InflightStoreInfo(tokens=list(range(2048)))
+        )
+
+        request = Request(
+            request_id="req-next",
+            prompt=prompt,
+            sampling_params=SamplingParams(max_tokens=16),
+        )
+
+        scheduler.add_request(request)
+
+        assert scheduler._should_defer_for_cache_freshness(request) is True
+        assert request.request_id in scheduler._cache_freshness_waits
+        future.result.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("block_size", "prompt_len", "store_len", "expected"),
+        [
+            # Less than one 256-token block is restorable: nothing to wait for.
+            (256, 3000, 200, False),
+            # A 2000-token overlap never reaches the 2048 GDN boundary block.
+            (2048, 3000, 2000, False),
+            # Exactly one full block is restorable: wait.
+            (256, 300, 256, True),
+        ],
+    )
+    def test_admission_freshness_gate_requires_one_restorable_block(
+        self, mock_model, mock_tokenizer, block_size, prompt_len, store_len, expected
+    ):
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        scheduler.block_aware_cache = MagicMock()
+        scheduler.config.paged_cache_block_size = block_size
+        prompt = list(range(prompt_len))
+
+        future = MagicMock()
+        future.done.return_value = False
+        scheduler._inflight_store_futures["req-prev"] = future
+        scheduler._inflight_store_info["req-prev"] = (
+            scheduler_module._InflightStoreInfo(tokens=list(range(store_len)))
+        )
+
+        request = Request(
+            request_id="req-next",
+            prompt=prompt,
+            sampling_params=SamplingParams(max_tokens=16),
+        )
+
+        scheduler.add_request(request)
+
+        assert scheduler._should_defer_for_cache_freshness(request) is expected
+        assert (request.request_id in scheduler._cache_freshness_waits) is expected
+        future.result.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("prompt_len", "overlap", "store_len", "expected"),
+        [
+            # A side-request sharing one 2048-token block with a 100K-token
+            # store: the wait would dwarf the prefill it saves.
+            (2300, 2048, 100_000, False),
+            # Exactly 16x the restorable overlap still waits ...
+            (2300, 2048, 16 * 2048, True),
+            # ... one token past it does not.
+            (2300, 2048, 16 * 2048 + 1, False),
+            # Applies above 4K too: a 5K prompt reusing 4096 of a 100K store.
+            (5000, 4096, 100_000, False),
+        ],
+    )
+    def test_admission_freshness_gate_bounds_store_size_by_overlap(
+        self, mock_model, mock_tokenizer, prompt_len, overlap, store_len, expected
+    ):
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        scheduler.block_aware_cache = MagicMock()
+        stored = list(range(store_len))
+        # The prompt diverges from the stored sequence right after `overlap`.
+        prompt = stored[:overlap] + list(range(10**6, 10**6 + prompt_len - overlap))
+
+        future = MagicMock()
+        future.done.return_value = False
+        scheduler._inflight_store_futures["req-prev"] = future
+        scheduler._inflight_store_info["req-prev"] = (
+            scheduler_module._InflightStoreInfo(tokens=stored)
+        )
+
+        request = Request(
+            request_id="req-next",
+            prompt=prompt,
+            sampling_params=SamplingParams(max_tokens=16),
+        )
+
+        scheduler.add_request(request)
+
+        assert scheduler._should_defer_for_cache_freshness(request) is expected
+        assert (request.request_id in scheduler._cache_freshness_waits) is expected
+        future.result.assert_not_called()
+
+    def test_admission_freshness_gate_filters_candidates_before_ranking(
+        self, mock_model, mock_tokenizer
+    ):
+        """An oversized longest-overlap store must not veto a smaller eligible one."""
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        scheduler.block_aware_cache = MagicMock()
+        big_store = list(range(100_000))
+        prompt = big_store[:2048] + list(range(10**6, 10**6 + 2300 - 2048))
+        # Shares the first 1024 tokens with the prompt, then diverges.
+        small_store = big_store[:1024] + list(range(2 * 10**6, 2 * 10**6 + 2300 - 1024))
+
+        big_future = MagicMock()
+        big_future.done.return_value = False
+        small_future = MagicMock()
+        small_future.done.return_value = False
+        scheduler._inflight_store_futures["req-big"] = big_future
+        scheduler._inflight_store_info["req-big"] = scheduler_module._InflightStoreInfo(
+            tokens=big_store
+        )
+        scheduler._inflight_store_futures["req-small"] = small_future
+        scheduler._inflight_store_info["req-small"] = (
+            scheduler_module._InflightStoreInfo(tokens=small_store)
+        )
+
+        request = Request(
+            request_id="req-next",
+            prompt=prompt,
+            sampling_params=SamplingParams(max_tokens=16),
+        )
+
+        scheduler.add_request(request)
+
+        assert scheduler._should_defer_for_cache_freshness(request) is True
+        wait = scheduler._cache_freshness_waits[request.request_id]
+        assert wait.store_request_id == "req-small"
+        assert wait.common_prefix == 1024
+        big_future.result.assert_not_called()
+        small_future.result.assert_not_called()
+
+        # With the only eligible store already visible, nothing is left to wait on.
+        scheduler._cache_freshness_waits.clear()
+        small_future.done.return_value = True
         assert scheduler._should_defer_for_cache_freshness(request) is False
         assert request.request_id not in scheduler._cache_freshness_waits
+
+    def test_scheduler_has_no_prompt_length_freshness_floor(self):
+        assert not hasattr(Scheduler, "_CACHE_FRESHNESS_WAIT_MIN_PROMPT_TOKENS")
 
     def test_admission_defers_for_immediate_4k_boundary_store(
         self, mock_model, mock_tokenizer


### PR DESCRIPTION
## Summary

A follow-up turn fired the instant the previous response finishes re-prefills the whole prompt even though the previous turn's store was correct and becomes restorable a few hundred milliseconds later (#3102; beaglemoo's 1-second-gap isolation is the tell). The scheduler already has the mechanism that closes this race — the non-blocking cache-freshness deferral from 4a17c629, which holds the waiting head at admission while a `store_cache` job sharing its prefix is in flight — but it is gated on `len(prompt) >= 4096` (`_CACHE_FRESHNESS_WAIT_MIN_PROMPT_TOKENS`, lowered from 8192 in #2472). The reporters' prompts are 3.2K–3.7K tokens, so the deferral never engages and the lookup races the store.

I reproduced it at stock `ebf4f1fa` with the default `max_concurrent_requests=8`: turn 1 ≈ 2.6K tokens, turn 2 ≈ 2.87K fired instantly → `cached_tokens=0` in 3/3 trials; with a 2 s gap → 2048 in 3/3; the same shape at 4.4K/4.7K → 4096 in 3/3 with the deferral firing. Two things worth knowing from the trace. At `max_concurrent_requests=1` the race does not occur at all, because the store-cache admission gate (`_StoreCacheGate`, cap = `max_num_seqs`) serialises the next admission behind the in-flight store — which is probably why single-client operators can't reproduce it. And the racer does more than miss: `store_cache` registers the block hash before `save_block` persists the payload, so a lookup that lands in that window sees `Cache hit … 2048 tokens`, fails to load the block, unregisters it (`Removed missing block from hash cache`), serves 0 and then re-stores the same block itself. That second part is untouched here and noted at the end.

The fix replaces the prompt-length floor with two per-candidate gates on the thing the floor was standing in for. First, at least one *restorable* block must be shared: `(common // block) * block >= block` with `block = self.config.paged_cache_block_size` (256 for KV models, the 2048-token boundary when the GDN split is active — the same alignment the store uses). Below that a wait cannot make anything visible. Second, the in-flight store must not be more than 16× larger than the restorable overlap. The wait costs roughly the store's duration, which scales with the tokens *that store* copies (10–20 µs/token measured here: 31 ms for 2048 tokens, 53 ms for 4096, 327–365 ms for 32,768 on Flash-Next; ~40 ms for a 128 MB 2048-token block on Qwen3.8-27B); the saving is the re-prefill of the overlap (0.6–1.1 ms/token in these runs, ~5 ms/token on the reporters' M2 Max). The 16× bound exists for the realistic bad case — a harness side-request (title/summary call) that shares only the system prompt with a 100K-token turn still being stored — and it applies at every prompt size, so a 5K prompt reusing 4096 of a 100K store stops waiting too. Both gates are evaluated inside the candidate loop before ranking, so a longest-overlap store that fails them cannot veto a smaller store that passes. The 8192/0.30 relevance gates, the 4 s timeout and the non-blocking mechanics are unchanged; the 4K DeepSeek boundary-snapshot case from #2471 still waits.

## Changes

- `omlx/scheduler.py`: `_find_relevant_inflight_store` drops `_CACHE_FRESHNESS_WAIT_MIN_PROMPT_TOKENS`, adds the per-candidate restorable-block floor and the `_CACHE_FRESHNESS_WAIT_MAX_STORE_TO_OVERLAP = 16` bound, and rewrites the rationale comment to the overlap/store economics (with the #2471 case kept as an example it still covers).
- `tests/test_scheduler.py`: `test_admission_does_not_defer_for_short_prompt_even_with_high_ratio` (4095-token prompt, 3584-token store) is inverted — that shape now defers and proceeds to lookup once the future is done, without ever calling `Future.result()`. New pins: the live #3102 shape (2875-token prompt vs a 2048-token GDN boundary store), the restorable floor (200 of 256 → no; 2000 under a 2048 block → no; exactly 256 → yes), the 16× bound (2048 overlap vs 100K store → no; vs 32,768 → yes; vs 32,769 → no; 5000 reusing 4096 of 100K → no), filter-before-rank with two stores in flight, and the absence of the old constant. Seven of the eleven assertions fail on the base with the code stashed; the other four pin negative cases the base also satisfies.

## Test plan

- `uv run pytest tests/` — 10740 passed, 29 skipped, 0 failed (4m34s, Python 3.12, MLX 0.32.2). Thirteen tests deselected because they fail identically on stock `upstream/main` `ebf4f1fa` locally with zero local changes (`test_deepseek_v4_dspark` ×5 bf16 exact-equality, `test_dflash_laguna`, `test_glm_moe_dsa_patch`, `test_mlx_vlm_glm5_next_compat`, `test_mlx_vlm_qwen4_exp_compat` ×2, `test_qwen4_qsa_decode_gather`, `test_qwen4_qsa_native_indexer` ×2) — same list as in #3361, looks like newer-silicon numerics that macos-14 CI can't see.
- Live A/B on the same server binary path (`uv run omlx serve --log-level debug --max-concurrent-requests 8`), stock `ebf4f1fa` vs this branch, temperature 0, cold turn 1 (`cached_tokens=0` asserted per trial), fresh content per trial so the SSD cache can't pre-seed a turn. Turn 2 streamed; TTFT = first content delta.

  | model | turn 2 | arm | `cached_tokens` | TTFT |
  |---|---|---|---|---|
  | Flash-Next (qwen4_exp, block 2048) | 2.87K, instant | stock | 0 / 0 / 0 | 2.21 / 2.22 / 2.23 s |
  | | 2.87K, +2 s gap | stock | 2048 ×3 | 0.98 / 0.98 / 1.00 s |
  | | 2.86K, instant | **patched** | **2048 ×3** | **0.96 / 0.96 / 0.96 s** |
  | | 2.86K, +2 s gap | patched | 2048 ×3 | 0.94 / 0.95 / 0.95 s |
  | | 4.69K, instant | stock | 4096 ×3 (existing deferral) | 0.87–0.89 s |
  | | 4.69K, instant | patched | 4096 ×3 | 0.82–0.86 s |
  | Qwen3.8-27B-oQ8 | 2.87K, instant | stock | 0 / 0 | 3.49 / 3.68 s |
  | | 2.87K, +2 s gap | stock | 2048 ×2 | 1.33 / 1.38 s |
  | | 2.86K, instant | **patched** | **2048 ×2** | **1.41 / 1.47 s** |
  | | 2.86K, +2 s gap | patched | 2048 ×2 | 1.30 / 1.33 s |

  Patched log: one `Deferring admission … common_prefix=2048/28xx` + `Completed cache freshness deferral` pair per instant trial, wait 51–52 ms, zero `Timed out cache freshness deferral`.
- Adverse case at the new 16× boundary, so the bound isn't just asserted: turn 1 a fresh 33.4K-token single message (boundary-aligned store = exactly 32,768 tokens), turn 2 a *fresh* conversation sharing the first ~2,150 tokens then diverging, fired instantly — the side-request shape. Stock: `cached_tokens=0`, TTFT 2.25 / 2.30 / 2.75 s. Patched: 2048 in 3/3, TTFT 1.17 / 1.12 / 1.11 s, deferral wait ≈0.41 s per trial (store 0.33–0.37 s + poll), gap-arm reference 0.66 s. The wait at the boundary is ~4× cheaper than the re-prefill it avoids here; on slower-prefill hardware the margin only grows.
- Not measured here: a machine where the store is slow relative to prefill (external SSD with `hot_cache_write_through`, or a memory-pressure write-through). The 4 s timeout still caps that case exactly as it did for ≥4K prompts.

Closes #3102. Left alone on purpose: the hash-registered-before-payload window in `store_cache` that lets a racing lookup unregister a live block — with this change the covered cases wait instead of racing, but a lookup that fails the relevance gates can still hit it; happy to follow up separately if that's wanted.

— Generated with Marshal · gate: READY · 104cf26 · tier: standard
verify bar: passed at 104cf26 — 1 check(s) + secrets scan, sha-keyed proof