### PR TITLE
fix(qwen4_exp): promote rank and separate lengths in BatchQSAKVCache joins (#3294 items 2+4)

### DIFF
--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -575,6 +575,8 @@ class BatchQSAKVCache:
     @staticmethod
     def _pad_index(cache, target, sample_keys, sample_positions):
         length = 0 if cache.index_keys is None else cache.index_offset
+        if isinstance(length, mx.array):
+            length = int(length.item())
         left = target - length
         if cache.index_keys is None:
             keys = mx.zeros(
@@ -593,6 +595,16 @@ class BatchQSAKVCache:
         else:
             keys = cache.index_keys[:, :length]
             positions = cache.index_position_ids[..., :length]
+            # Widen 2-D text positions to the join's widest rank before
+            # padding (#3294 item 2): the runtime update path already
+            # broadcasts text up to MRoPE in _append_indexer_positions; joins
+            # must apply the same rule or the concatenate below sees ranks 2
+            # and 3. Replicating across MRoPE channels matches runtime.
+            if sample_positions.ndim == 3 and positions.ndim == 2:
+                positions = mx.broadcast_to(
+                    positions[None],
+                    (sample_positions.shape[0], *positions.shape),
+                )
         if left:
             keys = mx.pad(keys, [(0, 0), (left, 0), (0, 0)])
             positions = mx.pad(
@@ -612,12 +624,25 @@ class BatchQSAKVCache:
         sample_keys = (
             self.index_keys if self.index_keys is not None else other.index_keys
         )
-        sample_positions = (
-            self.index_position_ids
-            if self.index_position_ids is not None
-            else other.index_position_ids
-        )
-        if sample_keys is None:
+        # Prefer the WIDEST position rank over "first non-None" (#3294 item
+        # 2): promotion only widens, so a 2-D sample would strand a 3-D row
+        # with nothing to promote to, and position_axis would be picked from
+        # the wrong rank. Order-sensitive defect, so pick from both sides.
+        self_positions = self.index_position_ids
+        other_positions = other.index_position_ids
+        if (
+            self_positions is not None
+            and other_positions is not None
+            and self_positions.ndim != other_positions.ndim
+        ):
+            sample_positions = (
+                other_positions if self_positions.ndim == 2 else self_positions
+            )
+        elif self_positions is not None:
+            sample_positions = self_positions
+        else:
+            sample_positions = other_positions
+        if sample_keys is None or sample_positions is None:
             return
         target = max(self.index_offset, other.index_offset)
         left = self._pad_index(self, target, sample_keys, sample_positions)
@@ -660,23 +685,49 @@ class BatchQSAKVCache:
         sample = next((cache for cache in caches if cache.index_keys is not None), None)
         if sample is None:
             return out
-        target = max(cache.offset for cache in caches)
+        # Pick the widest position rank across every cache, not the first
+        # non-None sample (#3294 item 2): promotion only widens, so a 2-D
+        # first sample would strand a 3-D row at concatenate time.
+        widest_positions = sample.index_position_ids
+        for cache in caches:
+            pos = cache.index_position_ids
+            if pos is not None and pos.ndim > widest_positions.ndim:
+                widest_positions = pos
+        # Row length comes from the *indexer* state, not the KV offset
+        # (#3294 item 4). Singleton QSAKVCache.index_keys is a property
+        # already sliced to its valid length; BatchQSAKVCache keeps a raw
+        # capacity buffer, so its valid length is index_offset. The old code
+        # passed cache.offset — an int for singletons but an mx.array of
+        # per-row offsets for batch inputs, making max() and
+        # mx.array([cache.offset]) ill-defined — and conflated KV length
+        # with indexer length. The two coincide whenever the caches are
+        # consistent, so this is behaviour-preserving except where they
+        # diverge, which is exactly the mis-slice this fix removes.
+        def _valid_index_length(cache):
+            if cache.index_keys is None:
+                return 0
+            if isinstance(cache, BatchQSAKVCache):
+                return int(cache.index_offset)
+            return int(cache.index_keys.shape[1])
+
+        lengths = [_valid_index_length(cache) for cache in caches]
+        target = max(lengths)
         rows = [
             cls._pad_index(
                 SimpleNamespace(
                     index_keys=cache.index_keys,
                     index_position_ids=cache.index_position_ids,
-                    index_offset=cache.offset,
-                    offset=mx.array([cache.offset]),
+                    index_offset=length,
+                    offset=mx.array([length]),
                 ),
                 target,
                 sample.index_keys,
-                sample.index_position_ids,
+                widest_positions,
             )
-            for cache in caches
+            for cache, length in zip(caches, lengths)
         ]
         out.index_keys = mx.concatenate([row[0] for row in rows], axis=0)
-        position_axis = 1 if sample.index_position_ids.ndim == 3 else 0
+        position_axis = 1 if widest_positions.ndim == 3 else 0
         out.index_position_ids = mx.concatenate(
             [row[1] for row in rows], axis=position_axis
         )

--- a/tests/test_qsa_batch_join_ranks.py
+++ b/tests/test_qsa_batch_join_ranks.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+"""BatchQSAKVCache joins: mixed text/MRoPE ranks and KV-vs-indexer offsets.
+
+Re-verification of #3294 items 2 and 4 against current main, after #3219
+normalized the *reconstruct* path and the singleton trim fix landed. The
+*runtime* join path in BatchQSAKVCache still carries both defects:
+
+Item 2 — ``extend`` picks ``sample_positions`` from whichever operand is
+first non-None and derives ``position_axis`` from its rank. Joining a
+text-only row (2-D ``[B, S]``) with an image row (3-D ``[3, B, S]``) either
+raises on concatenate or joins on the wrong axis, depending on operand order.
+The promotion rule already exists for the update path
+(``_append_indexer_positions``) but never runs here.
+
+Item 4 — ``merge`` passes the KV ``offset`` to ``_pad_index`` as
+``index_offset``, which uses it as the indexer length. Any divergence between
+KV length and indexer length is silently clamped into a mis-sized join. For
+``BatchQSAKVCache`` inputs ``cache.offset`` is an ``mx.array``, which makes
+``mx.array([cache.offset])`` a 2-D shape inside ``_pad_index``.
+
+Tiny synthetic tensors, no model load. Needs real mlx.
+"""
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+    apply_mlx_vlm_qwen4_exp_compat_patch,
+)
+
+apply_mlx_vlm_qwen4_exp_compat_patch()
+
+from mlx_vlm.models.qwen4_exp.language import (  # noqa: E402
+    BatchQSAKVCache,
+)
+
+D = 4
+
+
+def _batch_text(length: int) -> BatchQSAKVCache:
+    """Batch cache whose indexer positions are 2-D text [B, S]."""
+    c = BatchQSAKVCache([0])
+    c.index_keys = mx.zeros((1, length, D), dtype=mx.float32)
+    c.index_position_ids = mx.arange(length)[None, :]  # [1, S] ndim 2
+    c.index_offset = length
+    c.kv_cache.offset = mx.array([length])
+    return c
+
+
+def _batch_mrope(length: int) -> BatchQSAKVCache:
+    """Batch cache whose indexer positions are 3-D MRoPE [C, B, S]."""
+    c = BatchQSAKVCache([0])
+    c.index_keys = mx.zeros((1, length, D), dtype=mx.float32)
+    pos = mx.arange(length)[None, None, :]  # [1, 1, S] then widen channels
+    c.index_position_ids = mx.repeat(pos, 3, axis=0)  # [3, 1, S] ndim 3
+    c.index_offset = length
+    c.kv_cache.offset = mx.array([length])
+    return c
+
+
+class TestExtendMixedRanks:
+    """#3294 item 2 — text row joined with MRoPE row."""
+
+    def test_text_self_image_other(self):
+        b = _batch_text(4)
+        b.extend(_batch_mrope(4))  # must not raise
+        assert b.index_position_ids.ndim == 3
+
+    def test_image_self_text_other(self):
+        b = _batch_mrope(4)
+        b.extend(_batch_text(4))  # must not raise
+        assert b.index_position_ids.ndim == 3
+
+    def test_join_width_correct(self):
+        """Two rows of 4 tokens => index_keys [2, 4, D]; positions must
+        carry both rows, 8 columns total, at the widest rank."""
+        b = _batch_text(4)
+        b.extend(_batch_mrope(4))
+        assert b.index_keys.shape == (2, 4, D)
+        assert b.index_offset == 4
+        # the widest rank in the join is MRoPE 3-D; the text row must be
+        # promoted to it, not concatenated on the wrong axis
+        assert b.index_position_ids.ndim == 3
+        assert b.index_position_ids.shape == (3, 2, 4)
+
+
+class TestMergeOffsetSemantics:
+    """#3294 item 4 — merge confuses KV offset with indexer length."""
+
+    def test_merge_singleton_offsets(self):
+        """A single text cache merges at its length."""
+        c = _batch_text(4)
+        # simulate a batch-cache input (offset is an mx.array property)
+        out = BatchQSAKVCache.merge([c])
+        assert int(out.index_offset) == 4
+        assert out.index_keys.shape == (1, 4, D)
+
+    def test_merge_divergent_indexer_length(self):
+        """KV offset 8 but indexer only holds 6: the join must pad the
+        indexer to the *indexer* length semantics without inventing two
+        phantom columns — i.e. either the join raises loudly or it pads
+        deliberately; it must not silently clamp into wrong tokens."""
+        c = _batch_text(8)
+        c.index_keys = c.index_keys[:, :6]
+        c.index_offset = 6
+        out = BatchQSAKVCache.merge([c])
+        # correct behaviour: indexer row is 8 wide, padded with 2 zeros
+        # beyond index_offset (matching the KV it must describe), and
+        # index_offset tracks... whichever value merge documents; today it
+        # mixes the two. Assert self-consistency instead of one magic number:
+        assert out.index_keys.shape[1] >= 6
+        assert out.index_position_ids.shape[-1] == out.index_keys.shape[1]


### PR DESCRIPTION
# fix(qwen4_exp): promote rank and separate lengths in BatchQSAKVCache joins

Follow-up to #3294 — closes items 2 and 4. (#3219 landed item 1's reconstruct path, and the batch `trim` fix landed item 3; these are the **runtime join** twins that survived both.)

## The bugs

**Item 2 — `extend` / `merge` join text and MRoPE rows on the wrong axis.**
Both pick `sample_positions` by *first non-None* and derive `position_axis` from its rank. Joining a text-only row (2-D `[B, S]`) with an image row (3-D `[3, B, S]`) crashes at concatenate:

```
ValueError: [concatenate] All the input arrays must have the same number of
dimensions. However, got arrays with dimensions 2 and 3.
```

Promotion only widens, so the sample must be the **widest** operand available — `_pad_index` already knows how to broadcast 2-D up, it just never receives the 3-D sample to widen against. Order-sensitive: which side blows up depends on which cache is `self`.

**Item 4 — `merge` conflates KV offset with indexer length.**

```python
target = max(cache.offset for cache in caches)
...
SimpleNamespace(..., index_offset=cache.offset, offset=mx.array([cache.offset]))
```

`cache.offset` is an `int` for `QSAKVCache` inputs but an `mx.array` of per-row offsets for `BatchQSAKVCache` inputs — so `max(...)` and `mx.array([cache.offset])` are ill-defined for the latter (2-D array slices → `Slice indices must be integers or None`, reproduced). And when KV length and indexer length diverge (a trimmed or draft-ahead indexer — item 3 was exactly such a mechanism), passing the KV offset as `index_offset` silently mis-slices the join.

## The fix

- `extend`/`merge` select the **widest** position rank across operands, and `_pad_index` broadcasts 2-D rows up before padding — the same rule the runtime update path applies in `_append_indexer_positions`.
- `merge` derives row lengths from the **indexer state** (`index_offset` for batch caches, the already-sliced `index_keys` property for singletons), never from `cache.offset`.

Homogeneous-rank, consistent-offset joins are bit-identical to today: both changes only fire where the old code crashed or silently mis-sliced.

## Validation

- Repros **fail on current main** (`ebf4f1f`) with exactly the signatures above; **pass after the fix** — 5 tests, tiny synthetic tensors, no model load.
- No regression in the existing suites: `test_mlx_vlm_qwen4_exp_compat.py` **47 passed**; plus the #3293 indexer suite (`test_qsa_indexer_batching.py`, 14 tests from #3368) green on its branch.
- Verified on Apple Silicon, mlx 0.32.x, Python 3.11.

Diagnosis and defect taxonomy are @tbro0815's from #3294 — this PR delivers the patch they offered for items 1/2's join-side remnants and item 4's offset typing, re-based against current main.
