### PR TITLE
fix(mac): align the macOS app UI with system conventions

### DIFF
--- a/apps/omlx-mac/Sources/AppView/AppView.swift
+++ b/apps/omlx-mac/Sources/AppView/AppView.swift
@@ -21,8 +21,12 @@ struct AppView: View {
         let theme = scheme == .dark ? OMLXTheme.dark : OMLXTheme.light
         let section = selectedSection
 
-        NavigationSplitView {
+        // The sidebar is the only way to switch screens, so it must never
+        // collapse: pin visibility to `.all` and remove the toolbar toggle,
+        // matching System Settings.
+        NavigationSplitView(columnVisibility: .constant(.all)) {
             SettingsSidebar(selection: bindingForSelection())
+                .toolbar(removing: .sidebarToggle)
         } detail: {
             ContentScaffold(section: section, detailTitle: detailTitle) {
                 screen(for: section)
@@ -557,7 +561,34 @@ private struct ContentScaffold<Content: View>: View {
             }
         }
         .navigationTitle(titleText)
+        .modifier(ToolbarHeightKeeper())
         .background(theme.windowBg)
+    }
+}
+
+/// macOS collapses the unified toolbar to a compact title bar on panes
+/// that contribute no toolbar items. With the sidebar toggle removed,
+/// only screens with their own items (Logs, Model Settings) kept the
+/// full-height bar — so every screen contributes an invisible item to
+/// keep the height uniform. On macOS 26 the Liquid Glass capsule that
+/// toolbars draw around every item must be hidden explicitly, or the
+/// invisible item shows up as a small vertical bar.
+private struct ToolbarHeightKeeper: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(macOS 26.0, *) {
+            content.toolbar {
+                ToolbarItem {
+                    Color.clear.frame(width: 1, height: 1)
+                }
+                .sharedBackgroundVisibility(.hidden)
+            }
+        } else {
+            content.toolbar {
+                ToolbarItem {
+                    Color.clear.frame(width: 1, height: 1)
+                }
+            }
+        }
     }
 }
 

--- a/apps/omlx-mac/Sources/AppView/Screens/AboutScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/AboutScreen.swift
@@ -69,9 +69,9 @@ private struct HeroCard: View {
         .padding(18)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(theme.groupBg)
-        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .clipShape(RoundedRectangle(cornerRadius: theme.cornerRadius, style: .continuous))
         .overlay(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
+            RoundedRectangle(cornerRadius: theme.cornerRadius, style: .continuous)
                 .strokeBorder(theme.groupBorder, lineWidth: 0.5)
         )
         .padding(.horizontal, 14)

--- a/apps/omlx-mac/Sources/AppView/Screens/AccuracyBenchScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/AccuracyBenchScreen.swift
@@ -198,7 +198,7 @@ private struct ConfigurationSection: View {
                                  comment: "Sublabel under the Accuracy Bench model picker")) {
                 Popup(
                     selection: $selectedModelId,
-                    width: 320,
+                    width: .controlWide,
                     options: modelOptions
                 )
             }
@@ -417,7 +417,7 @@ private struct BenchmarkCard: View {
                         .foregroundStyle(theme.textTertiary)
                     Popup(
                         selection: $sampleSize,
-                        width: 90,
+                        width: .controlNarrow,
                         options: sampleSizeOptions
                     )
                 }

--- a/apps/omlx-mac/Sources/AppView/Screens/AccuracyBenchScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/AccuracyBenchScreen.swift
@@ -222,7 +222,7 @@ private struct ConfigurationSection: View {
                                  defaultValue: "Enable per-question reasoning traces (slower)",
                                  comment: "Sublabel under the Accuracy Bench extended-thinking toggle")
             ) {
-                Toggle("", isOn: $enableThinking).labelsHidden().toggleStyle(.switch)
+                RowSwitch(isOn: $enableThinking)
             }
 
             FreeRow {

--- a/apps/omlx-mac/Sources/AppView/Screens/AppearanceScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/AppearanceScreen.swift
@@ -138,7 +138,6 @@ struct AppearanceScreen: View {
                             )
                         ),
                     ])
-                    .frame(width: 200)
                 }
             }
 

--- a/apps/omlx-mac/Sources/AppView/Screens/AppearanceScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/AppearanceScreen.swift
@@ -65,9 +65,7 @@ struct AppearanceScreen: View {
                         comment: "Appearance row sublabel for the permanent Dock icon toggle"
                     )
                 ) {
-                    Toggle("", isOn: $showDockIcon)
-                        .labelsHidden()
-                        .toggleStyle(.switch)
+                    RowSwitch(isOn: $showDockIcon)
                 }
                 // Sits right under the Dock toggle because that's where people
                 // look for it — the Dock icon and the menu bar icon read as one
@@ -170,9 +168,7 @@ struct AppearanceScreen: View {
                         comment: "Appearance row sublabel for the LIV menubar item toggle"
                     )
                 ) {
-                    Toggle("", isOn: $showLiveActivity)
-                        .labelsHidden()
-                        .toggleStyle(.switch)
+                    RowSwitch(isOn: $showLiveActivity)
                 }
                 Row(
                     label: String(
@@ -186,9 +182,7 @@ struct AppearanceScreen: View {
                         comment: "Appearance row sublabel for the AVG menubar item toggle"
                     )
                 ) {
-                    Toggle("", isOn: $showAverageActivity)
-                        .labelsHidden()
-                        .toggleStyle(.switch)
+                    RowSwitch(isOn: $showAverageActivity)
                 }
                 Row(
                     label: String(
@@ -202,9 +196,7 @@ struct AppearanceScreen: View {
                         comment: "Appearance row sublabel for the ALL menubar item toggle"
                     )
                 ) {
-                    Toggle("", isOn: $showAlltimeActivity)
-                        .labelsHidden()
-                        .toggleStyle(.switch)
+                    RowSwitch(isOn: $showAlltimeActivity)
                 }
                 Row(
                     label: String(
@@ -218,9 +210,7 @@ struct AppearanceScreen: View {
                         comment: "Appearance row sublabel for the CPU usage bar menubar item toggle"
                     )
                 ) {
-                    Toggle("", isOn: $showCPUItem)
-                        .labelsHidden()
-                        .toggleStyle(.switch)
+                    RowSwitch(isOn: $showCPUItem)
                 }
                 Row(
                     label: String(
@@ -234,9 +224,7 @@ struct AppearanceScreen: View {
                         comment: "Appearance row sublabel for the GPU usage bar menubar item toggle"
                     )
                 ) {
-                    Toggle("", isOn: $showGPUItem)
-                        .labelsHidden()
-                        .toggleStyle(.switch)
+                    RowSwitch(isOn: $showGPUItem)
                 }
                 Row(
                     label: String(
@@ -251,9 +239,7 @@ struct AppearanceScreen: View {
                     ),
                     isLast: true
                 ) {
-                    Toggle("", isOn: $showMemoryItem)
-                        .labelsHidden()
-                        .toggleStyle(.switch)
+                    RowSwitch(isOn: $showMemoryItem)
                 }
             }
         }

--- a/apps/omlx-mac/Sources/AppView/Screens/AppearanceScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/AppearanceScreen.swift
@@ -46,7 +46,7 @@ struct AppearanceScreen: View {
                         comment: "Appearance row sublabel for the menubar refresh cadence picker"
                     )
                 ) {
-                    Popup(selection: $refreshInterval, width: 110, options: [
+                    Popup(selection: $refreshInterval, width: .controlCompact, options: [
                         (0.5, "0.5 s"),
                         (1.0, "1 s"),
                         (2.0, "2 s"),

--- a/apps/omlx-mac/Sources/AppView/Screens/ContextBenchScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ContextBenchScreen.swift
@@ -135,7 +135,6 @@ private struct ConfigurationSection: View {
                         (value: $0, label: "\($0 / 1024)k")
                     }
                 )
-                .frame(width: 320)
                 .disabled(running)
             }
 
@@ -162,7 +161,6 @@ private struct ConfigurationSection: View {
                     ],
                     icons: ["arrow.up.left.and.arrow.down.right", "speedometer"]
                 )
-                .frame(width: 240)
                 .disabled(running)
             }
 

--- a/apps/omlx-mac/Sources/AppView/Screens/ContextBenchScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ContextBenchScreen.swift
@@ -118,7 +118,7 @@ private struct ConfigurationSection: View {
                                  comment: "Sublabel under the Context Bench model picker")) {
                 Popup(
                     selection: $selectedModelId,
-                    width: 320,
+                    width: .controlWide,
                     options: modelOptions
                 )
             }

--- a/apps/omlx-mac/Sources/AppView/Screens/DownloadsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/DownloadsScreen.swift
@@ -803,7 +803,7 @@ private struct SuggestedSection: View {
             HStack(spacing: 6) {
                 Popup(
                     selection: $sort,
-                    width: 170,
+                    width: .controlMedium,
                     options: SuggestedSort.allCases.map { ($0, $0.label) }
                 )
                 Button {

--- a/apps/omlx-mac/Sources/AppView/Screens/DownloadsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/DownloadsScreen.swift
@@ -128,9 +128,11 @@ struct DownloadsScreen: View {
 
 // MARK: - Source switcher
 
-/// Segmented HF / ModelScope toggle pinned at the top of Downloads. When
-/// the server's modelscope SDK isn't installed (`/admin/api/ms/status`
-/// returns `available: false`), the MS option is disabled with a tooltip
+/// HF / ModelScope tabs pinned at the top of Downloads, rendered as a
+/// centered segmented control — the macOS convention for top-of-pane tabs
+/// (System Settings › Trackpad, Finder settings). When the server's
+/// modelscope SDK isn't installed (`/admin/api/ms/status` returns
+/// `available: false`), the MS option is disabled with a note underneath
 /// rather than hidden — so a user looking for it can see why it's not
 /// usable.
 private struct SourceSwitcher: View {
@@ -138,21 +140,24 @@ private struct SourceSwitcher: View {
     let msAvailable: Bool
 
     var body: some View {
-        HStack(spacing: 8) {
+        VStack(spacing: 6) {
             Segmented(
                 selection: $source,
                 options: DownloadSource.allCases.map { ($0, $0.label) }
             )
             .disabled(!msAvailable)
+            // A fixed frame makes the picker split the width into equal
+            // tab-sized segments instead of hugging the labels.
+            .frame(width: 280)
             if !msAvailable {
                 Text(String(localized: "downloads.source.ms_unavailable",
                             defaultValue: "ModelScope SDK unavailable in this build",
-                            comment: "Inline note shown beside the source switcher when the ModelScope SDK isn't installed"))
+                            comment: "Note shown under the source switcher when the ModelScope SDK isn't installed"))
                     .font(.omlxText(10.5))
                     .foregroundStyle(.secondary)
             }
-            Spacer(minLength: 0)
         }
+        .frame(maxWidth: .infinity)
         .padding(.horizontal, 14)
         .padding(.top, 4)
         .padding(.bottom, 8)

--- a/apps/omlx-mac/Sources/AppView/Screens/DownloadsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/DownloadsScreen.swift
@@ -107,13 +107,7 @@ struct DownloadsScreen: View {
                 onShowCard: { repo in vm.showModelCard(repoId: repo) }
             )
 
-            if let error = vm.lastError {
-                Text(error)
-                    .font(.omlxText(11))
-                    .foregroundStyle(.red)
-                    .padding(.horizontal, 18)
-                    .padding(.top, 8)
-            }
+            FooterBar(error: vm.lastError)
         }
         .task { await vm.start(client: services.client) }
         .onDisappear { vm.stop() }

--- a/apps/omlx-mac/Sources/AppView/Screens/IntegrationsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/IntegrationsScreen.swift
@@ -120,10 +120,9 @@ private struct ClaudeCodeSection: View {
                                  comment: "Sublabel for the context scaling toggle"),
                 isLast: !vm.contextScaling
             ) {
-                Toggle("", isOn: vm.bind($vm.contextScaling, save: {
+                RowSwitch(isOn: vm.bind($vm.contextScaling, save: {
                     Task { await vm.save(.contextScaling, client: client) }
                 }))
-                .labelsHidden().toggleStyle(.switch)
             }
             if vm.contextScaling {
                 Row(

--- a/apps/omlx-mac/Sources/AppView/Screens/IntegrationsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/IntegrationsScreen.swift
@@ -79,7 +79,7 @@ private struct ClaudeCodeSection: View {
                         selection: vm.bind($vm.opusModel, save: {
                             Task { await vm.save(.opusModel, client: client) }
                         }),
-                        width: 220,
+                        width: .controlMedium,
                         options: vm.modelOptions
                     )
                 }
@@ -90,7 +90,7 @@ private struct ClaudeCodeSection: View {
                         selection: vm.bind($vm.sonnetModel, save: {
                             Task { await vm.save(.sonnetModel, client: client) }
                         }),
-                        width: 220,
+                        width: .controlMedium,
                         options: vm.modelOptions
                     )
                 }
@@ -106,7 +106,7 @@ private struct ClaudeCodeSection: View {
                         selection: vm.bind($vm.haikuModel, save: {
                             Task { await vm.save(.haikuModel, client: client) }
                         }),
-                        width: 220,
+                        width: .controlMedium,
                         options: vm.modelOptions
                     )
                 }
@@ -139,7 +139,7 @@ private struct ClaudeCodeSection: View {
                         text: $vm.targetContextSizeText,
                         mono: true,
                         suffix: "tk",
-                        width: 130
+                        width: .controlCompact
                     )
                 }
             }
@@ -392,7 +392,7 @@ private struct IntegrationRow: View {
                     Spacer(minLength: 12)
                     Popup(
                         selection: modelBinding,
-                        width: 220,
+                        width: .controlMedium,
                         options: modelOptions
                     )
                 }
@@ -413,7 +413,7 @@ private struct IntegrationRow: View {
                         Spacer(minLength: 12)
                         Popup(
                             selection: profileBinding,
-                            width: 160,
+                            width: .controlMedium,
                             options: [
                                 ("minimal",   String(localized: "integrations.openclaw.profile.minimal",
                                                      defaultValue: "Minimal",
@@ -478,7 +478,7 @@ private struct MCPSection: View {
                     text: $vm.mcpConfigPath,
                     placeholder: "/path/to/mcp.json",
                     mono: true,
-                    width: 320
+                    width: .controlWide
                 )
             }
         }

--- a/apps/omlx-mac/Sources/AppView/Screens/IntegrationsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/IntegrationsScreen.swift
@@ -25,13 +25,7 @@ struct IntegrationsScreen: View {
             OtherIntegrationsSection(vm: vm, client: services.client)
             MCPSection(vm: vm, client: services.client)
 
-            if let error = vm.lastError {
-                Text(error)
-                    .font(.omlxText(11))
-                    .foregroundStyle(.red)
-                    .padding(.horizontal, 18)
-                    .padding(.top, 8)
-            }
+            FooterBar(error: vm.lastError)
         }
         .task { await vm.load(client: services.client) }
     }
@@ -144,8 +138,7 @@ private struct ClaudeCodeSection: View {
             }
         }
         if vm.contextScaling {
-            HStack {
-                Spacer()
+            FooterBar {
                 Button(String(localized: "integrations.target_context.apply",
                               defaultValue: "Apply",
                               comment: "Apply button for the Claude Code target context size field")) {
@@ -154,8 +147,6 @@ private struct ClaudeCodeSection: View {
                 .buttonStyle(.omlx(.primary))
                 .disabled(!vm.hasPendingContextSizeChange)
             }
-            .padding(.horizontal, 18)
-            .padding(.top, 6)
         }
     }
 }
@@ -236,36 +227,18 @@ private struct CommandBlock: View {
                     .strokeBorder(theme.groupBorder, lineWidth: 0.5)
             )
 
-            CopyButton(value: command)
-                .padding(.top, 6)
-                .padding(.trailing, 8)
+            // Same quiet copy affordance as `CodeChip`/`CopyIconButton`
+            // everywhere else — the previous locally-drawn boxed button was a
+            // second copy-button style.
+            CopyIconButton(
+                value: command,
+                helpText: String(localized: "integrations.command.copy",
+                                 defaultValue: "Copy command",
+                                 comment: "Tooltip for the copy button on a shell command block")
+            )
+            .padding(.top, 4)
+            .padding(.trailing, 4)
         }
-    }
-}
-
-private struct CopyButton: View {
-    let value: String
-    @State private var copied = false
-    @Environment(\.omlxTheme) private var theme
-
-    var body: some View {
-        Button {
-            let pb = NSPasteboard.general
-            pb.clearContents()
-            pb.setString(value, forType: .string)
-            copied = true
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.4) {
-                copied = false
-            }
-        } label: {
-            Image(systemName: copied ? "checkmark" : "document.on.document")
-                .font(.system(size: 11, weight: .medium))
-                .foregroundStyle(copied ? theme.successText : theme.textSecondary)
-                .padding(5)
-                .background(theme.controlBg)
-                .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
-        }
-        .buttonStyle(.plain)
     }
 }
 
@@ -481,8 +454,7 @@ private struct MCPSection: View {
                 )
             }
         }
-        HStack {
-            Spacer()
+        FooterBar {
             Button(String(localized: "integrations.mcp.apply",
                           defaultValue: "Apply",
                           comment: "Apply button for the MCP config path")) {
@@ -491,7 +463,5 @@ private struct MCPSection: View {
             .buttonStyle(.omlx(.primary))
             .disabled(!vm.hasPendingMCPChanges)
         }
-        .padding(.horizontal, 18)
-        .padding(.top, 6)
     }
 }

--- a/apps/omlx-mac/Sources/AppView/Screens/LogsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/LogsScreen.swift
@@ -32,7 +32,7 @@ struct LogsScreen: View {
                         isLast: true) {
                         Popup(
                             selection: $vm.selectedFile,
-                            width: 220,
+                            width: .controlMedium,
                             options: vm.fileOptions
                         )
                     }
@@ -95,7 +95,7 @@ struct LogsScreen: View {
 
         Popup(
             selection: $vm.lines,
-            width: 110,
+            width: .controlCompact,
             options: lineOptions
         )
     }

--- a/apps/omlx-mac/Sources/AppView/Screens/LogsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/LogsScreen.swift
@@ -45,13 +45,7 @@ struct LogsScreen: View {
                 .padding(.bottom, 8)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
-            if let error = vm.lastError {
-                Text(error)
-                    .font(.omlxText(11))
-                    .foregroundStyle(.red)
-                    .padding(.horizontal, 18)
-                    .padding(.top, 4)
-            }
+            FooterBar(error: vm.lastError)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .toolbar {

--- a/apps/omlx-mac/Sources/AppView/Screens/ModelCardSheet.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ModelCardSheet.swift
@@ -491,7 +491,7 @@ struct ModelCardSheet: View {
                 .keyboardShortcut(.defaultAction)
             }
         }
-        .padding(.horizontal, 18)
+        .padding(.horizontal, 20)
         .padding(.vertical, 12)
     }
 

--- a/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
@@ -53,13 +53,7 @@ struct ModelSettingsScreen: View {
                 AdvancedTab(vm: vm, client: services.client)
             }
 
-            if let error = vm.lastError {
-                Text(error)
-                    .font(.omlxText(11))
-                    .foregroundStyle(.red)
-                    .padding(.horizontal, 18)
-                    .padding(.top, 8)
-            }
+            FooterBar(error: vm.lastError)
         }
         .toolbar {
             ToolbarItem(placement: .navigation) {

--- a/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
@@ -514,7 +514,7 @@ private struct BasicTab: View {
                 sublabel: String(localized: "settings.basic.alias.sub",
                                  defaultValue: "Falls back to the model id",
                                  comment: "Sublabel for the model alias field")) {
-                TextInput(text: $vm.alias, placeholder: vm.modelID, mono: true, width: 220)
+                TextInput(text: $vm.alias, placeholder: vm.modelID, mono: true, width: .controlMedium)
                     .onSubmit { Task { await vm.save(.alias, client: client) } }
             }
             Row(label: String(localized: "settings.basic.model_type.label",
@@ -522,7 +522,7 @@ private struct BasicTab: View {
                               comment: "Row label for the model type override popup")) {
                 Popup(
                     selection: vm.bind($vm.modelTypeOverride, save: { Task { await vm.save(.modelType, client: client) } }),
-                    width: 170,
+                    width: .controlMedium,
                     options: ModelSettingsScreenVM.modelTypeOptions
                 )
             }
@@ -532,7 +532,7 @@ private struct BasicTab: View {
                 sublabel: String(localized: "settings.basic.context_window.sub",
                                  defaultValue: "Maximum tokens per request",
                                  comment: "Sublabel for the context window field")) {
-                TextInput(text: vm.bindProfile($vm.contextLength), mono: true, suffix: "tk", width: 110)
+                TextInput(text: vm.bindProfile($vm.contextLength), mono: true, suffix: "tk", width: .controlCompact)
             }
             Row(label: String(localized: "settings.basic.max_tokens.label",
                               defaultValue: "Max Tokens",
@@ -544,7 +544,7 @@ private struct BasicTab: View {
                           placeholder: String(localized: "settings.basic.max_tokens.placeholder",
                                               defaultValue: "Default",
                                               comment: "Placeholder shown when Max Tokens is empty (server default applies)"),
-                          mono: true, width: 110)
+                          mono: true, width: .controlCompact)
             }
             Row(label: String(localized: "settings.basic.temperature.label",
                               defaultValue: "Temperature",
@@ -552,7 +552,7 @@ private struct BasicTab: View {
                 sublabel: String(localized: "settings.basic.temperature.sub",
                                  defaultValue: "Sampling randomness (≥ 0). 0 = deterministic.",
                                  comment: "Sublabel describing the temperature field range")) {
-                TextInput(text: vm.bindProfile($vm.temperature), placeholder: "0.7", mono: true, width: 90)
+                TextInput(text: vm.bindProfile($vm.temperature), placeholder: "0.7", mono: true, width: .controlNarrow)
             }
             if !vm.isDiffusionModel {
                 Row(label: String(localized: "settings.basic.top_p.label",
@@ -561,7 +561,7 @@ private struct BasicTab: View {
                     sublabel: String(localized: "settings.basic.top_p.sub",
                                      defaultValue: "Nucleus sampling cutoff (0 < p ≤ 1).",
                                      comment: "Sublabel describing the top-p valid range")) {
-                    TextInput(text: vm.bindProfile($vm.topP), mono: true, width: 90)
+                    TextInput(text: vm.bindProfile($vm.topP), mono: true, width: .controlNarrow)
                 }
                 Row(label: String(localized: "settings.basic.top_k.label",
                                   defaultValue: "Top K",
@@ -569,7 +569,7 @@ private struct BasicTab: View {
                     sublabel: String(localized: "settings.basic.top_k.sub",
                                      defaultValue: "Limit candidates to top K (positive integer).",
                                      comment: "Sublabel describing the top-k field")) {
-                    TextInput(text: vm.bindProfile($vm.topK), mono: true, width: 90)
+                    TextInput(text: vm.bindProfile($vm.topK), mono: true, width: .controlNarrow)
                 }
                 Row(label: String(localized: "settings.basic.min_p.label",
                                   defaultValue: "Min P",
@@ -577,7 +577,7 @@ private struct BasicTab: View {
                     sublabel: String(localized: "settings.basic.min_p.sub",
                                      defaultValue: "Minimum probability floor (0 ≤ p ≤ 1).",
                                      comment: "Sublabel describing the min-p field range")) {
-                    TextInput(text: vm.bindProfile($vm.minP), mono: true, width: 90)
+                    TextInput(text: vm.bindProfile($vm.minP), mono: true, width: .controlNarrow)
                 }
                 Row(label: String(localized: "settings.basic.repetition_penalty.label",
                                   defaultValue: "Repetition Penalty",
@@ -587,7 +587,7 @@ private struct BasicTab: View {
                         : String(localized: "settings.basic.repetition_penalty.sub",
                                  defaultValue: "Penalize repeated tokens (−2 to 2).",
                                  comment: "Sublabel describing repetition-penalty range")) {
-                    TextInput(text: vm.bindProfile($vm.repetitionPenalty), mono: true, width: 90)
+                    TextInput(text: vm.bindProfile($vm.repetitionPenalty), mono: true, width: .controlNarrow)
                         .disabled(vm.vlmMtpEnabled)
                         .help(vm.vlmMtpEnabled ? vm.vlmMtpProcessorLockedReason : "")
                 }
@@ -599,7 +599,7 @@ private struct BasicTab: View {
                         : String(localized: "settings.basic.presence_penalty.sub",
                                  defaultValue: "Penalize tokens already present (−2 to 2).",
                                  comment: "Sublabel describing presence-penalty range")) {
-                    TextInput(text: vm.bindProfile($vm.presencePenalty), mono: true, width: 90)
+                    TextInput(text: vm.bindProfile($vm.presencePenalty), mono: true, width: .controlNarrow)
                         .disabled(vm.vlmMtpEnabled)
                         .help(vm.vlmMtpEnabled ? vm.vlmMtpProcessorLockedReason : "")
                 }
@@ -617,7 +617,7 @@ private struct BasicTab: View {
                           placeholder: String(localized: "settings.basic.ttl.placeholder",
                                               defaultValue: "No TTL",
                                               comment: "Placeholder shown when no TTL is configured"),
-                          mono: true, suffix: "s", width: 110)
+                          mono: true, suffix: "s", width: .controlCompact)
                     .onSubmit { Task { await vm.save(.ttl, client: client) } }
             }
         }
@@ -744,7 +744,7 @@ private struct AdvancedTab: View {
                     HStack(spacing: 8) {
                         if vm.thinkingBudgetEnabled {
                             TextInput(text: vm.bindProfile($vm.thinkingBudgetTokens),
-                                      mono: true, suffix: "tk", width: 110)
+                                      mono: true, suffix: "tk", width: .controlCompact)
                         }
                         Toggle("", isOn: vm.bindProfile($vm.thinkingBudgetEnabled))
                             .labelsHidden().toggleStyle(.switch)
@@ -760,7 +760,7 @@ private struct AdvancedTab: View {
                         if vm.limitToolResults {
                             TextInput(text: vm.bindProfile($vm.toolResultLimitTokens),
                                       placeholder: "4096",
-                                      mono: true, suffix: "tk", width: 110)
+                                      mono: true, suffix: "tk", width: .controlCompact)
                         }
                         Toggle("", isOn: vm.bindProfile($vm.limitToolResults))
                             .labelsHidden().toggleStyle(.switch)
@@ -782,7 +782,7 @@ private struct AdvancedTab: View {
                                      defaultValue: "Override the chain-of-thought parser. Leave empty to use the model's default.",
                                      comment: "Sublabel for the reasoning-parser override field")) {
                     TextInput(text: vm.bindProfile($vm.reasoningParser),
-                              placeholder: "auto", mono: true, width: 150)
+                              placeholder: "auto", mono: true, width: .controlCompact)
                 }
             }
             Row(label: String(localized: "settings.advanced.pin_memory.label",
@@ -938,7 +938,7 @@ private struct EntryEditor: View {
     let client: OMLXClient
     let entryID: UUID
 
-    private static let reasoningEffortValueWidth: CGFloat = 130
+    private static let reasoningEffortValueWidth: CGFloat = .controlCompact
 
     @Environment(\.omlxTheme) private var theme
 
@@ -1009,7 +1009,7 @@ private struct EntryEditor: View {
             HStack(spacing: 8) {
                 Popup(
                     selection: vm.bindProfile(binding.value),
-                    width: 130,
+                    width: .controlCompact,
                     options: [("true", "true"), ("false", "false")]
                 )
                 forceCheckbox
@@ -1076,7 +1076,6 @@ private struct EntryEditor: View {
             Popup(
                 selection: vm.bindProfile(binding.value),
                 width: Self.reasoningEffortValueWidth,
-                fillsWidth: true,
                 options: ChatTemplateKwargsCodec.reasoningEffortPresets.map {
                     ($0, $0)
                 }
@@ -1291,7 +1290,7 @@ private struct ExperimentalSection: View {
                         TextInput(text: vm.bindProfile($vm.qwen35AnePrefillSequenceLength),
                                   placeholder: "2048", mono: true,
                                   isNumeric: true, range: 1024...262_144,
-                                  step: 64, width: 190)
+                                  step: 64, width: .controlCompact)
                     }
                     Row(label: String(localized: "settings.experimental.qwen_ane.tail_padding.label",
                                       defaultValue: "Pad Intermediate Tails From",
@@ -1302,7 +1301,7 @@ private struct ExperimentalSection: View {
                         TextInput(text: vm.bindProfile($vm.qwen35AnePrefillTailPaddingMinTokens),
                                   placeholder: "0", mono: true,
                                   isNumeric: true, range: 0...262_143,
-                                  step: 1, width: 190)
+                                  step: 1, width: .controlCompact)
                     }
                     Row(label: String(localized: "settings.experimental.qwen_ane.mlp_fraction.label",
                                       defaultValue: "MLP on ANE",
@@ -1313,7 +1312,7 @@ private struct ExperimentalSection: View {
                         TextInput(text: vm.bindProfile($vm.qwen35AnePrefillFraction),
                                   placeholder: "0.53", mono: true,
                                   isNumeric: true, range: 0.05...0.90,
-                                  step: 0.005, width: 190)
+                                  step: 0.005, width: .controlCompact)
                     }
                     Row(label: String(localized: "settings.experimental.qwen_ane.mlp_layers.label",
                                       defaultValue: "MLP Layer Limit",
@@ -1324,7 +1323,7 @@ private struct ExperimentalSection: View {
                         TextInput(text: vm.bindProfile($vm.qwen35AnePrefillMaxLayers),
                                   placeholder: "64", mono: true,
                                   isNumeric: true, range: 1...256,
-                                  step: 1, width: 190)
+                                  step: 1, width: .controlCompact)
                     }
                     Row(label: String(localized: "settings.experimental.qwen_ane.dual.label",
                                       defaultValue: "Use Both ANEs",
@@ -1354,7 +1353,7 @@ private struct ExperimentalSection: View {
                             TextInput(text: vm.bindProfile($vm.qwen35AnePrefillCpuFraction),
                                       placeholder: "0.135", mono: true,
                                       isNumeric: true, range: 0...0.25,
-                                      step: 0.005, width: 190)
+                                      step: 0.005, width: .controlCompact)
                         }
                         Row(label: String(localized: "settings.experimental.qwen_ane.cpu_threads.label",
                                           defaultValue: "CPU Workers",
@@ -1365,7 +1364,7 @@ private struct ExperimentalSection: View {
                             TextInput(text: vm.bindProfile($vm.qwen35AnePrefillCpuThreads),
                                       placeholder: "8", mono: true,
                                       isNumeric: true, range: 0...64,
-                                      step: 1, width: 190)
+                                      step: 1, width: .controlCompact)
                         }
                         Row(label: String(localized: "settings.experimental.qwen_ane.cpu_down_fraction.label",
                                           defaultValue: "Down Projection on CPU",
@@ -1376,7 +1375,7 @@ private struct ExperimentalSection: View {
                             TextInput(text: vm.bindProfile($vm.qwen35AnePrefillCpuDownFraction),
                                       placeholder: "0", mono: true,
                                       isNumeric: true, range: 0...0.50,
-                                      step: 0.005, width: 190)
+                                      step: 0.005, width: .controlCompact)
                         }
                         Row(label: String(localized: "settings.experimental.qwen_ane.cpu_gdn_fraction.label",
                                           defaultValue: "GDN on CPU",
@@ -1387,7 +1386,7 @@ private struct ExperimentalSection: View {
                             TextInput(text: vm.bindProfile($vm.qwen35AnePrefillCpuGdnFraction),
                                       placeholder: "0", mono: true,
                                       isNumeric: true, range: 0...0.50,
-                                      step: 0.005, width: 190)
+                                      step: 0.005, width: .controlCompact)
                         }
                         Row(label: String(localized: "settings.experimental.qwen_ane.cpu_scheduler.label",
                                           defaultValue: "Performance-Aware Scheduling",
@@ -1418,7 +1417,7 @@ private struct ExperimentalSection: View {
                             TextInput(text: vm.bindProfile($vm.qwen35AnePrefillGdnFraction),
                                       placeholder: "0.5", mono: true,
                                       isNumeric: true, range: 0.05...0.90,
-                                      step: 0.005, width: 190)
+                                      step: 0.005, width: .controlCompact)
                         }
                         Row(label: String(localized: "settings.experimental.qwen_ane.gdn_layers.label",
                                           defaultValue: "GDN Layer Limit",
@@ -1429,7 +1428,7 @@ private struct ExperimentalSection: View {
                             TextInput(text: vm.bindProfile($vm.qwen35AnePrefillGdnMaxLayers),
                                       placeholder: "48", mono: true,
                                       isNumeric: true, range: 0...256,
-                                      step: 1, width: 190)
+                                      step: 1, width: .controlCompact)
                         }
                     }
                 }
@@ -1444,7 +1443,7 @@ private struct ExperimentalSection: View {
                     if vm.turboquantKvEnabled {
                         Popup(
                             selection: vm.bindProfile($vm.turboquantKvBits),
-                            width: 120,
+                            width: .controlCompact,
                             options: ModelSettingsScreenVM.turboquantKvBitsOptions
                         )
                     }
@@ -1467,7 +1466,7 @@ private struct ExperimentalSection: View {
                     HStack(spacing: 8) {
                         if vm.indexCacheEnabled {
                             TextInput(text: vm.bindProfile($vm.indexCacheFreq),
-                                      placeholder: "4", mono: true, width: 80)
+                                      placeholder: "4", mono: true, width: .controlNarrow)
                         }
                         Toggle("", isOn: vm.bindProfile($vm.indexCacheEnabled))
                             .labelsHidden().toggleStyle(.switch)
@@ -1494,7 +1493,7 @@ private struct ExperimentalSection: View {
                                      comment: "Sublabel for the SpecPrefill draft-model picker")) {
                     Popup(
                         selection: vm.bindProfile($vm.specprefillDraftModel),
-                        width: 260,
+                        width: .controlWide,
                         options: vm.draftModelOptions()
                     )
                 }
@@ -1503,7 +1502,7 @@ private struct ExperimentalSection: View {
                                   comment: "Row label for the SpecPrefill keep-rate dropdown")) {
                     Popup(
                         selection: vm.bindProfile($vm.specprefillKeepPct),
-                        width: 320,
+                        width: .controlWide,
                         options: ModelSettingsScreenVM.specprefillKeepPctOptions
                     )
                 }
@@ -1514,7 +1513,7 @@ private struct ExperimentalSection: View {
                                      defaultValue: "Min prompt tokens to trigger (shorter prompts use full prefill).",
                                      comment: "Sublabel for the SpecPrefill threshold field")) {
                     TextInput(text: vm.bindProfile($vm.specprefillThreshold),
-                              placeholder: "8192", mono: true, suffix: "tk", width: 110)
+                              placeholder: "8192", mono: true, suffix: "tk", width: .controlCompact)
                 }
             }
 
@@ -1534,7 +1533,7 @@ private struct ExperimentalSection: View {
                                   comment: "Row label for the DFlash draft-model picker")) {
                     Popup(
                         selection: vm.bindProfile($vm.dflashDraftModel),
-                        width: 260,
+                        width: .controlWide,
                         options: vm.draftModelOptions()
                     )
                 }
@@ -1553,7 +1552,7 @@ private struct ExperimentalSection: View {
                                       comment: "Row label for the DFlash draft quantization weight bits picker")) {
                         Popup(
                             selection: vm.bindProfile($vm.dflashDraftQuantWeightBits),
-                            width: 110,
+                            width: .controlCompact,
                             options: ModelSettingsScreenVM.dflashDraftQuantWeightBitsOptions
                         )
                     }
@@ -1562,7 +1561,7 @@ private struct ExperimentalSection: View {
                                       comment: "Row label for the DFlash draft quantization activation bits picker")) {
                         Popup(
                             selection: vm.bindProfile($vm.dflashDraftQuantActivationBits),
-                            width: 110,
+                            width: .controlCompact,
                             options: ModelSettingsScreenVM.dflashDraftQuantActivationBitsOptions
                         )
                     }
@@ -1571,7 +1570,7 @@ private struct ExperimentalSection: View {
                                       comment: "Row label for the DFlash draft quantization group size picker")) {
                         Popup(
                             selection: vm.bindProfile($vm.dflashDraftQuantGroupSize),
-                            width: 110,
+                            width: .controlCompact,
                             options: ModelSettingsScreenVM.dflashDraftQuantGroupSizeOptions
                         )
                     }
@@ -1586,7 +1585,7 @@ private struct ExperimentalSection: View {
                               placeholder: String(localized: "settings.experimental.dflash.max_ctx.placeholder",
                                                   defaultValue: "unlimited",
                                                   comment: "Placeholder shown when DFlash max-context is unset (no cap)"),
-                              mono: true, suffix: "tk", width: 130)
+                              mono: true, suffix: "tk", width: .controlCompact)
                 }
                 Row(label: String(localized: "settings.experimental.dflash.verify_mode.label",
                                   defaultValue: "Verify Mode",
@@ -1596,7 +1595,7 @@ private struct ExperimentalSection: View {
                                      comment: "Sublabel for the DFlash verify mode picker")) {
                     Popup(
                         selection: vm.bindProfile($vm.dflashVerifyMode),
-                        width: 140,
+                        width: .controlMedium,
                         options: ModelSettingsScreenVM.dflashVerifyModeOptions
                     )
                 }
@@ -1607,7 +1606,7 @@ private struct ExperimentalSection: View {
                                      defaultValue: "Draft model sliding-attention window. Empty = dflash default (2048).",
                                      comment: "Sublabel for the DFlash draft window size field")) {
                     TextInput(text: vm.bindProfile($vm.dflashDraftWindowSize),
-                              placeholder: "2048", mono: true, width: 110)
+                              placeholder: "2048", mono: true, width: .controlCompact)
                 }
                 Row(label: String(localized: "settings.experimental.dflash.sink_size.label",
                                   defaultValue: "Draft Sink Size",
@@ -1616,7 +1615,7 @@ private struct ExperimentalSection: View {
                                      defaultValue: "Attention-sink tokens always kept in the window. Empty = dflash default (0).",
                                      comment: "Sublabel for the DFlash draft sink size field")) {
                     TextInput(text: vm.bindProfile($vm.dflashDraftSinkSize),
-                              placeholder: "0", mono: true, width: 110)
+                              placeholder: "0", mono: true, width: .controlCompact)
                 }
                 Row(label: String(localized: "settings.experimental.dflash.block_size.label",
                                   defaultValue: "Runtime Block Size",
@@ -1625,7 +1624,7 @@ private struct ExperimentalSection: View {
                                      defaultValue: "Maximum draft and verify tokens per cycle. Empty = checkpoint default.",
                                      comment: "Sublabel for the DFlash runtime block size field")) {
                     TextInput(text: vm.bindProfile($vm.dflashBlockSize),
-                              placeholder: "checkpoint", mono: true, width: 110)
+                              placeholder: "checkpoint", mono: true, width: .controlCompact)
                 }
                 Row(label: String(localized: "settings.experimental.dflash.mem_cache.label",
                                   defaultValue: "DFlash in-memory cache",
@@ -1636,7 +1635,7 @@ private struct ExperimentalSection: View {
                     HStack(spacing: 8) {
                         if vm.dflashInMemoryCache {
                             TextInput(text: vm.bindProfile($vm.dflashInMemoryCacheGib),
-                                      placeholder: "8", mono: true, suffix: "GiB", width: 110)
+                                      placeholder: "8", mono: true, suffix: "GiB", width: .controlCompact)
                         }
                         Toggle("", isOn: vm.bindProfile($vm.dflashInMemoryCache))
                             .labelsHidden().toggleStyle(.switch)
@@ -1650,7 +1649,7 @@ private struct ExperimentalSection: View {
                                          defaultValue: "Maximum prefix snapshots kept in RAM. Each entry stores KV + draft GDN state.",
                                          comment: "Sublabel for the DFlash L1 cache max entries field")) {
                         TextInput(text: vm.bindProfile($vm.dflashInMemoryCacheMaxEntries),
-                                  placeholder: "4", mono: true, width: 110)
+                                  placeholder: "4", mono: true, width: .controlCompact)
                     }
                 }
                 Row(label: String(localized: "settings.experimental.dflash.ssd_cache.label",
@@ -1669,7 +1668,7 @@ private struct ExperimentalSection: View {
                                          defaultValue: "Disk budget for L2 spill; oldest entries are evicted when exceeded.",
                                          comment: "Sublabel for the DFlash SSD cache size field")) {
                         TextInput(text: vm.bindProfile($vm.dflashSsdCacheGib),
-                                  placeholder: "20", mono: true, suffix: "GiB", width: 110)
+                                  placeholder: "20", mono: true, suffix: "GiB", width: .controlCompact)
                     }
                 }
             }
@@ -1695,7 +1694,7 @@ private struct ExperimentalSection: View {
                                      comment: "Sublabel for the VLM MTP draft-model picker")) {
                     Popup(
                         selection: vm.bindProfile($vm.vlmMtpDraftModel),
-                        width: 260,
+                        width: .controlWide,
                         options: vm.vlmMtpDraftModelOptions()
                     )
                 }
@@ -1707,7 +1706,7 @@ private struct ExperimentalSection: View {
                                      comment: "Sublabel for the VLM MTP draft block-size field"),
                     isLast: true) {
                     TextInput(text: vm.bindProfile($vm.vlmMtpDraftBlockSize),
-                              placeholder: "4", mono: true, width: 80)
+                              placeholder: "4", mono: true, width: .controlNarrow)
                 }
             }
         }

--- a/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
@@ -708,8 +708,7 @@ private struct AdvancedTab: View {
                     sublabel: String(localized: "settings.advanced.enable_thinking.sub",
                                      defaultValue: "Enable reasoning/thinking mode for this model",
                                      comment: "Sublabel for the enable-thinking toggle")) {
-                    Toggle("", isOn: vm.bindProfile($vm.enableThinking))
-                        .labelsHidden().toggleStyle(.switch)
+                    RowSwitch(isOn: vm.bindProfile($vm.enableThinking))
                 }
                 if vm.isQwen4Exp && vm.qwen4PleSsdOffloadSupported {
                     Row(label: String(localized: "settings.advanced.qwen4_ssd_offload.label",
@@ -722,7 +721,7 @@ private struct AdvancedTab: View {
                             : String(localized: "settings.advanced.qwen4_ssd_offload.sub",
                                      defaultValue: "Keep the PLE N-gram table on SSD to save memory. Prefill can be slower after context changes.",
                                      comment: "Sublabel for the Qwen4 PLE SSD mmap toggle")) {
-                        Toggle("", isOn: vm.bind(
+                        RowSwitch(isOn: vm.bind(
                             $vm.qwen4PleSsdOffload,
                             save: {
                                 Task {
@@ -730,8 +729,6 @@ private struct AdvancedTab: View {
                                 }
                             }
                         ))
-                        .labelsHidden()
-                        .toggleStyle(.switch)
                         .disabled(vm.qwen4PleSsdOffloadForced)
                     }
                 }
@@ -746,8 +743,7 @@ private struct AdvancedTab: View {
                             TextInput(text: vm.bindProfile($vm.thinkingBudgetTokens),
                                       mono: true, suffix: "tk", width: .controlCompact)
                         }
-                        Toggle("", isOn: vm.bindProfile($vm.thinkingBudgetEnabled))
-                            .labelsHidden().toggleStyle(.switch)
+                        RowSwitch(isOn: vm.bindProfile($vm.thinkingBudgetEnabled))
                     }
                 }
                 Row(label: String(localized: "settings.advanced.tool_result_limit.label",
@@ -762,8 +758,7 @@ private struct AdvancedTab: View {
                                       placeholder: "4096",
                                       mono: true, suffix: "tk", width: .controlCompact)
                         }
-                        Toggle("", isOn: vm.bindProfile($vm.limitToolResults))
-                            .labelsHidden().toggleStyle(.switch)
+                        RowSwitch(isOn: vm.bindProfile($vm.limitToolResults))
                     }
                 }
                 Row(label: String(localized: "settings.advanced.force_sampling.label",
@@ -772,8 +767,7 @@ private struct AdvancedTab: View {
                     sublabel: String(localized: "settings.advanced.force_sampling.sub",
                                      defaultValue: "Override request sampling parameters with configured values",
                                      comment: "Sublabel for the force-sampling toggle")) {
-                    Toggle("", isOn: vm.bindProfile($vm.forceSampling))
-                        .labelsHidden().toggleStyle(.switch)
+                    RowSwitch(isOn: vm.bindProfile($vm.forceSampling))
                 }
                 Row(label: String(localized: "settings.advanced.reasoning_parser.label",
                                   defaultValue: "Reasoning Parser",
@@ -791,10 +785,9 @@ private struct AdvancedTab: View {
                 sublabel: String(localized: "settings.advanced.pin_memory.sub",
                                  defaultValue: "Keep this model resident between requests",
                                  comment: "Sublabel for the pin-in-memory toggle")) {
-                Toggle("", isOn: vm.bind($vm.isPinned, save: {
+                RowSwitch(isOn: vm.bind($vm.isPinned, save: {
                     Task { await vm.save(.isPinned, client: client) }
                 }))
-                .labelsHidden().toggleStyle(.switch)
             }
             Row(label: String(localized: "settings.advanced.favorite.label",
                               defaultValue: "Favorite",
@@ -802,10 +795,9 @@ private struct AdvancedTab: View {
                 sublabel: String(localized: "settings.advanced.favorite.sub",
                                  defaultValue: "List this model first in model lists",
                                  comment: "Sublabel for the favorite toggle")) {
-                Toggle("", isOn: vm.bind($vm.isFavorite, save: {
+                RowSwitch(isOn: vm.bind($vm.isFavorite, save: {
                     Task { await vm.save(.isFavorite, client: client) }
                 }))
-                .labelsHidden().toggleStyle(.switch)
             }
             // Security-sensitive row — flagged red to match the HTML
             // editor's visual treatment. HF custom-code execution gives
@@ -818,10 +810,9 @@ private struct AdvancedTab: View {
                                  defaultValue: "Execute HuggingFace custom model code. Only enable for models you trust. Per-model only — never inherited from profiles.",
                                  comment: "Sublabel describing the security implications of trust-remote-code"),
                 isLast: true) {
-                Toggle("", isOn: vm.bind($vm.trustRemoteCode, save: {
+                RowSwitch(isOn: vm.bind($vm.trustRemoteCode, save: {
                     Task { await vm.save(.trustRemoteCode, client: client) }
                 }))
-                .labelsHidden().toggleStyle(.switch)
                 .tint(theme.redDot)
             }
         }
@@ -1114,8 +1105,7 @@ private struct AccelerationSection: View {
                               comment: "Row label for the Lightning MTP toggle"),
                 sublabel: mtpSublabel,
                 isLast: true) {
-                Toggle("", isOn: vm.bindProfile($vm.mtpEnabled))
-                    .labelsHidden().toggleStyle(.switch)
+                RowSwitch(isOn: vm.bindProfile($vm.mtpEnabled))
                     .disabled(mtpToggleDisabled)
                     .help(vm.mtpConflictReason ?? vm.model?.mtpCompatibilityReason ?? "")
             }
@@ -1161,8 +1151,7 @@ private struct ExperimentalSection: View {
                     sublabel: String(localized: "settings.experimental.qwen_ane.sub",
                                      defaultValue: "Split fixed-shape Qwen 3.5/3.6/3.8 prompt processing across both ANEs and the GPU. Experimental private API; takes effect after the model reloads.",
                                      comment: "Sublabel describing Qwen ANE/GPU prefill acceleration")) {
-                    Toggle("", isOn: vm.bindProfile($vm.qwen35AnePrefillEnabled))
-                        .labelsHidden().toggleStyle(.switch)
+                    RowSwitch(isOn: vm.bindProfile($vm.qwen35AnePrefillEnabled))
                 }
                 Row(label: String(localized: "settings.experimental.qwen_ane.tuner.label",
                                   defaultValue: "Tune ANE Split",
@@ -1331,8 +1320,7 @@ private struct ExperimentalSection: View {
                         sublabel: String(localized: "settings.experimental.qwen_ane.dual.sub",
                                          defaultValue: "Pin one resident procedure bank to each physical ANE. Recommended on M3 Ultra.",
                                          comment: "Sublabel describing dual-ANE Qwen prefill")) {
-                        Toggle("", isOn: vm.bindProfile($vm.qwen35AnePrefillDualAne))
-                            .labelsHidden().toggleStyle(.switch)
+                        RowSwitch(isOn: vm.bindProfile($vm.qwen35AnePrefillDualAne))
                     }
                     Row(label: String(localized: "settings.experimental.qwen_ane.cpu.label",
                                       defaultValue: "Share MLP Work with CPU",
@@ -1340,8 +1328,7 @@ private struct ExperimentalSection: View {
                         sublabel: String(localized: "settings.experimental.qwen_ane.cpu.sub",
                                          defaultValue: "Requires a separate q4 checkpoint clone whose floating tensors are FP16. Retune the ANE MLP share when enabled.",
                                          comment: "Constraint and tuning guidance for Qwen CPU prefill sharing")) {
-                        Toggle("", isOn: vm.bindProfile($vm.qwen35AnePrefillCpuEnabled))
-                            .labelsHidden().toggleStyle(.switch)
+                        RowSwitch(isOn: vm.bindProfile($vm.qwen35AnePrefillCpuEnabled))
                     }
                     if vm.qwen35AnePrefillCpuEnabled {
                         Row(label: String(localized: "settings.experimental.qwen_ane.cpu_fraction.label",
@@ -1394,8 +1381,7 @@ private struct ExperimentalSection: View {
                             sublabel: String(localized: "settings.experimental.qwen_ane.cpu_scheduler.sub",
                                              defaultValue: "Distributes independent CPU shards across processor clusters and falls back automatically when unsupported.",
                                              comment: "Sublabel explaining performance-aware CPU scheduling")) {
-                            Toggle("", isOn: vm.bindProfile($vm.qwen35AnePrefillCpuSharedResource))
-                                .labelsHidden().toggleStyle(.switch)
+                            RowSwitch(isOn: vm.bindProfile($vm.qwen35AnePrefillCpuSharedResource))
                         }
                     }
                     Row(label: String(localized: "settings.experimental.qwen_ane.gdn.label",
@@ -1404,8 +1390,7 @@ private struct ExperimentalSection: View {
                         sublabel: String(localized: "settings.experimental.qwen_ane.gdn.sub",
                                          defaultValue: "Also split eligible GDN z+qkv input projections across ANE and GPU.",
                                          comment: "Sublabel describing Qwen GDN ANE acceleration")) {
-                        Toggle("", isOn: vm.bindProfile($vm.qwen35AnePrefillGdn))
-                            .labelsHidden().toggleStyle(.switch)
+                        RowSwitch(isOn: vm.bindProfile($vm.qwen35AnePrefillGdn))
                     }
                     if vm.qwen35AnePrefillGdn {
                         Row(label: String(localized: "settings.experimental.qwen_ane.gdn_fraction.label",
@@ -1447,8 +1432,7 @@ private struct ExperimentalSection: View {
                             options: ModelSettingsScreenVM.turboquantKvBitsOptions
                         )
                     }
-                    Toggle("", isOn: vm.bindProfile($vm.turboquantKvEnabled))
-                        .labelsHidden().toggleStyle(.switch)
+                    RowSwitch(isOn: vm.bindProfile($vm.turboquantKvEnabled))
                         .disabled(vm.vlmMtpEnabled)
                         .help(vm.vlmMtpEnabled ? vlmMtpOwnsSpeculativePathReason : "")
                 }
@@ -1468,8 +1452,7 @@ private struct ExperimentalSection: View {
                             TextInput(text: vm.bindProfile($vm.indexCacheFreq),
                                       placeholder: "4", mono: true, width: .controlNarrow)
                         }
-                        Toggle("", isOn: vm.bindProfile($vm.indexCacheEnabled))
-                            .labelsHidden().toggleStyle(.switch)
+                        RowSwitch(isOn: vm.bindProfile($vm.indexCacheEnabled))
                     }
                 }
             }
@@ -1479,8 +1462,7 @@ private struct ExperimentalSection: View {
                               defaultValue: "SpecPrefill",
                               comment: "Row label for the SpecPrefill toggle"),
                 sublabel: specprefillSublabel) {
-                Toggle("", isOn: vm.bindProfile($vm.specprefillEnabled))
-                    .labelsHidden().toggleStyle(.switch)
+                RowSwitch(isOn: vm.bindProfile($vm.specprefillEnabled))
                     .disabled(vm.vlmMtpEnabled)
                     .help(vm.vlmMtpEnabled ? vlmMtpOwnsSpeculativePathReason : "")
             }
@@ -1522,8 +1504,7 @@ private struct ExperimentalSection: View {
                               defaultValue: "DFlash",
                               comment: "Row label for the DFlash toggle"),
                 sublabel: dflashSublabel) {
-                Toggle("", isOn: vm.bindProfile($vm.dflashEnabled))
-                    .labelsHidden().toggleStyle(.switch)
+                RowSwitch(isOn: vm.bindProfile($vm.dflashEnabled))
                     .disabled(dflashToggleDisabled)
                     .help(dflashHelp)
             }
@@ -1543,8 +1524,7 @@ private struct ExperimentalSection: View {
                     sublabel: String(localized: "settings.experimental.dflash.draft_quant.sub",
                                      defaultValue: "Enable quantization for the draft model (weight, activation bits & group size).",
                                      comment: "Sublabel for the DFlash draft quantization toggle")) {
-                    Toggle("", isOn: vm.bindProfile($vm.dflashDraftQuantEnabled))
-                        .labelsHidden().toggleStyle(.switch)
+                    RowSwitch(isOn: vm.bindProfile($vm.dflashDraftQuantEnabled))
                 }
                 if vm.dflashDraftQuantEnabled {
                     Row(label: String(localized: "settings.experimental.dflash.draft_quant_weight.label",
@@ -1637,8 +1617,7 @@ private struct ExperimentalSection: View {
                             TextInput(text: vm.bindProfile($vm.dflashInMemoryCacheGib),
                                       placeholder: "8", mono: true, suffix: "GiB", width: .controlCompact)
                         }
-                        Toggle("", isOn: vm.bindProfile($vm.dflashInMemoryCache))
-                            .labelsHidden().toggleStyle(.switch)
+                        RowSwitch(isOn: vm.bindProfile($vm.dflashInMemoryCache))
                     }
                 }
                 if vm.dflashInMemoryCache {
@@ -1656,8 +1635,7 @@ private struct ExperimentalSection: View {
                                   defaultValue: "DFlash SSD cache",
                                   comment: "Row label for the DFlash L2 SSD cache toggle"),
                     sublabel: dflashSsdSublabel) {
-                    Toggle("", isOn: vm.bindProfile($vm.dflashSsdCache))
-                        .labelsHidden().toggleStyle(.switch)
+                    RowSwitch(isOn: vm.bindProfile($vm.dflashSsdCache))
                         .disabled(!(vm.model?.dflashSsdCacheAvailable ?? false) || !vm.dflashInMemoryCache)
                 }
                 if vm.dflashSsdCache && (vm.model?.dflashSsdCacheAvailable ?? false) {
@@ -1680,8 +1658,7 @@ private struct ExperimentalSection: View {
                               comment: "Row label for the VLM MTP toggle"),
                 sublabel: vlmMtpSublabel,
                 isLast: !vm.vlmMtpEnabled) {
-                Toggle("", isOn: vm.bindProfile($vm.vlmMtpEnabled))
-                    .labelsHidden().toggleStyle(.switch)
+                RowSwitch(isOn: vm.bindProfile($vm.vlmMtpEnabled))
                     .disabled(vlmMtpToggleDisabled)
                     .help(vm.vlmMtpConflictReason ?? "")
             }

--- a/apps/omlx-mac/Sources/AppView/Screens/ModelsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ModelsScreen.swift
@@ -34,13 +34,7 @@ struct ModelsScreen: View {
                 onToggleFavorite: { id, fav in vm.setFavorite(id: id, favorite: fav, client: services.client) }
             )
 
-            if let error = vm.lastError {
-                Text(error)
-                    .font(.omlxText(11))
-                    .foregroundStyle(.red)
-                    .padding(.horizontal, 18)
-                    .padding(.top, 8)
-            }
+            FooterBar(error: vm.lastError)
         }
         .task { await vm.start(client: services.client) }
         .onDisappear { vm.stop() }

--- a/apps/omlx-mac/Sources/AppView/Screens/NetworkScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/NetworkScreen.swift
@@ -67,7 +67,7 @@ private struct ProxiesSection: View {
                     text: $vm.httpProxy,
                     placeholder: "http://proxy.local:8080",
                     mono: true,
-                    width: 320
+                    width: .controlWide
                 )
             }
             Row(label: String(localized: "network.row.https_proxy.label",
@@ -77,7 +77,7 @@ private struct ProxiesSection: View {
                     text: $vm.httpsProxy,
                     placeholder: "http://proxy.local:8080",
                     mono: true,
-                    width: 320
+                    width: .controlWide
                 )
             }
             Row(
@@ -93,7 +93,7 @@ private struct ProxiesSection: View {
                     text: $vm.noProxy,
                     placeholder: "localhost,127.0.0.1,*.internal",
                     mono: true,
-                    width: 320
+                    width: .controlWide
                 )
             }
         }
@@ -129,7 +129,7 @@ private struct TLSSection: View {
                     text: $vm.caBundle,
                     placeholder: "/etc/ssl/certs/ca-bundle.pem",
                     mono: true,
-                    width: 320
+                    width: .controlWide
                 )
             }
         }

--- a/apps/omlx-mac/Sources/AppView/Screens/NetworkScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/NetworkScreen.swift
@@ -25,8 +25,7 @@ struct NetworkScreen: View {
             ProxiesSection(vm: vm)
             TLSSection(vm: vm)
 
-            HStack {
-                Spacer()
+            FooterBar(error: vm.lastError) {
                 Button(String(localized: "network.button.apply",
                               defaultValue: "Apply",
                               comment: "Footer button on the Network screen that commits the edited proxy/TLS values to the server")) {
@@ -35,10 +34,6 @@ struct NetworkScreen: View {
                 .buttonStyle(.omlx(.primary))
                 .disabled(!vm.hasPendingChanges || vm.isSaving)
             }
-            .padding(.horizontal, 18)
-            .padding(.top, 6)
-
-            HintFooter(error: vm.lastError)
         }
         .task { await vm.load(client: services.client) }
     }
@@ -136,18 +131,4 @@ private struct TLSSection: View {
     }
 }
 
-// MARK: - Hint footer
 
-private struct HintFooter: View {
-    let error: String?
-
-    var body: some View {
-        if let error {
-            Text(error)
-                .font(.omlxText(11))
-                .foregroundStyle(.red)
-                .padding(.horizontal, 18)
-                .padding(.top, 8)
-        }
-    }
-}

--- a/apps/omlx-mac/Sources/AppView/Screens/PerformanceScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/PerformanceScreen.swift
@@ -96,8 +96,7 @@ private struct SchedulerSection: View {
                                  defaultValue: "Split long prompts across scheduler ticks so other requests can interleave.",
                                  comment: "Sublabel for chunked prefill toggle")
             ) {
-                Toggle("", isOn: $vm.chunkedPrefill)
-                    .labelsHidden().toggleStyle(.switch)
+                RowSwitch(isOn: $vm.chunkedPrefill)
             }
             Row(
                 label: String(localized: "performance.scheduler.prefill_priority",
@@ -153,8 +152,7 @@ private struct MemoryLifecycleSection: View {
                                  defaultValue: "Preflight prefill memory before kicking the engine and defer generation scheduling near the ceiling.",
                                  comment: "Sublabel for prefill memory guard")
             ) {
-                Toggle("", isOn: $vm.prefillMemoryGuard)
-                    .labelsHidden().toggleStyle(.switch)
+                RowSwitch(isOn: $vm.prefillMemoryGuard)
             }
             Row(
                 label: String(localized: "performance.memory.guard_tier",
@@ -236,8 +234,7 @@ private struct MemoryLifecycleSection: View {
                                  comment: "Sublabel for model fallback toggle"),
                 isLast: true
             ) {
-                Toggle("", isOn: $vm.modelFallback)
-                    .labelsHidden().toggleStyle(.switch)
+                RowSwitch(isOn: $vm.modelFallback)
             }
         }
     }
@@ -307,8 +304,7 @@ private struct CacheSection: View {
                                  defaultValue: "Master switch for the engine's KV cache subsystem.",
                                  comment: "Sublabel for the master cache enable toggle")
             ) {
-                Toggle("", isOn: $vm.cacheEnabled)
-                    .labelsHidden().toggleStyle(.switch)
+                RowSwitch(isOn: $vm.cacheEnabled)
             }
             Row(
                 label: String(localized: "performance.cache.hot_only",
@@ -318,8 +314,7 @@ private struct CacheSection: View {
                                  defaultValue: "Skip SSD spillover. Useful on fast machines with abundant RAM.",
                                  comment: "Sublabel for hot cache only toggle")
             ) {
-                Toggle("", isOn: $vm.hotCacheOnly)
-                    .labelsHidden().toggleStyle(.switch)
+                RowSwitch(isOn: $vm.hotCacheOnly)
                     .disabled(!vm.cacheEnabled)
             }
             Row(

--- a/apps/omlx-mac/Sources/AppView/Screens/PerformanceScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/PerformanceScreen.swift
@@ -27,8 +27,7 @@ struct PerformanceScreen: View {
             MemoryLifecycleSection(vm: vm)
             CacheSection(vm: vm)
 
-            HStack {
-                Spacer()
+            FooterBar(error: vm.lastError) {
                 Button(String(localized: "performance.button.apply",
                               defaultValue: "Apply",
                               comment: "Apply button at the bottom of the Performance screen")) {
@@ -36,16 +35,6 @@ struct PerformanceScreen: View {
                 }
                 .buttonStyle(.omlx(.primary))
                 .disabled(!vm.hasPendingChanges || vm.isSaving)
-            }
-            .padding(.horizontal, 18)
-            .padding(.top, 6)
-
-            if let error = vm.lastError {
-                Text(error)
-                    .font(.omlxText(11))
-                    .foregroundStyle(.red)
-                    .padding(.horizontal, 18)
-                    .padding(.top, 8)
             }
         }
         .task { await vm.load(client: services.client) }

--- a/apps/omlx-mac/Sources/AppView/Screens/PerformanceScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/PerformanceScreen.swift
@@ -76,7 +76,7 @@ private struct SchedulerSection: View {
                                  defaultValue: "Cap on simultaneous /v1 requests.",
                                  comment: "Sublabel for max concurrent requests")
             ) {
-                TextInput(text: $vm.maxConcurrentText, mono: true, width: 90)
+                TextInput(text: $vm.maxConcurrentText, mono: true, width: .controlNarrow)
             }
             Row(
                 label: String(localized: "performance.scheduler.embedding_batch_size",
@@ -86,7 +86,7 @@ private struct SchedulerSection: View {
                                  defaultValue: "Max input texts per embedding forward pass.",
                                  comment: "Sublabel for embedding batch size")
             ) {
-                TextInput(text: $vm.embeddingBatchSizeText, mono: true, width: 90)
+                TextInput(text: $vm.embeddingBatchSizeText, mono: true, width: .controlNarrow)
             }
             Row(
                 label: String(localized: "performance.scheduler.chunked_prefill",
@@ -164,7 +164,7 @@ private struct MemoryLifecycleSection: View {
             ) {
                 Popup(
                     selection: $vm.memoryGuardTier,
-                    width: 150,
+                    width: .controlMedium,
                     options: [
                         ("safe",
                          String(localized: "performance.memory.guard_tier.safe",
@@ -202,7 +202,7 @@ private struct MemoryLifecycleSection: View {
                                             comment: "Placeholder for custom memory guard ceiling"),
                         mono: true,
                         suffix: "GB",
-                        width: 110
+                        width: .controlCompact
                     )
                 }
             }
@@ -224,7 +224,7 @@ private struct MemoryLifecycleSection: View {
                                         comment: "Placeholder text for the idle timeout field when disabled"),
                     mono: true,
                     suffix: "s",
-                    width: 110
+                    width: .controlCompact
                 )
             }
             Row(
@@ -334,7 +334,7 @@ private struct CacheSection: View {
                     text: $vm.hotCacheMaxSize,
                     placeholder: "0",
                     mono: true,
-                    width: 140
+                    width: .controlCompact
                 )
                 .disabled(!vm.cacheEnabled)
             }
@@ -350,7 +350,7 @@ private struct CacheSection: View {
                     text: $vm.ssdCacheDir,
                     placeholder: "<base_path>/cache",
                     mono: true,
-                    width: 280
+                    width: .controlWide
                 )
                 .disabled(!vm.cacheEnabled || vm.hotCacheOnly)
             }
@@ -368,7 +368,7 @@ private struct CacheSection: View {
                                         defaultValue: "auto",
                                         comment: "Memory field placeholder meaning automatic"),
                     mono: true,
-                    width: 140
+                    width: .controlCompact
                 )
                 .disabled(!vm.cacheEnabled || vm.hotCacheOnly)
             }
@@ -387,7 +387,7 @@ private struct CacheSection: View {
                                         defaultValue: "auto",
                                         comment: "Memory field placeholder meaning automatic"),
                     mono: true,
-                    width: 110
+                    width: .controlCompact
                 )
                 .disabled(!vm.cacheEnabled)
             }

--- a/apps/omlx-mac/Sources/AppView/Screens/PerformanceScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/PerformanceScreen.swift
@@ -110,7 +110,6 @@ private struct SchedulerSection: View {
                     ],
                     icons: ["arrow.up.left.and.arrow.down.right", "speedometer"]
                 )
-                .frame(width: 240)
             }
         }
     }

--- a/apps/omlx-mac/Sources/AppView/Screens/ProfileViews.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ProfileViews.swift
@@ -1067,7 +1067,9 @@ struct ProfileDetailCard: View {
                             .foregroundStyle(theme.textSecondary)
                     }
                     .toggleStyle(.switch)
-                    .controlSize(.mini)
+                    // Same switch size as `RowSwitch` so every switch in the
+                    // app reads as one control.
+                    .controlSize(.small)
                     if exposeAsModel, let exposedModelId {
                         Text(exposedModelId)
                             .font(.omlxMono(11))

--- a/apps/omlx-mac/Sources/AppView/Screens/ProfileViews.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ProfileViews.swift
@@ -324,10 +324,10 @@ struct ActiveProfileBanner: View {
         .padding(.vertical, isSlim ? 10 : 12)
         .background(bannerBackground)
         .overlay(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
+            RoundedRectangle(cornerRadius: theme.cornerRadius, style: .continuous)
                 .strokeBorder(bannerBorder, lineWidth: 0.5)
         )
-        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .clipShape(RoundedRectangle(cornerRadius: theme.cornerRadius, style: .continuous))
         .padding(.horizontal, 14)
         .padding(.bottom, 12)
     }
@@ -491,10 +491,10 @@ struct SaveAsPopover: View {
         .padding(12)
         .background(theme.groupBg)
         .overlay(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
+            RoundedRectangle(cornerRadius: theme.cornerRadius, style: .continuous)
                 .strokeBorder(theme.groupBorder, lineWidth: 0.5)
         )
-        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .clipShape(RoundedRectangle(cornerRadius: theme.cornerRadius, style: .continuous))
         .padding(.horizontal, 14)
         .padding(.bottom, 12)
         .onAppear { nameFocused = true }

--- a/apps/omlx-mac/Sources/AppView/Screens/QuantizationScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/QuantizationScreen.swift
@@ -103,7 +103,11 @@ struct QuantizationScreen: View {
             MessageBanner(error: vm.lastError, success: vm.lastSuccess)
 
             if vm.modelsLoaded && vm.models.isEmpty {
-                EmptyModelsBanner()
+                HintLine(text: String(localized: "quant.empty_models",
+                                      defaultValue: "No full-precision models found on disk. Download one from the Downloads tab first.",
+                                      comment: "Banner shown when no full-precision models are available to quantize"))
+                    .padding(.horizontal, 14)
+                    .padding(.top, 6)
             }
 
             QueueSection(
@@ -490,29 +494,6 @@ private struct EnhancedQuantizationSection: View {
                 }
             }
         }
-    }
-}
-
-private struct EmptyModelsBanner: View {
-    @Environment(\.omlxTheme) private var theme
-
-    var body: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "info.circle")
-                .font(.system(size: 11))
-                .foregroundStyle(theme.textTertiary)
-            Text(String(localized: "quant.empty_models",
-                        defaultValue: "No full-precision models found on disk. Download one from the Downloads tab first.",
-                        comment: "Banner shown when no full-precision models are available to quantize"))
-                .font(.omlxText(11.5))
-                .foregroundStyle(theme.textSecondary)
-            Spacer(minLength: 0)
-        }
-        .padding(10)
-        .background(theme.codeBg)
-        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-        .padding(.horizontal, 18)
-        .padding(.top, 6)
     }
 }
 

--- a/apps/omlx-mac/Sources/AppView/Screens/QuantizationScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/QuantizationScreen.swift
@@ -373,7 +373,7 @@ private struct AdvancedSection: View {
                                              defaultValue: "Exclude vision encoder weights (~2-3% smaller, text-only output)",
                                              comment: "Toggle row sublabel: text-only quantization effect")
                         ) {
-                            Toggle("", isOn: $textOnly).labelsHidden().toggleStyle(.switch)
+                            RowSwitch(isOn: $textOnly)
                         }
                     }
 
@@ -389,9 +389,7 @@ private struct AdvancedSection: View {
                                      defaultValue: "Unavailable — source model has no MTP heads",
                                      comment: "Toggle row sublabel when MTP isn't supported by the chosen source")
                     ) {
-                        Toggle("", isOn: $preserveMtp)
-                            .labelsHidden()
-                            .toggleStyle(.switch)
+                        RowSwitch(isOn: $preserveMtp)
                             .disabled(!selectedHasMTP)
                     }
 
@@ -446,7 +444,7 @@ private struct EnhancedQuantizationSection: View {
                                  comment: "Toggle sublabel explaining what enabling oQe does"),
                 isLast: !enabled
             ) {
-                Toggle("", isOn: $enabled).labelsHidden().toggleStyle(.switch)
+                RowSwitch(isOn: $enabled)
             }
 
             if enabled {
@@ -458,7 +456,7 @@ private struct EnhancedQuantizationSection: View {
                                      defaultValue: "Use a compatible cached imatrix when available; otherwise collect a new one.",
                                      comment: "Toggle sublabel for the oQe imatrix cache reuse option")
                 ) {
-                    Toggle("", isOn: $reuseCache).labelsHidden().toggleStyle(.switch)
+                    RowSwitch(isOn: $reuseCache)
                 }
 
                 Row(
@@ -488,7 +486,7 @@ private struct EnhancedQuantizationSection: View {
                                      comment: "Toggle sublabel for strict oQe imatrix coverage"),
                     isLast: true
                 ) {
-                    Toggle("", isOn: $strictCoverage).labelsHidden().toggleStyle(.switch)
+                    RowSwitch(isOn: $strictCoverage)
                 }
             }
         }
@@ -1077,7 +1075,7 @@ private struct UploadModalView: View {
                                      comment: "Toggle row sublabel explaining the private flag"),
                     isLast: true
                 ) {
-                    Toggle("", isOn: $isPrivate).labelsHidden().toggleStyle(.switch)
+                    RowSwitch(isOn: $isPrivate)
                 }
             }
         }
@@ -1115,7 +1113,7 @@ private struct UploadModalView: View {
                                          comment: "Toggle row sublabel for the re-download notice"),
                         isLast: true
                     ) {
-                        Toggle("", isOn: $addRedownloadNotice).labelsHidden().toggleStyle(.switch)
+                        RowSwitch(isOn: $addRedownloadNotice)
                     }
                 } else {
                     // Trailing row stays flush even when the toggle is hidden.

--- a/apps/omlx-mac/Sources/AppView/Screens/QuantizationScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/QuantizationScreen.swift
@@ -312,7 +312,7 @@ private struct EstimateStrip: View {
                              defaultValue: "Output size: ~\(outputSizeText)",
                              comment: "Estimate pill: predicted on-disk size of the quantized output. Placeholder is the formatted byte string"))
         }
-        .padding(.horizontal, 18)
+        .padding(.horizontal, 14)
         .padding(.top, 4)
         .padding(.bottom, 10)
     }

--- a/apps/omlx-mac/Sources/AppView/Screens/QuantizationScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/QuantizationScreen.swift
@@ -179,7 +179,7 @@ private struct SourceModelSection: View {
             ) {
                 Popup(
                     selection: $selectedModelPath,
-                    width: 320,
+                    width: .controlWide,
                     options: modelOptions
                 )
             }
@@ -195,7 +195,7 @@ private struct SourceModelSection: View {
                 ) {
                     Popup(
                         selection: $sensitivityModelPath,
-                        width: 320,
+                        width: .controlWide,
                         options: sensitivityOptions
                     )
                 }
@@ -209,7 +209,7 @@ private struct SourceModelSection: View {
                                  comment: "Row sublabel explaining the oQ level tradeoff")) {
                 Popup(
                     selection: $oqLevel,
-                    width: 120,
+                    width: .controlCompact,
                     options: levelOptions
                 )
             }
@@ -475,7 +475,7 @@ private struct EnhancedQuantizationSection: View {
                                             defaultValue: "Automatic",
                                             comment: "Placeholder for an automatically selected oQe imatrix cache path"),
                         mono: true,
-                        width: 320
+                        width: .controlWide
                     )
                 }
 
@@ -973,7 +973,7 @@ private struct UploadModalView: View {
                             placeholder: "hf_…",
                             isSecure: true,
                             mono: true,
-                            width: 220
+                            width: .controlMedium
                         )
                         Button {
                             Task { await vm.validateUploadToken(client: client) }
@@ -1010,7 +1010,7 @@ private struct UploadModalView: View {
                     ) {
                         Popup(
                             selection: $vm.uploadNamespace,
-                            width: 220,
+                            width: .controlMedium,
                             options: namespaceOptions
                         )
                     }
@@ -1063,7 +1063,7 @@ private struct UploadModalView: View {
                             text: $repoName,
                             placeholder: "model-id",
                             mono: true,
-                            width: 240
+                            width: .controlMedium
                         )
                     }
                 }
@@ -1101,7 +1101,7 @@ private struct UploadModalView: View {
                 ) {
                     Popup(
                         selection: $readmeSourcePath,
-                        width: 260,
+                        width: .controlWide,
                         options: readmeOptions
                     )
                 }

--- a/apps/omlx-mac/Sources/AppView/Screens/SecurityScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/SecurityScreen.swift
@@ -27,13 +27,7 @@ struct SecurityScreen: View {
             AuthenticationSection(vm: vm, client: services.client)
             SubKeysSection(vm: vm, client: services.client)
 
-            if let error = vm.lastError {
-                Text(error)
-                    .font(.omlxText(11))
-                    .foregroundStyle(.red)
-                    .padding(.horizontal, 18)
-                    .padding(.top, 8)
-            }
+            FooterBar(error: vm.lastError)
         }
         .task { await vm.load(client: services.client) }
     }

--- a/apps/omlx-mac/Sources/AppView/Screens/SecurityScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/SecurityScreen.swift
@@ -216,10 +216,9 @@ private struct AuthenticationSection: View {
                                  comment: "Sublabel for the disable API key verification toggle"),
                 isLast: true
             ) {
-                Toggle("", isOn: vm.bind($vm.skipApiKeyVerification, save: {
+                RowSwitch(isOn: vm.bind($vm.skipApiKeyVerification, save: {
                     Task { await vm.saveSkipApiKeyVerification(client: client) }
                 }))
-                .labelsHidden().toggleStyle(.switch)
             }
         }
     }

--- a/apps/omlx-mac/Sources/AppView/Screens/SecurityScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/SecurityScreen.swift
@@ -103,7 +103,7 @@ private struct APIKeyEditorRow: View {
                           comment: "Row label for the API key editor"),
             sublabel: sublabel, isLast: true) {
             HStack(spacing: 6) {
-                TextInput("security.api_key.row_label", text: $draft, placeholder: "sk-omlx-…", isSecure: !showKey, mono: true, width: 260)
+                TextInput("security.api_key.row_label", text: $draft, placeholder: "sk-omlx-…", isSecure: !showKey, mono: true, width: .controlMedium)
                     .onSubmit { Task { await save() } }
                 iconButton(systemName: showKey ? "eye.slash" : "eye",
                            help: showKey
@@ -270,7 +270,7 @@ private struct SubKeysSection: View {
                               placeholder: String(localized: "security.sub_keys.name_placeholder",
                                                   defaultValue: "Claude Code on laptop",
                                                   comment: "Placeholder text for sub-key name input"),
-                              width: 220)
+                              width: .controlMedium)
                 }
                 Row(label: String(localized: "security.sub_keys.key_label",
                                   defaultValue: "Key",
@@ -280,7 +280,7 @@ private struct SubKeysSection: View {
                                   placeholder: String(localized: "security.sub_keys.key_placeholder",
                                                       defaultValue: "sk-omlx-sub-…",
                                                       comment: "Placeholder text inside the sub-key value input"),
-                                  mono: true, width: 220)
+                                  mono: true, width: .controlMedium)
                         Button {
                             newKey = APIKeyGenerator.random()
                         } label: {

--- a/apps/omlx-mac/Sources/AppView/Screens/ServerScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ServerScreen.swift
@@ -316,7 +316,7 @@ struct ServerHeroCard: View {
         // Hero card surface follows the grouped Settings style. Status is
         // carried by the pill/actions, not by a colored background wash.
         .background(heroBackground)
-        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .clipShape(RoundedRectangle(cornerRadius: theme.cornerRadius, style: .continuous))
         .padding(.horizontal, 14)
         .padding(.bottom, 14)
     }
@@ -673,7 +673,8 @@ private struct ServerAdvancedSection: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .padding(.horizontal, 18)
+            // Matches SectionHeader's indent (card gutter + row inset).
+            .padding(.horizontal, 28)
             .padding(.top, 22)
             .padding(.bottom, 8)
 

--- a/apps/omlx-mac/Sources/AppView/Screens/ServerScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ServerScreen.swift
@@ -27,7 +27,7 @@ struct ServerScreen: View {
                                   comment: "Row label for the listen-address picker in Server screen")) {
                     Popup(
                         selection: vm.bind($vm.host, save: { vm.saveHost(services: services) }),
-                        width: 220,
+                        width: .controlMedium,
                         options: [
                             ("127.0.0.1", String(localized: "server.host.local_only",
                                                   defaultValue: "127.0.0.1 (Local only)",
@@ -53,7 +53,7 @@ struct ServerScreen: View {
                                      comment: "Sublabel under the Port field"),
                     isLast: true
                 ) {
-                    TextInput(text: $vm.portText, mono: true, width: 90)
+                    TextInput(text: $vm.portText, mono: true, width: .controlNarrow)
                 }
             }
 
@@ -106,7 +106,7 @@ struct ServerScreen: View {
                     isLast: true) {
                     Popup(
                         selection: vm.bind($vm.logLevel, save: vm.saveLogLevel),
-                        width: 130,
+                        width: .controlCompact,
                         options: [
                             ("error",   String(localized: "server.log_level.error",
                                                 defaultValue: "Error",
@@ -145,7 +145,7 @@ struct ServerScreen: View {
                                      defaultValue: "OMLX_BASE_PATH. Files move and the server restarts when this changes.",
                                      comment: "Sublabel under the Base Path field")
                 ) {
-                    TextInput(text: $vm.basePathText, mono: true, width: 280)
+                    TextInput(text: $vm.basePathText, mono: true, width: .controlWide)
                 }
                 FreeRow {
                     ModelDirectoriesEditor(vm: vm)
@@ -253,7 +253,7 @@ private struct ModelDirectoriesEditor: View {
             TextInput(text: Binding(
                 get: { vm.modelDirText(at: index) },
                 set: { vm.setModelDirText($0, at: index) }
-            ), mono: true, width: 340)
+            ), mono: true, width: .controlWide)
 
             Button {
                 vm.browseModelDirectory(at: index)
@@ -461,7 +461,7 @@ private struct ServerDefaultProfileEditor: View {
                     sublabel: String(localized: "server.profile.context_window.sub",
                                      defaultValue: "Maximum prompt + completion tokens.",
                                      comment: "Sublabel for the context window field")) {
-                    TextInput(text: $vm.samplingContextText, mono: true, suffix: "tk", width: 110)
+                    TextInput(text: $vm.samplingContextText, mono: true, suffix: "tk", width: .controlCompact)
                 }
                 Row(label: String(localized: "server.profile.max_tokens",
                                   defaultValue: "Max Tokens",
@@ -469,7 +469,7 @@ private struct ServerDefaultProfileEditor: View {
                     sublabel: String(localized: "server.profile.max_tokens.sub",
                                      defaultValue: "Server-wide cap on generated tokens.",
                                      comment: "Sublabel for the max tokens field")) {
-                    TextInput(text: $vm.samplingMaxTokensText, mono: true, suffix: "tk", width: 110)
+                    TextInput(text: $vm.samplingMaxTokensText, mono: true, suffix: "tk", width: .controlCompact)
                 }
                 Row(label: String(localized: "server.profile.temperature",
                                   defaultValue: "Temperature",
@@ -477,7 +477,7 @@ private struct ServerDefaultProfileEditor: View {
                     sublabel: String(localized: "server.profile.temperature.sub",
                                      defaultValue: "Sampling randomness (0–2).",
                                      comment: "Sublabel for the temperature field")) {
-                    TextInput(text: $vm.samplingTemperatureText, placeholder: "0.7", mono: true, width: 90)
+                    TextInput(text: $vm.samplingTemperatureText, placeholder: "0.7", mono: true, width: .controlNarrow)
                 }
                 Row(label: String(localized: "server.profile.top_p",
                                   defaultValue: "Top P",
@@ -485,7 +485,7 @@ private struct ServerDefaultProfileEditor: View {
                     sublabel: String(localized: "server.profile.top_p.sub",
                                      defaultValue: "Nucleus sampling cutoff (0–1).",
                                      comment: "Sublabel for the Top P field")) {
-                    TextInput(text: $vm.samplingTopPText, mono: true, width: 90)
+                    TextInput(text: $vm.samplingTopPText, mono: true, width: .controlNarrow)
                 }
                 Row(label: String(localized: "server.profile.top_k",
                                   defaultValue: "Top K",
@@ -493,7 +493,7 @@ private struct ServerDefaultProfileEditor: View {
                     sublabel: String(localized: "server.profile.top_k.sub",
                                      defaultValue: "Limit candidates to top K. 0 = disabled.",
                                      comment: "Sublabel for the Top K field")) {
-                    TextInput(text: $vm.samplingTopKText, mono: true, width: 90)
+                    TextInput(text: $vm.samplingTopKText, mono: true, width: .controlNarrow)
                 }
                 Row(label: String(localized: "server.profile.repetition_penalty",
                                   defaultValue: "Repetition Penalty",
@@ -503,7 +503,7 @@ private struct ServerDefaultProfileEditor: View {
                                      comment: "Sublabel for the repetition penalty field"),
                     isLast: !expanded
                 ) {
-                    TextInput(text: $vm.samplingRepetitionPenaltyText, mono: true, width: 90)
+                    TextInput(text: $vm.samplingRepetitionPenaltyText, mono: true, width: .controlNarrow)
                 }
                 if expanded {
                     // The remaining design rows aren't server-backed yet —
@@ -695,7 +695,7 @@ private struct ServerAdvancedSection: View {
                             text: $vm.maxAudioUploadSizeText,
                             placeholder: "100MB",
                             mono: true,
-                            width: 130
+                            width: .controlCompact
                         )
                     }
                     Row(
@@ -708,7 +708,7 @@ private struct ServerAdvancedSection: View {
                     ) {
                         Popup(
                             selection: vm.bind($vm.sseKeepaliveMode, save: vm.saveSseKeepaliveMode),
-                            width: 130,
+                            width: .controlCompact,
                             options: [
                                 ("chunk",   String(localized: "server.advanced.sse_keepalive.chunk",
                                                     defaultValue: "Chunk",
@@ -735,7 +735,7 @@ private struct ServerAdvancedSection: View {
                             text: $vm.serverAliasesText,
                             placeholder: "omlx.local, oMLX.lan",
                             mono: true,
-                            width: 320
+                            width: .controlWide
                         )
                     }
                 }

--- a/apps/omlx-mac/Sources/AppView/Screens/ServerScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ServerScreen.swift
@@ -88,11 +88,9 @@ struct ServerScreen: View {
                                      comment: "Sublabel explaining the auto-start on launch setting"),
                     isLast: true
                 ) {
-                    Toggle("", isOn: vm.bind($vm.autoStartOnLaunch, save: {
+                    RowSwitch(isOn: vm.bind($vm.autoStartOnLaunch, save: {
                         vm.saveAutoStartOnLaunch(services: services)
                     }))
-                    .labelsHidden()
-                    .toggleStyle(.switch)
                 }
             }
 
@@ -159,9 +157,7 @@ struct ServerScreen: View {
                                      comment: "Sublabel for enabling Hugging Face local cache discovery"),
                     isLast: true
                 ) {
-                    Toggle("", isOn: $vm.hfCacheEnabled)
-                        .labelsHidden()
-                        .toggleStyle(.switch)
+                    RowSwitch(isOn: $vm.hfCacheEnabled)
                 }
             }
             ServerAdvancedSection(vm: vm)

--- a/apps/omlx-mac/Sources/AppView/Screens/ServerScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ServerScreen.swift
@@ -162,8 +162,12 @@ struct ServerScreen: View {
             }
             ServerAdvancedSection(vm: vm)
 
-            HStack {
-                Spacer()
+            FooterBar(
+                hint: String(localized: "server.footer.hint",
+                             defaultValue: "Listen Address, Log Level, and SSE Keep-Alive Mode apply the moment you change them. The rest (port, default profile, storage, aliases) commits when you click Apply. Port and storage changes take effect after a server restart.",
+                             comment: "Hint footer text under the Server screen explaining which controls apply immediately vs. via the Apply button"),
+                error: vm.lastError
+            ) {
                 Button(String(localized: "server.button.apply",
                               defaultValue: "Apply",
                               comment: "Button to apply pending server settings: port, default profile, storage, and aliases")) {
@@ -173,10 +177,6 @@ struct ServerScreen: View {
                     .disabled(!vm.hasPendingServerChanges(services: services)
                               || vm.isMovingBasePath)
             }
-            .padding(.horizontal, 18)
-            .padding(.top, 6)
-
-            HintFooter(error: vm.lastError)
         }
         .task {
             // services.config is already populated by AppDelegate before this
@@ -740,24 +740,4 @@ private struct ServerAdvancedSection: View {
     }
 }
 
-// MARK: - Footer hint
 
-private struct HintFooter: View {
-    let error: String?
-    @Environment(\.omlxTheme) private var theme
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HintLine(text: String(localized: "server.footer.hint",
-                                  defaultValue: "Listen Address, Log Level, and SSE Keep-Alive Mode apply the moment you change them. The rest (port, default profile, storage, aliases) commits when you click Apply. Port and storage changes take effect after a server restart.",
-                                  comment: "Hint footer text under the Server screen explaining which controls apply immediately vs. via the Apply button"))
-            if let error {
-                Text(error)
-                    .font(.omlxText(11))
-                    .foregroundStyle(theme.redDot)
-            }
-        }
-        .padding(.horizontal, 18)
-        .padding(.top, 8)
-    }
-}

--- a/apps/omlx-mac/Sources/AppView/Screens/StatusScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/StatusScreen.swift
@@ -631,12 +631,10 @@ private struct UpdatesSection: View {
                                  defaultValue: "Look for updates daily in the background",
                                  comment: "Sublabel for the auto-check toggle")
             ) {
-                Toggle("", isOn: Binding(
+                RowSwitch(isOn: Binding(
                     get: { updates.autoCheck },
                     set: { updates.autoCheck = $0 }
                 ))
-                .labelsHidden()
-                .toggleStyle(.switch)
             }
             Row(
                 label: String(localized: "status.updates.auto_download",
@@ -647,12 +645,10 @@ private struct UpdatesSection: View {
                                  comment: "Sublabel for the automatic update notification toggle"),
                 isLast: true
             ) {
-                Toggle("", isOn: Binding(
+                RowSwitch(isOn: Binding(
                     get: { updates.autoNotify },
                     set: { updates.autoNotify = $0 }
                 ))
-                .labelsHidden()
-                .toggleStyle(.switch)
             }
         }
     }

--- a/apps/omlx-mac/Sources/AppView/Screens/StatusScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/StatusScreen.swift
@@ -125,12 +125,7 @@ struct StatusScreen: View {
                                   comment: "Section header for the updates section"))
             UpdatesSection(updates: services.updates)
 
-            if let error = vm.lastError {
-                Text(error)
-                    .font(.omlxText(11))
-                    .foregroundStyle(.red)
-                    .padding(.horizontal, 18).padding(.top, 8)
-            }
+            FooterBar(error: vm.lastError)
         }
         .task(id: vm.scope) {
             await vm.start(client: services.client)

--- a/apps/omlx-mac/Sources/AppView/Screens/StatusScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/StatusScreen.swift
@@ -619,7 +619,7 @@ private struct UpdatesSection: View {
                         get: { updates.channel },
                         set: { updates.channel = $0 }
                     ),
-                    width: 190,
+                    width: .controlMedium,
                     options: UpdateChannel.allCases.map { ($0, $0.displayName) }
                 )
             }

--- a/apps/omlx-mac/Sources/AppView/Screens/ThroughputBenchScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ThroughputBenchScreen.swift
@@ -242,9 +242,7 @@ private struct ConfigurationSection: View {
                 sublabel: String(localized: "bench.throughput.row.ane_alignment.sub",
                                  defaultValue: "Add one prompt token so PP4097 produces exactly 4,096 prefill rows. Aligned results remain local.",
                                  comment: "Explanation of the ANE-aligned throughput benchmark option")) {
-                Toggle("", isOn: $alignPromptToAne)
-                    .labelsHidden()
-                    .toggleStyle(.switch)
+                RowSwitch(isOn: $alignPromptToAne)
                     .disabled(running)
             }
 

--- a/apps/omlx-mac/Sources/AppView/Screens/ThroughputBenchScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ThroughputBenchScreen.swift
@@ -129,7 +129,7 @@ private struct DeviceChip: View {
                 .foregroundStyle(theme.textSecondary)
             Spacer(minLength: 0)
         }
-        .padding(.horizontal, 18)
+        .padding(.horizontal, 14)
         .padding(.top, 2)
         .padding(.bottom, 8)
     }
@@ -232,7 +232,6 @@ private struct ConfigurationSection: View {
                                      defaultValue: "Full · 2,048",
                                      comment: "Full 2048-token ANE benchmark warm-up option")),
                 ])
-                .frame(width: 260)
                 .disabled(running)
             }
 
@@ -915,7 +914,7 @@ private struct OwnerHashRow: View {
             }
             .buttonStyle(.omlx(.plain, size: .small))
         }
-        .padding(.horizontal, 18)
+        .padding(.horizontal, 14)
         .padding(.top, 4)
         .padding(.bottom, 10)
     }

--- a/apps/omlx-mac/Sources/AppView/Screens/ThroughputBenchScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ThroughputBenchScreen.swift
@@ -245,18 +245,18 @@ private struct ConfigurationSection: View {
                     .disabled(running)
             }
 
-            FreeRow {
-                ChipRow(
-                    title: String(localized: "bench.throughput.row.context_lengths.title",
-                                  defaultValue: "Context lengths",
-                                  comment: "Inline title above the prompt-length chip row"),
-                    sublabel: String(localized: "bench.throughput.row.context_lengths.sub",
-                                     defaultValue: "Prompt tokens to feed for each single-request trial",
-                                     comment: "Sublabel under the prompt-length chip row"),
+            Row(label: String(localized: "bench.throughput.row.context_lengths.title",
+                              defaultValue: "Context lengths",
+                              comment: "Inline title above the prompt-length chip row"),
+                sublabel: String(localized: "bench.throughput.row.context_lengths.sub",
+                                 defaultValue: "Prompt tokens to feed for each single-request trial",
+                                 comment: "Sublabel under the prompt-length chip row")) {
+                ChipGroup(
                     options: Self.promptLengthOptions,
                     selection: $promptLengths,
                     format: Self.formatPromptLength
                 )
+                .disabled(running)
             }
 
             Row(label: String(localized: "bench.throughput.row.gen_length.label",
@@ -273,18 +273,18 @@ private struct ConfigurationSection: View {
                 )
             }
 
-            FreeRow {
-                ChipRow(
-                    title: String(localized: "bench.throughput.row.batch_sizes.title",
-                                  defaultValue: "Batch sizes",
-                                  comment: "Inline title above the batch-size chip row"),
-                    sublabel: String(localized: "bench.throughput.row.batch_sizes.sub",
-                                     defaultValue: "Concurrent requests per batch in the continuous-batching phase",
-                                     comment: "Sublabel under the batch-size chip row"),
+            Row(label: String(localized: "bench.throughput.row.batch_sizes.title",
+                              defaultValue: "Batch sizes",
+                              comment: "Inline title above the batch-size chip row"),
+                sublabel: String(localized: "bench.throughput.row.batch_sizes.sub",
+                                 defaultValue: "Concurrent requests per batch in the continuous-batching phase",
+                                 comment: "Sublabel under the batch-size chip row")) {
+                ChipGroup(
                     options: Self.batchSizeOptions,
                     selection: $batchSizes,
                     format: { "\($0)" }
                 )
+                .disabled(running)
             }
 
             Row(isLast: true) {
@@ -354,36 +354,24 @@ private struct ConfigurationSection: View {
     }
 }
 
-// MARK: - Chip row
+// MARK: - Chip group
 
-private struct ChipRow: View {
-    let title: String
-    let sublabel: String
+/// Multi-select strip of toggle chips, used as a `Row` trailing. Styled to
+/// echo the segmented control — quiet fill, accent when selected — but with
+/// detached segments and gaps because multiple values can be active at once.
+private struct ChipGroup: View {
     let options: [Int]
     @Binding var selection: Set<Int>
     let format: (Int) -> String
 
-    @Environment(\.omlxTheme) private var theme
-
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(title)
-                    .font(.omlxText(13, weight: .medium))
-                    .foregroundStyle(theme.text)
-                Text(sublabel)
-                    .font(.omlxText(11.5))
-                    .foregroundStyle(theme.textSecondary)
-            }
-            HStack(spacing: 6) {
-                ForEach(options, id: \.self) { value in
-                    Chip(
-                        label: format(value),
-                        isSelected: selection.contains(value),
-                        onTap: { toggle(value) }
-                    )
-                }
-                Spacer(minLength: 0)
+        HStack(spacing: 5) {
+            ForEach(options, id: \.self) { value in
+                Chip(
+                    label: format(value),
+                    isSelected: selection.contains(value),
+                    onTap: { toggle(value) }
+                )
             }
         }
     }
@@ -408,19 +396,16 @@ private struct Chip: View {
         Button(action: onTap) {
             Text(label)
                 .font(.omlxText(11.5, weight: .medium))
-                .foregroundStyle(isSelected ? theme.accentText : theme.textSecondary)
+                // Chips must never compress: under width pressure SwiftUI
+                // would otherwise wrap "128K" to "12/8K". The label column
+                // absorbs the squeeze instead.
+                .fixedSize()
+                .foregroundStyle(isSelected ? theme.accentText : theme.text)
                 .padding(.horizontal, 10)
                 .padding(.vertical, 4)
                 .background(
                     RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .fill(isSelected ? theme.accent : theme.controlBg)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                .strokeBorder(
-                                    isSelected ? Color.clear : theme.inputBorder,
-                                    lineWidth: 0.5
-                                )
-                        )
+                        .fill(isSelected ? theme.accent : theme.hoverBg)
                 )
                 .contentShape(Rectangle())
         }

--- a/apps/omlx-mac/Sources/AppView/Screens/ThroughputBenchScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ThroughputBenchScreen.swift
@@ -197,7 +197,7 @@ private struct ConfigurationSection: View {
                                  comment: "Sublabel under the Throughput Bench model picker")) {
                 Popup(
                     selection: $selectedModelId,
-                    width: 320,
+                    width: .controlWide,
                     options: modelOptions
                 )
             }
@@ -210,7 +210,7 @@ private struct ConfigurationSection: View {
                                  comment: "Sublabel under the Throughput Bench context picker")) {
                 Popup(
                     selection: $contextProfile,
-                    width: 220,
+                    width: .controlMedium,
                     options: BenchmarkContextProfile.allCases.map {
                         PopupOption(value: $0, label: $0.localizedLabel)
                     }
@@ -272,7 +272,7 @@ private struct ConfigurationSection: View {
                     text: $genLength,
                     placeholder: "128",
                     mono: true,
-                    width: 110
+                    width: .controlCompact
                 )
             }
 

--- a/apps/omlx-mac/Sources/Menubar/MenubarMetricPopover.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarMetricPopover.swift
@@ -206,12 +206,19 @@ struct MetricSparkline: View {
             let isFlat = span <= .ulpOfOne
             let stepX = size.width / CGFloat(values.count - 1)
 
+            // Inset the plot range by half the stroke width so a series
+            // pinned to the floor (0%) or ceiling doesn't center its stroke
+            // on the canvas edge and render half-clipped.
+            let lineWidth: CGFloat = 1.2
+            let plotTop = lineWidth / 2
+            let plotHeight = size.height - lineWidth
+
             var trace = Path()
             for (index, value) in values.enumerated() {
                 let normalized = isFlat ? 0.5 : (value - low) / span
                 let point = CGPoint(
                     x: CGFloat(index) * stepX,
-                    y: size.height * (1 - CGFloat(normalized))
+                    y: plotTop + plotHeight * (1 - CGFloat(normalized))
                 )
                 if index == 0 {
                     trace.move(to: point)
@@ -235,7 +242,7 @@ struct MetricSparkline: View {
             context.stroke(
                 trace,
                 with: .color(color),
-                style: StrokeStyle(lineWidth: 1.2, lineJoin: .round)
+                style: StrokeStyle(lineWidth: lineWidth, lineJoin: .round)
             )
         }
         .frame(height: height)

--- a/apps/omlx-mac/Sources/Theme/Components/Button.swift
+++ b/apps/omlx-mac/Sources/Theme/Components/Button.swift
@@ -1,15 +1,18 @@
-// PR 3 — button styles for primary / destructive / plain / regular.
+// Button styles for primary / destructive / normal / plain.
 //
 // Use:
 //   Button("Save") { … }
 //     .buttonStyle(.omlx(.primary))
 //
-// The plain kind is the JSX "kind=plain" — borderless action label, e.g. the
-// chevron-only row buttons in screens.
+// primary / destructive / normal delegate to the native bordered styles so
+// buttons share bezel metrics, fonts, and disabled/pressed treatment with
+// the native fields and pickers they sit next to. plain stays a quiet
+// custom label (text-colored, hover-highlight only) because the native
+// borderless style would accent-tint the many icon-only row buttons.
 
 import SwiftUI
 
-struct OMLXButtonStyle: ButtonStyle {
+struct OMLXButtonStyle: PrimitiveButtonStyle {
     enum Kind: Sendable { case primary, destructive, normal, plain }
     enum Size: Sendable { case small, regular }
 
@@ -17,72 +20,46 @@ struct OMLXButtonStyle: ButtonStyle {
     let size: Size
 
     @Environment(\.omlxTheme) private var theme
-    /// Without this, a `.disabled()` button keeps its enabled paint because the
-    /// custom background ignores SwiftUI's default isEnabled tint. Users then
-    /// click an enabled-looking primary button and see no press animation
-    /// (SwiftUI suppresses `isPressed` on disabled buttons) — leading to the
-    /// "Apply only animates the first time" report. Reading `isEnabled` here
-    /// dims the whole label so disabled state is visually unmistakable.
-    @Environment(\.isEnabled) private var isEnabled
-
-    func makeBody(configuration: Configuration) -> some View {
-        let labelFont = Font.omlxText(size == .small ? 11.5 : 13, weight: .medium)
-        let hPad: CGFloat = size == .small ? 10 : 12
-        let vPad: CGFloat = size == .small ? 4 : 6
-
-        return configuration.label
-            .font(labelFont)
-            .padding(.horizontal, hPad)
-            .padding(.vertical, vPad)
-            .foregroundStyle(foreground(configuration))
-            .background(background(configuration))
-            .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
-            .overlay(border(configuration))
-            .opacity(opacity(configuration))
-            .contentShape(Rectangle())
-    }
-
-    /// Disabled state wins over press feedback. 0.45 is the macOS-feeling
-    /// "this control is inert" tint — tested against `.primary` (blue),
-    /// `.destructive` (red), `.normal` (themed control bg), and `.plain`
-    /// (transparent + dimmed text).
-    private func opacity(_ cfg: Configuration) -> Double {
-        guard isEnabled else { return 0.45 }
-        return cfg.isPressed ? 0.78 : 1.0
-    }
 
     @ViewBuilder
-    private func background(_ cfg: Configuration) -> some View {
+    func makeBody(configuration: Configuration) -> some View {
+        let button = Button(configuration)
+            .controlSize(size == .small ? .small : .regular)
         switch kind {
         case .primary:
-            theme.accent
+            button.buttonStyle(.borderedProminent)
         case .destructive:
-            theme.redDot
+            button.buttonStyle(.borderedProminent).tint(theme.redDot)
         case .normal:
-            theme.controlBg
+            button.buttonStyle(.bordered)
         case .plain:
-            cfg.isPressed ? theme.hoverBg : Color.clear
-        }
-    }
-
-    private func foreground(_ cfg: Configuration) -> Color {
-        switch kind {
-        case .primary, .destructive: return theme.accentText
-        case .normal: return theme.text
-        case .plain:  return theme.text
-        }
-    }
-
-    @ViewBuilder
-    private func border(_ cfg: Configuration) -> some View {
-        if kind == .normal {
-            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                .strokeBorder(theme.inputBorder, lineWidth: 0.5)
+            button.buttonStyle(QuietButtonStyle(theme: theme, size: size))
         }
     }
 }
 
-extension ButtonStyle where Self == OMLXButtonStyle {
+/// The former custom "plain" rendering: label in text color, hover-style
+/// highlight while pressed, dimmed when disabled.
+private struct QuietButtonStyle: ButtonStyle {
+    let theme: OMLXTheme
+    let size: OMLXButtonStyle.Size
+
+    @Environment(\.isEnabled) private var isEnabled
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.omlxText(size == .small ? 11.5 : 13, weight: .medium))
+            .padding(.horizontal, size == .small ? 10 : 12)
+            .padding(.vertical, size == .small ? 4 : 6)
+            .foregroundStyle(theme.text)
+            .background(configuration.isPressed ? theme.hoverBg : Color.clear)
+            .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+            .opacity(isEnabled ? (configuration.isPressed ? 0.78 : 1.0) : 0.45)
+            .contentShape(Rectangle())
+    }
+}
+
+extension PrimitiveButtonStyle where Self == OMLXButtonStyle {
     static func omlx(
         _ kind: OMLXButtonStyle.Kind = .normal,
         size: OMLXButtonStyle.Size = .regular

--- a/apps/omlx-mac/Sources/Theme/Components/Popup.swift
+++ b/apps/omlx-mac/Sources/Theme/Components/Popup.swift
@@ -1,4 +1,5 @@
-// PR 3 — dropdown picker styled to match the JSX `Popup`.
+// PR 3 — dropdown picker. Renders the native macOS menu picker so selects
+// share one bezel, height, and font with the rest of the system controls.
 
 import SwiftUI
 
@@ -13,78 +14,35 @@ struct Popup<Value: Hashable>: View {
     var titleKey: LocalizedStringKey
     let options: [PopupOption<Value>]
     let width: CGFloat?
-    let fillsWidth: Bool
 
-    @Environment(\.omlxTheme) private var theme
-
-    init(_ titleKey: LocalizedStringKey = "", selection: Binding<Value>, width: CGFloat? = nil, fillsWidth: Bool = false, options: [PopupOption<Value>]) {
+    init(_ titleKey: LocalizedStringKey = "", selection: Binding<Value>, width: CGFloat? = nil, options: [PopupOption<Value>]) {
         self.titleKey = titleKey
         self._selection = selection
         self.options = options
         self.width = width
-        self.fillsWidth = fillsWidth
     }
 
-    init(_ titleKey: LocalizedStringKey = "", selection: Binding<Value>, width: CGFloat? = nil, fillsWidth: Bool = false, options: [(Value, String)]) {
+    init(_ titleKey: LocalizedStringKey = "", selection: Binding<Value>, width: CGFloat? = nil, options: [(Value, String)]) {
         self.titleKey = titleKey
         self._selection = selection
         self.options = options.map { PopupOption(value: $0.0, label: $0.1) }
         self.width = width
-        self.fillsWidth = fillsWidth
     }
 
     var body: some View {
-        if fillsWidth, let width {
-            Menu {
-                ForEach(options) { opt in
-                    Button {
-                        selection = opt.value
-                    } label: {
-                        if opt.value == selection {
-                            Label(opt.label, systemImage: "checkmark")
-                        } else {
-                            Text(opt.label)
-                        }
-                    }
-                }
-            } label: {
-                HStack(spacing: 8) {
-                    Text(selectedOption?.label ?? "")
-                        .lineLimit(1)
-                    Spacer(minLength: 0)
-                    Image(systemName: "chevron.up.chevron.down")
-                        .font(.system(size: 10, weight: .semibold))
-                }
-                .font(.omlxText(13, weight: .medium))
-                .foregroundStyle(theme.text)
-                .padding(.horizontal, 10)
-                .padding(.vertical, 4)
-                .frame(width: width)
-                .background(theme.controlBg)
-                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .strokeBorder(theme.inputBorder, lineWidth: 0.5)
-                }
-                .contentShape(Rectangle())
+        Picker(titleKey, selection: $selection) {
+            ForEach(options) { opt in
+                Text(opt.label)
+                    .tag(opt.value)
             }
-            .menuStyle(.borderlessButton)
-            .accessibilityValue(selectedOption?.label ?? "")
-        } else {
-            Picker(titleKey, selection: $selection) {
-                ForEach(options) { opt in
-                    Text(opt.label)
-                        .tag(opt.value)
-                }
-            }
-            .labelsHidden()
-            .pickerStyle(.menu)
-            .frame(maxWidth: width)
         }
-    }
-
-    private var selectedOption: PopupOption<Value>? {
-        options.first { $0.value == selection }
+        .labelsHidden()
+        .pickerStyle(.menu)
+        // The native popup bezel hugs its label, and a bare `maxWidth` frame
+        // would center it — leaving air on both sides. Pin it trailing so
+        // select bezels end flush with the other controls in the column;
+        // `width` stays the cap that keeps long labels from sprawling.
+        .frame(maxWidth: width, alignment: .trailing)
     }
 }
 
@@ -93,13 +51,13 @@ struct Popup<Value: Hashable>: View {
     @Previewable @State var quant = "q4"
 
     VStack(alignment: .leading, spacing: 14) {
-        Popup(selection: $host, width: 220, options: [
+        Popup(selection: $host, width: .controlMedium, options: [
             ("127.0.0.1", "127.0.0.1 (Local only)"),
             ("0.0.0.0", "0.0.0.0 (IPv4 only)"),
             ("::", "0.0.0.0 & :: (All Networks)"),
             ("localhost", "localhost"),
         ])
-        Popup(selection: $quant, width: 120, options: [
+        Popup(selection: $quant, width: .controlCompact, options: [
             ("auto", "Auto"), ("q4", "q4"), ("q5", "q5"), ("q6", "q6"), ("q8", "q8"), ("fp16", "fp16"),
         ])
     }

--- a/apps/omlx-mac/Sources/Theme/Components/Row.swift
+++ b/apps/omlx-mac/Sources/Theme/Components/Row.swift
@@ -59,6 +59,24 @@ struct Row<Trailing: View>: View {
     }
 }
 
+/// Trailing on/off switch for a `Row`. One shared control so every screen
+/// gets the same size: `.small`, matching System Settings rows — the default
+/// regular switch reads oversized next to 13 pt row labels.
+struct RowSwitch: View {
+    @Binding var isOn: Bool
+
+    init(isOn: Binding<Bool>) {
+        self._isOn = isOn
+    }
+
+    var body: some View {
+        Toggle("", isOn: $isOn)
+            .labelsHidden()
+            .toggleStyle(.switch)
+            .controlSize(.small)
+    }
+}
+
 extension Row where Trailing == EmptyView {
     /// Label-only row (no trailing slot).
     init(label: String, sublabel: String? = nil, isLast: Bool = false) {
@@ -182,14 +200,14 @@ struct LinkRow<Icon: View>: View {
             CodeChip(value: "127.0.0.1:8000")
         }
         Row(label: "Auto-start on launch") {
-            Toggle("", isOn: $autoStart).labelsHidden().toggleStyle(.switch)
+            RowSwitch(isOn: $autoStart)
         }
         Row(
             label: "Require API Key",
             sublabel: "Reject unauthenticated /v1 requests",
             isLast: true
         ) {
-            Toggle("", isOn: $requireKey).labelsHidden().toggleStyle(.switch)
+            RowSwitch(isOn: $requireKey)
         }
     }
     .padding(.vertical, 14)

--- a/apps/omlx-mac/Sources/Theme/Components/Row.swift
+++ b/apps/omlx-mac/Sources/Theme/Components/Row.swift
@@ -158,8 +158,16 @@ struct LinkRow<Icon: View>: View {
         )
     }
 
+    @State private var hovering = false
+
+    // The whole row is one button (System Settings convention for rows
+    // that open a URL); the trailing ↗ is a passive indicator, not a
+    // separate control. Hover feedback replaces FreeRow so the highlight
+    // spans the full row width.
     var body: some View {
-        FreeRow(isLast: isLast) {
+        Button {
+            NSWorkspace.shared.open(url)
+        } label: {
             HStack(spacing: 10) {
                 iconView
                     .foregroundStyle(theme.textSecondary)
@@ -176,13 +184,24 @@ struct LinkRow<Icon: View>: View {
 
                 Spacer(minLength: 8)
 
-                Button {
-                    NSWorkspace.shared.open(url)
-                } label: {
-                    Label("common.open", systemImage: "arrow.up.right.square")
-                        .labelStyle(.iconOnly)
-                }
-                .buttonStyle(.omlx(.plain, size: .small))
+                Image(systemName: "arrow.up.right.square")
+                    .font(.system(size: 14))
+                    .foregroundStyle(theme.textSecondary)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .background(hovering ? theme.hoverBg : .clear)
+        .onHover { hovering = $0 }
+        .overlay(alignment: .bottom) {
+            if !isLast {
+                Rectangle()
+                    .fill(theme.rowSep)
+                    .frame(height: 0.5)
+                    .padding(.horizontal, 14)
             }
         }
     }

--- a/apps/omlx-mac/Sources/Theme/Components/ScreenScaffold.swift
+++ b/apps/omlx-mac/Sources/Theme/Components/ScreenScaffold.swift
@@ -106,6 +106,54 @@ struct HintLine: View {
             Text(text)
                 .font(.omlxText(11))
                 .foregroundStyle(theme.textTertiary)
+                .fixedSize(horizontal: false, vertical: true)
         }
+    }
+}
+
+/// Bottom action bar shared by screens with a trailing primary action
+/// (Apply and friends): optional hint on the left that wraps under width
+/// pressure, action buttons flush right, optional error line underneath.
+/// One component so the button/note relationship is identical everywhere.
+struct FooterBar<Actions: View>: View {
+    var hint: String? = nil
+    var error: String? = nil
+    @ViewBuilder var actions: () -> Actions
+
+    @Environment(\.omlxTheme) private var theme
+
+    private var hasHint: Bool { !(hint ?? "").isEmpty }
+    private var hasError: Bool { !(error ?? "").isEmpty }
+    private var hasActions: Bool { Actions.self != EmptyView.self }
+
+    var body: some View {
+        if hasHint || hasError || hasActions {
+            VStack(alignment: .leading, spacing: 6) {
+                if hasHint || hasActions {
+                    HStack(alignment: .center, spacing: 12) {
+                        if let hint, hasHint {
+                            HintLine(text: hint)
+                        }
+                        Spacer(minLength: 0)
+                        actions()
+                    }
+                }
+                if let error, hasError {
+                    Text(error)
+                        .font(.omlxText(11))
+                        .foregroundStyle(theme.redDot)
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.top, 8)
+        }
+    }
+}
+
+extension FooterBar where Actions == EmptyView {
+    /// Error-only (or hint-only) footer — the standard trailing status line
+    /// under a screen. Renders nothing while there is nothing to show.
+    init(hint: String? = nil, error: String? = nil) {
+        self.init(hint: hint, error: error) { EmptyView() }
     }
 }

--- a/apps/omlx-mac/Sources/Theme/Components/ScreenScaffold.swift
+++ b/apps/omlx-mac/Sources/Theme/Components/ScreenScaffold.swift
@@ -66,7 +66,7 @@ struct MessageBanner: View {
                 row(icon: "checkmark.circle.fill", text: success, color: theme.greenDot)
             }
         }
-        .padding(.horizontal, 18)
+        .padding(.horizontal, 14)
         .padding(.top, (hasError || hasSuccess) ? 6 : 0)
     }
 

--- a/apps/omlx-mac/Sources/Theme/Components/SectionHeader.swift
+++ b/apps/omlx-mac/Sources/Theme/Components/SectionHeader.swift
@@ -36,7 +36,9 @@ struct SectionHeader<Trailing: View>: View {
             Spacer(minLength: 0)
             trailing
         }
-        .padding(.horizontal, 14)
+        // 28 = card gutter (14) + row inset (14): header text lines up with
+        // the row text inside the ListGroup below, like System Settings.
+        .padding(.horizontal, 28)
         .padding(.top, 14)
         .padding(.bottom, 6)
     }

--- a/apps/omlx-mac/Sources/Theme/Components/TextInput.swift
+++ b/apps/omlx-mac/Sources/Theme/Components/TextInput.swift
@@ -40,7 +40,9 @@ struct TextInput: View {
         field
             .lineLimit(1)
             .textFieldStyle(.roundedBorder)
-            .font(mono ? .omlxMono(13, weight: .medium) : .omlxText(13, weight: .medium))
+            // Regular weight: native macOS fields never render medium-weight
+            // content, and the bolder text read as a foreign control.
+            .font(mono ? .omlxMono(13) : .omlxText(13))
             .foregroundStyle(theme.text)
             .overlay(alignment: .trailing) {
                 HStack(spacing: 0) {
@@ -55,7 +57,10 @@ struct TextInput: View {
                     }
                 }
             }
-            .frame(maxWidth: width)
+            // Fixed, not max: under `maxWidth` a long row label squeezes the
+            // field, so fields sharing a width token rendered ragged widths.
+            // A fixed frame makes equal tokens render equal; labels wrap.
+            .frame(width: width)
     }
 
     private var field: some View {
@@ -93,11 +98,11 @@ struct TextInput: View {
     @Previewable @State var showKey = false
     @Previewable @State var alias = ""
     VStack(alignment: .leading, spacing: 14) {
-        TextInput(text: $port, placeholder: "Port", mono: true, width: 110)
-        TextInput(text: $qty, placeholder: "Quantity", isNumeric: true, suffix: "qty", width: 160)
-        TextInput(text: $temperature, placeholder: "Temperature", isNumeric: true, range: 0...2, step: 0.1, width: 160)
+        TextInput(text: $port, placeholder: "Port", mono: true, width: .controlCompact)
+        TextInput(text: $qty, placeholder: "Quantity", isNumeric: true, suffix: "qty", width: .controlCompact)
+        TextInput(text: $temperature, placeholder: "Temperature", isNumeric: true, range: 0...2, step: 0.1, width: .controlCompact)
         HStack {
-            TextInput(text: $pwd, placeholder: "Admin password", isSecure: !showKey, width: 200)
+            TextInput(text: $pwd, placeholder: "Admin password", isSecure: !showKey, width: .controlMedium)
             Button {
                 showKey.toggle()
             } label: {
@@ -107,7 +112,7 @@ struct TextInput: View {
             .buttonStyle(.plain)
         }
         TextInput(text: $alias, placeholder: "model-id-suffix", mono: true,
-                  suffix: "alias", width: 240)
+                  suffix: "alias", width: .controlMedium)
     }
     .padding(24)
     .omlxThemed()

--- a/apps/omlx-mac/Sources/Theme/Theme.swift
+++ b/apps/omlx-mac/Sources/Theme/Theme.swift
@@ -261,6 +261,23 @@ extension View {
     func omlxThemed() -> some View { modifier(OMLXThemeBinder()) }
 }
 
+// MARK: - Control metrics
+
+/// Standard widths for trailing controls (text inputs, selects) in settings
+/// rows. Every `TextInput`/`Popup` picks the smallest token that fits its
+/// content instead of hand-tuning a per-row width, so control edges line up
+/// between rows and across screens.
+extension CGFloat {
+    /// Bare numbers: ports, counts, factors.
+    static let controlNarrow: CGFloat = 90
+    /// Numbers with a suffix or stepper, short enum selects.
+    static let controlCompact: CGFloat = 130
+    /// Names, keys, typical selects.
+    static let controlMedium: CGFloat = 220
+    /// Paths, URLs, model-id selects.
+    static let controlWide: CGFloat = 320
+}
+
 // MARK: - Color helpers
 
 extension Color {

--- a/apps/omlx-mac/Sources/Welcome/WelcomeWindow.swift
+++ b/apps/omlx-mac/Sources/Welcome/WelcomeWindow.swift
@@ -566,7 +566,7 @@ private struct WelcomeSetupBody: View {
                                          defaultValue: "Default 8000. Change this only if the port is already in use.",
                                          comment: "Sublabel for the port field with the recommended default")
                     ) {
-                        TextInput(text: $vm.portText, mono: true, width: 96)
+                        TextInput(text: $vm.portText, mono: true, width: .controlNarrow)
                     }
 
                     WelcomeDivider()
@@ -615,7 +615,7 @@ private struct WelcomeSetupBody: View {
                                          comment: "Sublabel explaining API key usage")
                     ) {
                         HStack(spacing: 0) {
-                            TextInput("welcome.api_key.placeholder", text: $vm.apiKey, placeholder: "sk-omlx-…", isSecure: !keyVisible, mono: true, width: 210)
+                            TextInput("welcome.api_key.placeholder", text: $vm.apiKey, placeholder: "sk-omlx-…", isSecure: !keyVisible, mono: true, width: .controlMedium)
                             Button {
                                 keyVisible.toggle()
                             } label: {


### PR DESCRIPTION
## Motivation

I like the app, but small inconsistencies added up. Controls had a different width on every row. Toggles were oversized next to the 13 pt row labels. Headers and footers did not line up between screens. Each problem is small, but together they made the app feel unfinished, and after a while I could not stop noticing them. This pull request is one consistency pass. It moves every screen onto shared components and System Settings conventions.

## What changed

The changes are visual only. The public component APIs (`.buttonStyle(.omlx(...))`, `Row`, `Popup`, `TextInput`) are unchanged at their call sites, except where noted below.

- Control widths: `Theme.swift` adds four shared width tokens (`.controlNarrow`, `.controlCompact`, `.controlMedium`, `.controlWide`). All ~111 `TextInput` and `Popup` call sites now use them, so the trailing controls on a screen line up in columns. `TextInput` now uses a fixed frame. Before, a long row label squeezed its field to a random width. `Popup` is now one native `.menu` picker. The custom-drawn `fillsWidth` variant is gone.
- Toggles: All ~50 bare `Toggle("", ...)` sites now use one shared `RowSwitch`. It renders a small switch, the same size as System Settings.
- Footers: A new shared `FooterBar` shows the hint, the actions, and the error line. It replaces two private `HintFooter` copies and per-screen red error text on 11 screens. The command blocks on the Integrations screen now reuse the quiet `CopyIconButton`.
- Buttons: `OMLXButtonStyle` now delegates to the native styles. Primary and destructive use `.borderedProminent`, destructive with a red tint, and normal uses `.bordered`. The `.plain` kind keeps the quiet look.
- Spacing: The screen gutter is 14 pt everywhere. Section headers are indented 28 pt, so the header text aligns with the row text, like System Settings. All top-level cards use the 14 pt theme corner radius. Segmented controls hug their content instead of fixed frames.
- Navigation: The sidebar can no longer collapse, because a collapsed sidebar had no path back. Every screen keeps one toolbar height. On macOS 26, the invisible toolbar item that holds this height hides its glass capsule.
- Details: The Downloads source switcher is now a centered pair of tabs. The About link rows are fully clickable and highlight on hover. The throughput bench chips fit in standard rows and do not wrap mid-number. The menubar sparkline no longer clips at 0% and 100%.

Net: 28 files, +465/−586.

## Tests

- The full unit test suite passes (`xcodebuild test`, scheme oMLX).
- I tested every screen in a staged debug build, in light and dark mode, down to the minimum window width.