### PR TITLE
feat: support modular ModernBERT CrossEncoder heads

### DIFF
--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -23,6 +23,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
+from .models.sentence_transformers import is_modernbert_cross_encoder
+
 logger = logging.getLogger(__name__)
 
 ModelType = Literal["llm", "vlm", "embedding", "reranker", "audio_stt", "audio_tts", "audio_sts"]
@@ -615,6 +617,12 @@ def detect_model_type(model_path: Path) -> ModelType:
             config = json.load(f)
     except (json.JSONDecodeError, IOError):
         return "llm"
+
+    # A modular SentenceTransformers CrossEncoder keeps the bare backbone
+    # architecture in config.json; its validated module chain is the more
+    # specific reranker signal and must win before embedding detection.
+    if is_modernbert_cross_encoder(model_path):
+        return "reranker"
 
     # Check architectures field for reranker first (more specific)
     architectures = config.get("architectures", [])

--- a/omlx/models/reranker.py
+++ b/omlx/models/reranker.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any, Dict, Tuple
 
 import mlx.core as mx
+import mlx.nn as nn
 
 from ..model_discovery import (
     CAUSAL_LM_RERANKER_ARCHITECTURES,
@@ -30,6 +31,10 @@ from ..patches.qwen3_sliding_window import apply_qwen3_sliding_window_patch
 from ..utils.image import load_image
 from .mlx_embeddings_compat import (
     patch_qwen3_vl_processor_for_torch_free_image_loading,
+)
+from .sentence_transformers import (
+    ModernBertCrossEncoderPipeline,
+    parse_modernbert_cross_encoder_pipeline,
 )
 
 logger = logging.getLogger(__name__)
@@ -53,13 +58,144 @@ class RerankOutput:
     """Output from rerank operation."""
 
     scores: list[float]
-    """Relevance scores for each document (0 to 1)."""
+    """Model-native relevance scores for each document."""
 
     indices: list[int]
     """Document indices sorted by score (descending)."""
 
     total_tokens: int
     """Total number of tokens processed."""
+
+
+class SentenceTransformersCrossEncoderHead(nn.Module):
+    """GELU Dense -> LayerNorm -> scalar Dense with raw output scores."""
+
+    def __init__(self, hidden_size: int, layer_norm_eps: float):
+        super().__init__()
+        self.dense = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.activation = nn.GELU(approx="precise")
+        self.norm = nn.LayerNorm(
+            hidden_size,
+            eps=layer_norm_eps,
+            bias=True,
+        )
+        self.output = nn.Linear(hidden_size, 1, bias=True)
+
+    def __call__(self, pooled: mx.array) -> mx.array:
+        hidden = self.activation(self.dense(pooled))
+        return self.output(self.norm(hidden))
+
+
+def _sanitize_sentence_transformers_modernbert_weights(
+    weights: dict[str, Any],
+    pipeline: ModernBertCrossEncoderPipeline,
+) -> dict[str, Any]:
+    """Map root backbone and nested SentenceTransformers tensors into MLX."""
+
+    head_keys = {
+        f"{pipeline.dense_path}.linear.weight": (
+            "head.dense.weight",
+            (pipeline.hidden_size, pipeline.hidden_size),
+        ),
+        f"{pipeline.layer_norm_path}.norm.weight": (
+            "head.norm.weight",
+            (pipeline.hidden_size,),
+        ),
+        f"{pipeline.layer_norm_path}.norm.bias": (
+            "head.norm.bias",
+            (pipeline.hidden_size,),
+        ),
+        f"{pipeline.output_path}.linear.weight": (
+            "head.output.weight",
+            (1, pipeline.hidden_size),
+        ),
+        f"{pipeline.output_path}.linear.bias": ("head.output.bias", (1,)),
+    }
+    module_prefixes = tuple(
+        f"{path}."
+        for path in (
+            pipeline.dense_path,
+            pipeline.layer_norm_path,
+            pipeline.output_path,
+        )
+    )
+    present_head_keys = {
+        key for key in weights if key.startswith(module_prefixes)
+    }
+    missing = sorted(set(head_keys) - present_head_keys)
+    if missing:
+        raise ValueError(
+            f"SentenceTransformers CrossEncoder is missing head tensor(s): {missing}"
+        )
+    unexpected = sorted(present_head_keys - set(head_keys))
+    if unexpected:
+        raise ValueError(
+            f"SentenceTransformers CrossEncoder has unexpected head tensor(s): {unexpected}"
+        )
+
+    mapped: dict[str, Any] = {}
+    for key, value in weights.items():
+        if key in head_keys:
+            target, expected_shape = head_keys[key]
+            actual_shape = tuple(int(dimension) for dimension in value.shape)
+            if actual_shape != expected_shape:
+                raise ValueError(
+                    f"{key} has shape {actual_shape}; expected {expected_shape}"
+                )
+        else:
+            target = key if key.startswith("model.") else f"model.{key}"
+        if target in mapped:
+            raise ValueError(f"Duplicate mapped model tensor: {target}")
+        mapped[target] = value
+    return mapped
+
+
+class ModernBertSentenceTransformersCrossEncoder(nn.Module):
+    """Bare ModernBERT plus a validated modular CrossEncoder scoring head."""
+
+    def __init__(self, config: Any, pipeline: ModernBertCrossEncoderPipeline):
+        super().__init__()
+        from mlx_embeddings.models.modernbert import ModernBertModel
+
+        self.config = config
+        self.pipeline = pipeline
+        self.model = ModernBertModel(config)
+        self.head = SentenceTransformersCrossEncoderHead(
+            pipeline.hidden_size,
+            pipeline.layer_norm_eps,
+        )
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        attention_mask: mx.array | None = None,
+        position_ids: mx.array | None = None,
+    ) -> Any:
+        from mlx_embeddings.models.base import BaseModelOutput
+
+        if attention_mask is None:
+            attention_mask = mx.ones(input_ids.shape, dtype=mx.int32)
+        encoder_outputs = self.model(
+            input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            output_hidden_states=False,
+            return_dict=True,
+        )
+        last_hidden_state = encoder_outputs["last_hidden_state"]
+        pooled = last_hidden_state[:, 0, :]
+        raw_scores = self.head(pooled)
+        return BaseModelOutput(
+            last_hidden_state=last_hidden_state,
+            pooler_output=raw_scores,
+            hidden_states=encoder_outputs.get("hidden_states"),
+        )
+
+    def sanitize(self, weights: dict[str, Any]) -> dict[str, Any]:
+        return _sanitize_sentence_transformers_modernbert_weights(
+            weights,
+            self.pipeline,
+        )
 
 
 class MLXRerankerModel:
@@ -105,6 +241,7 @@ class MLXRerankerModel:
         self.model_name = model_name
         self.trust_remote_code = trust_remote_code
 
+        self._resolved_model_path: Path | None = None
         self.model = None
         self.processor = None
         self._loaded = False
@@ -112,6 +249,7 @@ class MLXRerankerModel:
         self._is_causal_lm = False
         self._is_jina_reranker = False
         self._is_vl_reranker = False
+        self._is_sentence_transformers_cross_encoder = False
         self._token_true_id: int | None = None
         self._token_false_id: int | None = None
         self._doc_embed_token_id: int | None = None
@@ -123,9 +261,22 @@ class MLXRerankerModel:
         self._is_compiled = False
         self._compiled_seq_logits = None
 
-    def _get_architecture(self) -> str | None:
+    def _resolve_model_path(self) -> Path:
+        """Resolve a local directory for architecture and modular-file reads."""
+
+        if self._resolved_model_path is not None:
+            return self._resolved_model_path
+        model_path = Path(self.model_name)
+        if not model_path.exists():
+            from mlx_embeddings.utils import get_model_path
+
+            model_path = get_model_path(self.model_name)
+        self._resolved_model_path = model_path
+        return model_path
+
+    def _get_architecture(self, model_path: Path | None = None) -> str | None:
         """Get the model architecture from config.json."""
-        config_path = Path(self.model_name) / "config.json"
+        config_path = (model_path or Path(self.model_name)) / "config.json"
         if not config_path.exists():
             return None
 
@@ -229,6 +380,41 @@ class MLXRerankerModel:
             str(model_path), trust_remote_code=self.trust_remote_code
         )
 
+        return model, tokenizer
+
+    def _load_modernbert_sentence_transformers(
+        self, model_path: Path
+    ) -> Tuple[Any, Any]:
+        """Load a validated modular ModernBERT CrossEncoder pipeline."""
+
+        from mlx_embeddings.models.modernbert import ModelArgs
+        from mlx_embeddings.tokenizer_utils import load_tokenizer
+        from mlx_embeddings.utils import load_model
+
+        pipeline = parse_modernbert_cross_encoder_pipeline(model_path)
+
+        class _ConfiguredModernBertCrossEncoder(
+            ModernBertSentenceTransformersCrossEncoder
+        ):
+            def __init__(self, config: Any):
+                super().__init__(config, pipeline)
+
+        def _get_model_classes(config: dict[str, Any]) -> tuple[Any, Any, None, None]:
+            return _ConfiguredModernBertCrossEncoder, ModelArgs, None, None
+
+        model = load_model(
+            model_path,
+            model_config={
+                "global_rope_theta": pipeline.global_rope_theta,
+                "local_rope_theta": pipeline.local_rope_theta,
+            },
+            get_model_classes=_get_model_classes,
+            path_to_repo=self.model_name,
+        )
+        tokenizer = load_tokenizer(
+            model_path,
+            {"trust_remote_code": self.trust_remote_code},
+        )
         return model, tokenizer
 
     def _load_vl_reranker(self) -> Tuple[Any, Any]:
@@ -796,10 +982,12 @@ class MLXRerankerModel:
         if self._loaded:
             return
 
-        # Check architecture before loading
-        self._validate_architecture()
+        # Resolve Hub IDs before architecture dispatch so modular checkpoints
+        # cannot fall through to a generic embedding loader.
+        model_path = self._resolve_model_path()
+        self._validate_architecture(model_path)
 
-        arch = self._get_architecture()
+        arch = self._get_architecture(model_path)
         logger.info(f"Loading reranker model: {self.model_name} (arch={arch})")
 
         try:
@@ -822,6 +1010,12 @@ class MLXRerankerModel:
                 # Use omlx native implementation
                 self.model, self.processor = self._load_xlm_roberta()
                 self._num_labels = getattr(self.model.config, "num_labels", None)
+            elif arch == "ModernBertModel":
+                self.model, self.processor = (
+                    self._load_modernbert_sentence_transformers(model_path)
+                )
+                self._is_sentence_transformers_cross_encoder = True
+                self._num_labels = 1
             else:
                 # Use mlx-embeddings for other architectures (ModernBert, etc.)
                 patch_qwen3_vl_processor_for_torch_free_image_loading()
@@ -845,6 +1039,7 @@ class MLXRerankerModel:
                 f"Reranker model loaded successfully: {self.model_name} "
                 f"(arch={arch}, num_labels={self._num_labels}, "
                 f"causal_lm={self._is_causal_lm}, vl={self._is_vl_reranker}, "
+                f"sentence_transformers={self._is_sentence_transformers_cross_encoder}, "
                 f"compiled={self._is_compiled})"
             )
 
@@ -923,6 +1118,7 @@ class MLXRerankerModel:
         self._compiled_seq_logits = None
         self._is_compiled = False
 
+        self._resolved_model_path = None
         self.model = None
         self.processor = None
         self._loaded = False
@@ -930,6 +1126,7 @@ class MLXRerankerModel:
         self._is_causal_lm = False
         self._is_jina_reranker = False
         self._is_vl_reranker = False
+        self._is_sentence_transformers_cross_encoder = False
         self._token_true_id = None
         self._token_false_id = None
         self._doc_embed_token_id = None
@@ -1385,11 +1582,10 @@ class MLXRerankerModel:
         # Ensure computation is done
         mx.eval(logits)
 
-        # Extract relevance scores
-        # For binary classification (num_labels=1), score is already sigmoid applied
-        # For multi-class, take the positive class probability
+        # Extract model-native relevance scores. Sequence-classification loaders
+        # may return probabilities, while modular CrossEncoders intentionally
+        # return signed raw regression scores.
         if logits.shape[-1] == 1:
-            # Binary classification: sigmoid already applied by model
             scores = logits.squeeze(-1).tolist()
         else:
             # Multi-class: take last column (typically "relevant" class)
@@ -1450,14 +1646,15 @@ class MLXRerankerModel:
         """Get the number of classification labels."""
         return self._num_labels
 
-    def _validate_architecture(self) -> None:
+    def _validate_architecture(self, model_path: Path | None = None) -> None:
         """
         Validate that the model architecture is supported.
 
         Raises:
             ValueError: If the architecture is not supported
         """
-        config_path = Path(self.model_name) / "config.json"
+        resolved_path = model_path or Path(self.model_name)
+        config_path = resolved_path / "config.json"
         if not config_path.exists():
             # If no config.json, let mlx-embeddings handle validation
             return
@@ -1499,6 +1696,10 @@ class MLXRerankerModel:
                     f"'reranker' or 'rerank'. Please rename the directory or "
                     f"use the correct model."
                 )
+            return
+
+        if arch == "ModernBertModel":
+            parse_modernbert_cross_encoder_pipeline(resolved_path)
             return
 
         if arch not in SUPPORTED_RERANKER_ARCHITECTURES:

--- a/omlx/models/sentence_transformers.py
+++ b/omlx/models/sentence_transformers.py
@@ -1,0 +1,339 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Validation for supported SentenceTransformers model pipelines."""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ModernBertCrossEncoderPipeline:
+    """Validated module layout for a modular ModernBERT CrossEncoder."""
+
+    hidden_size: int
+    pooling_path: str
+    dense_path: str
+    layer_norm_path: str
+    output_path: str
+    layer_norm_eps: float
+    global_rope_theta: float
+    local_rope_theta: float
+
+
+def _json_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"Could not read {label}: {path}") from error
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a JSON object: {path}")
+    return value
+
+
+def _module_path(model_path: Path, value: Any, label: str) -> tuple[str, Path]:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label} module path must be a non-empty string")
+    relative = Path(value)
+    if (
+        relative.is_absolute()
+        or len(relative.parts) != 1
+        or relative.parts[0]
+        in {
+            ".",
+            "..",
+        }
+    ):
+        raise ValueError(f"{label} module path escapes model directory: {value!r}")
+    root = model_path.resolve()
+    resolved = (root / relative).resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as error:
+        raise ValueError(
+            f"{label} module path escapes model directory: {value!r}"
+        ) from error
+    if not resolved.is_dir():
+        raise ValueError(f"{label} module directory does not exist: {resolved}")
+    return value, resolved
+
+
+def _positive_int(value: Any, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{label} must be a positive integer")
+    return value
+
+
+def _positive_float(value: Any, label: str) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or value <= 0
+    ):
+        raise ValueError(f"{label} must be a finite positive number")
+    return float(value)
+
+
+def _activation_name(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label} must be a non-empty string")
+    return value.rsplit(".", 1)[-1]
+
+
+def _expect_field(
+    config: dict[str, Any], field: str, expected: Any, label: str
+) -> None:
+    if config.get(field) != expected:
+        raise ValueError(
+            f"{label} requires {field}={expected!r}; got {config.get(field)!r}"
+        )
+
+
+def is_modernbert_cross_encoder(model_path: str | Path) -> bool:
+    """Detect the explicit CrossEncoder marker without claiming compatibility."""
+
+    root = Path(model_path)
+    try:
+        config = _json_object(root / "config.json", "model config")
+        cross_encoder = _json_object(
+            root / "config_sentence_transformers.json",
+            "SentenceTransformers config",
+        )
+    except ValueError:
+        return False
+    return (
+        config.get("architectures") == ["ModernBertModel"]
+        and config.get("model_type") == "modernbert"
+        and cross_encoder.get("model_type") == "CrossEncoder"
+    )
+
+
+def parse_modernbert_cross_encoder_pipeline(
+    model_path: str | Path,
+) -> ModernBertCrossEncoderPipeline:
+    """Parse the one modular ModernBERT CrossEncoder layout oMLX can execute.
+
+    The narrow contract prevents a generic embedding export from being admitted as
+    a reranker merely because it contains a Dense module.
+    """
+
+    root = Path(model_path)
+    config = _json_object(root / "config.json", "model config")
+    if config.get("architectures") != ["ModernBertModel"]:
+        raise ValueError(
+            "SentenceTransformers CrossEncoder requires architectures="
+            "['ModernBertModel']"
+        )
+    if config.get("model_type") != "modernbert":
+        raise ValueError(
+            "SentenceTransformers CrossEncoder requires model_type='modernbert'"
+        )
+    hidden_size = _positive_int(config.get("hidden_size"), "hidden_size")
+    global_rope_theta = _positive_float(
+        config.get("global_rope_theta", 160000.0),
+        "global_rope_theta",
+    )
+    local_rope_theta = _positive_float(
+        config.get("local_rope_theta", 10000.0),
+        "local_rope_theta",
+    )
+    rope_parameters = config.get("rope_parameters")
+    if rope_parameters is not None:
+        if not isinstance(rope_parameters, dict):
+            raise ValueError("rope_parameters must be a JSON object")
+        full_attention = rope_parameters.get("full_attention")
+        sliding_attention = rope_parameters.get("sliding_attention")
+        if not isinstance(full_attention, dict) or not isinstance(
+            sliding_attention, dict
+        ):
+            raise ValueError(
+                "rope_parameters must declare full_attention and sliding_attention"
+            )
+        if (
+            full_attention.get("rope_type") != "default"
+            or sliding_attention.get("rope_type") != "default"
+        ):
+            raise ValueError("Only default ModernBERT RoPE parameters are supported")
+        global_rope_theta = _positive_float(
+            full_attention.get("rope_theta"),
+            "full_attention rope_theta",
+        )
+        local_rope_theta = _positive_float(
+            sliding_attention.get("rope_theta"),
+            "sliding_attention rope_theta",
+        )
+
+    layer_types = config.get("layer_types")
+    if layer_types is not None:
+        num_hidden_layers = _positive_int(
+            config.get("num_hidden_layers"),
+            "num_hidden_layers",
+        )
+        global_attn_every = _positive_int(
+            config.get("global_attn_every_n_layers", 3),
+            "global_attn_every_n_layers",
+        )
+        expected_layer_types = [
+            "full_attention" if index % global_attn_every == 0 else "sliding_attention"
+            for index in range(num_hidden_layers)
+        ]
+        if layer_types != expected_layer_types:
+            raise ValueError(
+                "ModernBERT layer_types do not match the supported "
+                "global_attn_every_n_layers topology"
+            )
+
+    cross_encoder = _json_object(
+        root / "config_sentence_transformers.json",
+        "SentenceTransformers config",
+    )
+    _expect_field(cross_encoder, "model_type", "CrossEncoder", "CrossEncoder config")
+    if (
+        _activation_name(
+            cross_encoder.get("activation_fn"), "CrossEncoder outer activation"
+        )
+        != "Identity"
+    ):
+        raise ValueError(
+            "CrossEncoder outer activation must be Identity for raw scores"
+        )
+
+    modules_path = root / "modules.json"
+    try:
+        modules = json.loads(modules_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(
+            f"Could not read SentenceTransformers modules: {modules_path}"
+        ) from error
+    expected_types = ["Transformer", "Pooling", "Dense", "LayerNorm", "Dense"]
+    if not isinstance(modules, list) or len(modules) != len(expected_types):
+        raise ValueError(
+            "Unsupported SentenceTransformers module chain; expected "
+            "Transformer -> Pooling -> Dense -> LayerNorm -> Dense"
+        )
+    for index, (module, expected_type) in enumerate(zip(modules, expected_types)):
+        if not isinstance(module, dict):
+            raise ValueError(f"SentenceTransformers module {index} must be an object")
+        module_type = module.get("type")
+        if (
+            module.get("idx") != index
+            or not isinstance(module_type, str)
+            or not module_type.startswith("sentence_transformers.")
+            or module_type.rsplit(".", 1)[-1] != expected_type
+        ):
+            raise ValueError(
+                "Unsupported SentenceTransformers module chain; expected "
+                "Transformer -> Pooling -> Dense -> LayerNorm -> Dense"
+            )
+    if modules[0].get("path") not in {"", "."}:
+        raise ValueError("Transformer module must load from the model root")
+
+    pooling_path, pooling_dir = _module_path(root, modules[1].get("path"), "Pooling")
+    dense_path, dense_dir = _module_path(root, modules[2].get("path"), "Dense")
+    layer_norm_path, layer_norm_dir = _module_path(
+        root, modules[3].get("path"), "LayerNorm"
+    )
+    output_path, output_dir = _module_path(root, modules[4].get("path"), "output Dense")
+
+    pooling = _json_object(pooling_dir / "config.json", "Pooling config")
+    pooling_mode = pooling.get("pooling_mode")
+    if pooling_mode is None and pooling.get("pooling_mode_cls_token") is True:
+        conflicting_modes = (
+            "pooling_mode_lasttoken",
+            "pooling_mode_max_tokens",
+            "pooling_mode_mean_sqrt_len_tokens",
+            "pooling_mode_mean_tokens",
+            "pooling_mode_weightedmean_tokens",
+        )
+        if not any(pooling.get(field) is True for field in conflicting_modes):
+            pooling_mode = "cls"
+    if pooling_mode != "cls":
+        raise ValueError("SentenceTransformers reranker requires CLS pooling")
+    pooling_dimension = pooling.get(
+        "embedding_dimension",
+        pooling.get("word_embedding_dimension"),
+    )
+    if pooling_dimension != hidden_size:
+        raise ValueError(
+            "Pooling config requires embedding_dimension or "
+            f"word_embedding_dimension={hidden_size}; got {pooling_dimension!r}"
+        )
+
+    dense = _json_object(dense_dir / "config.json", "Dense config")
+    _expect_field(dense, "in_features", hidden_size, "Dense config hidden_size")
+    _expect_field(dense, "out_features", hidden_size, "Dense config hidden_size")
+    _expect_field(dense, "bias", False, "Dense config bias=false")
+    _expect_field(
+        dense,
+        "module_input_name",
+        "sentence_embedding",
+        "Dense config",
+    )
+    _expect_field(
+        dense,
+        "module_output_name",
+        "sentence_embedding",
+        "Dense config",
+    )
+    if _activation_name(dense.get("activation_function"), "Dense activation") != "GELU":
+        raise ValueError("SentenceTransformers hidden Dense activation must be GELU")
+
+    layer_norm = _json_object(layer_norm_dir / "config.json", "LayerNorm config")
+    _expect_field(
+        layer_norm,
+        "dimension",
+        hidden_size,
+        "LayerNorm config hidden_size",
+    )
+    layer_norm_eps = layer_norm.get("eps", 1e-5)
+    if (
+        isinstance(layer_norm_eps, bool)
+        or not isinstance(layer_norm_eps, (int, float))
+        or not math.isfinite(layer_norm_eps)
+        or layer_norm_eps <= 0
+    ):
+        raise ValueError("LayerNorm eps must be a finite positive number")
+
+    output = _json_object(output_dir / "config.json", "output Dense config")
+    _expect_field(output, "in_features", hidden_size, "output Dense config")
+    _expect_field(output, "out_features", 1, "output Dense config out_features=1")
+    _expect_field(output, "bias", True, "output Dense config bias=true")
+    _expect_field(
+        output,
+        "module_input_name",
+        "sentence_embedding",
+        "output Dense config",
+    )
+    _expect_field(output, "module_output_name", "scores", "output Dense config")
+    if (
+        _activation_name(output.get("activation_function"), "output Dense activation")
+        != "Identity"
+    ):
+        raise ValueError(
+            "SentenceTransformers output Dense activation must be Identity"
+        )
+
+    return ModernBertCrossEncoderPipeline(
+        hidden_size=hidden_size,
+        pooling_path=pooling_path,
+        dense_path=dense_path,
+        layer_norm_path=layer_norm_path,
+        output_path=output_path,
+        layer_norm_eps=float(layer_norm_eps),
+        global_rope_theta=global_rope_theta,
+        local_rope_theta=local_rope_theta,
+    )
+
+
+def is_modernbert_cross_encoder_pipeline(model_path: str | Path) -> bool:
+    """Return whether ``model_path`` satisfies the strict supported contract."""
+
+    try:
+        parse_modernbert_cross_encoder_pipeline(model_path)
+    except (OSError, TypeError, ValueError):
+        return False
+    return True

--- a/tests/test_sentence_transformers_reranker.py
+++ b/tests/test_sentence_transformers_reranker.py
@@ -1,0 +1,400 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SentenceTransformers ModernBERT CrossEncoder reranker coverage."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from omlx.model_discovery import detect_model_type
+from omlx.models.reranker import (
+    MLXRerankerModel,
+    ModernBertSentenceTransformersCrossEncoder,
+    SentenceTransformersCrossEncoderHead,
+    _sanitize_sentence_transformers_modernbert_weights,
+)
+from omlx.models.sentence_transformers import (
+    ModernBertCrossEncoderPipeline,
+    parse_modernbert_cross_encoder_pipeline,
+)
+
+
+def _write_json(path: Path, value) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+def _write_pipeline(tmp_path: Path, hidden_size: int = 4) -> Path:
+    _write_json(
+        tmp_path / "config.json",
+        {
+            "architectures": ["ModernBertModel"],
+            "model_type": "modernbert",
+            "hidden_size": hidden_size,
+        },
+    )
+    _write_json(
+        tmp_path / "config_sentence_transformers.json",
+        {
+            "activation_fn": "torch.nn.modules.linear.Identity",
+            "model_type": "CrossEncoder",
+        },
+    )
+    _write_json(
+        tmp_path / "modules.json",
+        [
+            {
+                "idx": 0,
+                "name": "0",
+                "path": "",
+                "type": "sentence_transformers.base.modules.transformer.Transformer",
+            },
+            {
+                "idx": 1,
+                "name": "1",
+                "path": "1_Pooling",
+                "type": "sentence_transformers.sentence_transformer.modules.pooling.Pooling",
+            },
+            {
+                "idx": 2,
+                "name": "2",
+                "path": "2_Dense",
+                "type": "sentence_transformers.base.modules.dense.Dense",
+            },
+            {
+                "idx": 3,
+                "name": "3",
+                "path": "3_LayerNorm",
+                "type": "sentence_transformers.sentence_transformer.modules.layer_norm.LayerNorm",
+            },
+            {
+                "idx": 4,
+                "name": "4",
+                "path": "4_Dense",
+                "type": "sentence_transformers.base.modules.dense.Dense",
+            },
+        ],
+    )
+    _write_json(
+        tmp_path / "1_Pooling/config.json",
+        {
+            "embedding_dimension": hidden_size,
+            "include_prompt": True,
+            "pooling_mode": "cls",
+        },
+    )
+    _write_json(
+        tmp_path / "2_Dense/config.json",
+        {
+            "activation_function": "torch.nn.modules.activation.GELU",
+            "bias": False,
+            "in_features": hidden_size,
+            "module_input_name": "sentence_embedding",
+            "module_output_name": "sentence_embedding",
+            "out_features": hidden_size,
+        },
+    )
+    _write_json(
+        tmp_path / "3_LayerNorm/config.json",
+        {"dimension": hidden_size},
+    )
+    _write_json(
+        tmp_path / "4_Dense/config.json",
+        {
+            "activation_function": "torch.nn.modules.linear.Identity",
+            "bias": True,
+            "in_features": hidden_size,
+            "module_input_name": "sentence_embedding",
+            "module_output_name": "scores",
+            "out_features": 1,
+        },
+    )
+    return tmp_path
+
+
+def _load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_parse_and_discover_modernbert_cross_encoder(tmp_path) -> None:
+    model_path = _write_pipeline(tmp_path)
+
+    pipeline = parse_modernbert_cross_encoder_pipeline(model_path)
+
+    assert pipeline == ModernBertCrossEncoderPipeline(
+        hidden_size=4,
+        pooling_path="1_Pooling",
+        dense_path="2_Dense",
+        layer_norm_path="3_LayerNorm",
+        output_path="4_Dense",
+        layer_norm_eps=1e-5,
+        global_rope_theta=160000.0,
+        local_rope_theta=10000.0,
+    )
+    assert detect_model_type(model_path) == "reranker"
+    MLXRerankerModel(str(model_path))._validate_architecture()
+
+
+def test_hub_id_resolves_before_modular_loader_dispatch(tmp_path, monkeypatch) -> None:
+    model_path = _write_pipeline(tmp_path)
+    loader = MLXRerankerModel("example/ettin-cross-encoder")
+    loaded_model = MagicMock()
+    loaded_model.config = MagicMock()
+    seen_paths = []
+    monkeypatch.setattr(
+        "mlx_embeddings.utils.get_model_path",
+        lambda model_name: model_path,
+    )
+    monkeypatch.setattr(
+        loader,
+        "_load_modernbert_sentence_transformers",
+        lambda resolved: seen_paths.append(resolved) or (loaded_model, MagicMock()),
+    )
+    monkeypatch.setattr(loader, "_try_compile", lambda: False)
+
+    loader.load()
+
+    assert seen_paths == [model_path]
+    assert loader._resolved_model_path == model_path
+    assert loader._is_sentence_transformers_cross_encoder is True
+
+
+def test_parser_translates_nested_modernbert_rope_parameters(tmp_path) -> None:
+    model_path = _write_pipeline(tmp_path)
+    config = _load_json(model_path / "config.json")
+    config["rope_parameters"] = {
+        "full_attention": {"rope_type": "default", "rope_theta": 160000.0},
+        "sliding_attention": {"rope_type": "default", "rope_theta": 160000.0},
+    }
+    _write_json(model_path / "config.json", config)
+
+    pipeline = parse_modernbert_cross_encoder_pipeline(model_path)
+
+    assert pipeline.global_rope_theta == 160000.0
+    assert pipeline.local_rope_theta == 160000.0
+
+
+def test_parser_accepts_legacy_cls_pooling_config(tmp_path) -> None:
+    model_path = _write_pipeline(tmp_path)
+    pooling_path = model_path / "1_Pooling/config.json"
+    pooling = _load_json(pooling_path)
+    pooling.pop("embedding_dimension")
+    pooling.pop("pooling_mode")
+    pooling["word_embedding_dimension"] = 4
+    pooling["pooling_mode_cls_token"] = True
+    pooling["pooling_mode_mean_tokens"] = False
+    _write_json(pooling_path, pooling)
+
+    pipeline = parse_modernbert_cross_encoder_pipeline(model_path)
+
+    assert pipeline.hidden_size == 4
+    assert detect_model_type(model_path) == "reranker"
+
+
+def test_parser_rejects_unrepresentable_layer_topology(tmp_path) -> None:
+    model_path = _write_pipeline(tmp_path)
+    config = _load_json(model_path / "config.json")
+    config.update(
+        {
+            "num_hidden_layers": 4,
+            "global_attn_every_n_layers": 3,
+            "layer_types": ["full_attention"] * 4,
+        }
+    )
+    _write_json(model_path / "config.json", config)
+
+    with pytest.raises(ValueError, match="layer_types"):
+        parse_modernbert_cross_encoder_pipeline(model_path)
+    assert detect_model_type(model_path) == "reranker"
+
+
+@pytest.mark.parametrize(
+    ("target", "field", "value", "match"),
+    [
+        ("1_Pooling/config.json", "pooling_mode", "mean", "CLS pooling"),
+        (
+            "2_Dense/config.json",
+            "activation_function",
+            "torch.nn.modules.activation.ReLU",
+            "GELU",
+        ),
+        ("2_Dense/config.json", "bias", True, "bias=false"),
+        ("2_Dense/config.json", "out_features", 3, "hidden_size"),
+        ("3_LayerNorm/config.json", "dimension", 3, "hidden_size"),
+        (
+            "4_Dense/config.json",
+            "activation_function",
+            "torch.nn.modules.activation.Sigmoid",
+            "Identity",
+        ),
+        ("4_Dense/config.json", "bias", False, "bias=true"),
+        ("4_Dense/config.json", "out_features", 2, "out_features=1"),
+        (
+            "config_sentence_transformers.json",
+            "activation_fn",
+            "torch.nn.modules.activation.Sigmoid",
+            "outer activation",
+        ),
+    ],
+)
+def test_parser_rejects_incompatible_pipeline(
+    tmp_path, target, field, value, match
+) -> None:
+    model_path = _write_pipeline(tmp_path)
+    config_path = model_path / target
+    config = _load_json(config_path)
+    config[field] = value
+    _write_json(config_path, config)
+
+    with pytest.raises(ValueError, match=match):
+        parse_modernbert_cross_encoder_pipeline(model_path)
+    assert detect_model_type(model_path) == "reranker"
+
+
+def test_parser_rejects_wrong_module_order(tmp_path) -> None:
+    model_path = _write_pipeline(tmp_path)
+    modules = _load_json(model_path / "modules.json")
+    modules[2], modules[3] = modules[3], modules[2]
+    modules[2]["idx"] = 2
+    modules[3]["idx"] = 3
+    _write_json(model_path / "modules.json", modules)
+
+    with pytest.raises(ValueError, match="module chain"):
+        parse_modernbert_cross_encoder_pipeline(model_path)
+    assert detect_model_type(model_path) == "reranker"
+
+
+def test_parser_rejects_module_path_escape(tmp_path) -> None:
+    model_path = _write_pipeline(tmp_path)
+    modules = _load_json(model_path / "modules.json")
+    modules[2]["path"] = "../outside"
+    _write_json(model_path / "modules.json", modules)
+
+    with pytest.raises(ValueError, match="escapes model directory"):
+        parse_modernbert_cross_encoder_pipeline(model_path)
+
+
+def test_head_returns_raw_signed_scores() -> None:
+    import mlx.core as mx
+
+    head = SentenceTransformersCrossEncoderHead(hidden_size=2, layer_norm_eps=1e-5)
+    head.load_weights(
+        [
+            ("dense.weight", mx.eye(2)),
+            ("norm.weight", mx.ones((2,))),
+            ("norm.bias", mx.zeros((2,))),
+            ("output.weight", mx.array([[1.0, -1.0]])),
+            ("output.bias", mx.array([-0.5])),
+        ]
+    )
+    scores = head(mx.array([[1.0, 2.0], [2.0, 1.0]])).squeeze(-1)
+    mx.eval(scores)
+
+    assert scores[0].item() < -1.0
+    assert scores[1].item() > 0.0
+    assert scores[0].item() < 0.0  # proves no sigmoid/clamp
+
+
+def test_sanitize_maps_nested_head_weights_and_validates_shapes(tmp_path) -> None:
+    pipeline = parse_modernbert_cross_encoder_pipeline(_write_pipeline(tmp_path))
+    weights = {
+        "embeddings.tok_embeddings.weight": np.zeros((16, 4), dtype=np.float32),
+        "2_Dense.linear.weight": np.zeros((4, 4), dtype=np.float32),
+        "3_LayerNorm.norm.weight": np.ones((4,), dtype=np.float32),
+        "3_LayerNorm.norm.bias": np.zeros((4,), dtype=np.float32),
+        "4_Dense.linear.weight": np.zeros((1, 4), dtype=np.float32),
+        "4_Dense.linear.bias": np.zeros((1,), dtype=np.float32),
+    }
+
+    mapped = _sanitize_sentence_transformers_modernbert_weights(weights, pipeline)
+
+    assert set(mapped) == {
+        "model.embeddings.tok_embeddings.weight",
+        "head.dense.weight",
+        "head.norm.weight",
+        "head.norm.bias",
+        "head.output.weight",
+        "head.output.bias",
+    }
+    assert "head.dense.bias" not in mapped
+
+    weights["2_Dense.linear.weight"] = np.zeros((3, 4), dtype=np.float32)
+    with pytest.raises(ValueError, match="2_Dense.linear.weight.*expected"):
+        _sanitize_sentence_transformers_modernbert_weights(weights, pipeline)
+
+
+def test_sanitize_rejects_missing_or_unexpected_head_tensors(tmp_path) -> None:
+    pipeline = parse_modernbert_cross_encoder_pipeline(_write_pipeline(tmp_path))
+    valid = {
+        "2_Dense.linear.weight": np.zeros((4, 4), dtype=np.float32),
+        "3_LayerNorm.norm.weight": np.ones((4,), dtype=np.float32),
+        "3_LayerNorm.norm.bias": np.zeros((4,), dtype=np.float32),
+        "4_Dense.linear.weight": np.zeros((1, 4), dtype=np.float32),
+        "4_Dense.linear.bias": np.zeros((1,), dtype=np.float32),
+    }
+    missing = dict(valid)
+    missing.pop("4_Dense.linear.bias")
+    with pytest.raises(ValueError, match="missing head tensor"):
+        _sanitize_sentence_transformers_modernbert_weights(missing, pipeline)
+
+    unexpected = dict(valid)
+    unexpected["2_Dense.linear.bias"] = np.zeros((4,), dtype=np.float32)
+    with pytest.raises(ValueError, match="unexpected head tensor"):
+        _sanitize_sentence_transformers_modernbert_weights(unexpected, pipeline)
+
+
+def test_wrapper_uses_cls_backbone_output_and_raw_head_score() -> None:
+    import mlx.core as mx
+    from mlx_embeddings.models.modernbert import ModelArgs
+
+    pipeline = ModernBertCrossEncoderPipeline(
+        hidden_size=2,
+        pooling_path="1_Pooling",
+        dense_path="2_Dense",
+        layer_norm_path="3_LayerNorm",
+        output_path="4_Dense",
+        layer_norm_eps=1e-5,
+        global_rope_theta=160000.0,
+        local_rope_theta=10000.0,
+    )
+    config = ModelArgs(
+        model_type="modernbert",
+        vocab_size=16,
+        hidden_size=2,
+        num_hidden_layers=1,
+        intermediate_size=4,
+        num_attention_heads=1,
+        max_position_embeddings=8,
+        local_attention=4,
+        architectures=["ModernBertModel"],
+    )
+    model = ModernBertSentenceTransformersCrossEncoder(config, pipeline)
+    model.model = MagicMock(
+        return_value={
+            "last_hidden_state": mx.array(
+                [[[1.0, 2.0], [99.0, 99.0]], [[2.0, 1.0], [99.0, 99.0]]]
+            ),
+            "hidden_states": None,
+        }
+    )
+    model.head.load_weights(
+        [
+            ("dense.weight", mx.eye(2)),
+            ("norm.weight", mx.ones((2,))),
+            ("norm.bias", mx.zeros((2,))),
+            ("output.weight", mx.array([[1.0, -1.0]])),
+            ("output.bias", mx.array([-0.5])),
+        ]
+    )
+
+    output = model(
+        input_ids=mx.array([[1, 2], [1, 2]]),
+        attention_mask=mx.ones((2, 2)),
+    )
+    mx.eval(output.pooler_output)
+
+    assert output.pooler_output.shape == (2, 1)
+    assert output.pooler_output[0, 0].item() < -1.0
+    assert output.pooler_output[1, 0].item() > 0.0


### PR DESCRIPTION
## Summary

Add support for SentenceTransformers ModernBERT CrossEncoder checkpoints that serialize their scoring head as a module stack:

`Transformer → CLS Pooling → GELU Dense → LayerNorm → Identity scalar Dense`

This is the layout used by `cross-encoder/ettin-reranker-1b-v1`.

## Implementation

- Detect explicit ModernBERT CrossEncoder markers before generic embedding discovery.
- Validate the module order, direct-child paths, pooling mode, dimensions, activations, biases, outer activation, and representable attention topology.
- Reuse `mlx_embeddings.load_model` with an oMLX wrapper that maps the nested head safetensors into normal MLX modules.
- Translate nested ModernBERT full/sliding RoPE parameters into the scalar fields consumed by `mlx-embeddings`.
- Resolve Hugging Face repository IDs before architecture dispatch.
- Return signed raw regression scores without sigmoid, softmax, clamping, or normalization.
- Continue rejecting incompatible CrossEncoder module stacks at load time with an actionable validation error.

## Verification

- New focused tests: 20 passed.
- Adjacent discovery/reranker/server tests: 346 passed.
- Full suite: 10,622 passed, 208 skipped, 77 deselected.
- Ruff and Black pass for the new files; `git diff --check` passes.
- Real Ettin F32 comparison over 12 query/document pairs against sentence-transformers Torch CPU:
  - maximum absolute raw-score difference: `0.00303`
  - mean absolute difference: `0.00100`
  - score-sign agreement: 12/12
  - ranking order preserved
- Compiled MLX scoring path loads and executes successfully.

## Safety

- No checkpoint files are rewritten.
- Nested module paths are constrained to direct children of the model directory.
- Required head tensors and exact shapes are checked before loading.
- Unexpected or missing head tensors fail closed.
- `trust_remote_code` behavior is unchanged and remains opt-in.
