### PR TITLE
Expose effective cache_block_size in /v1/models/status

### DIFF
--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -3131,6 +3131,20 @@ class EnginePool:
         shutdown_mlx_executor()
         logger.info("Engine pool shutdown complete")
 
+    @staticmethod
+    def _entry_cache_block_size(entry: "EngineEntry") -> int | None:
+        """Effective prefix-cache block size for a loaded entry, else None.
+
+        The scheduler adjusts the configured block size at load time
+        (RotatingKVCache window alignment, ArraysCache enlargement, pooling
+        models), so the live value is only known once the engine exists.
+        Exposing it lets clients that resend a stable prefix pad it to a
+        block multiple and avoid the trailing-partial-block re-prefill.
+        """
+        scheduler = getattr(getattr(entry.engine, "engine", None), "scheduler", None)
+        config = getattr(scheduler, "config", None)
+        return getattr(config, "paged_cache_block_size", None)
+
     def get_status(self) -> dict:
         """
         Get pool status for monitoring endpoints.
@@ -3162,6 +3176,7 @@ class EnginePool:
                     "actual_size": e.actual_size,
                     "pinned": e.is_pinned,
                     "engine_type": e.engine_type,
+                    "cache_block_size": self._entry_cache_block_size(e),
                     "model_type": e.model_type,
                     "config_model_type": e.config_model_type,
                     "realtime_stt": is_realtime_stt_model(

--- a/tests/test_status_cache_block_size.py
+++ b/tests/test_status_cache_block_size.py
@@ -1,0 +1,35 @@
+"""cache_block_size in /v1/models/status entries.
+
+The effective paged-cache block size is a load-time value (the scheduler
+adjusts the configured size per model cache type), so status reports the live
+value for loaded entries and None otherwise. Clients use it to pad stable
+prefixes to block multiples (see #3348).
+"""
+
+from types import SimpleNamespace
+
+from omlx.engine_pool import EnginePool
+
+
+def _entry(engine):
+    return SimpleNamespace(engine=engine)
+
+
+def test_loaded_entry_reports_scheduler_block_size():
+    engine = SimpleNamespace(
+        engine=SimpleNamespace(
+            scheduler=SimpleNamespace(
+                config=SimpleNamespace(paged_cache_block_size=2048)
+            )
+        )
+    )
+    assert EnginePool._entry_cache_block_size(_entry(engine)) == 2048
+
+
+def test_unloaded_entry_reports_none():
+    assert EnginePool._entry_cache_block_size(_entry(None)) is None
+
+
+def test_engine_without_scheduler_reports_none():
+    engine = SimpleNamespace(engine=SimpleNamespace())
+    assert EnginePool._entry_cache_block_size(_entry(engine)) is None


### PR DESCRIPTION
Follows from #3348: your block-boundary diagnosis reproduced cleanly on our rigs (warm-prefix TTFT 0.93 s -> 0.33 s and a 5-stream task set 6.8 s -> 2.5 s wall once the prefix was padded past the boundary). The remaining gap is that clients cannot discover the block size to align against: it varies by host (2048 vs 4096 in your note) and by model cache type at load time.

This adds `cache_block_size` to each `/v1/models/status` entry:

- the live `scheduler.config.paged_cache_block_size` for loaded models, which is the value after `_align_block_size_with_rotating_window` / `_enlarge_block_size_for_arrays_cache` have adjusted it;
- `null` for unloaded models, matching the existing `actual_size` semantics, since the effective value only exists once the engine is up.

Access is a defensive getattr chain via the documented `_engine.engine.scheduler` path, so engine types without a scheduler simply report null. Unit tests cover loaded, unloaded, and scheduler-less entries; they pass against 0.6.4's runtime.

With this, an agentic client can pad its stable system prefix to a block multiple programmatically instead of discovering the trailing-partial-block behaviour through benchmarks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
