### PR TITLE
fix(scheduler): time prefill-side boundary snapshot capture

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -6438,33 +6438,48 @@ class Scheduler:
         # Offload snapshot to SSD if store is available, keeping only a
         # None marker in the dict.  Falls back to in-memory storage when
         # the SSD store is unavailable or the write fails.
-        if self._boundary_snapshot_store is not None:
-            # Keep the extraction + serialization eval on the per-engine
-            # stream, mirroring _eval_snapshot_cache on the in-memory path
-            # below. save() slices the live cache state and mx.eval's it on
-            # this (owner) thread; unwrapped, those ops bind to gpu,0 and
-            # split the prefill graph across streams (#2330 hardening).
-            with mx.stream(self._stream):
-                saved = self._boundary_snapshot_store.save(
-                    request_id,
-                    token_count,
-                    snapshot_cache,
-                    self._extract_snapshot_cache_states,
-                    block_size=block_size,
-                )
-            if saved:
-                self._boundary_cache_snapshots[request_id][token_count] = None
-                storage = "ssd"
+        # The persist branch runs synchronously inside prefill (slice + eval of
+        # the recurrent state, serialization, SSD pending-slot wait). Time it so
+        # the cost shows up in the phase log next to the decode-side capture
+        # phases instead of hiding inside prefill wall time (#3070).
+        with self._phase_timer("prefill_boundary_capture"):
+            if self._boundary_snapshot_store is not None:
+                # Keep the extraction + serialization eval on the per-engine
+                # stream, mirroring _eval_snapshot_cache on the in-memory path
+                # below. save() slices the live cache state and mx.eval's it on
+                # this (owner) thread; unwrapped, those ops bind to gpu,0 and
+                # split the prefill graph across streams (#2330 hardening).
+                with mx.stream(self._stream):
+                    saved = self._boundary_snapshot_store.save(
+                        request_id,
+                        token_count,
+                        snapshot_cache,
+                        self._extract_snapshot_cache_states,
+                        block_size=block_size,
+                    )
+                if saved:
+                    self._boundary_cache_snapshots[request_id][token_count] = None
+                    storage = "ssd"
+                else:
+                    self._boundary_snapshot_diagnostics.record(
+                        "ssd_fallback",
+                        reason="ssd_save_failed",
+                        request_id=request_id,
+                        token_count=token_count,
+                        block_size=block_size,
+                        source="prefill",
+                        storage="memory",
+                    )
+                    self._boundary_cache_snapshots[request_id][token_count] = (
+                        _compact_boundary_snapshot_value(
+                            self._prefill_snapshot_value(snapshot_cache),
+                            token_count,
+                            block_size,
+                            self._stream,
+                        )
+                    )
+                    storage = "memory"
             else:
-                self._boundary_snapshot_diagnostics.record(
-                    "ssd_fallback",
-                    reason="ssd_save_failed",
-                    request_id=request_id,
-                    token_count=token_count,
-                    block_size=block_size,
-                    source="prefill",
-                    storage="memory",
-                )
                 self._boundary_cache_snapshots[request_id][token_count] = (
                     _compact_boundary_snapshot_value(
                         self._prefill_snapshot_value(snapshot_cache),
@@ -6474,16 +6489,6 @@ class Scheduler:
                     )
                 )
                 storage = "memory"
-        else:
-            self._boundary_cache_snapshots[request_id][token_count] = (
-                _compact_boundary_snapshot_value(
-                    self._prefill_snapshot_value(snapshot_cache),
-                    token_count,
-                    block_size,
-                    self._stream,
-                )
-            )
-            storage = "memory"
 
         self._boundary_snapshot_required = True
         self._enable_mtp_boundary_alignment()

--- a/tests/test_prefix_cache_cachelist_mixed.py
+++ b/tests/test_prefix_cache_cachelist_mixed.py
@@ -302,6 +302,7 @@ def test_prefill_snapshot_decoupled_from_live_cache():
     """In-memory prefill boundary snapshots must capture the state AT the
     boundary. Storing the live cache objects aliased every boundary to
     the prefill's final state (KVCache mutates its buffer in place)."""
+    from collections import defaultdict
     from types import SimpleNamespace
 
     from omlx.scheduler import Scheduler
@@ -319,7 +320,10 @@ def test_prefill_snapshot_decoupled_from_live_cache():
         _boundary_snapshot_required=False,
         _stream=mx.default_stream(mx.default_device()),
         _PREFILL_SNAPSHOT_MARKER=Scheduler._PREFILL_SNAPSHOT_MARKER,
+        _phase_total_ms=defaultdict(float),
+        _phase_count=defaultdict(int),
     )
+    stub._phase_timer = lambda phase: Scheduler._phase_timer(stub, phase)
     stub._extract_cache_states = lambda caches: Scheduler._extract_cache_states(
         stub, caches
     )

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3000,6 +3000,99 @@ class TestSchedulerBoundarySnapshots:
 
         assert request.request_id not in scheduler._boundary_cache_snapshots
 
+    def _prefill_boundary_scheduler(self, mock_model, mock_tokenizer, store=None):
+        """Scheduler, registered request and stateful stub cache for the timer tests."""
+        scheduler = Scheduler(
+            model=mock_model,
+            tokenizer=mock_tokenizer,
+            config=SchedulerConfig(paged_cache_block_size=4),
+        )
+        scheduler.block_aware_cache = MagicMock()
+        scheduler._boundary_snapshot_store = store
+        request = Request(
+            request_id="req-prefill-timer",
+            prompt="hello",
+            sampling_params=SamplingParams(),
+        )
+        scheduler.requests[request.request_id] = request
+        scheduler.running[request.request_id] = request
+        snapshot_cache = [type("RotatingKVCache", (), {})()]
+        return scheduler, request, snapshot_cache
+
+    def test_prefill_boundary_snapshot_times_memory_capture(
+        self, mock_model, mock_tokenizer
+    ):
+        """The in-memory persist path must land in the phase timers.
+
+        #3070: the decode-side capture is timed in three phases while the
+        prefill-side twin ran untimed inside prefill, so its cost never
+        appeared in ``Cache phase timings``.
+        """
+        scheduler, request, snapshot_cache = self._prefill_boundary_scheduler(
+            mock_model, mock_tokenizer
+        )
+
+        scheduler._on_prefill_boundary_snapshot(request.request_id, snapshot_cache, 4)
+
+        assert scheduler.get_phase_stats()["prefill_boundary_capture"]["count"] == 1
+        assert (
+            scheduler._boundary_cache_snapshots[request.request_id][4] == snapshot_cache
+        )
+        assert scheduler._boundary_snapshot_required is True
+        assert mock_model._omlx_mtp_commit_align == 4
+
+    def test_prefill_boundary_snapshot_times_ssd_capture(
+        self, mock_model, mock_tokenizer
+    ):
+        """The SSD persist path is timed; the snapshot entry stays a marker."""
+        store = MagicMock()
+        store.save.return_value = True
+        scheduler, request, snapshot_cache = self._prefill_boundary_scheduler(
+            mock_model, mock_tokenizer, store=store
+        )
+        scheduler._on_prefill_boundary_snapshot(request.request_id, snapshot_cache, 4)
+
+        assert scheduler.get_phase_stats()["prefill_boundary_capture"]["count"] == 1
+        assert scheduler._boundary_cache_snapshots[request.request_id][4] is None
+        diag = scheduler._boundary_snapshot_diagnostics.snapshot()
+        assert diag["captures_ssd"] == 1
+        assert diag["last_event"]["event"] == "capture_success"
+        assert diag["last_event"]["storage"] == "ssd"
+
+    def test_prefill_boundary_snapshot_times_ssd_fallback(
+        self, mock_model, mock_tokenizer
+    ):
+        """A failed SSD save falls back to memory inside the same timed phase."""
+        store = MagicMock()
+        store.save.return_value = False
+        scheduler, request, snapshot_cache = self._prefill_boundary_scheduler(
+            mock_model, mock_tokenizer, store=store
+        )
+        scheduler._on_prefill_boundary_snapshot(request.request_id, snapshot_cache, 4)
+
+        assert scheduler.get_phase_stats()["prefill_boundary_capture"]["count"] == 1
+        assert scheduler._boundary_cache_snapshots[request.request_id][4] is not None
+        diag = scheduler._boundary_snapshot_diagnostics.snapshot()
+        assert diag["ssd_fallbacks"] == 1
+        assert diag["captures_memory"] == 1
+        assert diag["last_event"]["event"] == "capture_success"
+        assert diag["last_event"]["storage"] == "memory"
+
+    def test_prefill_boundary_snapshot_unaligned_is_not_timed(
+        self, mock_model, mock_tokenizer
+    ):
+        """Early returns happen before the persist branch and record no phase."""
+        scheduler, request, snapshot_cache = self._prefill_boundary_scheduler(
+            mock_model, mock_tokenizer
+        )
+        scheduler._on_prefill_boundary_snapshot(request.request_id, snapshot_cache, 3)
+
+        assert "prefill_boundary_capture" not in scheduler.get_phase_stats()
+        diag = scheduler._boundary_snapshot_diagnostics.snapshot()
+        assert diag["reasons"]["unaligned_token_count"] == 1
+        assert diag["last_event"]["event"] == "capture_skipped"
+        assert diag["last_event"]["reason"] == "unaligned_token_count"
+
     def test_emit_prefill_boundary_snapshot_persists_before_uid_assignment(
         self, mock_model, mock_tokenizer
     ):


### PR DESCRIPTION
## Summary

The scheduler's cache phase timers (`Cache phase timings: …` at INFO) cover the decode-side boundary capture in three phases — `boundary_capture_sync`, `boundary_capture_extract`, `boundary_snapshot_save` — but the prefill-side twin, `_on_prefill_boundary_snapshot`, has no timer at all. Its persist branch does the expensive part synchronously on the inference thread, inside prefill: slice and `mx.eval` the recurrent / ArraysCache state, serialize it, and wait for an SSD pending slot (or build the in-memory value when no store is available). None of that shows up in the phase log.

That is the gap #3070 points at: block-crossing turns on hybrid GDN models pay a ~5-6 s premium while the timed store phases report milliseconds, so "whatever dominates is not inside the timed store phases". This PR makes the untimed path measurable. It does not claim to explain the premium — with the phase in the log, the next report can say whether the snapshot persist accounts for it or something else in prefill does.

## Changes

- `omlx/scheduler.py`: wrap the persist branch of `_on_prefill_boundary_snapshot` (SSD save, SSD-fallback in-memory value, no-store in-memory value) in one `_phase_timer("prefill_boundary_capture")`. The diagnostics records, the early-return guards, `_boundary_snapshot_required`, the MTP alignment call and the DEBUG line stay outside the timer; the `mx.stream(self._stream)` wrapping of the SSD save from #2330 stays inside it, unchanged. The whitespace-insensitive diff is the `with` line and a comment; no other function is touched and no existing phase name changes.
- `tests/test_scheduler.py`: four tests beside the existing prefill-boundary tests, asserting the phase is recorded exactly once on each persist path (no store, `save()` → True, `save()` → False fallback) and not recorded on an unaligned early return.
- `tests/test_prefix_cache_cachelist_mixed.py`: the `SimpleNamespace` stub that drives `_on_prefill_boundary_snapshot` gains the two phase dicts and a `_phase_timer` bound to the real method (it hand-wires every `self` method the function calls).

## Test plan

- `uv run pytest tests/test_scheduler.py tests/test_prefix_cache_cachelist_mixed.py tests/test_qwen4_qsa_prefill_memory.py -q` — 261 passed. The four new tests were written first and failed with `KeyError: 'prefill_boundary_capture'` before the scheduler change.
- Full suite `uv run pytest tests/ -q` — see the gate result below.
- `ruff check omlx/scheduler.py` reports the same 32 pre-existing findings before and after; the new test block adds none.
- Behaviour is unchanged by construction (a timer wrapping a branch); the phase appears in the INFO line through the existing generic loop over `_phase_total_ms`, so a server with the paged SSD cache on a hybrid model will show `prefill_boundary_capture=<ms>/<n>` next to the decode-side phases after the first block-crossing prefill.

Related to #3070 — instruments the untimed prefill-side capture so the premium can be attributed; does not fix it.

— Generated with Marshal · gate: READY · 0255a46 · tier: standard
verify bar: passed at 0255a46 — 1 check(s) + secrets scan, sha-keyed proof