### PR TITLE
feat: add Llama-Nemotron reranker adapter

### DIFF
--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -201,10 +201,18 @@ EMBEDDING_ARCHITECTURES = {
     "SiglipTextModel",
 }
 
+# Bidirectional Llama rerankers (e.g. nvidia/llama-nemotron-rerank-1b-v2).
+# The architecture string alone separates them from their embedding sibling,
+# LlamaBidirectionalModel, so no directory-name heuristic is needed.
+LLAMA_BIDIRECTIONAL_RERANKER_ARCHITECTURE = (
+    "LlamaBidirectionalForSequenceClassification"
+)
+
 # Supported reranker architectures
 SUPPORTED_RERANKER_ARCHITECTURES = {
     "ModernBertForSequenceClassification",  # via mlx-embeddings
     "XLMRobertaForSequenceClassification",  # omlx native implementation
+    LLAMA_BIDIRECTIONAL_RERANKER_ARCHITECTURE,  # omlx native implementation
     "JinaForRanking",  # Jina v3 listwise reranker
 }
 

--- a/omlx/models/llama_bidirectional_reranker.py
+++ b/omlx/models/llama_bidirectional_reranker.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Llama bidirectional reranker for omlx.
+
+Implements LlamaBidirectionalForSequenceClassification (for example
+nvidia/llama-nemotron-rerank-1b-v2): a Llama backbone run with full
+bidirectional attention, masked mean pooling over the real tokens, and a
+bias-free scalar classification head.
+
+The head returns raw signed logits. Unlike the other SequenceClassification
+rerankers in this package, no sigmoid or softmax is applied here: the
+reference implementation documents each score as a raw logit and leaves the
+optional probability transform to the caller.
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Union
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm.models.llama import ModelArgs as LlamaBackboneArgs
+from mlx_lm.models.llama import TransformerBlock
+
+from ..model_discovery import LLAMA_BIDIRECTIONAL_RERANKER_ARCHITECTURE
+from .base_model import BaseModelArgs, BaseModelOutput, mean_pooling
+
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    """LlamaBidirectionalForSequenceClassification configuration."""
+
+    model_type: str = "llama_bidirec"
+    hidden_size: int = 2048
+    num_hidden_layers: int = 16
+    intermediate_size: int = 8192
+    num_attention_heads: int = 32
+    num_key_value_heads: Optional[int] = None
+    head_dim: Optional[int] = None
+    max_position_embeddings: int = 131072
+    vocab_size: int = 128256
+    rms_norm_eps: float = 1e-5
+    rope_theta: float = 500000.0
+    rope_scaling: Optional[Dict[str, Union[float, str]]] = None
+    rope_traditional: bool = False
+    tie_word_embeddings: bool = True
+    attention_bias: bool = False
+    mlp_bias: bool = False
+
+    # Classification head.
+    architectures: List[str] = field(
+        default_factory=lambda: [LLAMA_BIDIRECTIONAL_RERANKER_ARCHITECTURE]
+    )
+    pooling: str = "avg"
+    temperature: float = 1.0
+    num_labels: Optional[int] = None
+    id2label: Optional[Dict[str, str]] = None
+    label2id: Optional[Dict[str, int]] = None
+
+    def __post_init__(self):
+        if self.num_key_value_heads is None:
+            self.num_key_value_heads = self.num_attention_heads
+        if self.head_dim is None:
+            self.head_dim = self.hidden_size // self.num_attention_heads
+        if self.num_labels is None:
+            # These checkpoints ship id2label and no explicit num_labels, which
+            # is how HuggingFace's PretrainedConfig derives the head width.
+            self.num_labels = len(self.id2label) if self.id2label else 1
+        if self.architectures != [LLAMA_BIDIRECTIONAL_RERANKER_ARCHITECTURE]:
+            raise ValueError(
+                f"Expected architecture {LLAMA_BIDIRECTIONAL_RERANKER_ARCHITECTURE}; "
+                f"got {self.architectures}"
+            )
+        if self.pooling != "avg":
+            # Every other pooling mode would score a different vector through
+            # the same head, so fail closed instead of silently mis-ranking.
+            raise ValueError(
+                f"Unsupported pooling {self.pooling!r}; only 'avg' is implemented"
+            )
+        if self.temperature <= 0:
+            raise ValueError(f"temperature must be positive; got {self.temperature}")
+
+    def backbone_args(self) -> LlamaBackboneArgs:
+        """Arguments for the shared mlx-lm Llama transformer blocks."""
+        return LlamaBackboneArgs(
+            model_type="llama",
+            hidden_size=self.hidden_size,
+            num_hidden_layers=self.num_hidden_layers,
+            intermediate_size=self.intermediate_size,
+            num_attention_heads=self.num_attention_heads,
+            rms_norm_eps=self.rms_norm_eps,
+            vocab_size=self.vocab_size,
+            head_dim=self.head_dim,
+            max_position_embeddings=self.max_position_embeddings,
+            num_key_value_heads=self.num_key_value_heads,
+            attention_bias=self.attention_bias,
+            mlp_bias=self.mlp_bias,
+            rope_theta=self.rope_theta,
+            rope_traditional=self.rope_traditional,
+            rope_scaling=self.rope_scaling,
+            tie_word_embeddings=self.tie_word_embeddings,
+        )
+
+
+def bidirectional_attention_mask(
+    attention_mask: mx.array,
+    dtype: mx.Dtype,
+) -> mx.array:
+    """Build an additive mask where every token attends to every real token.
+
+    The mask is keyed on columns only, so a padding row still sees the real
+    tokens. That keeps every softmax row finite; masking padding rows as well
+    would make them all ``-inf`` and produce NaNs that spread through the
+    batch, even though those rows are later dropped by the pooling mask.
+    """
+    if attention_mask.ndim != 2:
+        raise ValueError(
+            "attention_mask must have shape (batch, sequence); "
+            f"got {attention_mask.shape}"
+        )
+    batch_size, sequence_length = attention_mask.shape
+    key_mask = attention_mask.astype(mx.bool_)[:, None, None, :]
+    additive = mx.where(key_mask, 0.0, -mx.inf).astype(dtype)
+    return mx.broadcast_to(
+        additive,
+        (batch_size, 1, sequence_length, sequence_length),
+    )
+
+
+class LlamaBidirectionalModel(nn.Module):
+    """Llama backbone without the causal mask."""
+
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        backbone = args.backbone_args()
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [
+            TransformerBlock(args=backbone) for _ in range(args.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        attention_mask: Optional[mx.array] = None,
+    ) -> mx.array:
+        hidden_states = self.embed_tokens(input_ids)
+        if attention_mask is None:
+            attention_mask = mx.ones(input_ids.shape, dtype=mx.int32)
+        mask = bidirectional_attention_mask(attention_mask, hidden_states.dtype)
+        for layer in self.layers:
+            hidden_states = layer(hidden_states, mask, cache=None)
+        return self.norm(hidden_states)
+
+
+class Model(nn.Module):
+    """Bidirectional Llama with a scalar relevance head."""
+
+    def __init__(self, config: ModelArgs):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.model = LlamaBidirectionalModel(config)
+        # Root-level attribute so the parameter path is exactly `score.weight`,
+        # matching the checkpoint. The reference head carries no bias.
+        self.score = nn.Linear(config.hidden_size, config.num_labels, bias=False)
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        attention_mask: Optional[mx.array] = None,
+    ) -> BaseModelOutput:
+        if attention_mask is None:
+            attention_mask = mx.ones(input_ids.shape, dtype=mx.int32)
+        hidden_states = self.model(input_ids, attention_mask=attention_mask)
+        pooled = mean_pooling(hidden_states, attention_mask)
+        # Raw signed logits: the reference leaves the sigmoid to the caller, so
+        # applying one here would silently change the score domain.
+        logits = self.score(pooled) / self.config.temperature
+        return BaseModelOutput(
+            last_hidden_state=hidden_states,
+            text_embeds=None,
+            pooler_output=logits,
+        )
+
+    def sanitize(self, weights):
+        """Drop tensors this port does not use and keep every other key as-is.
+
+        ``score.weight`` sits at the checkpoint root beside ``model.*``, which
+        is exactly where this module places it, so no key is rewritten. A
+        blanket ``model.`` prefix rule would move the head out of reach and
+        break weight loading.
+        """
+        return {
+            key: value
+            for key, value in weights.items()
+            if "rotary_emb.inv_freq" not in key and key != "lm_head.weight"
+        }
+
+    @property
+    def layers(self):
+        return self.model.layers

--- a/omlx/models/reranker.py
+++ b/omlx/models/reranker.py
@@ -8,6 +8,7 @@ and CausalLM-based reranker models on Apple's MLX framework.
 Supports:
 - ModernBertForSequenceClassification (via mlx-embeddings)
 - XLMRobertaForSequenceClassification (omlx native implementation)
+- LlamaBidirectionalForSequenceClassification (omlx native implementation)
 - CausalLM-based rerankers (e.g., Qwen3-Reranker) via yes/no logit scoring
 """
 
@@ -22,6 +23,7 @@ import mlx.core as mx
 
 from ..model_discovery import (
     CAUSAL_LM_RERANKER_ARCHITECTURES,
+    LLAMA_BIDIRECTIONAL_RERANKER_ARCHITECTURE,
     MULTIMODAL_RERANKER_ARCHITECTURES,
     SUPPORTED_RERANKER_ARCHITECTURES,
     _is_causal_lm_reranker,
@@ -53,7 +55,12 @@ class RerankOutput:
     """Output from rerank operation."""
 
     scores: list[float]
-    """Relevance scores for each document (0 to 1)."""
+    """Relevance scores for each document.
+
+    Most architectures emit a 0-to-1 score. Models whose reference
+    implementation documents a raw logit (LlamaBidirectional rerankers) emit
+    unbounded signed scores instead, so compare them by rank, not magnitude.
+    """
 
     indices: list[int]
     """Document indices sorted by score (descending)."""
@@ -112,6 +119,7 @@ class MLXRerankerModel:
         self._is_causal_lm = False
         self._is_jina_reranker = False
         self._is_vl_reranker = False
+        self._is_llama_bidirectional = False
         self._token_true_id: int | None = None
         self._token_false_id: int | None = None
         self._doc_embed_token_id: int | None = None
@@ -230,6 +238,74 @@ class MLXRerankerModel:
         )
 
         return model, tokenizer
+
+    @staticmethod
+    def _load_llama_bidirectional_tokenizer(model_path: Path) -> Any:
+        """Load the tokenizer without resolving the model config.
+
+        These checkpoints declare a custom ``model_type`` plus an ``auto_map``,
+        so AutoTokenizer resolves the *model* config to decide about remote
+        code -- and transformers >= 5 cannot parse the transformers-4.44-era
+        rope block they ship. The tokenizer is fully self-describing, so load
+        it directly: the model config is already parsed into ModelArgs, and
+        this keeps the repository's own Python out of the process entirely.
+        """
+        from transformers import PreTrainedTokenizerFast
+
+        declared_class = None
+        tokenizer_config_path = model_path / "tokenizer_config.json"
+        if tokenizer_config_path.exists():
+            with open(tokenizer_config_path) as f:
+                declared_class = json.load(f).get("tokenizer_class")
+        if declared_class not in (None, "PreTrainedTokenizerFast"):
+            raise ValueError(
+                "LlamaBidirectional rerankers are expected to ship a "
+                f"PreTrainedTokenizerFast tokenizer; got {declared_class!r}."
+            )
+
+        # The reference implementation pads left and falls back to the EOS
+        # token when the tokenizer ships no pad token.
+        tokenizer = PreTrainedTokenizerFast.from_pretrained(
+            str(model_path),
+            padding_side="left",
+        )
+        if tokenizer.pad_token is None:
+            tokenizer.pad_token = tokenizer.eos_token
+        return tokenizer
+
+    def _load_llama_bidirectional(self) -> Tuple[Any, Any]:
+        """Load a bidirectional Llama reranker using the omlx native model."""
+        import mlx.core as mx
+
+        from .llama_bidirectional_reranker import Model, ModelArgs
+
+        model_path = Path(self.model_name)
+
+        with open(model_path / "config.json") as f:
+            config_dict = json.load(f)
+
+        config = ModelArgs(
+            **{
+                k: v
+                for k, v in config_dict.items()
+                if k in ModelArgs.__dataclass_fields__
+            }
+        )
+
+        model = Model(config)
+
+        # mx.load reads safetensors straight into MLX arrays and handles the
+        # bfloat16 weights these checkpoints ship; see _load_xlm_roberta.
+        weights = {}
+        for weight_file in model_path.glob("*.safetensors"):
+            weights.update(mx.load(str(weight_file)))
+        weights = model.sanitize(weights)
+
+        model.load_weights(list(weights.items()))
+        mx.eval(model.parameters())
+        model.train(False)
+
+        return model, self._load_llama_bidirectional_tokenizer(model_path)
 
     def _load_vl_reranker(self) -> Tuple[Any, Any]:
         """Load a multimodal reranker (e.g., Qwen3-VL-Reranker) via mlx-embeddings.
@@ -822,6 +898,11 @@ class MLXRerankerModel:
                 # Use omlx native implementation
                 self.model, self.processor = self._load_xlm_roberta()
                 self._num_labels = getattr(self.model.config, "num_labels", None)
+            elif arch == LLAMA_BIDIRECTIONAL_RERANKER_ARCHITECTURE:
+                # Use omlx native implementation
+                self.model, self.processor = self._load_llama_bidirectional()
+                self._is_llama_bidirectional = True
+                self._num_labels = getattr(self.model.config, "num_labels", None)
             else:
                 # Use mlx-embeddings for other architectures (ModernBert, etc.)
                 patch_qwen3_vl_processor_for_torch_free_image_loading()
@@ -930,6 +1011,7 @@ class MLXRerankerModel:
         self._is_causal_lm = False
         self._is_jina_reranker = False
         self._is_vl_reranker = False
+        self._is_llama_bidirectional = False
         self._token_true_id = None
         self._token_false_id = None
         self._doc_embed_token_id = None
@@ -947,6 +1029,10 @@ class MLXRerankerModel:
     # Default max_length per model type
     _DEFAULT_MAX_LENGTH_SEQ_CLASSIFICATION = 512
     _DEFAULT_MAX_LENGTH_CAUSAL_LM = 8192
+    # LlamaBidirectional rerankers are trained and evaluated to 8192 tokens.
+    # Their tokenizer_config.json still carries the base model's 4096
+    # model_max_length, so the default is pinned here rather than read from it.
+    _DEFAULT_MAX_LENGTH_LLAMA_BIDIRECTIONAL = 8192
 
     def rerank(
         self,
@@ -1002,6 +1088,15 @@ class MLXRerankerModel:
                 else self._DEFAULT_MAX_LENGTH_CAUSAL_LM
             )
             return self._rerank_causal_lm(query_str, docs_str, effective_max_length)
+        elif self._is_llama_bidirectional:
+            effective_max_length = (
+                max_length
+                if max_length is not None
+                else self._DEFAULT_MAX_LENGTH_LLAMA_BIDIRECTIONAL
+            )
+            return self._rerank_llama_bidirectional(
+                query_str, docs_str, effective_max_length
+            )
         else:
             effective_max_length = (
                 max_length
@@ -1311,6 +1406,117 @@ class MLXRerankerModel:
             total_tokens=total_tokens,
         )
 
+    def _forward_seq_logits(
+        self,
+        input_ids: mx.array,
+        attention_mask: mx.array,
+    ) -> mx.array:
+        """Run the classification head, preferring the compiled logits path.
+
+        Shared by every SequenceClassification reranker so the compile
+        fallback is defined once. Returns logits of shape
+        (batch_size, num_labels), already evaluated.
+        """
+        logits = None
+        if self._is_compiled and self._compiled_seq_logits is not None:
+            try:
+                model_inputs = {
+                    "input_ids": input_ids,
+                    "attention_mask": attention_mask,
+                }
+                logits = self._compiled_seq_logits(model_inputs)
+            except Exception as e:
+                logger.warning(
+                    f"compiled reranker path failed for {self.model_name}: {e}; "
+                    f"disabling compile and falling back to eager forward()"
+                )
+                self._is_compiled = False
+                self._compiled_seq_logits = None
+
+        if logits is None:
+            if not callable(self.model):
+                raise ValueError("SequenceClassification model is not initialized.")
+            outputs = self.model(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+            )
+
+            # pooler_output shape: (batch_size, num_labels)
+            if hasattr(outputs, "pooler_output") and outputs.pooler_output is not None:
+                logits = outputs.pooler_output
+            else:
+                raise ValueError(
+                    "Model output does not contain pooler_output. "
+                    "Ensure the model is a SequenceClassification model."
+                )
+
+        mx.eval(logits)
+        return logits
+
+    @staticmethod
+    def _format_llama_bidirectional_prompt(query: str, document: str) -> str:
+        """Render one pair with the reference prompt template.
+
+        Byte-identical to the upstream model card and its vLLM chat template.
+        The spacing around the two newlines is part of the template, and the
+        pair is encoded as a single sequence: a Llama tokenizer has no
+        sentence-pair scheme, so pair encoding would feed the model an
+        off-distribution input without raising.
+        """
+        return f"question:{query} \n \n passage:{document}"
+
+    def _rerank_llama_bidirectional(
+        self,
+        query: str,
+        documents: list[str],
+        max_length: int = 8192,
+    ) -> RerankOutput:
+        """Rerank using a bidirectional Llama sequence-classification head."""
+        processor = self.processor
+        if not callable(processor):
+            raise ValueError("LlamaBidirectional processor is not initialized.")
+
+        texts = [
+            self._format_llama_bidirectional_prompt(query, document)
+            for document in documents
+        ]
+
+        inputs = processor(
+            texts,
+            max_length=max_length,
+            padding=True,
+            truncation=True,
+            return_tensors="np",
+        )
+
+        input_ids = mx.array(inputs["input_ids"])
+        attention_mask = mx.array(inputs["attention_mask"])
+
+        logits = self._forward_seq_logits(input_ids, attention_mask)
+
+        if logits.shape[-1] != 1:
+            raise ValueError(
+                "LlamaBidirectional rerankers expect a single-label head; "
+                f"got {logits.shape[-1]} labels."
+            )
+        # Raw signed logits, deliberately not squashed: the reference documents
+        # the score as a logit and leaves any sigmoid to the caller.
+        scores = logits.squeeze(-1).tolist()
+
+        indexed_scores = list(enumerate(scores))
+        indexed_scores.sort(key=lambda x: x[1], reverse=True)
+        sorted_indices = [idx for idx, _ in indexed_scores]
+
+        # Count the real tokens actually scored. _count_tokens assumes the
+        # (query, document) pair encoding this path deliberately avoids.
+        total_tokens = int(attention_mask.sum().item())
+
+        return RerankOutput(
+            scores=scores,
+            indices=sorted_indices,
+            total_tokens=total_tokens,
+        )
+
     def _rerank_seq_classification(
         self,
         query: str,
@@ -1347,43 +1553,7 @@ class MLXRerankerModel:
         input_ids = mx.array(inputs["input_ids"])
         attention_mask = mx.array(inputs["attention_mask"])
 
-        # Forward pass (compiled primitive logits path when available)
-        logits = None
-        if self._is_compiled and self._compiled_seq_logits is not None:
-            try:
-                model_inputs = {
-                    "input_ids": input_ids,
-                    "attention_mask": attention_mask,
-                }
-                logits = self._compiled_seq_logits(model_inputs)
-            except Exception as e:
-                logger.warning(
-                    f"compiled reranker path failed for {self.model_name}: {e}; "
-                    f"disabling compile and falling back to eager forward()"
-                )
-                self._is_compiled = False
-                self._compiled_seq_logits = None
-
-        if logits is None:
-            if not callable(self.model):
-                raise ValueError("SequenceClassification model is not initialized.")
-            outputs = self.model(
-                input_ids=input_ids,
-                attention_mask=attention_mask,
-            )
-
-            # Extract scores from pooler_output
-            # pooler_output shape: (batch_size, num_labels)
-            if hasattr(outputs, "pooler_output") and outputs.pooler_output is not None:
-                logits = outputs.pooler_output
-            else:
-                raise ValueError(
-                    "Model output does not contain pooler_output. "
-                    "Ensure the model is a SequenceClassification model."
-                )
-
-        # Ensure computation is done
-        mx.eval(logits)
+        logits = self._forward_seq_logits(input_ids, attention_mask)
 
         # Extract relevance scores
         # For binary classification (num_labels=1), score is already sigmoid applied

--- a/tests/test_llama_bidirectional_reranker.py
+++ b/tests/test_llama_bidirectional_reranker.py
@@ -1,0 +1,310 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the native LlamaBidirectional sequence-classification reranker."""
+
+import json
+
+import mlx.core as mx
+import pytest
+from mlx.utils import tree_flatten
+
+from omlx.model_discovery import (
+    LLAMA_BIDIRECTIONAL_RERANKER_ARCHITECTURE,
+    SUPPORTED_RERANKER_ARCHITECTURES,
+)
+from omlx.models.llama_bidirectional_reranker import (
+    Model,
+    ModelArgs,
+    bidirectional_attention_mask,
+)
+from omlx.models.reranker import MLXRerankerModel
+
+ARCH = LLAMA_BIDIRECTIONAL_RERANKER_ARCHITECTURE
+
+
+def _config(**overrides) -> ModelArgs:
+    values = {
+        "hidden_size": 8,
+        "num_hidden_layers": 1,
+        "intermediate_size": 16,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 1,
+        "head_dim": 4,
+        "vocab_size": 32,
+        "max_position_embeddings": 64,
+        "rope_theta": 500000.0,
+        "id2label": {"0": "LABEL_0"},
+    }
+    values.update(overrides)
+    return ModelArgs(**values)
+
+
+def _tiny_model(**overrides) -> Model:
+    model = Model(_config(**overrides))
+    mx.eval(model.parameters())
+    model.train(False)
+    return model
+
+
+# --- configuration -----------------------------------------------------------
+
+
+def test_num_labels_is_derived_from_id2label() -> None:
+    assert _config().num_labels == 1
+    assert _config(id2label=None).num_labels == 1
+    assert _config(id2label={"0": "a", "1": "b"}).num_labels == 2
+
+
+def test_explicit_num_labels_wins_over_id2label() -> None:
+    assert _config(num_labels=3, id2label={"0": "a"}).num_labels == 3
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"architectures": ["LlamaBidirectionalModel"]},
+        {"pooling": "cls"},
+        {"temperature": 0.0},
+        {"temperature": -1.0},
+    ],
+)
+def test_config_fails_closed_on_unsupported_variants(override) -> None:
+    with pytest.raises(ValueError):
+        _config(**override)
+
+
+# --- discovery and routing ---------------------------------------------------
+
+
+def test_architecture_is_registered_as_a_supported_reranker() -> None:
+    assert ARCH in SUPPORTED_RERANKER_ARCHITECTURES
+
+
+def test_validate_architecture_accepts_without_directory_hint(tmp_path) -> None:
+    # Deliberately a directory name with no "rerank" substring: this
+    # architecture is self-disambiguating, unlike the CausalLM/VLM rerankers.
+    model_dir = tmp_path / "plain-name"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text(json.dumps({"architectures": [ARCH]}))
+
+    MLXRerankerModel(str(model_dir))._validate_architecture()
+
+
+def test_embedding_sibling_is_not_a_supported_reranker() -> None:
+    assert "LlamaBidirectionalModel" not in SUPPORTED_RERANKER_ARCHITECTURES
+
+
+def test_tokenizer_loader_rejects_an_unexpected_tokenizer_class(tmp_path) -> None:
+    (tmp_path / "tokenizer_config.json").write_text(
+        json.dumps({"tokenizer_class": "LlamaTokenizer"})
+    )
+
+    with pytest.raises(ValueError, match="PreTrainedTokenizerFast"):
+        MLXRerankerModel._load_llama_bidirectional_tokenizer(tmp_path)
+
+
+# --- attention mask ----------------------------------------------------------
+
+
+def test_mask_is_bidirectional_and_excludes_padding_keys() -> None:
+    mask = bidirectional_attention_mask(mx.array([[1, 1, 1, 0]]), mx.float32)
+    mx.eval(mask)
+
+    assert mask.shape == (1, 1, 4, 4)
+    # Both directions are visible between real tokens.
+    assert mask[0, 0, 0, 2].item() == 0.0
+    assert mask[0, 0, 2, 0].item() == 0.0
+    # The padding column is masked for every query row.
+    assert mask[0, 0, 0, 3].item() == float("-inf")
+    assert mask[0, 0, 3, 3].item() == float("-inf")
+
+
+def test_padding_rows_keep_a_finite_key_so_softmax_cannot_produce_nan() -> None:
+    mask = bidirectional_attention_mask(mx.array([[1, 0]]), mx.float32)
+    mx.eval(mask)
+
+    # Row 1 is a padding query; it must still see the real token at column 0.
+    assert mask[0, 0, 1, 0].item() == 0.0
+
+
+def test_mask_rejects_wrong_rank() -> None:
+    with pytest.raises(ValueError):
+        bidirectional_attention_mask(mx.ones((2, 3, 4)), mx.float32)
+
+
+# --- weights -----------------------------------------------------------------
+
+
+def test_score_head_is_root_level_and_bias_free() -> None:
+    model = _tiny_model()
+    flat = dict(tree_flatten(model.parameters()))
+
+    assert "score.weight" in flat
+    assert flat["score.weight"].shape == (1, 8)
+    assert "score.bias" not in flat
+
+
+def test_sanitize_preserves_the_checkpoint_namespace() -> None:
+    model = _tiny_model()
+    weights = {
+        "model.embed_tokens.weight": mx.zeros((32, 8)),
+        "score.weight": mx.zeros((1, 8)),
+        "model.layers.0.self_attn.rotary_emb.inv_freq": mx.zeros((4,)),
+        "lm_head.weight": mx.zeros((32, 8)),
+    }
+
+    sanitized = model.sanitize(weights)
+
+    # score.weight stays at the root; a blanket "model." prefix would hide it.
+    assert set(sanitized) == {"model.embed_tokens.weight", "score.weight"}
+
+
+def test_sanitized_checkpoint_keys_load_into_the_model() -> None:
+    model = _tiny_model()
+    checkpoint = {
+        key: mx.zeros(value.shape) for key, value in tree_flatten(model.parameters())
+    }
+    checkpoint["lm_head.weight"] = mx.zeros((32, 8))
+
+    model.load_weights(list(model.sanitize(checkpoint).items()))
+    mx.eval(model.parameters())
+
+
+# --- forward -----------------------------------------------------------------
+
+
+def test_forward_returns_a_raw_unsquashed_logit() -> None:
+    model = _tiny_model()
+    input_ids = mx.array([[1, 2, 3]])
+    attention_mask = mx.ones((1, 3), dtype=mx.int32)
+
+    output = model(input_ids=input_ids, attention_mask=attention_mask)
+    mx.eval(output.pooler_output, output.last_hidden_state)
+
+    assert output.pooler_output.shape == (1, 1)
+    assert output.text_embeds is None
+
+    # Recompute the head by hand. Any sigmoid, softmax or normalization in the
+    # model path would break this equality.
+    hidden = output.last_hidden_state
+    pooled = mx.sum(hidden, axis=1) / 3.0
+    expected = pooled @ model.score.weight.T
+    assert mx.allclose(output.pooler_output, expected, atol=1e-5)
+
+
+def test_temperature_scales_the_logit() -> None:
+    warm = _tiny_model()
+    cold = _tiny_model(temperature=2.0)
+    cold.update(warm.parameters())
+    mx.eval(cold.parameters())
+
+    input_ids = mx.array([[1, 2, 3]])
+    attention_mask = mx.ones((1, 3), dtype=mx.int32)
+    warm_logit = warm(input_ids=input_ids, attention_mask=attention_mask).pooler_output
+    cold_logit = cold(input_ids=input_ids, attention_mask=attention_mask).pooler_output
+    mx.eval(warm_logit, cold_logit)
+
+    assert mx.allclose(cold_logit, warm_logit / 2.0, atol=1e-5)
+
+
+def test_padding_does_not_change_a_sequence_score() -> None:
+    """Left padding must be inert: RoPE logits depend only on relative offsets
+    and padding keys are masked, so a pair scores the same alone and in a
+    padded batch. This is the sharpest check on mask and pooling correctness."""
+    model = _tiny_model()
+
+    alone = model(
+        input_ids=mx.array([[5, 6, 7]]),
+        attention_mask=mx.ones((1, 3), dtype=mx.int32),
+    ).pooler_output
+    # Same sequence, left-padded to length 5 inside a batch.
+    batched = model(
+        input_ids=mx.array([[0, 0, 5, 6, 7], [1, 2, 3, 4, 9]]),
+        attention_mask=mx.array([[0, 0, 1, 1, 1], [1, 1, 1, 1, 1]]),
+    ).pooler_output
+    mx.eval(alone, batched)
+
+    assert mx.allclose(alone[0], batched[0], atol=1e-4)
+
+
+# --- prompt and scoring path -------------------------------------------------
+
+
+def test_prompt_template_matches_the_reference_byte_for_byte() -> None:
+    rendered = MLXRerankerModel._format_llama_bidirectional_prompt("q text", "d text")
+
+    assert rendered == "question:q text \n \n passage:d text"
+
+
+class _RecordingProcessor:
+    """Minimal tokenizer stand-in that records how it was called."""
+
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, texts, **kwargs):
+        self.calls.append({"texts": texts, **kwargs})
+        batch = len(texts)
+        return {
+            "input_ids": [[1, 2, 3] for _ in range(batch)],
+            "attention_mask": [[1, 1, 1] for _ in range(batch)],
+        }
+
+
+def _wired_reranker(model, processor) -> MLXRerankerModel:
+    reranker = MLXRerankerModel("unused")
+    reranker.model = model
+    reranker.processor = processor
+    reranker._loaded = True
+    reranker._is_llama_bidirectional = True
+    reranker._num_labels = 1
+    return reranker
+
+
+def test_rerank_defaults_to_the_8192_token_ceiling() -> None:
+    processor = _RecordingProcessor()
+    reranker = _wired_reranker(_tiny_model(), processor)
+
+    reranker.rerank("query", ["doc one", "doc two"])
+
+    assert MLXRerankerModel._DEFAULT_MAX_LENGTH_LLAMA_BIDIRECTIONAL == 8192
+    assert processor.calls[0]["max_length"] == 8192
+
+
+def test_rerank_encodes_single_templated_sequences_not_pairs() -> None:
+    processor = _RecordingProcessor()
+    reranker = _wired_reranker(_tiny_model(), processor)
+
+    reranker.rerank("what is ml", ["ml is", "weather is"])
+
+    call = processor.calls[0]
+    # One positional list of fully rendered strings, never a (queries, docs) pair.
+    assert call["texts"] == [
+        "question:what is ml \n \n passage:ml is",
+        "question:what is ml \n \n passage:weather is",
+    ]
+    assert call["padding"] is True
+    assert call["truncation"] is True
+
+
+def test_rerank_sorts_by_raw_score_and_counts_real_tokens() -> None:
+    model = _tiny_model()
+    # Force a deterministic, clearly signed ordering through the head.
+    model.score.weight = mx.array([[1.0] + [0.0] * 7])
+    mx.eval(model.parameters())
+    reranker = _wired_reranker(model, _RecordingProcessor())
+
+    output = reranker.rerank("query", ["doc one", "doc two"])
+
+    assert len(output.scores) == 2
+    assert output.indices == sorted(
+        range(2), key=lambda i: output.scores[i], reverse=True
+    )
+    # Six real tokens across the two 3-token rows; no padding was emitted.
+    assert output.total_tokens == 6
+
+
+def test_rerank_rejects_a_multi_label_head() -> None:
+    reranker = _wired_reranker(_tiny_model(num_labels=2), _RecordingProcessor())
+
+    with pytest.raises(ValueError, match="single-label head"):
+        reranker.rerank("query", ["doc"])


### PR DESCRIPTION
## Summary

Add native support for `LlamaBidirectionalForSequenceClassification` rerankers, such as `nvidia/llama-nemotron-rerank-1b-v2`.

## Implementation

New `omlx/models/llama_bidirectional_reranker.py`, following the existing native `xlm_roberta.py` precedent:

- Llama backbone run with full bidirectional attention instead of a causal mask.
- Masked mean pooling over the real tokens, then a bias-free root `score` head divided by `temperature`.
- **Raw signed logits, no sigmoid.** The reference documents each score as a logit and leaves the probability transform to the caller, so squashing here would silently change the score domain. `RerankOutput.scores` is documented accordingly.
- `sanitize()` keeps `score.weight` at the checkpoint root; a blanket `model.` prefix would move the head out of reach and break weight loading.
- Config fails closed on a causal architecture, a non-`avg` pooling mode, or a non-positive temperature.

Wiring:

- `model_discovery.py` registers the architecture. It is self-disambiguating from its embedding sibling `LlamaBidirectionalModel`, so no directory-name heuristic is needed.
- `reranker.py` dispatches to the new loader, renders the reference prompt `question:{query} \n \n passage:{document}` as a **single sequence** (a Llama tokenizer has no sentence-pair scheme, so pair encoding would feed the model off-distribution input without raising), and defaults to the model's 8192-token ceiling rather than the 512 encoder default or the stale 4096 in `tokenizer_config.json`.
- The tokenizer is loaded directly rather than through `AutoTokenizer`: these checkpoints declare a custom `model_type` plus an `auto_map`, so `AutoTokenizer` resolves the *model* config, and transformers >= 5 cannot parse the transformers-4.44-era rope block they ship. This also keeps the repository's own Python out of the process.
- The compiled/eager forward is extracted into one shared `_forward_seq_logits` helper instead of duplicating the compile-fallback logic per scoring path.

## Verification

Reference parity against the three query/document pairs published in the model card:

| | model card | this port | delta |
|---|---|---|---|
| doc 1 | `20.6250` | `20.625` | `0.0` |
| doc 2 | `-23.1250` | `-23.125` | `0.0` |
| doc 3 | `-0.2617` | `-0.283203125` | `0.0215` |

Ranking `[0, 2, 1]` and all three signs match. The two large-magnitude scores match the exact bf16 value; the residual on the third is bf16 rounding on a near-zero logit.

- New focused tests: **24 passed**.
- Full suite: **10,626 passed**, 208 skipped, 77 deselected.
- Compiled scoring path active (`mx.compile`), 199 tokens on the reference batch.
- A metamorphic test asserts a sequence scores identically alone and left-padded inside a batch, pinning mask and pooling correctness.

No model repository code is executed and no checkpoint files are rewritten.
