### PR TITLE
feat(activity): report the caller's X-Request-ID on activity rows

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -5279,6 +5279,19 @@ async def get_server_activity(is_admin: bool = Depends(require_admin)):
     return {"active_models": _build_active_models_data()}
 
 
+def _client_request_id_fields(request) -> dict:
+    """Return the caller's own request id for an activity row, if it sent one.
+
+    The engine's request id is internal and never returned over HTTP, so a
+    client polling the activity API cannot otherwise tell which in-flight row
+    is its own once two requests run concurrently. Omitted entirely for
+    requests without an ``X-Request-ID`` header, so their rows keep the
+    existing shape.
+    """
+    client_request_id = getattr(request, "client_request_id", None)
+    return {"client_request_id": client_request_id} if client_request_id else {}
+
+
 def _build_active_models_data() -> dict:
     """Build active models status for the dashboard Active Models card."""
     from ..model_discovery import format_size
@@ -5375,6 +5388,7 @@ def _build_active_models_data() -> dict:
                         "queue_position": idx,
                         "elapsed_seconds": max(0.0, now - req.arrival_time),
                         "prompt_tokens": getattr(req, "num_prompt_tokens", 0),
+                        **_client_request_id_fields(req),
                     }
                     for idx, req in enumerate(waiting_queue, start=1)
                 ]
@@ -5387,6 +5401,8 @@ def _build_active_models_data() -> dict:
                 activities = snapshot.get("activities", [])
 
         prefilling = tracker.get_model_progress(model_id)
+        for row in prefilling:
+            row.update(_client_request_id_fields(running_by_id.get(row["request_id"])))
         prefilling_ids = {p["request_id"] for p in prefilling}
         if has_scheduler_snapshot:
             active_request_ids = set(running_by_id) | prefilling_ids
@@ -5419,6 +5435,7 @@ def _build_active_models_data() -> dict:
                     "last_activity_age_seconds": last_activity_age,
                     "prompt_tokens": getattr(req, "num_prompt_tokens", 0) if req else 0,
                     "max_tokens": getattr(req, "max_tokens", None) if req else None,
+                    **_client_request_id_fields(req),
                 }
             )
 

--- a/omlx/engine_core.py
+++ b/omlx/engine_core.py
@@ -42,7 +42,12 @@ from .exceptions import (
 )
 from .model_registry import get_registry
 from .output_collector import RequestOutputCollector, RequestStreamState
-from .request import Request, RequestOutput, SamplingParams
+from .request import (
+    Request,
+    RequestOutput,
+    SamplingParams,
+    current_client_request_id,
+)
 from .scheduler import Scheduler, SchedulerConfig, _sync_and_clear_cache
 from .utils.fatal import FATAL_TEARDOWN_TIMEOUT_S, fatal_exit
 from .utils.hardware import format_bytes
@@ -613,6 +618,9 @@ class EngineCore:
             skip_cache_store=skip_cache_store,
             benchmark_trace=benchmark_trace,
             benchmark_ane_sequence_length=benchmark_ane_sequence_length,
+            # Every engine path (streaming or not, LLM or VLM) mints its id
+            # here, so this is the one place the caller's id can be attached.
+            client_request_id=current_client_request_id.get(),
         )
 
         # SpecPrefill: resolve per-request settings.

--- a/omlx/request.py
+++ b/omlx/request.py
@@ -9,8 +9,34 @@ request management system, simplified for MLX backend.
 
 import enum
 import time
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+
+# Longest caller-supplied request id the activity API will echo back. Bounds
+# what an arbitrary header can pin in memory for the life of a request.
+CLIENT_REQUEST_ID_MAX_LEN = 128
+
+# Carries the caller's ``X-Request-ID`` from the HTTP layer to the point where
+# an engine mints its own request id, without threading a parameter through
+# every engine signature. Each request runs in its own task, so the value
+# cannot leak between concurrent requests.
+current_client_request_id: ContextVar[Optional[str]] = ContextVar(
+    "omlx_client_request_id", default=None
+)
+
+
+def client_request_id_from_headers(headers) -> Optional[str]:
+    """Return a usable ``X-Request-ID`` from raw ASGI headers, or None.
+
+    Whitespace-only values count as absent; long values are truncated to
+    ``CLIENT_REQUEST_ID_MAX_LEN``.
+    """
+    for key, value in headers:
+        if key.lower() == b"x-request-id":
+            text = value.decode("latin-1").strip()
+            return text[:CLIENT_REQUEST_ID_MAX_LEN] or None
+    return None
 
 if TYPE_CHECKING:
     from .cache.paged_cache import BlockTable
@@ -149,6 +175,12 @@ class Request:
     # This is never set by ordinary API traffic.
     benchmark_trace: bool = False
     benchmark_ane_sequence_length: int = 0
+    # The caller's own ``X-Request-ID``, when it sent one. The engine mints
+    # ``request_id`` internally and never returns it over HTTP, so this is the
+    # only handle a client has for finding its row on the activity API while
+    # the request is in flight. Display-only: never used for scheduling,
+    # caching, or identity.
+    client_request_id: Optional[str] = None
     # Effective prefill widths observed by the scheduler. These are populated
     # only for benchmark_trace requests so the benchmark summary can distinguish
     # a requested scheduler step from the model calls actually delivered after

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -194,6 +194,7 @@ from .exceptions import (
     SchedulerQueueFullError,
 )
 from .model_settings import forced_ct_keys, merge_chat_template_request_kwargs
+from .request import client_request_id_from_headers, current_client_request_id
 from .server_metrics import get_server_metrics, reset_server_metrics
 
 logging.basicConfig(level=logging.INFO)
@@ -1062,7 +1063,34 @@ class DebugRequestLoggingMiddleware:
         await self.app(scope, cached_receive, send)
 
 
+class ClientRequestIdMiddleware:
+    """Pure ASGI middleware exposing the caller's ``X-Request-ID`` downstream.
+
+    Lets a client correlate its own request with the row the activity API
+    reports for it: the engine mints its request id internally and never
+    returns it, so without this the two cannot be matched under concurrency.
+
+    Must be pure ASGI rather than ``BaseHTTPMiddleware``. The latter runs the
+    endpoint in a separate task and returns before a streaming body is
+    iterated, so the value would already be gone by the time the engine
+    registers the request — which happens lazily, during iteration.
+
+    Requests that send no header are untracked, exactly as before.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http":
+            current_client_request_id.set(
+                client_request_id_from_headers(scope.get("headers") or ())
+            )
+        await self.app(scope, receive, send)
+
+
 app.add_middleware(DebugRequestLoggingMiddleware)
+app.add_middleware(ClientRequestIdMiddleware)
 
 
 # =============================================================================

--- a/tests/test_active_models_visibility.py
+++ b/tests/test_active_models_visibility.py
@@ -616,3 +616,57 @@ def test_dflash_dashboard_localizes_metrics_and_shows_session_fallbacks():
     for locale_path in i18n_dir.glob("*.json"):
         locale = json.loads(locale_path.read_text(encoding="utf-8"))
         assert not keys - locale.keys(), f"{locale_path.name} is missing DFlash keys"
+
+
+def test_active_models_rows_carry_the_callers_request_id_only_when_sent():
+    """A request that sent ``X-Request-ID`` is reported with ``client_request_id``.
+
+    Rows for requests that sent no header keep their existing shape, so the
+    key is absent rather than null.
+    """
+    running_request = SimpleNamespace(
+        request_id="gen-1",
+        client_request_id="caller-gen",
+        generation_started_at=100.0,
+        last_activity_at=109.5,
+        num_output_tokens=20,
+        num_prompt_tokens=12,
+        max_tokens=64,
+    )
+    prefilling_request = SimpleNamespace(
+        request_id="prefill-1", client_request_id="caller-prefill"
+    )
+    waiting_request = SimpleNamespace(
+        request_id="wait-1",
+        arrival_time=105.0,
+        num_prompt_tokens=30,
+    )
+    scheduler = SimpleNamespace(
+        snapshot_for_admin=lambda: {
+            "running_by_id": {"gen-1": running_request, "prefill-1": prefilling_request},
+            "waiting": [waiting_request],
+        },
+    )
+
+    with (
+        patch.object(admin_routes, "_get_engine_pool", return_value=FakePool(scheduler)),
+        patch("omlx.admin.routes._get_server_state", return_value=None),
+        patch.object(admin_routes, "_get_settings_manager", return_value=None),
+        patch.object(admin_routes, "_get_global_settings", return_value=None),
+        patch("omlx.prefill_progress.get_prefill_tracker", return_value=FakePrefillTracker()),
+        patch("time.monotonic", return_value=110.0),
+    ):
+        data = admin_routes._build_active_models_data()
+
+    model = data["models"][0]
+    assert model["prefilling"] == [
+        {
+            "request_id": "prefill-1",
+            "processed": 10,
+            "total": 20,
+            "client_request_id": "caller-prefill",
+        }
+    ]
+    assert model["generating"][0]["request_id"] == "gen-1"
+    assert model["generating"][0]["client_request_id"] == "caller-gen"
+    assert "client_request_id" not in model["waiting"][0]

--- a/tests/test_client_request_id.py
+++ b/tests/test_client_request_id.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for caller request-id correlation on the activity API."""
+
+import asyncio
+
+from omlx.request import (
+    CLIENT_REQUEST_ID_MAX_LEN,
+    Request,
+    client_request_id_from_headers,
+    current_client_request_id,
+)
+
+
+def test_header_is_extracted():
+    headers = [(b"host", b"localhost"), (b"x-request-id", b"caller-abc")]
+    assert client_request_id_from_headers(headers) == "caller-abc"
+
+
+def test_missing_header_is_none():
+    assert client_request_id_from_headers([(b"host", b"localhost")]) is None
+    assert client_request_id_from_headers(()) is None
+
+
+def test_blank_header_counts_as_absent():
+    assert client_request_id_from_headers([(b"x-request-id", b"   ")]) is None
+    assert client_request_id_from_headers([(b"x-request-id", b"")]) is None
+
+
+def test_header_is_trimmed_and_bounded():
+    value = b"  " + b"a" * (CLIENT_REQUEST_ID_MAX_LEN + 50) + b"  "
+    result = client_request_id_from_headers([(b"x-request-id", value)])
+    assert result == "a" * CLIENT_REQUEST_ID_MAX_LEN
+
+
+def test_request_has_no_caller_id_by_default():
+    """A request that sent no header is untracked, exactly as before."""
+    assert Request.__dataclass_fields__["client_request_id"].default is None
+
+
+def test_context_var_defaults_to_none():
+    assert current_client_request_id.get() is None
+
+
+def test_context_var_is_isolated_between_tasks():
+    """Concurrent requests must not observe each other's caller id."""
+    observed: dict[str, str | None] = {}
+
+    async def handler(name: str, value: str) -> None:
+        current_client_request_id.set(value)
+        await asyncio.sleep(0)  # force interleaving
+        observed[name] = current_client_request_id.get()
+
+    async def main() -> None:
+        await asyncio.gather(handler("a", "caller-a"), handler("b", "caller-b"))
+
+    asyncio.run(main())
+    assert observed == {"a": "caller-a", "b": "caller-b"}
+
+
+async def test_middleware_exposes_the_header_while_the_body_is_produced():
+    """The id must still be readable when a streaming body is iterated.
+
+    That is when the engine registers the request, and it happens after the
+    endpoint has returned; a middleware that restores the context on return
+    would lose the value before it is needed.
+    """
+    from omlx.server import ClientRequestIdMiddleware
+
+    seen: list[str | None] = []
+
+    async def app(scope, receive, send):
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        seen.append(current_client_request_id.get())
+        await send({"type": "http.response.body", "body": b"x", "more_body": False})
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message):
+        pass
+
+    middleware = ClientRequestIdMiddleware(app)
+    await middleware(
+        {"type": "http", "headers": [(b"host", b"x"), (b"x-request-id", b"caller-1")]},
+        receive,
+        send,
+    )
+    await middleware({"type": "http", "headers": [(b"host", b"x")]}, receive, send)
+    assert seen == ["caller-1", None]
+
+
+async def test_middleware_ignores_non_http_scopes():
+    from omlx.server import ClientRequestIdMiddleware
+
+    called: list[str] = []
+
+    async def app(scope, receive, send):
+        called.append(scope["type"])
+
+    await ClientRequestIdMiddleware(app)({"type": "lifespan"}, None, None)
+    assert called == ["lifespan"]
+    assert current_client_request_id.get() is None

--- a/tests/test_engine_core.py
+++ b/tests/test_engine_core.py
@@ -26,7 +26,7 @@ from omlx.engine_core import (
 )
 from omlx.exceptions import PrefillMemoryAbortedError, PrefillMemoryExceededError
 from omlx.output_collector import RequestOutputCollector
-from omlx.request import RequestOutput, SamplingParams
+from omlx.request import RequestOutput, SamplingParams, current_client_request_id
 from omlx.scheduler import SchedulerConfig, SchedulerOutput
 
 
@@ -336,6 +336,30 @@ class TestEngineCoreAddRequest:
 
                 assert request_id == "custom-request-001"
             finally:
+                await engine.stop()
+                engine.close()
+
+    @pytest.mark.asyncio
+    async def test_add_request_records_the_callers_request_id(
+        self, mock_model, mock_tokenizer
+    ):
+        """The caller's X-Request-ID in the task context is stamped on the request."""
+        with patch("omlx.engine_core.get_registry") as mock_registry:
+            mock_registry.return_value.acquire.return_value = True
+
+            engine = EngineCore(model=mock_model, tokenizer=mock_tokenizer)
+            token = current_client_request_id.set("caller-123")
+
+            try:
+                await engine.start()
+
+                request_id = await engine.add_request(prompt="Hello")
+
+                request = engine.scheduler.get_request(request_id)
+                assert request is not None
+                assert request.client_request_id == "caller-123"
+            finally:
+                current_client_request_id.reset(token)
                 await engine.stop()
                 engine.close()
 


### PR DESCRIPTION
## Why

The engine mints `request_id` internally and never returns it over HTTP; the caller only ever sees its completion id. So a client polling `/admin/api/activity` to show prefill or decode progress cannot tell which in-flight row is its own. Fine for one request, wrong as soon as two run concurrently.

## What

oMLX already honours a caller's `X-Request-ID` for the prefill memory guard's error body. This carries the same header to the activity rows:

- pure ASGI middleware stores the trimmed, 128-char-capped header in a `ContextVar`. `BaseHTTPMiddleware` would run the endpoint in a separate task and return before a streaming body is iterated, so the value would be gone by the time the engine registers the request;
- `EngineCore.add_request` stamps it on `Request.client_request_id`, the one place every engine path (batched and VLM, streaming and not) mints its id;
- `waiting`, `prefilling` and `generating` rows carry `client_request_id` only when the caller sent one, so rows for everything else are unchanged.

Display-only: never used for scheduling, caching or identity.

## Verification

On a running server: two concurrent streaming requests, a non-streaming request, and a request without the header each landed on the right row (the last with no `client_request_id` key at all); a long prompt showed its id while still prefilling.

Tests: `tests/test_client_request_id.py` (header parsing, `ContextVar` isolation, and the middleware still exposing the id while a streaming body is produced), a new case in `tests/test_active_models_visibility.py`, and one in `tests/test_engine_core.py` (`pytest tests/test_client_request_id.py tests/test_active_models_visibility.py tests/test_engine_core.py tests/test_prefill_progress.py tests/test_server.py`: all pass).

## Related

#2311 proposes richer `X-oMLX-*` attribution with dashboard UI; this is the id-only subset, using its "omit when absent" row convention. #2980 makes the streaming completion id the engine id; the two compose, and this remains useful before the first byte and for non-streaming calls.
