### PR TITLE
fix(cache): warn at startup when this model's SSD blocks have another block_size

### DIFF
--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -2250,6 +2250,13 @@ class PagedSSDCacheManager(CacheManager):
         skipped_incompatible = 0
         skipped_incompatible_bytes = 0
         errors = 0
+        # Why each incompatible block was rejected, and — separately — the
+        # blocks of THIS model that were rejected only because they were
+        # written with another paged block size (the #3066 upgrade path,
+        # where the ArraysCache block size moved 2048 -> 4096 on large hosts
+        # and the whole cache went dark with no signal beyond the count).
+        reason_counts: dict[str, int] = {}
+        same_model_size_mismatch: dict[int, tuple[int, int]] = {}
 
         for subdir in self.SUBDIR_CHARS:
             subdir_path = self._cache_dir / subdir
@@ -2262,9 +2269,31 @@ class PagedSSDCacheManager(CacheManager):
                     metadata = self._read_file_metadata(file_path)
                     if metadata is None:
                         continue
-                    if not self._is_compatible_block(metadata):
+                    reason = self._incompatibility_reason(metadata)
+                    if reason is not None:
                         skipped_incompatible += 1
                         skipped_incompatible_bytes += metadata.file_size
+                        reason_counts[reason] = reason_counts.get(reason, 0) + 1
+                        # Only a POSITIVE model match counts toward the
+                        # warning: with no expected model name the model
+                        # check is skipped, and another model's blocks must
+                        # never be reported as this model's dead blocks.
+                        # Legacy blocks with no stamped size (0) are rejected
+                        # under the same label but are not "another block
+                        # size", so they stay out of the warning.
+                        if (
+                            reason == "block_size"
+                            and metadata.block_size > 0
+                            and self._expected_model_name
+                            and metadata.model_name == self._expected_model_name
+                        ):
+                            count, size = same_model_size_mismatch.get(
+                                metadata.block_size, (0, 0)
+                            )
+                            same_model_size_mismatch[metadata.block_size] = (
+                                count + 1,
+                                size + metadata.file_size,
+                            )
                         self._incompatible_index.add(metadata)
                         continue
                     self._index.add(metadata)
@@ -2295,7 +2324,42 @@ class PagedSSDCacheManager(CacheManager):
             log_msg += f", skipped_gdn_sidecars={sidecars_skipped}"
         if sidecars_bytes > 0:
             log_msg += f", gdn_size={format_bytes(sidecars_bytes)}"
+        if skipped_incompatible > 0:
+            # Same order as the checks in _incompatibility_reason.
+            reasons = ", ".join(
+                f"{name}={reason_counts[name]}"
+                for name in (
+                    "model_name",
+                    "num_layers",
+                    "block_size",
+                    "layer_cache_types",
+                    "cache_signature",
+                )
+                if reason_counts.get(name)
+            )
+            log_msg += f" [reasons: {reasons}]"
         logger.info(log_msg)
+
+        if same_model_size_mismatch:
+            stale_blocks = sum(
+                count for count, _size in same_model_size_mismatch.values()
+            )
+            stale_bytes = sum(
+                size for _count, size in same_model_size_mismatch.values()
+            )
+            stale_sizes = ", ".join(
+                f"block_size={size} ({count})"
+                for size, (count, _bytes) in sorted(same_model_size_mismatch.items())
+            )
+            logger.warning(
+                f"SSD cache: {stale_blocks} block(s) ({format_bytes(stale_bytes)}) "
+                f"for model '{self._expected_model_name}' were written with "
+                f"{stale_sizes} but this server uses configured "
+                f"block_size={self._expected_block_size}; blocks of another "
+                f"block size cannot be reused. They stay on disk and count "
+                f"against the SSD cache budget until LRU eviction or "
+                f"POST /api/ssd-cache/clear reclaims them."
+            )
 
         # Startup can find a cache directory that already exceeds the shared
         # SSD budget. Converge immediately before serving requests.
@@ -2591,29 +2655,38 @@ class PagedSSDCacheManager(CacheManager):
 
     def _is_compatible_block(self, metadata: PagedSSDBlockMetadata) -> bool:
         """Return True when a block can be indexed for this manager."""
+        return self._incompatibility_reason(metadata) is None
+
+    def _incompatibility_reason(self, metadata: PagedSSDBlockMetadata) -> str | None:
+        """Name the first compatibility check a block fails, or None if it passes.
+
+        Same checks and order as the boolean gate used to have; the label lets
+        the startup scan tell "another model shares this directory" from
+        "this model's blocks were written with another block_size".
+        """
         if self._expected_model_name and metadata.model_name:
             if metadata.model_name != self._expected_model_name:
-                return False
+                return "model_name"
         if self._expected_num_layers > 0 and metadata.num_layers > 0:
             if metadata.num_layers != self._expected_num_layers:
-                return False
+                return "num_layers"
         if self._expected_block_size > 0:
             if metadata.block_size <= 0:
-                return False
+                return "block_size"
             if metadata.block_size != self._expected_block_size:
-                return False
+                return "block_size"
         if self._expected_layer_cache_types is not None:
             if _canonicalize_layer_cache_types(
                 metadata.layer_cache_types
             ) != _canonicalize_layer_cache_types(self._expected_layer_cache_types):
-                return False
+                return "layer_cache_types"
         # Always gate the payload layout.  A manager without any other
         # expectation still must not index a split block as an embedded block
         # (or vice versa).  Signatures from before layout stamping default to
         # embedded inside ``_is_compatible_cache_signature``.
         if not self._is_compatible_cache_signature(metadata):
-            return False
-        return True
+            return "cache_signature"
+        return None
 
     def _is_compatible_cache_signature(self, metadata: PagedSSDBlockMetadata) -> bool:
         """Return True when a saved cache_signature matches enabled checks."""

--- a/tests/test_paged_ssd_cache.py
+++ b/tests/test_paged_ssd_cache.py
@@ -34,6 +34,7 @@ from omlx.cache.paged_ssd_cache import (
     _write_safetensors_no_mx,
     parse_size,
 )
+from omlx.utils.formatting import format_bytes
 
 
 def _has_mlx() -> bool:
@@ -1261,6 +1262,369 @@ class TestPagedSSDCacheManagerWithMLX:
         ]
         assert scan_lines, "scan completion log not emitted"
         assert "skipped_incompatible=3 blocks" in scan_lines[-1]
+
+    # -- Startup scan: reason tally + same-model block_size WARNING --------------
+    #
+    # Since e6939218 (#1413) blocks that fail the compatibility check are never
+    # indexed, so the per-hit "Cache block size mismatch" WARNING in
+    # prefix_cache.py cannot fire for them. After the ArraysCache block size
+    # moved 2048 -> 4096 on large hosts (#3066) the only trace of a dead cache
+    # was the INFO ``skipped_incompatible=N`` count, indistinguishable from
+    # legitimate multi-model sharing of the directory.
+
+    def _scan_records(self, caplog, cache_dir, **expectations):
+        # Only the scan under test: an earlier manager in the same test (or
+        # a suite-wide INFO level left by another test) must not leak records.
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="omlx.cache.paged_ssd_cache"):
+            manager = PagedSSDCacheManager(
+                cache_dir=cache_dir,
+                max_size_bytes=1024**3,
+                **expectations,
+            )
+        summaries = [
+            r for r in caplog.records if "SSD cache scan complete" in r.message
+        ]
+        size_warnings = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "block_size=" in r.message
+        ]
+        assert len(summaries) == 1, "scan completion log not emitted exactly once"
+        return manager, summaries[0], size_warnings
+
+    def test_scan_warns_same_model_block_size_mismatch(
+        self, tmp_path: Path, mock_mlx, caplog
+    ):
+        """Same-model blocks rejected on block_size alone get ONE WARNING."""
+        mx = mock_mlx
+        cache_dir = tmp_path / "ssd_cache"
+        stale_a = self._write_versioned_fixture_block(
+            cache_dir,
+            mx,
+            b"\x50" + b"\x00" * 31,
+            num_layers=40,
+            model_name="m",
+            block_size=2048,
+        )
+        stale_b = self._write_versioned_fixture_block(
+            cache_dir,
+            mx,
+            b"\x51" + b"\x00" * 31,
+            num_layers=40,
+            model_name="m",
+            block_size=2048,
+        )
+        stale_c = self._write_versioned_fixture_block(
+            cache_dir,
+            mx,
+            b"\x52" + b"\x00" * 31,
+            num_layers=40,
+            model_name="m",
+            block_size=1024,
+        )
+        other = self._write_versioned_fixture_block(
+            cache_dir,
+            mx,
+            b"\x53" + b"\x00" * 31,
+            num_layers=40,
+            model_name="other",
+            block_size=4096,
+        )
+
+        manager, summary, size_warnings = self._scan_records(
+            caplog,
+            cache_dir,
+            expected_model_name="m",
+            expected_num_layers=40,
+            expected_block_size=4096,
+        )
+
+        assert len(size_warnings) == 1
+        warning = size_warnings[0]
+        assert warning.name == "omlx.cache.paged_ssd_cache"
+        assert caplog.records.index(warning) > caplog.records.index(summary)
+        stale_bytes = sum(p.stat().st_size for p in (stale_a, stale_b, stale_c))
+        for needle in (
+            "3 block",
+            format_bytes(stale_bytes),
+            "block_size=2048",
+            "block_size=1024",
+            "configured block_size=4096",
+            "'m'",
+            "cannot be reused",
+            "LRU eviction",
+            "POST /api/ssd-cache/clear",
+        ):
+            assert needle in warning.message, needle
+
+        assert "skipped_incompatible=4 blocks" in summary.message
+        assert summary.message.endswith(" [reasons: model_name=1, block_size=3]")
+        for h in (0x50, 0x51, 0x52, 0x53):
+            assert not manager.has_block(bytes([h]) + b"\x00" * 31)
+        for path in (stale_a, stale_b, stale_c, other):
+            assert path.exists()
+
+    def test_scan_block_size_warning_absent_for_model_name_mismatch(
+        self, tmp_path: Path, mock_mlx, caplog
+    ):
+        """Another model sharing the directory is INFO-only."""
+        mx = mock_mlx
+        cache_dir = tmp_path / "ssd_cache"
+        paths = [
+            self._write_versioned_fixture_block(
+                cache_dir,
+                mx,
+                bytes([0x60 + i]) + b"\x00" * 31,
+                num_layers=40,
+                model_name="other",
+                block_size=4096,
+            )
+            for i in range(2)
+        ]
+        manager, summary, size_warnings = self._scan_records(
+            caplog,
+            cache_dir,
+            expected_model_name="m",
+            expected_num_layers=40,
+            expected_block_size=4096,
+        )
+        assert size_warnings == []
+        assert "skipped_incompatible=2 blocks" in summary.message
+        assert summary.message.endswith(" [reasons: model_name=2]")
+        for i, path in enumerate(paths):
+            assert not manager.has_block(bytes([0x60 + i]) + b"\x00" * 31)
+            assert path.exists()
+
+    def test_scan_block_size_warning_absent_for_layer_count_mismatch(
+        self, tmp_path: Path, mock_mlx, caplog
+    ):
+        """A same-model layer-count mismatch is INFO-only."""
+        mx = mock_mlx
+        cache_dir = tmp_path / "ssd_cache"
+        paths = [
+            self._write_versioned_fixture_block(
+                cache_dir,
+                mx,
+                bytes([0x60 + i]) + b"\x00" * 31,
+                num_layers=30,
+                model_name="m",
+                block_size=4096,
+            )
+            for i in range(2)
+        ]
+        manager, summary, size_warnings = self._scan_records(
+            caplog,
+            cache_dir,
+            expected_model_name="m",
+            expected_num_layers=40,
+            expected_block_size=4096,
+        )
+        assert size_warnings == []
+        assert "skipped_incompatible=2 blocks" in summary.message
+        assert summary.message.endswith(" [reasons: num_layers=2]")
+        for i, path in enumerate(paths):
+            assert not manager.has_block(bytes([0x60 + i]) + b"\x00" * 31)
+            assert path.exists()
+
+    def test_scan_block_size_warning_absent_without_expected_model_name(
+        self, tmp_path: Path, mock_mlx, caplog
+    ):
+        """No positive model match (empty expectation) -> tally only, no WARNING.
+
+        ``factory.py`` passes ``config.model_name or ""``; with no expected
+        model the check is skipped and another model's blocks must never be
+        reported as this model's dead blocks.
+        """
+        mx = mock_mlx
+        cache_dir = tmp_path / "ssd_cache"
+        paths = [
+            self._write_versioned_fixture_block(
+                cache_dir,
+                mx,
+                bytes([0x60 + i]) + b"\x00" * 31,
+                num_layers=40,
+                model_name="other",
+                block_size=2048,
+            )
+            for i in range(2)
+        ]
+        manager, summary, size_warnings = self._scan_records(
+            caplog,
+            cache_dir,
+            expected_model_name="",
+            expected_num_layers=40,
+            expected_block_size=4096,
+        )
+        assert size_warnings == []
+        assert "skipped_incompatible=2 blocks" in summary.message
+        assert summary.message.endswith(" [reasons: block_size=2]")
+        for i, path in enumerate(paths):
+            assert not manager.has_block(bytes([0x60 + i]) + b"\x00" * 31)
+            assert path.exists()
+
+    def test_scan_block_size_warning_absent_for_legacy_unstamped_size(
+        self, tmp_path: Path, mock_mlx, caplog
+    ):
+        """A same-model block with no stamped size (0) is rejected but is not
+        "another block size": it counts under the reason tally only."""
+        mx = mock_mlx
+        cache_dir = tmp_path / "ssd_cache"
+        path = self._write_versioned_fixture_block(
+            cache_dir,
+            mx,
+            b"\x60" + b"\x00" * 31,
+            num_layers=40,
+            model_name="m",
+            block_size=0,
+        )
+        manager, summary, size_warnings = self._scan_records(
+            caplog,
+            cache_dir,
+            expected_model_name="m",
+            expected_num_layers=40,
+            expected_block_size=4096,
+        )
+        assert size_warnings == []
+        assert "skipped_incompatible=1 blocks" in summary.message
+        assert summary.message.endswith(" [reasons: block_size=1]")
+        assert not manager.has_block(b"\x60" + b"\x00" * 31)
+        assert path.exists()
+
+    def test_scan_block_size_warning_absent_when_expected_block_size_unset(
+        self, tmp_path: Path, mock_mlx, caplog
+    ):
+        """With no expected block size mixed sizes index exactly as today."""
+        mx = mock_mlx
+        cache_dir = tmp_path / "ssd_cache"
+        for i, size in enumerate((2048, 4096)):
+            self._write_versioned_fixture_block(
+                cache_dir,
+                mx,
+                bytes([0x60 + i]) + b"\x00" * 31,
+                num_layers=40,
+                model_name="m",
+                block_size=size,
+            )
+        manager, summary, size_warnings = self._scan_records(
+            caplog,
+            cache_dir,
+            expected_model_name="m",
+            expected_num_layers=40,
+            expected_block_size=0,
+        )
+        assert size_warnings == []
+        assert "skipped_incompatible" not in summary.message
+        assert "[reasons:" not in summary.message
+        for i in range(2):
+            assert manager.has_block(bytes([0x60 + i]) + b"\x00" * 31)
+
+    def _reason_manager(self, tmp_path: Path):
+        return PagedSSDCacheManager(
+            cache_dir=tmp_path / "ssd_cache",
+            max_size_bytes=1024**3,
+            expected_model_name="m",
+            expected_num_layers=40,
+            expected_block_size=4096,
+            expected_layer_cache_types=["KVCache"],
+        )
+
+    @staticmethod
+    def _metadata(**overrides) -> PagedSSDBlockMetadata:
+        fields = dict(
+            block_hash=b"\x01" * 32,
+            file_path=Path("/nonexistent/block.safetensors"),
+            file_size=1,
+            token_count=32,
+            created_at=0.0,
+            last_access=0.0,
+            num_layers=40,
+            model_name="m",
+            block_size=4096,
+            cache_signature="",
+            layer_cache_types=["KVCache"],
+        )
+        fields.update(overrides)
+        return PagedSSDBlockMetadata(**fields)
+
+    def test_incompatibility_reason_labels_single_failures(
+        self, tmp_path: Path, mock_mlx
+    ):
+        """Each single failing check maps to its own label; compatible -> None."""
+        manager = self._reason_manager(tmp_path)
+        split_signature = json.dumps({"payload_layout": "split"})
+        cases = [
+            (self._metadata(), None),
+            (self._metadata(model_name="other"), "model_name"),
+            (self._metadata(num_layers=30), "num_layers"),
+            (self._metadata(block_size=2048), "block_size"),
+            (self._metadata(block_size=0), "block_size"),
+            (self._metadata(layer_cache_types=["ArraysCache"]), "layer_cache_types"),
+            (self._metadata(cache_signature=split_signature), "cache_signature"),
+        ]
+        # The rejecting signature really is rejected by the signature check
+        # alone, so the label below is that check's and not a side effect.
+        assert not manager._is_compatible_cache_signature(
+            self._metadata(cache_signature=split_signature)
+        )
+        for metadata, expected in cases:
+            assert manager._incompatibility_reason(metadata) == expected, expected
+            assert manager._is_compatible_block(metadata) is (expected is None)
+
+    def test_incompatibility_reason_first_failure_ordering(
+        self, tmp_path: Path, mock_mlx, caplog
+    ):
+        """Multiple failures report the FIRST check in the fixed order."""
+        manager = self._reason_manager(tmp_path)
+        split_signature = json.dumps({"payload_layout": "split"})
+        assert (
+            manager._incompatibility_reason(
+                self._metadata(model_name="other", block_size=2048)
+            )
+            == "model_name"
+        )
+        assert (
+            manager._incompatibility_reason(
+                self._metadata(num_layers=30, block_size=2048)
+            )
+            == "num_layers"
+        )
+        assert (
+            manager._incompatibility_reason(
+                self._metadata(block_size=2048, layer_cache_types=["ArraysCache"])
+            )
+            == "block_size"
+        )
+        assert (
+            manager._incompatibility_reason(
+                self._metadata(
+                    layer_cache_types=["ArraysCache"], cache_signature=split_signature
+                )
+            )
+            == "layer_cache_types"
+        )
+
+        # Through the scan: a same-model block wrong on BOTH layers and size is
+        # a num_layers reject and must not trigger the block_size WARNING.
+        mx = mock_mlx
+        cache_dir = tmp_path / "scan_dir"
+        self._write_versioned_fixture_block(
+            cache_dir,
+            mx,
+            b"\x70" + b"\x00" * 31,
+            num_layers=30,
+            model_name="m",
+            block_size=2048,
+        )
+        _manager, summary, size_warnings = self._scan_records(
+            caplog,
+            cache_dir,
+            expected_model_name="m",
+            expected_num_layers=40,
+            expected_block_size=4096,
+        )
+        assert size_warnings == []
+        assert summary.message.endswith(" [reasons: num_layers=1]")
 
     def test_model_switch_enforces_shared_ssd_limit_on_new_save(
         self, tmp_path: Path, mock_mlx


### PR DESCRIPTION
## Summary

When the paged SSD cache starts, `PagedSSDCacheManager._scan_existing_files` reads every block's metadata and quietly sets aside the blocks that fail the compatibility check. That is deliberate — the directory can be shared by several models (#1413) — but the check returns a bare bool, so the scan cannot tell "another model's blocks live here" from "every block of the model I just loaded was written with a different `block_size` and is now unusable". Both cases surface identically, as `skipped_incompatible=N blocks` at INFO.

The second case is what an operator hits after #3066: on ≥ 64 GiB non-NAX hosts the ArraysCache block size moved 2048 → 4096, `_enlarge_block_size_for_arrays_cache` takes `max(2048, prefill_step_size, floor)` so the old size cannot be pinned back, and the whole SSD cache for that model goes dark on the next start. TTFT is cold again, the blocks keep counting against the SSD budget until LRU age evicts them, and the log offers nothing to connect the two. The per-hit `Cache block size mismatch … Invalidating cache hit` warning does not help here: rejected blocks are never indexed, so it cannot fire for them.

This PR makes that situation visible at startup with one WARNING, and gives the INFO summary a per-reason breakdown so the shared-directory case stays recognisable as such.

## Changes

- `omlx/cache/paged_ssd_cache.py`: `_is_compatible_block` now delegates to a new `_incompatibility_reason`, which returns the first failing check — `model_name`, `num_layers`, `block_size`, `layer_cache_types`, `cache_signature` — in exactly the order the boolean used to test them, so the three call sites classify identically. The scan tallies rejects by reason and appends `[reasons: model_name=1, block_size=3]` to the existing `SSD cache scan complete` line (the existing substrings are untouched). When blocks of the loaded model — a positive name match only; an empty expected name never counts, since `factory.py` passes `config.model_name or ""` — were rejected for `block_size` alone, one WARNING names how many blocks and bytes, each stored `block_size`, the configured one, and the two ways to reclaim the space (LRU eviction or `POST /api/ssd-cache/clear`). Nothing is deleted, indexed or evicted differently.
- `tests/test_paged_ssd_cache.py` (additions only): the positive case with two stored sizes; negative cases for model-name mismatch, layer-count mismatch, empty expected model name, unset expected block size and a legacy unstamped size (`block_size=0`, which is rejected but is not "another block size" and stays out of the WARNING) — each asserting no WARNING, the exact reasons suffix and unchanged indexing; label tests for every single-check failure and for first-failure ordering when several checks fail at once.

The rewrite drops one baseline ruff SIM103 hit in the replaced function (15 → 14 in the file); the copied conditions keep upstream's shape otherwise.

## Test plan

- `uv run pytest tests/test_paged_ssd_cache.py -q` — 178 passed (170 existing, unchanged, + 8 new). The tests were written first: six failed with `AttributeError: … no attribute '_incompatibility_reason'` / the missing suffix and WARNING before the change; the two "nothing to warn about" negatives pass by construction.
- Full suite — see the gate result below.
- Manual expectation on a host that crossed the #3066 boundary with an existing cache: the first start after the upgrade logs one line of the form `SSD cache: N block(s) (X GB) for model '<name>' were written with block_size=2048 (N) but this server uses configured block_size=4096; blocks of another block size cannot be reused. …`, immediately after the scan summary; a directory shared by two models logs nothing new beyond the `[reasons: model_name=N]` suffix.

Related to #3066 — surfaces the dead cache after the block-size change and names the reclaim paths; it does not restore reuse of the old blocks (that would need re-chunking, a separate design question). Also relevant to the "cache stopped working after upgrade" reports around #3317.

— Generated with Marshal · gate: READY · 57c5e54 · tier: standard
verify bar: passed at 57c5e54 — 1 check(s) + secrets scan, sha-keyed proof