### PR TITLE
fix: keep non-ASCII intact in response_format output

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -4008,7 +4008,7 @@ async def create_chat_completion(
                     cleaned_text or regular_content, response_format
                 )
                 if parsed_json is not None:
-                    cleaned_text = json.dumps(parsed_json)
+                    cleaned_text = json.dumps(parsed_json, ensure_ascii=False)
                 if not is_valid:
                     logger.warning(f"JSON validation failed: {error}")
 
@@ -4948,7 +4948,7 @@ async def stream_chat_completion(
                 cleaned_text, request.response_format
             )
             if parsed_json is not None:
-                cleaned_text = json.dumps(parsed_json)
+                cleaned_text = json.dumps(parsed_json, ensure_ascii=False)
             if not is_valid:
                 logger.warning(f"JSON validation failed: {error}")
 
@@ -6462,7 +6462,7 @@ async def create_response(
                     cleaned_text or regular_content, response_format
                 )
                 if parsed_json is not None:
-                    cleaned_text = json.dumps(parsed_json)
+                    cleaned_text = json.dumps(parsed_json, ensure_ascii=False)
                 if not is_valid:
                     logger.warning(f"JSON validation failed: {error}")
 
@@ -7026,7 +7026,7 @@ async def stream_responses_api(
     if response_format and not tool_calls:
         _, parsed_json, is_valid, error = parse_json_output(final_text, response_format)
         if parsed_json is not None:
-            final_text = json.dumps(parsed_json)
+            final_text = json.dumps(parsed_json, ensure_ascii=False)
         if not is_valid:
             logger.warning(f"JSON validation failed: {error}")
 

--- a/tests/integration/test_server_endpoints.py
+++ b/tests/integration/test_server_endpoints.py
@@ -2437,3 +2437,100 @@ class TestJsonOutputParsing:
         data = response.json()
         output_text = data["output"][0]["content"][0]["text"]
         assert "Hello" in output_text
+
+    def test_chat_completion_preserves_non_ascii(self, client, mock_llm_engine):
+        """Non-ASCII text must survive response_format re-serialization (#3402).
+
+        The JSON is re-serialized after schema validation; without
+        ``ensure_ascii=False`` the escapes land inside ``message.content``
+        itself, so the client sees a literal ``\\u0418`` after decoding.
+        """
+        mock_llm_engine.chat = AsyncMock(
+            return_value=MockGenerationOutput(
+                text='{"име": "Иван", "град": "София"}',
+                prompt_tokens=10,
+                completion_tokens=8,
+                finish_reason="stop",
+                finished=True,
+            )
+        )
+
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "Върни JSON"}],
+                "response_format": {"type": "json_object"},
+            },
+        )
+
+        assert response.status_code == 200
+        content = response.json()["choices"][0]["message"]["content"]
+        assert "\\u" not in content
+        assert "Иван" in content
+        assert json.loads(content) == {"име": "Иван", "град": "София"}
+
+    def test_responses_preserves_non_ascii(self, client, mock_llm_engine):
+        """Responses API must not ASCII-escape JSON output either."""
+        mock_llm_engine.chat = AsyncMock(
+            return_value=MockGenerationOutput(
+                text='{"град": "София", "температура": 15}',
+                prompt_tokens=10,
+                completion_tokens=8,
+                finish_reason="stop",
+                finished=True,
+            )
+        )
+
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": "test-model",
+                "input": "Върни JSON",
+                "text": {"format": {"type": "json_object"}},
+            },
+        )
+
+        assert response.status_code == 200
+        output_text = response.json()["output"][0]["content"][0]["text"]
+        assert "\\u" not in output_text
+        assert json.loads(output_text) == {"град": "София", "температура": 15}
+
+    def test_responses_stream_preserves_non_ascii(self, client, mock_llm_engine):
+        """The streaming Responses path re-serializes too and must match."""
+
+        async def stream_chat(messages, **kwargs):
+            yield MockGenerationOutput(
+                text='{"град": "София"}',
+                new_text='{"град": "София"}',
+                prompt_tokens=3,
+                completion_tokens=6,
+                finish_reason="stop",
+                finished=True,
+            )
+
+        mock_llm_engine.stream_chat = stream_chat
+
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": "test-model",
+                "input": "Върни JSON",
+                "text": {"format": {"type": "json_object"}},
+                "stream": True,
+            },
+        )
+
+        assert response.status_code == 200
+        events = [
+            json.loads(line.removeprefix("data: "))
+            for line in response.text.splitlines()
+            if line.startswith("data: ")
+        ]
+        done = next(
+            event
+            for event in events
+            if event.get("type") == "response.output_text.done"
+        )
+        assert "\\u" not in done["text"]
+        assert json.loads(done["text"]) == {"град": "София"}


### PR DESCRIPTION
Fixes #3402.

## Problem

With `response_format` set, non-ASCII model output comes back as literal `\uXXXX` escapes **inside** `message.content` — not as wire-level JSON escaping, so a client that decodes the response still holds a string of backslash-u sequences. Cyrillic, CJK, accented Latin and emoji are all affected. vLLM does not do this; neither does oMLX's own tool-calling path.

## Cause

The `response_format` branch parses the model's JSON and re-serializes it with a bare `json.dumps()`, whose `ensure_ascii` defaults to `True`:

```python
>>> json.dumps({"име": "Иван"})
'{"\\u0438\\u043c\\u0435": "\\u0418\\u0432\\u0430\\u043d"}'
>>> json.dumps({"име": "Иван"}, ensure_ascii=False)
'{"име": "Иван"}'
```

Four call sites, one per execution path: `create_chat_completion` (4011), `stream_chat_completion` (4951), `create_response` (6465), `stream_responses_api` (7029).

The tool-calling path in the same file already gets this right — `json.dumps(args, ensure_ascii=False)` at 4022, 5026, 5497, 5935, 6455, 7019, and `format_tool_arguments()` in `omlx/api/tool_calling.py:117`. Only the `response_format` branch was missed. `parse_json_output()` is untouched; it returns a parsed object and never serializes.

## Change

`ensure_ascii=False` at all four sites — 4 lines.

## Tests

Three regression tests added to `TestJsonOutputParsing` in `tests/integration/test_server_endpoints.py`, covering `/v1/chat/completions` (non-streaming), `/v1/responses` (non-streaming) and `/v1/responses` (streaming). Each asserts the content carries no `\u` escape and round-trips to the original Cyrillic object.

All three fail on `main` and pass with the fix:

```
# before
3 failed, 4 passed
# after
7 passed
```

`tests/integration/test_server_endpoints.py` — 81 passed.

The buffered chat-completions stream branch (4951) is fixed but not covered by a test: reaching it requires tools present with an inactive `ToolCallStreamFilter`, which the existing mock harness has no path to.

## Notes for the maintainer

- I could not run the suite on real hardware — no Apple Silicon here. The tests were executed on Linux against the actual FastAPI app with `mlx`/`mlx_lm`/`mlx_vlm` import-stubbed; the endpoint code under test is pure Python and does not touch MLX. Three unrelated `TestParseToolCallsGemma4RealParser` tests fail in that environment (they need the real `mlx_lm` Gemma 4 parser) — they fail identically on unmodified `main`, so they are an artifact of the stub, not of this change. Worth a confirming run on a Mac.
- Two adjacent observations from #3402, left out of this PR to keep the diff minimal:
  - The re-serialization also reformats output that was already valid JSON (whitespace, key order). Skipping the re-dump when the raw text parses cleanly would match vLLM more closely.
  - `/v1/chat/completions` with `stream: true` normally passes deltas through raw, so streaming already returned correct Cyrillic while non-streaming did not — the same request produced different bytes depending on the `stream` flag.
