### PR TITLE
fix(vlm): scalarize Qwen3.5 temporal repeat on MLX 0.32.2

### DIFF
--- a/omlx/patches/mlx_vlm_qwen35_vision_repeat.py
+++ b/omlx/patches/mlx_vlm_qwen35_vision_repeat.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MLX 0.32.2 compatibility for the pinned Qwen3-VL vision tower.
+
+The pinned mlx-vlm revision passes ``grid_thw[i, 0]`` (an MLX scalar array)
+as ``mx.repeat``'s repeat count.  MLX 0.32.2 requires a Python integer.  This
+is the same scalarization shipped upstream for the shared Qwen vision tower;
+the tensor graph and image resolution remain otherwise unchanged.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Any
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+
+def _call_with_scalar_repeat(
+    self: Any,
+    hidden_states: mx.array,
+    grid_thw: mx.array,
+    **kwargs: Any,
+) -> mx.array:
+    del kwargs
+
+    hidden_states = self.patch_embed(hidden_states)
+    pos_embeds = self.fast_pos_embed_interpolate(grid_thw)
+    hidden_states = hidden_states + pos_embeds
+    rotary_pos_emb = self.rot_pos_emb(grid_thw)
+
+    seq_len = hidden_states.shape[0]
+    hidden_states = hidden_states.reshape(seq_len, -1)
+    rotary_pos_emb = rotary_pos_emb.reshape(seq_len, -1)
+
+    cu_seqlens = []
+    for i in range(grid_thw.shape[0]):
+        spatial_seq_len = grid_thw[i, 1] * grid_thw[i, 2]
+        temporal_patches = int(grid_thw[i, 0])
+        cu_seqlens.append(mx.repeat(spatial_seq_len, temporal_patches))
+
+    cu_seqlens = mx.concatenate(cu_seqlens)
+    cu_seqlens = mx.cumsum(cu_seqlens.astype(mx.int32), axis=0)
+    cu_seqlens = mx.pad(
+        cu_seqlens,
+        (1, 0),
+        mode="constant",
+        constant_values=0,
+    )
+
+    deepstack_feature_lists = []
+    for layer_num, block in enumerate(self.blocks):
+        hidden_states = block(
+            hidden_states,
+            cu_seqlens=cu_seqlens,
+            rotary_pos_emb=rotary_pos_emb,
+        )
+        if layer_num in self.deepstack_visual_indexes:
+            deepstack_feature = self.deepstack_merger_list[
+                self.deepstack_visual_indexes.index(layer_num)
+            ](hidden_states)
+            deepstack_feature_lists.append(deepstack_feature)
+
+    hidden_states = self.merger(hidden_states)
+    return hidden_states, deepstack_feature_lists
+
+
+_call_with_scalar_repeat._omlx_qwen35_scalar_repeat = True
+
+
+def apply_qwen35_vision_repeat_patch() -> bool:
+    """Patch only the older mlx-vlm implementation that needs scalarization."""
+    try:
+        from mlx_vlm.models.qwen3_vl.vision import VisionModel
+    except Exception:
+        logger.debug("Qwen3-VL vision repeat patch import failed", exc_info=True)
+        return False
+
+    current = VisionModel.__call__
+    if getattr(current, "_omlx_qwen35_scalar_repeat", False):
+        return True
+    try:
+        source = inspect.getsource(current)
+    except (OSError, TypeError):
+        source = ""
+    if "int(grid_thw[i, 0])" in source:
+        return True
+    if "mx.repeat(seq_len, grid_thw[i, 0])" not in source:
+        logger.warning(
+            "Qwen3-VL vision implementation is unfamiliar; refusing compatibility patch"
+        )
+        return False
+
+    VisionModel.__call__ = _call_with_scalar_repeat
+    logger.info("Qwen3-VL MLX-safe temporal repeat patch applied")
+    return True
+
+
+__all__ = ["apply_qwen35_vision_repeat_patch"]

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -700,6 +700,17 @@ def maybe_apply_pre_load_patches(
                 model_name,
             )
 
+    if for_vlm and model_type and model_type.startswith("qwen3_5"):
+        from ..patches.mlx_vlm_qwen35_vision_repeat import (
+            apply_qwen35_vision_repeat_patch,
+        )
+
+        if apply_qwen35_vision_repeat_patch():
+            logger.info(
+                "Qwen3.5 MLX-safe vision repeat patch applied for %s",
+                model_name,
+            )
+
     # Apply the MTP patch whenever the model has MTP heads on a compatible
     # model_type — even when mtp_enabled is False. The patch is required
     # for *sanitize correctness*: stock mlx-lm Model.sanitize triggers a

--- a/tests/test_mlx_vlm_qwen35_vision_repeat.py
+++ b/tests/test_mlx_vlm_qwen35_vision_repeat.py
@@ -1,0 +1,32 @@
+from types import SimpleNamespace
+
+import mlx.core as mx
+
+from omlx.patches import mlx_vlm_qwen35_vision_repeat as patch
+
+
+def test_qwen35_vision_repeat_scalarizes_temporal_count():
+    fake = SimpleNamespace(
+        patch_embed=lambda value: value,
+        fast_pos_embed_interpolate=lambda grid: mx.zeros((2, 4)),
+        rot_pos_emb=lambda grid: mx.zeros((2, 4)),
+        blocks=[],
+        deepstack_visual_indexes=[],
+        deepstack_merger_list=[],
+        merger=lambda value: value,
+    )
+
+    output, deepstack = patch._call_with_scalar_repeat(
+        fake,
+        mx.zeros((2, 4)),
+        mx.array([[1, 1, 2]], dtype=mx.int32),
+    )
+
+    mx.eval(output)
+    assert output.shape == (2, 4)
+    assert deepstack == []
+
+
+def test_qwen35_vision_repeat_patch_is_idempotent():
+    assert patch.apply_qwen35_vision_repeat_patch()
+    assert patch.apply_qwen35_vision_repeat_patch()


### PR DESCRIPTION
## Summary

- scalarize the Qwen3-VL temporal patch count before passing it to `mx.repeat`
- apply the compatibility patch only to Qwen3.5-family VLM loads
- preserve the checkpoint image budget, pixels, and tensor computation unchanged
- fail closed if the pinned mlx-vlm implementation no longer matches the known call shape

This mirrors the scalar-repeat compatibility correction from mlx-vlm PR #1982 / commit `1249c7d`, which our Qwen4 compatibility bridge already used. The gap affected Qwen3.8-27B because it inherits the pinned Qwen3-VL vision tower directly.

## Failure reproduced

A fresh Python 3.13 install resolved MLX 0.32.2. Text, exact-resident TTFT, and required tool calls passed, but a real PNG request ended as an empty stream with:

```
repeat(): incompatible function arguments
Invoked with types: mlx.core.array, mlx.core.array
```

The long-lived development venv used MLX 0.32.0, which accepted the old call and masked the release-install incompatibility.

## Validation

- 187 focused tests passed on the upstream branch
- 191 Fusion cache/MTP/lifecycle tests passed
- clean GitHub clone + fresh Python 3.13 venv + MLX 0.32.2
- Qwen3.8-27B real screenshot completed HTTP 200 through the native VLM path (3,116 image tokens)
- Qwen3.8 Flash-Next image, required-tool, and three-turn TTFT checks also passed

Lossless by design: this converts a scalar array to the equivalent Python integer required by the MLX API. It does not cap resolution, alter preprocessing, or change model math.