### PR TITLE
perf(glm5_next): compile the small elementwise ops of the recurrent layer into two graphs

### DIFF
--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/language.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/language.py
@@ -50,13 +50,7 @@ class Glm5NextRMSNormGated(nn.Module):
         self.weight = mx.ones(hidden_size)
 
     def __call__(self, hidden_states: mx.array, gate: mx.array) -> mx.array:
-        dt = hidden_states.dtype
-        x = hidden_states.astype(mx.float32)
-        var = (x * x).mean(-1, keepdims=True)
-        x = x * mx.rsqrt(var + self.eps)
-        x = self.weight.astype(mx.float32) * x
-        x = x * mx.sigmoid(gate.astype(mx.float32))
-        return x.astype(dt)
+        return _gated_rms_norm(hidden_states, gate, self.weight, self.eps)
 
 
 class Glm5NextForgetGate(nn.Module):
@@ -86,6 +80,34 @@ class Glm5NextForgetGate(nn.Module):
 
 def _l2norm(x: mx.array, eps: float = 1e-6) -> mx.array:
     return x * mx.rsqrt((x * x).sum(axis=-1, keepdims=True) + eps)
+
+
+@mx.compile
+def _qkv_from_conv(conv_raw, num_heads, head_dim, qkv_dim, scale):
+    # silu -> split -> reshape -> l2norm(q), l2norm(k): a dozen elementwise
+    # ops and two reductions that, left loose, cost ~0.06 ms per layer at
+    # decode (34 layers). Compiled, MLX fuses them into a few launches.
+    conv_out = nn.silu(conv_raw)
+    B, S, _ = conv_out.shape
+    q, k, v = mx.split(conv_out, [qkv_dim, 2 * qkv_dim], axis=-1)
+    q = q.reshape(B, S, num_heads, head_dim)
+    k = k.reshape(B, S, num_heads, head_dim)
+    v = v.reshape(B, S, num_heads, head_dim)
+    in_dtype = q.dtype
+    q = (_l2norm(q.astype(mx.float32)) * scale).astype(in_dtype)
+    k = _l2norm(k.astype(mx.float32)).astype(in_dtype)
+    return q, k, v
+
+
+@mx.compile
+def _gated_rms_norm(hidden_states, gate, weight, eps):
+    dt = hidden_states.dtype
+    x = hidden_states.astype(mx.float32)
+    var = (x * x).mean(-1, keepdims=True)
+    x = x * mx.rsqrt(var + eps)
+    x = weight.astype(mx.float32) * x
+    x = x * mx.sigmoid(gate.astype(mx.float32))
+    return x.astype(dt)
 
 
 def recurrent_kimi_delta(
@@ -251,20 +273,18 @@ class Glm5NextLinearAttention(nn.Module):
                 )
             else:
                 cache[0] = mx.contiguous(conv_input[:, -state_size:, :])
-        conv_out = nn.silu(self.conv1d(conv_input))
-
-        q, k, v = mx.split(conv_out, [self.qkv_dim, 2 * self.qkv_dim], axis=-1)
-        q = q.reshape(B, S, self.num_heads, self.head_dim)
-        k = k.reshape(B, S, self.num_heads, self.head_dim)
-        v = v.reshape(B, S, self.num_heads, self.head_dim)
+        q, k, v = _qkv_from_conv(
+            self.conv1d(conv_input),
+            self.num_heads,
+            self.head_dim,
+            self.qkv_dim,
+            self.head_dim**-0.5,
+        )
 
         fg = self.forget_gate
         a = linear_forward(fg.f_b_proj, fa_o).reshape(
             B, S, self.num_heads, self.head_dim
         )
-        in_dtype = q.dtype
-        q = (_l2norm(q.astype(mx.float32)) * (self.head_dim**-0.5)).astype(in_dtype)
-        k = _l2norm(k.astype(mx.float32)).astype(in_dtype)
 
         state = cache[1] if cache is not None else None
         out, state = gated_delta_update(


### PR DESCRIPTION
Between the input projection and the recurrent kernel of a glm5_next
linear-attention layer sit a dozen elementwise ops (silu, split,
reshape, two l2norms) and, on the way out, the gated norm (six ops).
Left loose they cost ~0.1 ms per layer per decode step; under mx.compile
MLX fuses each group into a few launches. Same math, only grouped.

Measured on GLM-5.3-Flash oQ2e (M1 Ultra, median of 40 decode steps):
T=1 47.4 -> 46.2 ms per step; T=4 96.3 -> 94.2 ms.
