### PR TITLE
perf(moe): the affine block kernels engaged at 64 routes, where they cost 2-2.7x the plain gather

### DIFF
--- a/omlx/patches/deepseek_v4/switch_layers.py
+++ b/omlx/patches/deepseek_v4/switch_layers.py
@@ -21,6 +21,29 @@ _DEEPSEEK_MXFP4_SMALL_BLOCK_VARIANT = 1
 _DEEPSEEK_MXFP4_LARGE_BLOCK_BM = 32
 _DEEPSEEK_MXFP4_LARGE_BLOCK_VARIANT = 2
 _DEEPSEEK_AFFINE_LARGE_BLOCK_MIN_ROUTES = 8192
+# Below this many (token, expert) routes the stock unsorted gather_qmm runs;
+# at/above it routes are sorted by expert. Measured on M1 Ultra, GLM-5.3 oQ2e
+# (affine 2-bit, g64), one MoE layer, ms per layer:
+#   T=4:  unsorted 1.23 · sorted stock 1.11 · sorted native blocks 2.95
+#   T=8:  unsorted 2.10 · sorted stock 1.91 · sorted native blocks 5.13
+#   T=64: unsorted 12.3 · sorted stock 10.7 · sorted native blocks 15.8
+#   T=128: unsorted 24.2 · sorted stock 20.9 · sorted native blocks 19.4
+# Sorting pays from T=4 (32 routes); the affine block kernel only pays past
+# ~900 routes, so it has its own floor below. The old single threshold of 64
+# routes sent every 8..110-token window (DFlash block-8 verify, batched
+# decode at B>=8) down the block kernel at 2-2.7x the cost.
+# Route-count crossovers for the affine (oQ 2/3-bit) MoE path, measured on
+# M1 Ultra with real GLM-5.3-Flash expert weights (2-bit, group 64):
+#   - sorting the routes pays off from 32 routes;
+#   - the native block kernels only beat mx.gather_qmm from ~1024 routes
+#     (the crossover sits at T=128 x 8 experts); below it they cost 2-2.7x.
+# The single 64-route gate that engaged both at once sat exactly in the
+# losing region. Same pattern as _DEEPSEEK_MXFP4_LARGE_BLOCK_MIN_ROUTES below:
+# tuned on one machine, overridable per deployment.
+_SORT_MIN_ROUTES = int(os.environ.get("OMLX_DEEPSEEK_SORT_MIN_ROUTES", "32"))
+_AFFINE_NATIVE_MIN_ROUTES = int(
+    os.environ.get("OMLX_DEEPSEEK_AFFINE_BLOCK_MIN_ROUTES", "1024")
+)
 # Tuned on M3 Ultra. Set this to 8192 to restore the previous crossover on
 # other pre-NAX chips; M5 prefill uses the NAX fallback below.
 _DEEPSEEK_MXFP4_LARGE_BLOCK_MIN_ROUTES = int(
@@ -243,6 +266,7 @@ class QuantizedSwitchLinear(nn.Module):
             sorted_indices
             and x.ndim == 3
             and x.shape[-2] == 1
+            and int(x.shape[0]) >= _AFFINE_NATIVE_MIN_ROUTES
             and dtype in (mx.float16, mx.bfloat16)
             and self.group_size == 64
             and self.bits in (2, 3)
@@ -417,7 +441,7 @@ class SwitchGLU(nn.Module):
         x = mx.expand_dims(x, (-2, -3))
         original_dtype = x.dtype
 
-        do_sort = indices.size >= 64
+        do_sort = indices.size >= _SORT_MIN_ROUTES
         idx = indices
         inv_order = None
         if do_sort:
@@ -595,7 +619,7 @@ class SwitchMLP(nn.Module):
     def __call__(self, x, indices) -> mx.array:
         x = mx.expand_dims(x, (-2, -3))
 
-        do_sort = indices.size >= 64
+        do_sort = indices.size >= _SORT_MIN_ROUTES
         idx = indices
         inv_order = None
         if do_sort:

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -2370,3 +2370,48 @@ class TestIndexerFallbackTiling:
         _, dm = self._reduce_and_ref()
         assert 64 * 512 * dm._INDEXER_POOL_TILE < 2**31
         assert dm._INDEXER_MAX_ELEMS < 2**31
+
+
+class TestAffineBlockRouteThreshold:
+    """The affine block kernels must not engage below the measured crossover:
+    at 64 routes they cost 2-2.7x the plain gather (M1 Ultra, GLM-5.3-Flash
+    2-bit experts). The decision is testable without the Metal kernel."""
+
+    def _linear(self):
+        from omlx.patches.deepseek_v4 import switch_layers as sl
+
+        import mlx.core as mx
+
+        linear = sl.QuantizedSwitchLinear(
+            64, 64, num_experts=2, bias=False, group_size=64, bits=2
+        )
+        # affine metadata in the activation dtype, as a loaded oQ checkpoint has
+        linear.scales = linear.scales.astype(mx.bfloat16)
+        if linear.get("biases") is None:
+            linear.biases = mx.zeros_like(linear.scales)
+        linear.biases = linear.biases.astype(mx.bfloat16)
+        return linear
+
+    def test_affine_blocks_engage_only_from_the_route_threshold(self, monkeypatch):
+        import mlx.core as mx
+
+        from omlx.patches.deepseek_v4 import switch_layers as sl
+
+        monkeypatch.setattr(sl.glm_fast, "has_symbol", lambda name: True)
+        linear = self._linear()
+        below = mx.zeros((sl._AFFINE_NATIVE_MIN_ROUTES - 1, 1, 64), dtype=mx.bfloat16)
+        at = mx.zeros((sl._AFFINE_NATIVE_MIN_ROUTES, 1, 64), dtype=mx.bfloat16)
+        assert linear._can_use_affine_blocks(below, sorted_indices=True) is False
+        assert linear._can_use_affine_blocks(at, sorted_indices=True) is True
+        # unsorted routes never take the block path, whatever the count
+        assert linear._can_use_affine_blocks(at, sorted_indices=False) is False
+
+    def test_thresholds_default_to_the_measured_crossovers(self):
+        from omlx.patches.deepseek_v4 import switch_layers as sl
+
+        assert sl._SORT_MIN_ROUTES == 32
+        assert sl._AFFINE_NATIVE_MIN_ROUTES == 1024
+        # both are environment-overridable, like the mxfp4 neighbour
+        src = open(sl.__file__, encoding="utf-8").read()
+        assert "OMLX_DEEPSEEK_SORT_MIN_ROUTES" in src
+        assert "OMLX_DEEPSEEK_AFFINE_BLOCK_MIN_ROUTES" in src

--- a/tests/test_glm_moe_dsa_patch.py
+++ b/tests/test_glm_moe_dsa_patch.py
@@ -821,15 +821,18 @@ def test_deepseek_switchglu_uses_affine_block_kernels(monkeypatch):
     monkeypatch.setattr(fast, "deepseek_affine_gather_qmm_pair_concat_blocks", pair_spy)
     monkeypatch.setattr(fast, "deepseek_affine_gather_qmm_blocks", single_spy)
 
-    x = mx.random.normal((1, 32, 128), dtype=mx.bfloat16)
+    # 512 tokens x 2 = 1024 routes: the affine block kernels only engage from
+    # _AFFINE_NATIVE_MIN_ROUTES (below that the sorted stock gather_qmm is
+    # faster — measured in switch_layers.py).
+    x = mx.random.normal((1, 512, 128), dtype=mx.bfloat16)
     indices = mx.array(
-        [[[(i + j) % 8 for j in range(2)] for i in range(32)]],
+        [[[(i + j) % 8 for j in range(2)] for i in range(512)]],
         dtype=mx.int32,
     )
     y = model(x, indices)
     mx.eval(y)
 
-    assert y.shape == (1, 32, 2, 128)
+    assert y.shape == (1, 512, 2, 128)
     assert calls == {"pair": 1, "single": 1}
 
 
@@ -882,16 +885,19 @@ def test_deepseek_switchglu_uses_fp16_affine_blocks_for_bf16_inputs(monkeypatch)
     monkeypatch.setattr(fast, "deepseek_affine_gather_qmm_pair_concat_blocks", pair_spy)
     monkeypatch.setattr(fast, "deepseek_affine_gather_qmm_blocks", single_spy)
 
-    x = mx.random.normal((1, 32, 128), dtype=mx.bfloat16)
+    # 512 tokens x 2 = 1024 routes: the affine block kernels only engage from
+    # _AFFINE_NATIVE_MIN_ROUTES (below that the sorted stock gather_qmm is
+    # faster — measured in switch_layers.py).
+    x = mx.random.normal((1, 512, 128), dtype=mx.bfloat16)
     indices = mx.array(
-        [[[(i + j) % 8 for j in range(2)] for i in range(32)]],
+        [[[(i + j) % 8 for j in range(2)] for i in range(512)]],
         dtype=mx.int32,
     )
     y = model(x, indices)
     mx.eval(y)
 
     assert y.dtype == mx.bfloat16
-    assert y.shape == (1, 32, 2, 128)
+    assert y.shape == (1, 512, 2, 128)
     assert calls == {
         "pair": 1,
         "single": 1,
@@ -1328,3 +1334,48 @@ def test_glm_adaptive_decode_clears_only_on_the_512_step_cadence():
 
     assert bg._steps_counter == 1
     assert streams == []
+
+
+def test_deepseek_switchglu_keeps_small_windows_off_the_block_kernels(monkeypatch):
+    """8..110-token windows (DFlash block-8 verify, batched decode) used to be
+    sent down the affine block kernel at 2-2.7x the cost of the sorted stock
+    gather_qmm (measured on M1 Ultra, GLM-5.3 oQ2e). Below
+    _AFFINE_NATIVE_MIN_ROUTES the block kernel must stay out."""
+    mx = pytest.importorskip("mlx.core")
+    pytest.importorskip("mlx.nn")
+    from omlx.custom_kernels.glm_moe_dsa import fast
+    from omlx.patches.deepseek_v4 import switch_layers as sl
+    from omlx.patches.deepseek_v4.switch_layers import SwitchGLU
+
+    if not fast.is_native_available() or not fast.has_symbol(
+        "deepseek_affine_gather_qmm_blocks"
+    ):
+        pytest.skip("native affine block kernels unavailable")
+
+    mx.random.seed(23)
+    model = SwitchGLU(128, 64, 8)
+    for name in ("gate_proj", "up_proj", "down_proj"):
+        layer = getattr(model, name).to_quantized(group_size=64, bits=2, mode="affine")
+        layer.scales = layer.scales.astype(mx.float16)
+        layer.biases = layer.biases.astype(mx.float16)
+        setattr(model, name, layer)
+
+    calls = {"single": 0}
+    orig_single = fast.deepseek_affine_gather_qmm_blocks
+
+    def single_spy(*args, **kwargs):
+        calls["single"] += 1
+        return orig_single(*args, **kwargs)
+
+    monkeypatch.setattr(fast, "deepseek_affine_gather_qmm_blocks", single_spy)
+
+    x = mx.random.normal((1, 8, 128), dtype=mx.float16)  # 8 tokens x 8 = 64 routes
+    indices = mx.array(
+        [[[(i + j) % 8 for j in range(8)] for i in range(8)]], dtype=mx.int32
+    )
+    assert indices.size >= sl._SORT_MIN_ROUTES
+    assert indices.size < sl._AFFINE_NATIVE_MIN_ROUTES
+    y = model(x, indices)
+    mx.eval(y)
+    assert y.shape == (1, 8, 8, 128)
+    assert calls == {"single": 0}


### PR DESCRIPTION
A single 64-route gate turned on both route sorting and the native affine
block kernels. Measured on M1 Ultra with real GLM-5.3-Flash expert weights
(2-bit, group 64), per layer: sorting pays off from 32 routes, but the block
kernels only beat mx.gather_qmm from ~1024 routes (the crossover is at
T=128 x 8 experts); between 64 and ~900 routes they cost 2-2.7x. Decode and
the MTP verify window live exactly in that band.

Split the gate: sort from 32 routes, block kernels from 1024. Server, batch
of 8 (B=8, 300 tokens each): 278.5 -> 173.5 ms/step, 28.7 -> 46.1 tok/s.
Prefill (chunks >= 512 tokens, >= 4096 routes) stays on the block kernels.

Both thresholds are environment-overridable (OMLX_DEEPSEEK_SORT_MIN_ROUTES,
OMLX_DEEPSEEK_AFFINE_BLOCK_MIN_ROUTES), like the mxfp4 neighbour: they were
tuned on one machine. The two existing block-kernel parity tests now feed
512 tokens x 2 experts = 1024 routes — the smallest count at which the
kernels engage — and a new decision test checks the threshold without the
Metal kernel present.
