### PR TITLE
perf(moe): serve gate+up from one concatenated projection at decode (opt-in, glm5_next on)

### DIFF
--- a/omlx/patches/deepseek_v4/switch_layers.py
+++ b/omlx/patches/deepseek_v4/switch_layers.py
@@ -21,6 +21,29 @@ _DEEPSEEK_MXFP4_SMALL_BLOCK_VARIANT = 1
 _DEEPSEEK_MXFP4_LARGE_BLOCK_BM = 32
 _DEEPSEEK_MXFP4_LARGE_BLOCK_VARIANT = 2
 _DEEPSEEK_AFFINE_LARGE_BLOCK_MIN_ROUTES = 8192
+# Below this many (token, expert) routes the stock unsorted gather_qmm runs;
+# at/above it routes are sorted by expert. Measured on M1 Ultra, GLM-5.3 oQ2e
+# (affine 2-bit, g64), one MoE layer, ms per layer:
+#   T=4:  unsorted 1.23 · sorted stock 1.11 · sorted native blocks 2.95
+#   T=8:  unsorted 2.10 · sorted stock 1.91 · sorted native blocks 5.13
+#   T=64: unsorted 12.3 · sorted stock 10.7 · sorted native blocks 15.8
+#   T=128: unsorted 24.2 · sorted stock 20.9 · sorted native blocks 19.4
+# Sorting pays from T=4 (32 routes); the affine block kernel only pays past
+# ~900 routes, so it has its own floor below. The old single threshold of 64
+# routes sent every 8..110-token window (DFlash block-8 verify, batched
+# decode at B>=8) down the block kernel at 2-2.7x the cost.
+# Route-count crossovers for the affine (oQ 2/3-bit) MoE path, measured on
+# M1 Ultra with real GLM-5.3-Flash expert weights (2-bit, group 64):
+#   - sorting the routes pays off from 32 routes;
+#   - the native block kernels only beat mx.gather_qmm from ~1024 routes
+#     (the crossover sits at T=128 x 8 experts); below it they cost 2-2.7x.
+# The single 64-route gate that engaged both at once sat exactly in the
+# losing region. Same pattern as _DEEPSEEK_MXFP4_LARGE_BLOCK_MIN_ROUTES below:
+# tuned on one machine, overridable per deployment.
+_SORT_MIN_ROUTES = int(os.environ.get("OMLX_DEEPSEEK_SORT_MIN_ROUTES", "32"))
+_AFFINE_NATIVE_MIN_ROUTES = int(
+    os.environ.get("OMLX_DEEPSEEK_AFFINE_BLOCK_MIN_ROUTES", "1024")
+)
 # Tuned on M3 Ultra. Set this to 8192 to restore the previous crossover on
 # other pre-NAX chips; M5 prefill uses the NAX fallback below.
 _DEEPSEEK_MXFP4_LARGE_BLOCK_MIN_ROUTES = int(
@@ -243,6 +266,7 @@ class QuantizedSwitchLinear(nn.Module):
             sorted_indices
             and x.ndim == 3
             and x.shape[-2] == 1
+            and int(x.shape[0]) >= _AFFINE_NATIVE_MIN_ROUTES
             and dtype in (mx.float16, mx.bfloat16)
             and self.group_size == 64
             and self.bits in (2, 3)
@@ -417,7 +441,7 @@ class SwitchGLU(nn.Module):
         x = mx.expand_dims(x, (-2, -3))
         original_dtype = x.dtype
 
-        do_sort = indices.size >= 64
+        do_sort = indices.size >= _SORT_MIN_ROUTES
         idx = indices
         inv_order = None
         if do_sort:
@@ -595,7 +619,7 @@ class SwitchMLP(nn.Module):
     def __call__(self, x, indices) -> mx.array:
         x = mx.expand_dims(x, (-2, -3))
 
-        do_sort = indices.size >= 64
+        do_sort = indices.size >= _SORT_MIN_ROUTES
         idx = indices
         inv_order = None
         if do_sort:

--- a/omlx/patches/deepseek_v4/switch_layers.py
+++ b/omlx/patches/deepseek_v4/switch_layers.py
@@ -421,6 +421,58 @@ class SwiGLU(nn.Module):
         return swiglu(gate, x)
 
 
+# Opt-in PER INSTANCE (glu._fuse_gate_up = True, set by whoever builds the
+# model): the concatenated pair steers the kernel to a different tile
+# variant and the sum lands 1 fp16 ulp from the reference, so the exact-
+# parity tests in this file (and families that did not measure a gain) stay
+# on the bit-identical path. OMLX_MOE_FUSE_GATE_UP=0 is the global kill switch.
+_FUSE_GATE_UP = os.environ.get("OMLX_MOE_FUSE_GATE_UP", "1") != "0"
+
+
+def _fuse_gate_up_storage(glu) -> bool:
+    """Concatenate gate+up on the output axis and serve both from ONE projection.
+
+    At decode (T<=8) every MoE layer launched one gather for the gate and
+    another for the up with the SAME input and the SAME indices; a gather
+    costs launch latency, not bandwidth (moving 21 or 71 MB costs the same).
+    The native pair kernel only covered the block path (>=1024 routes). The
+    fusion here is in STORAGE: up_proj's arrays become the concatenated pair,
+    gate_proj's are released (left with 0 output columns), and every existing
+    kernel path of the projection computes both at once — a split returns the
+    halves. Bench on real 2-bit g64 weights (GLM-5.3-Flash): T=1 0.60 -> 0.53
+    ms, T=8 1.84 -> 1.61, max diff 0.0 in isolation.
+    """
+    up, gate = glu.up_proj, glu.gate_proj
+    if not (
+        isinstance(up, QuantizedSwitchLinear)
+        and isinstance(gate, QuantizedSwitchLinear)
+        and getattr(up, "mode", "affine") == "affine"
+        and getattr(gate, "mode", "affine") == "affine"
+        and "bias" not in up
+        and "bias" not in gate
+        and hasattr(up, "biases")
+        and hasattr(gate, "biases")
+        and up.group_size == gate.group_size
+        and up.bits == gate.bits
+        and up.weight.shape == gate.weight.shape
+        and up.weight.dtype == gate.weight.dtype
+    ):
+        return False
+    half = up.output_dims
+    up.weight = mx.contiguous(mx.concatenate([up.weight, gate.weight], axis=1))
+    up.scales = mx.contiguous(mx.concatenate([up.scales, gate.scales], axis=1))
+    up.biases = mx.contiguous(mx.concatenate([up.biases, gate.biases], axis=1))
+    mx.eval(up.weight, up.scales, up.biases)
+    # The gate loses its arrays (0 output columns): the originals' memory is
+    # returned, and any path that still called it would fail loudly.
+    gate.weight = gate.weight[:, :0]
+    gate.scales = gate.scales[:, :0]
+    gate.biases = gate.biases[:, :0]
+    mx.eval(gate.weight, gate.scales, gate.biases)
+    glu._gate_up_half = half
+    return True
+
+
 class SwitchGLU(nn.Module):
     def __init__(
         self,
@@ -441,6 +493,15 @@ class SwitchGLU(nn.Module):
         x = mx.expand_dims(x, (-2, -3))
         original_dtype = x.dtype
 
+        if _FUSE_GATE_UP and not self.training and getattr(self, "_fuse_gate_up", False):
+            fused = getattr(self, "_gate_up_half", None)
+            if fused is None and not getattr(self, "_gate_up_fuse_tried", False):
+                self._gate_up_fuse_tried = True
+                if _fuse_gate_up_storage(self):
+                    fused = self._gate_up_half
+        else:
+            fused = None
+
         do_sort = indices.size >= _SORT_MIN_ROUTES
         idx = indices
         inv_order = None
@@ -451,7 +512,13 @@ class SwitchGLU(nn.Module):
 
         block_plan = None
         native_kinds = None
-        projections = (self.up_proj, self.gate_proj, self.down_proj)
+        # With the fusion the pair also answers for the gate: the triple keeps
+        # its shape (the block path reads native_kinds[2] for down_proj).
+        projections = (
+            (self.up_proj, self.up_proj, self.down_proj)
+            if fused is not None
+            else (self.up_proj, self.gate_proj, self.down_proj)
+        )
         use_f16_moe = original_dtype == mx.bfloat16 and all(
             isinstance(p, QuantizedSwitchLinear)
             and p._has_affine_metadata_dtype(mx.float16)
@@ -487,7 +554,8 @@ class SwitchGLU(nn.Module):
             x = x.astype(mx.float16)
 
         use_pair_proj = (
-            block_plan is not None
+            fused is None
+            and block_plan is not None
             and native_kinds is not None
             and native_kinds[0] == "mxfp4"
             and native_kinds[1] == "mxfp4"
@@ -496,7 +564,8 @@ class SwitchGLU(nn.Module):
             and self.up_proj.num_experts == self.gate_proj.num_experts
         )
         use_affine_pair_proj = (
-            block_plan is not None
+            fused is None
+            and block_plan is not None
             and native_kinds is not None
             and native_kinds[0] == "affine"
             and native_kinds[1] == "affine"
@@ -558,6 +627,12 @@ class SwitchGLU(nn.Module):
             hidden_dims = self.up_proj.output_dims
             x_up = x_pair[..., :hidden_dims]
             x_gate = x_pair[..., hidden_dims:]
+        elif fused is not None:
+            # The fused projection computes gate and up at once through
+            # WHICHEVER kernel path it picks (gather_qmm, native block).
+            x_pair = self.up_proj(x, idx, sorted_indices=do_sort, block_plan=block_plan)
+            x_up = x_pair[..., :fused]
+            x_gate = x_pair[..., fused:]
         else:
             x_up = self.up_proj(x, idx, sorted_indices=do_sort, block_plan=block_plan)
             x_gate = self.gate_proj(

--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/language.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/language.py
@@ -777,6 +777,10 @@ class Glm5NextMoE(nn.Module):
             config.n_routed_experts,
             activation=Glm5NextClampedSwiGLU(config.swiglu_limit),
         )
+        # Decode-time gate+up fusion: measured on GLM-5.3-Flash oQ2e (+5%
+        # per step), 1 fp16 ulp from the separate gathers — opt-in for this
+        # family only.
+        self.switch_mlp._fuse_gate_up = True
         self.gate = Glm5NextMoEGate(config)
         self.shared_experts = None
         if config.n_shared_experts is not None:

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -2370,3 +2370,48 @@ class TestIndexerFallbackTiling:
         _, dm = self._reduce_and_ref()
         assert 64 * 512 * dm._INDEXER_POOL_TILE < 2**31
         assert dm._INDEXER_MAX_ELEMS < 2**31
+
+
+class TestAffineBlockRouteThreshold:
+    """The affine block kernels must not engage below the measured crossover:
+    at 64 routes they cost 2-2.7x the plain gather (M1 Ultra, GLM-5.3-Flash
+    2-bit experts). The decision is testable without the Metal kernel."""
+
+    def _linear(self):
+        from omlx.patches.deepseek_v4 import switch_layers as sl
+
+        import mlx.core as mx
+
+        linear = sl.QuantizedSwitchLinear(
+            64, 64, num_experts=2, bias=False, group_size=64, bits=2
+        )
+        # affine metadata in the activation dtype, as a loaded oQ checkpoint has
+        linear.scales = linear.scales.astype(mx.bfloat16)
+        if linear.get("biases") is None:
+            linear.biases = mx.zeros_like(linear.scales)
+        linear.biases = linear.biases.astype(mx.bfloat16)
+        return linear
+
+    def test_affine_blocks_engage_only_from_the_route_threshold(self, monkeypatch):
+        import mlx.core as mx
+
+        from omlx.patches.deepseek_v4 import switch_layers as sl
+
+        monkeypatch.setattr(sl.glm_fast, "has_symbol", lambda name: True)
+        linear = self._linear()
+        below = mx.zeros((sl._AFFINE_NATIVE_MIN_ROUTES - 1, 1, 64), dtype=mx.bfloat16)
+        at = mx.zeros((sl._AFFINE_NATIVE_MIN_ROUTES, 1, 64), dtype=mx.bfloat16)
+        assert linear._can_use_affine_blocks(below, sorted_indices=True) is False
+        assert linear._can_use_affine_blocks(at, sorted_indices=True) is True
+        # unsorted routes never take the block path, whatever the count
+        assert linear._can_use_affine_blocks(at, sorted_indices=False) is False
+
+    def test_thresholds_default_to_the_measured_crossovers(self):
+        from omlx.patches.deepseek_v4 import switch_layers as sl
+
+        assert sl._SORT_MIN_ROUTES == 32
+        assert sl._AFFINE_NATIVE_MIN_ROUTES == 1024
+        # both are environment-overridable, like the mxfp4 neighbour
+        src = open(sl.__file__, encoding="utf-8").read()
+        assert "OMLX_DEEPSEEK_SORT_MIN_ROUTES" in src
+        assert "OMLX_DEEPSEEK_AFFINE_BLOCK_MIN_ROUTES" in src

--- a/tests/test_glm_moe_dsa_patch.py
+++ b/tests/test_glm_moe_dsa_patch.py
@@ -821,15 +821,18 @@ def test_deepseek_switchglu_uses_affine_block_kernels(monkeypatch):
     monkeypatch.setattr(fast, "deepseek_affine_gather_qmm_pair_concat_blocks", pair_spy)
     monkeypatch.setattr(fast, "deepseek_affine_gather_qmm_blocks", single_spy)
 
-    x = mx.random.normal((1, 32, 128), dtype=mx.bfloat16)
+    # 512 tokens x 2 = 1024 routes: the affine block kernels only engage from
+    # _AFFINE_NATIVE_MIN_ROUTES (below that the sorted stock gather_qmm is
+    # faster — measured in switch_layers.py).
+    x = mx.random.normal((1, 512, 128), dtype=mx.bfloat16)
     indices = mx.array(
-        [[[(i + j) % 8 for j in range(2)] for i in range(32)]],
+        [[[(i + j) % 8 for j in range(2)] for i in range(512)]],
         dtype=mx.int32,
     )
     y = model(x, indices)
     mx.eval(y)
 
-    assert y.shape == (1, 32, 2, 128)
+    assert y.shape == (1, 512, 2, 128)
     assert calls == {"pair": 1, "single": 1}
 
 
@@ -882,16 +885,19 @@ def test_deepseek_switchglu_uses_fp16_affine_blocks_for_bf16_inputs(monkeypatch)
     monkeypatch.setattr(fast, "deepseek_affine_gather_qmm_pair_concat_blocks", pair_spy)
     monkeypatch.setattr(fast, "deepseek_affine_gather_qmm_blocks", single_spy)
 
-    x = mx.random.normal((1, 32, 128), dtype=mx.bfloat16)
+    # 512 tokens x 2 = 1024 routes: the affine block kernels only engage from
+    # _AFFINE_NATIVE_MIN_ROUTES (below that the sorted stock gather_qmm is
+    # faster — measured in switch_layers.py).
+    x = mx.random.normal((1, 512, 128), dtype=mx.bfloat16)
     indices = mx.array(
-        [[[(i + j) % 8 for j in range(2)] for i in range(32)]],
+        [[[(i + j) % 8 for j in range(2)] for i in range(512)]],
         dtype=mx.int32,
     )
     y = model(x, indices)
     mx.eval(y)
 
     assert y.dtype == mx.bfloat16
-    assert y.shape == (1, 32, 2, 128)
+    assert y.shape == (1, 512, 2, 128)
     assert calls == {
         "pair": 1,
         "single": 1,
@@ -1328,3 +1334,48 @@ def test_glm_adaptive_decode_clears_only_on_the_512_step_cadence():
 
     assert bg._steps_counter == 1
     assert streams == []
+
+
+def test_deepseek_switchglu_keeps_small_windows_off_the_block_kernels(monkeypatch):
+    """8..110-token windows (DFlash block-8 verify, batched decode) used to be
+    sent down the affine block kernel at 2-2.7x the cost of the sorted stock
+    gather_qmm (measured on M1 Ultra, GLM-5.3 oQ2e). Below
+    _AFFINE_NATIVE_MIN_ROUTES the block kernel must stay out."""
+    mx = pytest.importorskip("mlx.core")
+    pytest.importorskip("mlx.nn")
+    from omlx.custom_kernels.glm_moe_dsa import fast
+    from omlx.patches.deepseek_v4 import switch_layers as sl
+    from omlx.patches.deepseek_v4.switch_layers import SwitchGLU
+
+    if not fast.is_native_available() or not fast.has_symbol(
+        "deepseek_affine_gather_qmm_blocks"
+    ):
+        pytest.skip("native affine block kernels unavailable")
+
+    mx.random.seed(23)
+    model = SwitchGLU(128, 64, 8)
+    for name in ("gate_proj", "up_proj", "down_proj"):
+        layer = getattr(model, name).to_quantized(group_size=64, bits=2, mode="affine")
+        layer.scales = layer.scales.astype(mx.float16)
+        layer.biases = layer.biases.astype(mx.float16)
+        setattr(model, name, layer)
+
+    calls = {"single": 0}
+    orig_single = fast.deepseek_affine_gather_qmm_blocks
+
+    def single_spy(*args, **kwargs):
+        calls["single"] += 1
+        return orig_single(*args, **kwargs)
+
+    monkeypatch.setattr(fast, "deepseek_affine_gather_qmm_blocks", single_spy)
+
+    x = mx.random.normal((1, 8, 128), dtype=mx.float16)  # 8 tokens x 8 = 64 routes
+    indices = mx.array(
+        [[[(i + j) % 8 for j in range(8)] for i in range(8)]], dtype=mx.int32
+    )
+    assert indices.size >= sl._SORT_MIN_ROUTES
+    assert indices.size < sl._AFFINE_NATIVE_MIN_ROUTES
+    y = model(x, indices)
+    mx.eval(y)
+    assert y.shape == (1, 8, 8, 128)
+    assert calls == {"single": 0}

--- a/tests/test_glm_moe_dsa_patch.py
+++ b/tests/test_glm_moe_dsa_patch.py
@@ -1379,3 +1379,57 @@ def test_deepseek_switchglu_keeps_small_windows_off_the_block_kernels(monkeypatc
     mx.eval(y)
     assert y.shape == (1, 8, 8, 128)
     assert calls == {"single": 0}
+
+
+def test_switchglu_gate_up_fusion_matches_reference_and_frees_gate():
+    """With the per-instance opt-in, gate+up come out of ONE concatenated
+    projection; the result stays within 1 fp16 ulp of the separate gathers
+    and the gate arrays are released (0 columns). Without the opt-in nothing
+    changes (bit-identical)."""
+    import mlx.core as mx
+
+    from omlx.patches.deepseek_v4.switch_layers import SwitchGLU
+
+    mx.random.seed(11)
+    def make():
+        m = SwitchGLU(128, 64, 8)
+        for name in ("gate_proj", "up_proj", "down_proj"):
+            layer = getattr(m, name).to_quantized(group_size=64, bits=2, mode="affine")
+            layer.scales = layer.scales.astype(mx.float16)
+            layer.biases = layer.biases.astype(mx.float16)
+            setattr(m, name, layer)
+        m.eval()
+        return m
+
+    mx.random.seed(3)
+    ref = make()
+    mx.random.seed(3)
+    fus = make()
+    fus._fuse_gate_up = True
+
+    x = mx.random.normal((1, 2, 128)).astype(mx.float16)
+    idx = mx.random.randint(0, 8, (1, 2, 4))
+    a = ref(x, idx)
+    b = fus(x, idx)
+    mx.eval(a, b)
+    assert fus._gate_up_half == 64
+    assert fus.gate_proj.weight.shape[1] == 0, "gate arrays were not released"
+    assert fus.up_proj.output_dims == 128, "up_proj did not become the pair"
+    dif = float(mx.max(mx.abs(a - b)).item())
+    assert dif <= 2e-3, f"fusion diverges beyond fp16 rounding: {dif:.2e}"
+
+    # the second call reuses the already-built pair and stays identical
+    c = fus(x, idx)
+    mx.eval(c)
+    assert float(mx.max(mx.abs(b - c)).item()) == 0.0
+
+    # and the SORTED/block path (prefill: >=1024 routes) also works fused —
+    # this is where the server crashed with the projection triple shrunk to
+    # two (native_kinds[2] out of range).
+    xg = mx.random.normal((1, 200, 128)).astype(mx.float16)
+    ig = mx.random.randint(0, 8, (1, 200, 8))
+    a2 = ref(xg, ig)
+    b2 = fus(xg, ig)
+    mx.eval(a2, b2)
+    dif2 = float(mx.max(mx.abs(a2 - b2)).item())
+    assert dif2 <= 2e-3, f"sorted path diverges: {dif2:.2e}"


### PR DESCRIPTION
Every MoE layer launched one gather for gate_proj and another for
up_proj with the same input and the same expert indices. Below the block
kernels (decode: 8-64 routes) a gather costs launch latency, not
bandwidth — moving 21 or 71 MB costs the same — so the second launch is
pure overhead. The native pair kernel only covered the block path
(>=1024 routes).

The fusion is in storage: on first use, up_proj's weight/scales/biases
become the concatenated pair, gate_proj's are released (0 output
columns, memory returned, and any stray caller fails loudly), and every
existing kernel path of the projection computes both halves at once; a
split returns them. The projection triple keeps its shape (the pair
answers for the gate) because the block path indexes native_kinds[2]
for down_proj — the first version shrank it to two and crashed the
sorted/prefill path with 'tuple index out of range'; the test covers
that path too (200 tokens x 8 routes).

Opt-in per instance (glu._fuse_gate_up = True): the pair steers the
kernel to another tile variant and lands 1 fp16 ulp from the reference,
so the exact-parity tests and the families that did not measure a gain
stay bit-identical. glm5_next enables it at construction.
OMLX_MOE_FUSE_GATE_UP=0 is the kill switch.

Measured on GLM-5.3-Flash oQ2e (2-bit g64, M1 Ultra): isolated MoE
layer T=1 0.60 -> 0.53 ms, T=8 1.84 -> 1.61 ms, max diff 0.0; full
decode step T=1 44.7 -> 42.4 ms (+5%), T=3 71.7 -> 70.3 ms.


---
Stacked on #3409 (the block-kernel route threshold): this branch carries that commit too, so the diff here shows both until it merges. The fusion itself is the second commit.
