### PR TITLE
fix(api): publish time_to_first_token / prompt_eval_duration / generation_duration on non-streaming responses

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -3514,6 +3514,16 @@ async def create_completion(
                         if model_load_duration > 1.0
                         else None
                     ),
+                    # The streaming path already publishes the timing split; the
+                    # values are computed above for the metrics recorder either
+                    # way. Without them every non-streaming consumer falls back
+                    # to total_time and charges prompt processing to the decode
+                    # clock (measured on GLM-5.3-Flash: 1.62 s of 6.69 s, 24%).
+                    time_to_first_token=(
+                        round(prefill_duration, 2) if prefill_duration > 0 else None
+                    ),
+                    prompt_eval_duration=round(prefill_duration, 2),
+                    generation_duration=round(gen_duration, 2),
                     total_time=round(elapsed, 2),
                 ),
             ).model_dump_json(exclude_none=True)
@@ -4051,6 +4061,16 @@ async def create_chat_completion(
                         if model_load_duration > 1.0
                         else None
                     ),
+                    # The streaming path already publishes the timing split; the
+                    # values are computed above for the metrics recorder either
+                    # way. Without them every non-streaming consumer falls back
+                    # to total_time and charges prompt processing to the decode
+                    # clock (measured on GLM-5.3-Flash: 1.62 s of 6.69 s, 24%).
+                    time_to_first_token=(
+                        round(ttft, 2) if ttft > 0 else None
+                    ),
+                    prompt_eval_duration=round(metric_prefill_duration, 2),
+                    generation_duration=round(metric_gen_duration, 2),
                     total_time=round(elapsed, 2),
                 ),
             ).model_dump_json(exclude_none=True)

--- a/tests/integration/test_server_endpoints.py
+++ b/tests/integration/test_server_endpoints.py
@@ -10,6 +10,7 @@ import json
 from dataclasses import dataclass, field
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
+import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
@@ -2437,3 +2438,58 @@ class TestJsonOutputParsing:
         data = response.json()
         output_text = data["output"][0]["content"][0]["text"]
         assert "Hello" in output_text
+
+
+class TestNonStreamingUsageDurations:
+    """Non-streaming responses must publish the same timing split the streaming
+    path already does. Without it every non-streaming consumer falls back to
+    total_time and charges prompt processing to the decode clock — measured on
+    GLM-5.3-Flash: 1.62 s of a 6.69 s request (24%) misattributed."""
+
+    @staticmethod
+    def _output_with_first_token(**kw):
+        import time as _time
+
+        async def _side_effect(*args, **kwargs):
+            await asyncio.sleep(0.02)
+            out = MockGenerationOutput(**kw)
+            out.first_token_at = _time.perf_counter()  # same clock as the handler
+            await asyncio.sleep(0.02)
+            return out
+
+        return AsyncMock(side_effect=_side_effect)
+
+    def test_chat_completion_publishes_timing_split(self, client, mock_llm_engine):
+        mock_llm_engine.chat = self._output_with_first_token(
+            text="Chat response.", prompt_tokens=26, completion_tokens=5
+        )
+        mock_llm_engine.generate = mock_llm_engine.chat
+
+        response = client.post(
+            "/v1/chat/completions",
+            json={"model": "test-model", "messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert response.status_code == 200
+        usage = response.json()["usage"]
+        assert usage["time_to_first_token"] > 0
+        assert usage["prompt_eval_duration"] == usage["time_to_first_token"]
+        assert usage["generation_duration"] > 0
+        assert usage["prompt_eval_duration"] + usage["generation_duration"] == pytest.approx(
+            usage["total_time"], abs=0.02
+        )
+
+    def test_completion_publishes_timing_split(self, client, mock_llm_engine):
+        mock_llm_engine.generate = self._output_with_first_token(
+            text="Generated response.", prompt_tokens=26, completion_tokens=5
+        )
+
+        response = client.post(
+            "/v1/completions", json={"model": "test-model", "prompt": "hi"}
+        )
+
+        assert response.status_code == 200
+        usage = response.json()["usage"]
+        assert usage["time_to_first_token"] > 0
+        assert usage["prompt_eval_duration"] == usage["time_to_first_token"]
+        assert usage["generation_duration"] > 0


### PR DESCRIPTION
The streaming path publishes the timing split in its final usage chunk; the
non-streaming /v1/completions and /v1/chat/completions responses carried only
total_time, although both handlers already compute prefill and generation
durations for the metrics recorder. Every non-streaming consumer therefore
fell back to total_time and charged prompt processing to the decode clock —
measured on GLM-5.3-Flash (M1 Ultra): 1.62 s of a 6.69 s request (24%)
misattributed to generation.

The two Usage payloads now carry the same three fields the streaming path
does, from the values already in scope. Tests drive both handlers through
TestClient with a mocked engine that stamps first_token_at, and fail without
the change (KeyError on the missing fields).
