### PR TITLE
fix(mtp): the marginal-cost slope of the depth controller excludes the plain step

### DIFF
--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -2042,8 +2042,11 @@ class _DepthController:
         # and priciest measured depths. Falls back to the prior until two
         # depths exist. This is what self-calibrates the controller to the real
         # (model x chip x context) marginal instead of a hardcoded value.
-        if len(self.t) >= 2:
-            depths = sorted(self.t)
+        # Depth 0 is the plain step, which sits below the L=1 -> L=2 verify
+        # jump (see _t_est): including it in the slope overstates the per-row
+        # marginal. Only speculative depths define the slope.
+        depths = sorted(d for d in self.t if d > 0)
+        if len(depths) >= 2:
             lo, hi = depths[0], depths[-1]
             if hi > lo:
                 slope = (self.t[hi] - self.t[lo]) / (hi - lo)

--- a/tests/test_mtp_depth_controller.py
+++ b/tests/test_mtp_depth_controller.py
@@ -443,3 +443,15 @@ def test_std_tax_probe_measures_and_smooths():
     for _ in range(_STD_TAX_SAMPLES):
         _record_std_tax_sample(gb, 11.0)
     assert 1.0 < model._omlx_mtp_loop_tax < 1.2
+
+
+def test_marginal_est_ignores_the_plain_step_in_the_slope():
+    """t[0] is the plain step, below the L=1 -> L=2 jump (_t_est says so);
+    including it in the slope overstates the per-row marginal. Measured on
+    GLM-5.3-Flash: plain 48, d1 71, d2 93 -> the real marginal is 22; with
+    depth 0 in the fit a warm-up with a low t[0] would give (93-30)/2 = 31.5."""
+    c = _DepthController(3, marginal_ms=7.0)
+    c.t = {0: 30.0, 1: 71.0, 2: 93.0}
+    assert math.isclose(c._marginal_est(), 22.0, rel_tol=1e-9)
+    c.t = {0: 30.0, 1: 71.0}
+    assert c._marginal_est() == 7.0, "one speculative depth leaves the prior"


### PR DESCRIPTION
_marginal_est fitted the per-row slope over every observed depth, including
depth 0 — the plain (non-speculative) step, which sits below the L=1 -> L=2
verify jump. Including it overstated the per-row marginal cost and made the
controller more reluctant to climb than the measured cycle times justify.
Only speculative depths (d > 0) define the slope now.

No throughput claim: measured on GLM-5.3-Flash (M1 Ultra, prose, 5x300)
20.04 +/- 0.50 -> 20.22 +/- 0.29 tok/s, within noise. The change makes the
estimate honest, not faster.
