### PR TITLE
fix(scheduler): an eviction pause mid external prefill lost progress and duplicated KV tokens

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -3619,7 +3619,22 @@ class Scheduler:
                 # stored from there on misaligned — the next prefix hit
                 # generates garbage (GLM-5.3, 02/09, only reachable when the
                 # MTP head's memory pushed the throttle into a paused chunk).
-                if existing_cache is not None and processed_tokens > 0:
+                #
+                # A COLD prompt has to commit too. The restored-prefix case was
+                # the one measured in 02/09, so the commit was gated on
+                # ``existing_cache``; a cold prompt builds ``prompt_cache``
+                # locally, the pause dropped it with this exception, and the
+                # retry started from token zero. Measured 05/09 on GLM-5.3-Flash
+                # oQ2e: a 229.923-token prompt was paused at 206.336 tokens
+                # ("needs prefill headroom ... current=111.76GB target=112.48GB"),
+                # the eviction reclaimed 1,56 GB, and the request was re-admitted
+                # as ``new=229923 kv_exact=0`` — 19 minutes of prefill thrown
+                # away, and nothing stops it from happening again at the same
+                # point. Attaching the advanced cache to the request is what the
+                # retry path already reads (``cache_to_use = request.prompt_cache``).
+                if processed_tokens > 0:
+                    if existing_cache is None:
+                        request.prompt_cache = prompt_cache
                     request.cached_tokens = (
                         int(getattr(request, "cached_tokens", 0) or 0) + processed_tokens
                     )

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -3601,13 +3601,30 @@ class Scheduler:
             # so the hard cap is honored before the chunk-end check. Raises
             # RuntimeError if the min chunk would exceed the cap — the
             # #1405 cleanup path catches it and emits an error to the client.
-            n_to_process = self._adaptive_chunk_size(
-                n_to_process,
-                request_id=request.request_id,
-                loop_label="external",
-                kv_len=base_size + processed_tokens,
-                gathered_core=gathered_core,
-            )
+            try:
+                n_to_process = self._adaptive_chunk_size(
+                    n_to_process,
+                    request_id=request.request_id,
+                    loop_label="external",
+                    kv_len=base_size + processed_tokens,
+                    gathered_core=gathered_core,
+                )
+            except _PrefillEvictionNeeded:
+                # The eviction pause re-queues the request keeping its
+                # prompt_cache, which this loop has already advanced in
+                # place by ``processed_tokens``. Commit that progress, or
+                # the retry re-feeds the same tokens on top of the advanced
+                # cache: a duplicated span in the KV, boundary snapshots
+                # labelled one block behind the cache, and every block
+                # stored from there on misaligned — the next prefix hit
+                # generates garbage (GLM-5.3, 02/09, only reachable when the
+                # MTP head's memory pushed the throttle into a paused chunk).
+                if existing_cache is not None and processed_tokens > 0:
+                    request.cached_tokens = (
+                        int(getattr(request, "cached_tokens", 0) or 0) + processed_tokens
+                    )
+                    request.remaining_tokens = tokens[processed_tokens:]
+                raise
 
             # Pre-chunk safety guard: NEVER submit a chunk whose predicted peak
             # would breach the prefill safety cap. The Metal command-buffer

--- a/tests/test_scheduler_prefill_eviction_progress.py
+++ b/tests/test_scheduler_prefill_eviction_progress.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+"""An eviction pause MID external prefill must not lose the progress made.
+
+The external prefill loop sizes each chunk through the adaptive throttle,
+which may raise ``_PrefillEvictionNeeded`` — including AFTER chunks have
+already entered the cache (the ``prompt_cache`` object is advanced in
+place). The pause re-queued the request with the ``remaining_tokens`` and
+``cached_tokens`` it started with, so on retry the same tokens were fed
+again on top of the advanced cache: a DUPLICATED span in the KV, boundary
+snapshots labelled one block behind what the cache actually held
+(``tc=7680 ... kv=8192``, measured on GLM-5.3-Flash), and every block
+stored from there on misaligned — the next request that hit that prefix
+generated garbage ("NoNo", "DEDEDE"). It only showed up with the MTP head
+enabled, because only then did memory pressure push the throttle far
+enough to pause a chunk.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+from mlx_lm.models.cache import KVCache
+
+from omlx.request import Request, SamplingParams
+from omlx.scheduler import Scheduler, SchedulerConfig, _PrefillEvictionNeeded
+
+
+class _CountingModel:
+    """Only pushes positions into a KVCache: the offset is what matters."""
+
+    def __init__(self):
+        self.layers = [SimpleNamespace()]
+        self.args = SimpleNamespace(num_hidden_layers=1)
+
+    def __call__(self, inputs, cache=None, **kwargs):
+        S = inputs.shape[1]
+        cache[0].update_and_fetch(mx.zeros((1, 1, S, 4)), mx.zeros((1, 1, S, 4)))
+        return mx.zeros((1, S, 8))
+
+    def make_cache(self):
+        return [KVCache()]
+
+    def parameters(self):
+        return {}
+
+
+def test_pause_mid_external_prefill_commits_the_progress(mock_tokenizer):
+    model = _CountingModel()
+    scheduler = Scheduler(
+        model=model, tokenizer=mock_tokenizer, config=SchedulerConfig(prefill_step_size=4)
+    )
+    # restored prefix: 4 tokens already in the cache
+    cache = model.make_cache()
+    model(mx.zeros((1, 4), dtype=mx.int32), cache=cache)
+    prompt = list(range(100, 116))  # 16 tokens; 12 to go (the last is the generator's)
+    request = Request(request_id="req-pause", prompt=prompt, sampling_params=SamplingParams())
+    request.prompt_token_ids = prompt
+    request.num_prompt_tokens = len(prompt)
+    request.cached_tokens = 4
+    request.remaining_tokens = prompt[4:]
+    request.prompt_cache = cache
+    scheduler.requests[request.request_id] = request
+
+    calls = {"n": 0}
+    original = scheduler._adaptive_chunk_size
+
+    def throttle_on_the_second(requested, **kw):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise _PrefillEvictionNeeded(
+                SimpleNamespace(reason="adaptive_prefill_throttle", request_id=request.request_id)
+            )
+        return original(requested, **kw)
+
+    scheduler._adaptive_chunk_size = throttle_on_the_second
+
+    with pytest.raises(_PrefillEvictionNeeded):
+        scheduler._do_external_prefill(request, request.remaining_tokens, cache)
+
+    # the cache advanced by ONE chunk (4 tokens) before the pause
+    assert cache[0].offset == 8
+    # and the request has to know it: what is left starts AFTER what went in
+    assert request.cached_tokens == 8, request.cached_tokens
+    assert request.remaining_tokens == prompt[8:], request.remaining_tokens
+    assert request.prompt_cache is cache

--- a/tests/test_scheduler_prefill_eviction_progress.py
+++ b/tests/test_scheduler_prefill_eviction_progress.py
@@ -84,3 +84,47 @@ def test_pause_mid_external_prefill_commits_the_progress(mock_tokenizer):
     assert request.cached_tokens == 8, request.cached_tokens
     assert request.remaining_tokens == prompt[8:], request.remaining_tokens
     assert request.prompt_cache is cache
+
+
+def test_pause_on_a_cold_prompt_commits_the_progress_too(mock_tokenizer):
+    """The case the first fix missed: with no restored prefix, the pause restarted at token zero.
+
+    Measured 05/09 on GLM-5.3-Flash oQ2e: a cold 229,923-token prompt was paused at
+    206,336 tokens for headroom (111.76 GB against a 112.48 GB target), the eviction
+    reclaimed 1.56 GB, and the request was re-admitted as new (new=229923, kv_exact=0)
+    — 19 minutes of prefill thrown away, with nothing preventing the same at 206k again.
+    The locally built cache has to go onto the request, which is where the retry reads it.
+    """
+    model = _CountingModel()
+    scheduler = Scheduler(
+        model=model, tokenizer=mock_tokenizer, config=SchedulerConfig(prefill_step_size=4)
+    )
+    prompt = list(range(100, 116))
+    request = Request(request_id="req-cold", prompt=prompt, sampling_params=SamplingParams())
+    request.prompt_token_ids = prompt
+    request.num_prompt_tokens = len(prompt)
+    request.cached_tokens = 0
+    request.remaining_tokens = prompt
+    request.prompt_cache = None
+    scheduler.requests[request.request_id] = request
+
+    calls = {"n": 0}
+    original = scheduler._adaptive_chunk_size
+
+    def throttle_on_third(requested, **kw):
+        calls["n"] += 1
+        if calls["n"] == 3:
+            raise _PrefillEvictionNeeded(
+                SimpleNamespace(reason="adaptive_prefill_throttle", request_id=request.request_id)
+            )
+        return original(requested, **kw)
+
+    scheduler._adaptive_chunk_size = throttle_on_third
+    with pytest.raises(_PrefillEvictionNeeded):
+        scheduler._do_external_prefill(request, prompt, None)
+
+    # two chunks of 4 went in before the pause; the cache must be ON THE REQUEST
+    assert request.prompt_cache is not None
+    assert request.prompt_cache[0].offset == 8
+    assert request.cached_tokens == 8, request.cached_tokens
+    assert request.remaining_tokens == prompt[8:], request.remaining_tokens


### PR DESCRIPTION
## The warm path: a restored prefix

The external prefill loop sizes each chunk through the adaptive throttle,
which can raise `_PrefillEvictionNeeded` AFTER chunks have already entered
the cache (`prompt_cache` is advanced in place). The pause re-queued the
request with the `remaining_tokens`/`cached_tokens` it started with, so the
retry fed the same tokens again on top of the advanced cache.

The damage compounds: a duplicated span in the KV, boundary snapshots
labelled one block behind what the cache held ("tc=7680 kv=8192",
"tc=8192 kv=8704"), and every block stored from there on misaligned —
layer 3's KV differed in 2.6 of 2 positions, i.e. it held keys for OTHER
tokens. The next request that hit those blocks generated garbage ("NoNo",
"DEDEDE", "Sand Sand"). Reproduced through the API in three steps: A
stores the prefix, B restores and prefills while throttled, C hits it and
generates garbage (2 of 2).

It only surfaced with the MTP head enabled, because only then did memory
pressure push the throttle far enough to pause a chunk — the head was the
witness, not the cause.

The pause now commits the progress: `cached_tokens += processed` and
`remaining_tokens` = what is left.

## The cold path: no prefix at all

The commit above only committed the progress when `existing_cache` was set.
A **cold** prompt builds its cache locally, so `existing_cache is None` and the
pause re-admitted the request from token zero — the whole prefill so far,
thrown away.

Measured 05/09 on GLM-5.3-Flash oQ2e: a cold 229,923-token prompt was paused at
206,336 tokens for headroom, the eviction reclaimed 1.56 GB, and the request
came back as `new=229923 kv_exact=0` — **19 minutes of prefill lost**. With the
fix, the next 229k run paused twice at 192k, each pause cost ~6 s, and only the
remaining 36k tokens were re-admitted.

## Tests

- `test_pause_mid_external_prefill_commits_the_progress` — fails without the first commit (`4 == 8`).
- `test_pause_on_a_cold_prompt_commits_the_progress_too` — fails with the first commit alone (`prompt_cache` is `None`).
