### PR TITLE
fix(mtp): the reconcile re-prefill runs in scheduler-sized chunks, not one forward

### DIFF
--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -1296,8 +1296,23 @@ def _reconcile_mtp_to_standard(gen_batch: Any, state: _MtpState) -> bool:
         procs = _proc_list(gen_batch)
         _set_singleton_mrope_delta(gen_batch)
         tok_arr = _ensure_uint32(mx.array(list(tokens)))
+        # Re-prefill in the scheduler's chunk size, not in one forward: a
+        # single forward of the whole context (13-30k tokens in an agent
+        # loop) both blows memory (the prefill throttle fired only with MTP
+        # on) and lands on sparse-attention paths the chunked prefill never
+        # takes, so the rebuilt cache diverged from a chunked one from layer
+        # 7 on (GLM-5.3, prefill_one_vs_chunks.py). Chunked, it matches the
+        # prefill the request already had.
+        step = int(getattr(gen_batch, "prefill_step_size", 0) or 0) or 512
+        total = int(tok_arr.shape[0])
+        logits = None
         # Inherits the per-engine stream from the enclosing BatchGenerator context.
-        logits, _, _ = _call_backbone(gen_batch.model, tok_arr[None, :], new_cache)
+        for start in range(0, total, step):
+            logits, _, _ = _call_backbone(
+                gen_batch.model, tok_arr[None, start : start + step], new_cache
+            )
+            if start + step < total:
+                mx.eval(logits)
         last_logits = logits[:, -1, :]  # (1, vocab) — dist after tokens[-1]
 
         if state.queue:

--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -2821,3 +2821,47 @@ class TestLoopTaxHygiene:
         assert tracker.recently_active(3.0)  # just-finished counts
         tracker.clear()
         assert not tracker.recently_active(3.0)
+
+
+class TestReconcileChunked:
+    def test_reconcile_re_prefills_in_scheduler_chunks(self, monkeypatch):
+        """The reconcile re-prefill uses the generator's prefill step, never a
+        single forward over the whole context: memory and sparse-attention
+        paths differ from the chunked prefill the request already had."""
+        from collections import deque
+        from types import SimpleNamespace
+
+        import mlx.core as mx
+        import numpy as np
+
+        from omlx.patches.mlx_lm_mtp import batch_generator
+
+        shapes = []
+
+        class _FakeCache:
+            def __init__(self):
+                self.offset = 0
+                self._mtp_undo = None
+
+        def fake_backbone(model, inputs, cache, n_confirmed=0):
+            shapes.append(int(inputs.shape[1]))
+            cache[0].offset += int(inputs.shape[1])
+            arr = np.full((1, int(inputs.shape[1]), 8), -10.0, dtype=np.float32)
+            arr[0, -1, 5] = 10.0
+            return mx.array(arr), None, None
+
+        monkeypatch.setattr(batch_generator, "_rebuild_singleton_cache", lambda m: [_FakeCache()])
+        monkeypatch.setattr(batch_generator, "_call_backbone", fake_backbone)
+        tokens = list(range(1300))
+        state = batch_generator._MtpState(uid=1, queue=deque())
+        batch = SimpleNamespace(
+            model=object(), uids=[1], tokens=[tokens], _num_tokens=[len(tokens)],
+            samplers=[None], fallback_sampler=lambda lp: mx.argmax(lp, axis=-1).astype(mx.uint32),
+            logits_processors=[], _next_tokens=mx.array([999]), _next_logprobs=[],
+            _token_context=[], prompt_cache=[object()], _omlx_mtp_state=state,
+            prefill_step_size=512,
+        )
+        assert batch_generator._reconcile_mtp_to_standard(batch, state) is True
+        assert shapes == [512, 512, 276], shapes
+        assert batch.prompt_cache[0].offset == 1300
+        assert batch._next_tokens.tolist() == [5]


### PR DESCRIPTION
When the MTP cycle falls back to the plain step, _reconcile_mtp_to_standard
rebuilds the cache by re-prefilling the whole history. It did that in a
single forward — 13-30k tokens in an agent loop — which both blows memory
(the prefill throttle fired only with MTP on) and lands on sparse-attention
paths the chunked prefill never takes.

Measured on GLM-5.3-Flash oQ2e (2602 tokens): the cache rebuilt in one shot
diverges from the chunked one (512) from layer 7 on (38 positions), and at
nearly every position from layer 19 on. It now uses the generator's
prefill_step_size (512 on the server), so the rebuilt cache matches the
prefill the request already had.

Test: test_reconcile_re_prefills_in_scheduler_chunks asserts the chunk
shapes (512, 512, 276) for a 1300-token history.
