### PR TITLE
fix(mtp): the chain rollback could not find the method behind the VLM adapter

### DIFF
--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -3201,7 +3201,16 @@ def _chain_rollback(
         except Exception as exc:
             logger.debug("rollback_speculative_cache failed: %s", exc)
             return False
-    rollback = getattr(model, "mtp_partial_rollback", None)
+    # The mlx-vlm runtimes stamp ``mtp_partial_rollback`` on the inner
+    # LanguageModel, but the batch sees oMLX's ``VLMModelAdapter`` wrapper,
+    # which does not forward it — measured on GLM-5.3 vision: every reject
+    # raised "cache layer rejects chain rollback" and reconciled (2 tok/s).
+    rollback = None
+    for candidate in (model, getattr(model, "language_model", None),
+                      getattr(model, "_language_model", None)):
+        rollback = getattr(candidate, "mtp_partial_rollback", None)
+        if callable(rollback):
+            break
     if callable(rollback):
         try:
             return bool(rollback(prompt_cache, accepted, num_drafts))

--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -2821,3 +2821,28 @@ class TestLoopTaxHygiene:
         assert tracker.recently_active(3.0)  # just-finished counts
         tracker.clear()
         assert not tracker.recently_active(3.0)
+
+
+def test_chain_rollback_finds_the_method_behind_the_vlm_adapter():
+    """On the server the batch does not see the LanguageModel: it sees
+    ``VLMModelAdapter``, which does not forward ``mtp_partial_rollback``. The
+    chain rollback looked only at the wrapper, found nothing, and EVERY reject
+    fell through to "cache layer rejects chain rollback" plus a reconcile —
+    measured on a GLM-5.3 vision checkpoint at 2 tok/s with cycles=0. It now
+    looks at the inner model too.
+    """
+    from omlx.patches.mlx_lm_mtp import batch_generator as bg
+
+    calls = []
+
+    class _Language:
+        def mtp_partial_rollback(self, cache, accepted, num_drafts):
+            calls.append((accepted, num_drafts))
+            return True
+
+    class _Adapter:
+        def __init__(self):
+            self._language_model = _Language()
+
+    assert bg._chain_rollback(_Adapter(), [], 1, 3, None) is True
+    assert calls == [(1, 3)]


### PR DESCRIPTION
The mlx-vlm runtimes stamp mtp_partial_rollback on the inner LanguageModel,
but the batch sees oMLX's VLMModelAdapter wrapper, which does not forward
it. _chain_rollback looked only at the wrapper, found nothing, and every
draft reject fell through to "cache layer rejects chain rollback" plus a
full reconcile.

Measured on a GLM-5.3 vision checkpoint before the fix: 2 tok/s with the
MTP head reporting cycles=0 — speculation was on, doing nothing but paying
the reconcile. After: 17.5 / 19.8 / 18.9 tok/s over 3x300 tokens at 73%
acceptance, against 18.8 / 19.2 / 19.2 with the head off.

The lookup now walks model, language_model and _language_model.
