### PR TITLE
fix(prefill): three admission-charge bugs in the transient tracker (reclaim sum, impossible seed, observed-max ordering)

### DIFF
--- a/omlx/prefill_transient_tracker.py
+++ b/omlx/prefill_transient_tracker.py
@@ -140,6 +140,28 @@ class PrefillTransientTracker:
 
         history = self._history(gathered_core)
 
+        # The sanity bound gates the running max too, so it runs FIRST. The
+        # clamp below is on TOTAL bytes, which a small chunk passes at an
+        # impossible rate: measured on GLM-5.3-Flash (M1 Ultra), a 32-token
+        # floor chunk read 3.54GB (110MB/token), cleared the 4GB clamp, and
+        # pinned observed_max_bytes for the rest of the process. Admission
+        # charges that max as a flat floor with no multiplier, so it then
+        # priced 3.54GB where the analytic estimate for the same chunk is
+        # 0.27GB and refused a 159K-token prompt by 250MB.
+        per_token = transient_bytes / n_tokens
+        if per_token > self._PER_TOKEN_SANITY_BYTES:
+            logger.debug(
+                "PrefillTransientTracker(%s): dropped %.1f-byte/token sample "
+                "above the per-token sanity bound (%d)",
+                self._model_id,
+                per_token,
+                self._PER_TOKEN_SANITY_BYTES,
+            )
+            # Not counted as a sample: the next sane reading has to SEED the
+            # EWMA (an EWMA of 0 would reject every later sample as an
+            # outlier against 0 x ratio).
+            return
+
         # The very first sample in each execution regime carries weight
         # page-fault and load-residue noise, so it seeds that regime's EWMA
         # but is excluded from its running max.
@@ -156,20 +178,6 @@ class PrefillTransientTracker:
                     transient_bytes,
                     self._OBSERVED_MAX_CLAMP_BYTES,
                 )
-
-        per_token = transient_bytes / n_tokens
-        if per_token > self._PER_TOKEN_SANITY_BYTES:
-            logger.debug(
-                "PrefillTransientTracker(%s): dropped %.1f-byte/token sample "
-                "above the per-token sanity bound (%d)",
-                self._model_id,
-                per_token,
-                self._PER_TOKEN_SANITY_BYTES,
-            )
-            # Not counted as a sample: the next sane reading has to SEED the
-            # EWMA (an EWMA of 0 would reject every later sample as an
-            # outlier against 0 x ratio).
-            return
         if history.samples == 0:
             history.ewma_per_token = per_token
         elif per_token > history.ewma_per_token * self._EWMA_OUTLIER_RATIO:

--- a/omlx/prefill_transient_tracker.py
+++ b/omlx/prefill_transient_tracker.py
@@ -68,9 +68,19 @@ class PrefillTransientTracker:
         return self._gathered_history if gathered_core is True else self._dense_history
 
     def record_reclaim(self, reclaimed_bytes: int) -> None:
-        """Accumulate footprint released since the last positive sample."""
+        """Hold the LARGEST footprint released since the last positive sample.
+
+        The charge prices one reallocation of the pool MLX gave back, so it is
+        bounded by the biggest single release — not by their sum. Summing made
+        the charge grow without limit across a run of negative deltas: measured
+        on GLM-5.3-Flash-oQ2e, a short conversation stacked 22.97GB of charge on
+        top of a 1.02GB computed transient, and every long prompt after it was
+        rejected by the pre-chunk guard at a 124GB ceiling.
+        """
         if reclaimed_bytes > 0:
-            self._recent_reclaim_bytes += int(reclaimed_bytes)
+            self._recent_reclaim_bytes = max(
+                self._recent_reclaim_bytes, int(reclaimed_bytes)
+            )
 
     def clear_reclaim(self) -> None:
         """Drop the charge once any positive measurement confirms realloc.

--- a/omlx/prefill_transient_tracker.py
+++ b/omlx/prefill_transient_tracker.py
@@ -54,6 +54,16 @@ class PrefillTransientTracker:
     # above the largest observed legitimate fluctuation and below the
     # observed outlier.
     _EWMA_OUTLIER_RATIO = 8.0
+    # Physically impossible as a per-token cost (KV + SDPA transient of any
+    # served model stays far below this): a reading above it is buffer-pool
+    # growth or load residue divided by a small chunk, and must not seed the
+    # EWMA, blend into it, nor land in last_delta_bytes/last_n_tokens — the
+    # predictor reads that pair as a rate and takes the MAX with the EWMA.
+    # Measured on GLM-5.3-Flash (M1 Ultra): a 14-token warm-up right after
+    # load left 2.2 GB of residue and seeded the EWMA at 157 MB/token, so a
+    # 29K-token prompt ran at the 32-token floor for 186 s; the real cost is
+    # 2.1–5.7 MB/token.
+    _PER_TOKEN_SANITY_BYTES = 32 * 1024**2
 
     def __init__(self, model_id: str = "") -> None:
         self._model_id = model_id
@@ -148,6 +158,18 @@ class PrefillTransientTracker:
                 )
 
         per_token = transient_bytes / n_tokens
+        if per_token > self._PER_TOKEN_SANITY_BYTES:
+            logger.debug(
+                "PrefillTransientTracker(%s): dropped %.1f-byte/token sample "
+                "above the per-token sanity bound (%d)",
+                self._model_id,
+                per_token,
+                self._PER_TOKEN_SANITY_BYTES,
+            )
+            # Not counted as a sample: the next sane reading has to SEED the
+            # EWMA (an EWMA of 0 would reject every later sample as an
+            # outlier against 0 x ratio).
+            return
         if history.samples == 0:
             history.ewma_per_token = per_token
         elif per_token > history.ewma_per_token * self._EWMA_OUTLIER_RATIO:

--- a/tests/test_prefill_tracker_reclaim_once.py
+++ b/tests/test_prefill_tracker_reclaim_once.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The reclaim charge is priced ONCE, not accumulated without bound.
+
+When a prefill chunk ends up holding LESS memory than before, the tracker
+records the difference: MLX's buffer pool may need to allocate that space
+again on the next chunk, so the guard prices that risk up front.
+
+The field's own comment says it is priced **once** ("prices it once until a
+positive measurement confirms reallocation"). The code summed instead. Each
+release stacked on the previous one, and since the sum only clears when a
+chunk grows, a short conversation that releases memory several times left the
+charge armed for the next conversation.
+
+Measured on GLM-5.3-Flash (M1 Ultra, 128GB): with the same 2048-token chunk
+and the same context length, the predicted charge ran from 1.02GB (clean) to
+23.99GB (poisoned). The computed term is worth 1.02GB; the other 22.97GB were
+stacked releases. With the machine's ceiling at 124GB and the model holding
+107GB, that refuses every long prompt.
+"""
+
+from omlx.prefill_transient_tracker import PrefillTransientTracker
+
+GB = 1024**3
+MB = 1024**2
+
+
+def _tracker():
+    return PrefillTransientTracker(model_id="test")
+
+
+def test_a_single_release_is_priced_at_its_own_value():
+    t = _tracker()
+    t.record_reclaim(512 * MB)
+    assert t.recent_reclaim_bytes == 512 * MB
+
+
+def test_consecutive_releases_do_not_accumulate():
+    """Twenty 512MB releases are not 10GB to reallocate at once."""
+    t = _tracker()
+    for _ in range(20):
+        t.record_reclaim(512 * MB)
+    assert t.recent_reclaim_bytes == 512 * MB
+
+
+def test_the_largest_release_is_the_one_that_counts():
+    t = _tracker()
+    t.record_reclaim(200 * MB)
+    t.record_reclaim(1500 * MB)
+    t.record_reclaim(300 * MB)
+    assert t.recent_reclaim_bytes == 1500 * MB
+
+
+def test_a_growing_chunk_clears_the_charge():
+    """Regression: the behaviour that already existed still holds."""
+    t = _tracker()
+    t.record_reclaim(800 * MB)
+    t.clear_reclaim()
+    assert t.recent_reclaim_bytes == 0
+
+
+def test_a_positive_chunk_clears_the_charge_through_update():
+    t = _tracker()
+    t.record_reclaim(800 * MB)
+    t.update(2048, 512 * MB)
+    assert t.recent_reclaim_bytes == 0
+
+
+def test_a_zero_or_negative_release_does_not_count():
+    t = _tracker()
+    t.record_reclaim(0)
+    t.record_reclaim(-100 * MB)
+    assert t.recent_reclaim_bytes == 0
+
+
+def test_the_measured_incident():
+    """The short conversation releases repeatedly; the long prompt came next.
+
+    Before: 22.97GB of charge. After: the largest single event, 1.52GB —
+    which is what the server log showed being reclaimed at once.
+    """
+    t = _tracker()
+    for released in (526 * MB, 1520 * MB, 900 * MB, 480 * MB, 1200 * MB):
+        t.record_reclaim(released)
+    assert t.recent_reclaim_bytes == 1520 * MB
+    assert t.recent_reclaim_bytes < 2 * GB

--- a/tests/test_prefill_transient_tracker.py
+++ b/tests/test_prefill_transient_tracker.py
@@ -78,7 +78,8 @@ class TestEwmaOutlierGuard:
             "EWMA must not reach the ~3690.5 KB/token value observed in "
             "production before this fix"
         )
-        # The raw sample is still visible for diagnostics.
+        # The raw sample is still visible for diagnostics (it is within the
+        # per-token sanity bound; see the test below for the one that is not).
         assert t.last_n_tokens == 185
         assert t.last_delta_bytes == int(10497.1 * 1024 * 185)
 
@@ -151,10 +152,11 @@ class TestObservedMax:
         ewma_before = t.bytes_per_token
         t.update(32, 5 * 1024**3, floor_sample=True)  # above 4GiB clamp
         assert t.observed_max_bytes == 200_000_000, "outlier must not enter"
-        assert t.samples == 3, "outlier still counts as a sample"
-        # This 5GiB/32-token reading is also a >8x EWMA outlier (see
-        # TestEwmaOutlierGuard), so it must not move the EWMA either —
-        # it is excluded from both the observed-max and the EWMA now.
+        # 5GiB over 32 tokens is 168MB/token, above the per-token sanity
+        # bound, so it is dropped before counting: a sample is a reading the
+        # tracker accepted (an accepted-but-zero EWMA would reject every later
+        # sane reading as an outlier against 0 x ratio).
+        assert t.samples == 2, "an impossible per-token reading is not a sample"
         assert t.bytes_per_token == ewma_before
 
     def test_skipped_samples_do_not_touch_max(self):
@@ -226,3 +228,39 @@ class TestExecutionRegimes:
 
         assert t.observed_max_bytes == 900 * 1024**2
         assert t.observed_max_bytes_for(True) == 40 * 1024**2
+
+
+def test_a_sample_rejected_as_an_outlier_does_not_become_the_predictor_rate():
+    """The predictor takes the MAX of the EWMA and
+    `last_delta_bytes / last_n_tokens`. Recording the outlier raw in those two
+    fields handed the predictor the very number the EWMA had rejected:
+    measured end-to-end on GLM-5.3-Flash, `per_token=158198KB` for a 143-token
+    chunk (a 22GB buffer-pool delta) against a real 2.1-5.7MB/token — and the
+    chunk dropped to the 32-token floor, 3.9x slower.
+    """
+    t = PrefillTransientTracker("glm")
+    t.update(2048, 1 * 1024**3)          # sane seed: 0.5MB/token
+    t.update(1024, 600 * 1024**2)        # another sane one
+    sane_rate = t.last_delta_bytes / t.last_n_tokens
+    t.update(143, 22 * 1024**3)          # 158MB/token: physically impossible
+    assert t.last_delta_bytes / t.last_n_tokens == sane_rate, (
+        "a reading above the per-token physical bound must not become the "
+        "`last_delta/last_n` rate the predictor consumes"
+    )
+    t.update(2048, 3 * 1024**3)          # 1.5MB/token: a REAL peak, kept
+    assert t.last_n_tokens == 2048 and t.last_delta_bytes == 3 * 1024**3
+    assert t.bytes_per_token < 1 * 1024**2
+
+
+def test_a_small_seed_carrying_load_residue_does_not_poison_the_ewma():
+    """The 14-token warm-up right after load leaves ~2.2GB of pool residue:
+    157MB/token. The seeding clamp is on TOTAL bytes (4GB), so it passed — and
+    the EWMA was born 30-75x above the real rate. Measured: a 29K-token prompt
+    ran at the 32-token floor for 186s.
+    """
+    t = PrefillTransientTracker("glm")
+    t.update(14, int(2.2 * 1024**3))
+    assert t.bytes_per_token == 0.0, "an impossible seed must not become the EWMA"
+    assert t.last_n_tokens == 0
+    t.update(2048, 4 * 1024**3)  # 2MB/token, the real one
+    assert 1.5 * 1024**2 < t.bytes_per_token < 2.5 * 1024**2

--- a/tests/test_prefill_transient_tracker.py
+++ b/tests/test_prefill_transient_tracker.py
@@ -159,6 +159,24 @@ class TestObservedMax:
         assert t.samples == 2, "an impossible per-token reading is not a sample"
         assert t.bytes_per_token == ewma_before
 
+    def test_impossible_rate_under_the_clamp_never_becomes_the_max(self):
+        # The clamp is on TOTAL bytes while the sanity bound is a RATE, so a
+        # small chunk can clear the first and still break the second. Measured
+        # on GLM-5.3-Flash (M1 Ultra): a 32-token floor chunk read 3.54GB —
+        # 110MB/token, comfortably under the 4GiB clamp — and pinned the max
+        # for the rest of the process. Admission charges that max as a flat
+        # floor with no multiplier, so it priced 3.54GB where the analytic
+        # estimate for the same chunk is 0.27GB and refused a 159K-token
+        # prompt by 250MB.
+        t = PrefillTransientTracker("m")
+        t.update(32, 100_000_000, floor_sample=True)  # first sample, excluded
+        t.update(32, 200_000_000, floor_sample=True)  # 6.3MB/token, accepted
+        t.update(32, int(3.54 * 1024**3), floor_sample=True)  # 113MB/token
+        assert t.observed_max_bytes == 200_000_000, (
+            "an impossible per-token rate must not become the admission floor"
+        )
+        assert t.samples == 2, "an impossible per-token reading is not a sample"
+
     def test_skipped_samples_do_not_touch_max(self):
         t = PrefillTransientTracker("m")
         t.update(32, 100_000_000, floor_sample=True)


### PR DESCRIPTION
Three admission-charge bugs in PrefillTransientTracker, one commit each, all measured on GLM-5.3-Flash oQ2e (M1 Ultra, 128GB). Each one alone made the pre-chunk guard refuse long prompts that fit.

## fix(prefill): price the reclaim charge once, not as a running sum

The tracker records how much memory a prefill chunk gave back, because
MLX's buffer pool may need to allocate that space again on the next
chunk. The field's own comment says it is priced once ("prices it once
until a positive measurement confirms reallocation"); the code summed
every release onto the previous one, and the sum only clears when a
chunk grows.

A short conversation releases memory several times in a row and left the
charge stacked, armed for the next conversation. Measured on
GLM-5.3-Flash (M1 Ultra, 128GB) with the same 2048-token chunk and the
same context length: the computed term is worth 1.02GB and the charge
reached 23.99GB — the other 22.97GB were stacked releases. With the
machine's ceiling at 124GB and the model holding 107GB, that refuses
every long prompt.

The charge becomes the LARGEST single release, which is what one pool
reallocation would actually cost.

## fix(prefill): an impossible per-token reading must not seed or steer the chunk predictor

The 14-token warm-up right after a model load leaves ~2.2GB of buffer-pool
residue; divided by 14 tokens that reads as 157MB/token. The seeding clamp
was on TOTAL bytes (4GB), so it passed, and the EWMA was born 30-75x above
the real rate — the predictor cut the first chunk down to the 32-token
floor ("chunk 2048 -> 32 ... per_token=157025.1KB" in the server log), and
the same number reached the predictor through the last_delta/last_n pair
even when the EWMA rejected it as an outlier.

Measured on the real model (GLM-5.3-Flash oQ2e, 4096-token context): the
per-token peak is 5.7MB at a 32-token chunk and 2.1MB at 2048. A 32MB/token
bound — the 128K-context SDPA row of a 64-head model is ~16MB — drops the
whole reading, without counting it as a sample so the next sane one seeds
the EWMA.

After the fix the same prompt went from "chunk 2048 -> 32" to "chunk
2048 -> 512, per_token=6025.7KB". Wall time for 29K tokens was unchanged
(186 -> 181s): that prompt's bottleneck is long-context attention, not the
chunk size. What changes is that admission stops refusing long prompts on
the strength of a reading no model can produce.

## fix(prefill): the per-token sanity bound must gate the observed max too

The observed-max clamp is on TOTAL bytes (4GiB) while the sanity bound is
a RATE (32MB/token), and the max was updated before the rate was checked.
A small chunk clears the first while breaking the second, and the reading
the tracker then rejects as physically impossible has already become the
admission floor — a flat bound with no multiplier that the predictor
cannot undercut, pinned for the rest of the process.

Measured on GLM-5.3-Flash (M1 Ultra, 128GB): a 32-token floor chunk read
3.54GB — 110MB/token, comfortably under the 4GiB clamp — and pinned
observed_max_bytes. Admission then priced 3.54GB where the analytic
profile for that same chunk at kv_len=159200 is 0.27GB, and the pre-chunk
guard refused a 159K-token prompt by 250MB:

  [guard:external] admission terms: current=112.23GB
      predicted_transient=3.54GB observed_max_bytes=3.54GB

Moving the rate check above the max update fixes it: same two guards,
correct order. Test: an impossible rate under the clamp leaves the max at
the last legitimate floor sample.

