### PR TITLE
Preserve model identity in SSE keepalive chunks

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2119,12 +2119,12 @@ _KEEPALIVE_COMPLETION_CHUNK = (
 )
 
 
-def _completion_keepalive_chunk(response_id: str) -> str:
-    """Keepalive frame that shares the stream's completion id."""
+def _completion_keepalive_chunk(response_id: str, model: str) -> str:
+    """Keepalive frame that shares the stream's completion and model identity."""
     return (
         'data: {"id":"' + response_id + '","object":"text_completion","created":0,'
-        '"model":"keepalive",'
-        '"choices":[{"index":0,"text":"","logprobs":null,"finish_reason":null}]}\n\n'
+        + '"model":' + json.dumps(model) + ','
+        + '"choices":[{"index":0,"text":"","logprobs":null,"finish_reason":null}]}\n\n'
     )
 _KEEPALIVE_ANTHROPIC_PING = 'event: ping\ndata: {"type":"ping"}\n\n'
 
@@ -2156,8 +2156,8 @@ def _resolve_keepalive(protocol: str) -> Optional[str]:
     return None
 
 
-def _chat_keepalive_chunk(response_id: str) -> str:
-    """Keepalive frame that shares the stream's completion id.
+def _chat_keepalive_chunk(response_id: str, model: str) -> str:
+    """Keepalive frame that shares the stream's completion and model identity.
 
     The static ``_KEEPALIVE_CHAT_CHUNK`` carries a sentinel id
     (``chatcmpl-keepalive``) that differs from the real completion chunks.
@@ -2175,8 +2175,8 @@ def _chat_keepalive_chunk(response_id: str) -> str:
     """
     return (
         'data: {"id":"' + response_id + '","object":"chat.completion.chunk",'
-        '"created":0,"model":"keepalive",'
-        '"choices":[{"index":0,"delta":{"role":"assistant","content":""},'
+        + '"created":0,"model":' + json.dumps(model) + ','
+        + '"choices":[{"index":0,"delta":{"role":"assistant","content":""},'
         '"finish_reason":null}]}\n\n'
     )
 
@@ -2839,7 +2839,7 @@ async def _create_markitdown_chat_completion(
         response_id = f"chatcmpl-{uuid.uuid4().hex[:8]}"
         keepalive = _resolve_keepalive("openai_chat")
         if keepalive == _KEEPALIVE_CHAT_CHUNK:
-            keepalive = _chat_keepalive_chunk(response_id)
+            keepalive = _chat_keepalive_chunk(response_id, request.model)
         markdown_chunks = stream_messages_to_markdown_async(
             request.messages,
             global_settings=_server_state.global_settings,
@@ -3373,7 +3373,7 @@ async def create_completion(
             response_id = f"cmpl-{uuid.uuid4().hex[:8]}"
             keepalive = _resolve_keepalive("openai_completion")
             if keepalive == _KEEPALIVE_COMPLETION_CHUNK:
-                keepalive = _completion_keepalive_chunk(response_id)
+                keepalive = _completion_keepalive_chunk(response_id, request.model)
             return StreamingResponse(
                 _release_after_stream(
                     _with_sse_keepalive(
@@ -3910,7 +3910,7 @@ async def create_chat_completion(
             response_id = f"chatcmpl-{uuid.uuid4().hex[:8]}"
             keepalive = _resolve_keepalive("openai_chat")
             if keepalive == _KEEPALIVE_CHAT_CHUNK:
-                keepalive = _chat_keepalive_chunk(response_id)
+                keepalive = _chat_keepalive_chunk(response_id, request.model)
             sse_headers = {"X-Accel-Buffering": "no", "Cache-Control": "no-cache"}
             if response_format_warning:
                 sse_headers["Warning"] = response_format_warning

--- a/tests/test_sse_keepalive.py
+++ b/tests/test_sse_keepalive.py
@@ -194,11 +194,13 @@ class TestCompletionKeepaliveSharesStreamId:
     def test_frame_uses_given_response_id(self):
         from omlx.server import _completion_keepalive_chunk
 
-        frame = _completion_keepalive_chunk("cmpl-abc123")
+        model = 'GLM-5.3-Flash-oQ4e "quoted"'
+        frame = _completion_keepalive_chunk("cmpl-abc123", model)
         assert frame.startswith("data: ")
         assert frame.endswith("\n\n")
         payload = json.loads(frame.removeprefix("data: ").strip())
         assert payload["id"] == "cmpl-abc123"
+        assert payload["model"] == model
         assert payload["object"] == "text_completion"
         assert payload["choices"][0]["text"] == ""
         assert payload["choices"][0]["finish_reason"] is None
@@ -207,7 +209,9 @@ class TestCompletionKeepaliveSharesStreamId:
         from omlx.server import _completion_keepalive_chunk
 
         payload = json.loads(
-            _completion_keepalive_chunk("cmpl-real").removeprefix("data: ").strip()
+            _completion_keepalive_chunk("cmpl-real", "test-model")
+            .removeprefix("data: ")
+            .strip()
         )
         assert payload["id"] != "cmpl-keepalive"
 
@@ -225,11 +229,13 @@ class TestChatKeepaliveSharesStreamId:
     def test_frame_uses_given_response_id(self):
         from omlx.server import _chat_keepalive_chunk
 
-        frame = _chat_keepalive_chunk("chatcmpl-abc123")
+        model = 'GLM-5.3-Flash-oQ4e "quoted"'
+        frame = _chat_keepalive_chunk("chatcmpl-abc123", model)
         assert frame.startswith("data: ")
         assert frame.endswith("\n\n")
         payload = json.loads(frame.removeprefix("data: ").strip())
         assert payload["id"] == "chatcmpl-abc123"
+        assert payload["model"] == model
         assert payload["object"] == "chat.completion.chunk"
         assert payload["choices"][0]["delta"]["role"] == "assistant"
         assert payload["choices"][0]["delta"]["content"] == ""
@@ -239,7 +245,9 @@ class TestChatKeepaliveSharesStreamId:
         from omlx.server import _chat_keepalive_chunk
 
         payload = json.loads(
-            _chat_keepalive_chunk("chatcmpl-real").removeprefix("data: ").strip()
+            _chat_keepalive_chunk("chatcmpl-real", "test-model")
+            .removeprefix("data: ")
+            .strip()
         )
         assert payload["id"] != "chatcmpl-keepalive"
 
@@ -268,7 +276,10 @@ class TestChatKeepaliveCarriesRole:
     def test_id_sharing_frame_carries_assistant_role(self):
         from omlx.server import _chat_keepalive_chunk
 
-        assert self._first_chunk_role(_chat_keepalive_chunk("chatcmpl-x")) == "assistant"
+        assert (
+            self._first_chunk_role(_chat_keepalive_chunk("chatcmpl-x", "test-model"))
+            == "assistant"
+        )
 
 
 class TestResolveKeepalive:


### PR DESCRIPTION
## Problem

With `sse_keepalive_mode = "chunk"`, oMLX sends a protocol-valid no-op chunk before the first generated chunk. The dynamic keepalive helpers replace the sentinel response ID with the real stream ID, but still report the literal model name `keepalive`.

That makes model identity inconsistent within one stream: the initial chunk reports `keepalive`, while subsequent chunks report the requested model.

Some clients retain model metadata from the first differing chunk. Pi's OpenAI completions adapter does this when recording `responseModel`, producing assistant records like:

```text
model: GLM-5.3-Flash-oQ4e
responseModel: keepalive
```

`pi-cache-optimizer` prefers `responseModel` when attributing cache telemetry so routed-provider responses are assigned to the model that actually served them. Consequently, real GLM requests and cache hits were recorded under the nonexistent model `omlx-hera/keepalive`. Caching still worked, but per-model statistics were incorrect and the active GLM model appeared absent.

## Fix

Pass `request.model` into the dynamic chat and text-completion keepalive helpers and serialize it with `json.dumps`. The generated no-op chunks now share both response ID and model identity with the real stream.

The static sentinel chunks remain unchanged because `_resolve_keepalive` uses them to select protocol-specific behavior before callers create the stream-specific frame. Existing empty delta, assistant role, and finish-reason behavior is preserved.

## Impact

- Keeps OpenAI stream model metadata internally consistent.
- Prevents clients from persisting `keepalive` as the response model.
- Restores correct per-model attribution in `pi-cache-optimizer` without requiring a client-specific exception.
- Applies the same invariant to chat completions, MarkItDown chat completions, and text completions.

## Verification

- `pytest tests/test_sse_keepalive.py` — 15 passed, 3 skipped
- `ruff check tests/test_sse_keepalive.py`
- Downstream Nix package build and install checks passed.
- Live streamed GLM probe after activation returned the requested model in the initial keepalive frame:

```json
{"model":"GLM-5.3-Flash-oQ4e","role":"assistant"}
```
