### PR TITLE
fix(dflash): handle memory-pressure aborts

### DIFF
--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -336,6 +336,12 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         self._executor_tokenizer = None
         self._loaded = False
         self._active_request = False
+        # DFlash runs outside Scheduler, so memory-pressure aborts cannot use
+        # EngineCore's request registry. Keep the stop events for every
+        # submitted generation instead; the process memory enforcer calls
+        # abort_all_requests() to signal them at the next DFlash event boundary.
+        self._stop_events_lock = threading.Lock()
+        self._active_stop_events: set[threading.Event] = set()
         self._model_type_str = None
         self._fallback_engine: BaseEngine | None = None
         self._in_fallback_mode = False
@@ -1286,7 +1292,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
 
             for event in event_iter:
                 if stop_event.is_set():
-                    logger.info("DFlash generation aborted by client")
+                    logger.info("DFlash generation abort requested")
                     break
 
                 if isinstance(event, TokenEvent):
@@ -1390,12 +1396,21 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                 loop,
             )
             self._active_request = False
+            self._unregister_stop_event(stop_event)
 
     def _tokenize_prompt(self, prompt: str | list[int]) -> list[int]:
         """Return prompt IDs without re-tokenizing an already-tokenized prompt."""
         if isinstance(prompt, list):
             return list(prompt)
         return list(self._tokenizer_obj.encode(prompt))
+
+    def _register_stop_event(self, stop_event: threading.Event) -> None:
+        with self._stop_events_lock:
+            self._active_stop_events.add(stop_event)
+
+    def _unregister_stop_event(self, stop_event: threading.Event) -> None:
+        with self._stop_events_lock:
+            self._active_stop_events.discard(stop_event)
 
     async def generate(
         self,
@@ -1501,7 +1516,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                 parser_final = None
                 for event in event_iter:
                     if stop_event.is_set():
-                        logger.info("DFlash generation aborted by client")
+                        logger.info("DFlash generation abort requested")
                         break
                     if isinstance(event, TokenEvent):
                         if first_token_at is None:
@@ -1542,9 +1557,15 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                             logger.debug(f"event_iter.close() raised: {exc}")
                 self._end_runtime_cache_request(cache_manager)
                 self._active_request = False
+                self._unregister_stop_event(stop_event)
 
         self._active_request = True
-        future = loop.run_in_executor(get_mlx_executor(), _run)
+        self._register_stop_event(stop_event)
+        try:
+            future = loop.run_in_executor(get_mlx_executor(), _run)
+        except Exception:
+            self._unregister_stop_event(stop_event)
+            raise
         try:
             try:
                 (
@@ -1710,23 +1731,28 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         # Models card reads this activity instead of a scheduler snapshot.
         activity_id = self._begin_activity("generate", detail="generating")
         self._active_request = True
-        future = loop.run_in_executor(
-            get_mlx_executor(),
-            self._run_generate_streaming,
-            prompt_tokens,
-            max_tokens,
-            temperature,
-            top_p,
-            top_k,
-            min_p,
-            repetition_penalty,
-            int(repetition_context_size),
-            seed,
-            tools,
-            queue,
-            loop,
-            stop_event,
-        )
+        self._register_stop_event(stop_event)
+        try:
+            future = loop.run_in_executor(
+                get_mlx_executor(),
+                self._run_generate_streaming,
+                prompt_tokens,
+                max_tokens,
+                temperature,
+                top_p,
+                top_k,
+                min_p,
+                repetition_penalty,
+                int(repetition_context_size),
+                seed,
+                tools,
+                queue,
+                loop,
+                stop_event,
+            )
+        except Exception:
+            self._unregister_stop_event(stop_event)
+            raise
 
         total_text = ""
         total_completion = 0
@@ -1975,8 +2001,37 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             return True
         if self._active_request:
             return True
+        with self._stop_events_lock:
+            if self._active_stop_events:
+                return True
         with self._active_lock:
             return self._active_count > 0
+
+    async def abort_all_requests(self) -> int:
+        """Signal every in-flight DFlash generation to stop.
+
+        The process memory enforcer relies on this method at hard pressure.
+        DFlash does not use Scheduler request objects, so its per-generation
+        threading events are the authoritative abort handles.
+        """
+        aborted = 0
+        fallback = self._fallback_engine
+        if fallback is not None:
+            abort_fallback = getattr(fallback, "abort_all_requests", None)
+            if callable(abort_fallback):
+                result = abort_fallback()
+                if hasattr(result, "__await__"):
+                    result = await result
+                if isinstance(result, (int, float)):
+                    aborted += max(0, int(result))
+
+        with self._stop_events_lock:
+            stop_events = tuple(self._active_stop_events)
+        for stop_event in stop_events:
+            if not stop_event.is_set():
+                stop_event.set()
+                aborted += 1
+        return aborted
 
     def get_stats(self) -> dict[str, Any]:
         return {

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -2,8 +2,9 @@
 """Tests for DFlash engine integration."""
 
 import json
+import threading
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -1529,6 +1530,35 @@ class TestDFlashActivityTracking:
         engine._reset_activity_tracking()
         assert engine.get_activity_snapshot()["active_requests"] == 0
         assert engine.has_active_requests() is False
+
+    @pytest.mark.asyncio
+    async def test_memory_pressure_abort_signals_active_generations(self):
+        engine = self._engine()
+        first = threading.Event()
+        second = threading.Event()
+        engine._register_stop_event(first)
+        engine._register_stop_event(second)
+
+        assert engine.has_active_requests() is True
+        assert await engine.abort_all_requests() == 2
+        assert first.is_set()
+        assert second.is_set()
+
+        # Repeated pressure polls must not count the same request twice.
+        assert await engine.abort_all_requests() == 0
+
+        engine._unregister_stop_event(first)
+        engine._unregister_stop_event(second)
+        assert engine.has_active_requests() is False
+
+    @pytest.mark.asyncio
+    async def test_memory_pressure_abort_delegates_to_fallback(self):
+        engine = self._engine()
+        engine._fallback_engine = MagicMock()
+        engine._fallback_engine.abort_all_requests = AsyncMock(return_value=3)
+
+        assert await engine.abort_all_requests() == 3
+        engine._fallback_engine.abort_all_requests.assert_awaited_once()
 
 
 class TestDFlashRuntimeCacheStats:


### PR DESCRIPTION
## What changed

- track the stop event for each in-flight DFlash generation
- implement `DFlashEngine.abort_all_requests()` so process-level memory enforcement can stop primary DFlash requests
- delegate aborts to the fallback engine when it is active
- keep active-request reporting accurate until the executor actually exits

## Why

DFlash bypasses `Scheduler`, but unlike the batched and VLM engines it did not expose `abort_all_requests()`. Under hard memory pressure, `ProcessMemoryEnforcer` therefore identified the DFlash model as busy but could not signal its active generation. It repeatedly logged `aborted 0 request(s)` and left a long-context request running under severe unified-memory pressure.

The generation loops already poll a `threading.Event` between DFlash events. This change registers those existing events for the lifetime of their executor work and uses them as the engine's abort handles. Repeated pressure polls are idempotent and do not count an already-signalled request again.

## Validation

- `python -m pytest -q tests/test_dflash_engine.py tests/test_process_memory_enforcer.py` (281 passed)
- `ruff check omlx/engine/dflash.py tests/test_dflash_engine.py`
