### PR TITLE
feat(ane): price prefill banks at admission from the compiled size

### DIFF
--- a/docs/experimental/qwen35_ane_prefill.md
+++ b/docs/experimental/qwen35_ane_prefill.md
@@ -211,6 +211,57 @@ FP16 gate/up and GDN rows, the down-projection GPU suffix, and bounded
 materialization scratch. This projected size participates in the normal memory
 guard before the model begins loading.
 
+## Pricing the banks at admission
+
+A resident bank is charged to the kernel's neural ledger and excluded from
+`phys_footprint`, so the ordinary accounting cannot see it and admission has
+never charged for it. The compiled program size is what the driver wires, and
+it is available before the load commits anything: compiling one projection
+reports exactly the `wiredMemory` the driver goes on to report
+at program-create. Measured across two contractions, three output widths, two
+dtypes and four chunk widths, on blobs from 5.77 MB to 94.37 MB.
+
+The size is fixed by the geometry rather than by the weight values — checked
+across eighteen arms at three geometries, including all-zero, constant and
+widely varying scales — so one compile prices every layer that shares a shape.
+The 64-layer 27B MLP slice and the 48-layer GDN slice are two shapes, and two
+compiles therefore price the whole layout. `engine_pool` caches one price per
+geometry and adds the total to the projected size.
+
+Compiler options change the compiled size as well, so the price is only
+valid for the option set the load path actually uses; the agreement with
+`wiredMemory` is what establishes that, not the geometry alone. The effect
+is program-dependent rather than a fixed offset, and it is not small: on a
+measured convolution fixture a single scheduling option moved the compiled
+size by 16%.
+
+The compiler is reached through `ANECompiler.framework`, resolved by name.
+Its target comes from the runtime's own `aneArchitectureType` rather than a
+chip table, read from the local device, so the probe compiles for the machine
+it runs on. That request is honoured rather than quietly defaulted, which can
+be checked on its own: compile one source for two architectures and the
+outputs differ byte-for-byte at the same length.
+
+When the framework or the symbol is missing the price is zero and admission
+keeps its previous behaviour, which is to charge nothing for the banks. Do
+not substitute the neural ledger figure for the wired one: the difference
+between them varies with chunk width.
+
+The GDN width comes from the backend's own recurrent-safe boundary rather
+than a second copy of that rule, so a fraction too small to cover z is priced
+at nothing, exactly as it is offloaded. The size of one program is measured;
+what remains a prediction is the layer count, since layers the backend later
+declines for dtype or row alignment are charged anyway. The total therefore
+errs high, which is the safe direction for the guard.
+
+Pricing a shape stages a zero-filled blob of that projection's weight
+shape, so it transiently holds about twice that before the load starts.
+
+Two things this does not cover. The ratio a probe compile costs against the
+load it prices is not measured here, and identical inputs produce images of
+identical size but differing content, so a compiled artifact must never be
+identified by hashing it — the cache key is the descriptor, not the image.
+
 ## Recurrent-safe GDN validation
 
 The current z-only policy was selected from a controlled 32K comparison on

--- a/omlx/custom_kernels/qwen35_prefill/csrc/bindings.cpp
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/bindings.cpp
@@ -41,6 +41,10 @@ NB_MODULE(_ext, m) {
       "qwen35_ane_hybrid_nax_enabled",
       &omlx::qwen35_prefill_kernels::qwen35_ane_hybrid_nax_enabled);
   m.def(
+      "qwen35_ane_program_bytes",
+      &omlx::qwen35_prefill_kernels::qwen35_ane_program_bytes,
+      "input_dim"_a, "output_dim"_a, "sequence_length"_a);
+  m.def(
       "qwen35_ane_profile_set_enabled",
       &omlx::qwen35_prefill_kernels::qwen35_ane_profile_set_enabled,
       "enabled"_a);

--- a/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.h
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.h
@@ -123,6 +123,11 @@ private:
 
 bool qwen35_ane_available();
 bool qwen35_ane_hybrid_nax_enabled();
+// Compiled byte count for one INT8 linear projection of this geometry, which
+// is what the driver wires when the program is loaded. Returns 0 when the
+// private compiler is unavailable, so callers keep their own estimate.
+size_t qwen35_ane_program_bytes(int input_dim, int output_dim,
+                                int sequence_length);
 bool qwen35_cpu_shared_resource_available();
 void qwen35_ane_profile_set_enabled(bool enabled);
 void qwen35_ane_profile_reset();

--- a/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.mm
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.mm
@@ -1403,6 +1403,126 @@ bool qwen35_ane_available() {
   }
 }
 
+size_t qwen35_ane_program_bytes(int input_dim, int output_dim,
+                                int sequence_length) {
+  if (input_dim <= 0 || output_dim <= 0 || sequence_length <= 0) {
+    return 0;
+  }
+  @autoreleasepool {
+    try {
+      // ANECompiler is a separate framework from the runtime, and its entry
+      // point is resolved by name so a missing symbol costs an estimate
+      // rather than a load failure.
+      using Compile = int (*)(CFDictionaryRef, CFDictionaryRef,
+                              void (^)(int, CFDictionaryRef));
+      static void *compiler = dlopen("/System/Library/PrivateFrameworks/"
+                                     "ANECompiler.framework/ANECompiler",
+                                     RTLD_NOW);
+      static auto compile =
+          compiler ? reinterpret_cast<Compile>(dlsym(compiler, "ANECCompile"))
+                   : nullptr;
+      if (!compile) {
+        return 0;
+      }
+      // The compile target is a die class the runtime already knows; deriving
+      // it from a chip identifier here would be one more table to keep.
+      load_ane_framework();
+      Class device_info = NSClassFromString(@"_ANEDeviceInfo");
+      SEL architecture = @selector(aneArchitectureType);
+      if (!device_info || ![device_info respondsToSelector:architecture]) {
+        return 0;
+      }
+      NSString *target =
+          ((id (*)(Class, SEL))objc_msgSend)(device_info, architecture);
+      if (![target isKindOfClass:[NSString class]] || !target.length) {
+        return 0;
+      }
+
+      NSString *root = [NSTemporaryDirectory()
+          stringByAppendingPathComponent:
+              [@"omlx-ane-price-"
+                  stringByAppendingString:[[NSUUID UUID] UUIDString]]];
+      NSString *source = [root stringByAppendingPathComponent:@"src"];
+      NSString *weights = [source stringByAppendingPathComponent:@"weights"];
+      NSString *output = [root stringByAppendingPathComponent:@"out"];
+      NSFileManager *files = [NSFileManager defaultManager];
+      auto cleanup = [&]() { [files removeItemAtPath:root error:nil]; };
+      if (![files createDirectoryAtPath:weights
+              withIntermediateDirectories:YES
+                               attributes:nil
+                                    error:nil] ||
+          ![files createDirectoryAtPath:output
+              withIntermediateDirectories:YES
+                               attributes:nil
+                                    error:nil]) {
+        cleanup();
+        return 0;
+      }
+
+      // Weight values do not change the compiled size, so zeros of the right
+      // shape price the real program. The vector is a transient copy the blob
+      // helper needs; it is released before the compile returns.
+      const size_t data_bytes =
+          static_cast<size_t>(output_dim) * static_cast<size_t>(input_dim);
+      const size_t scale_bytes = static_cast<size_t>(output_dim) * 2;
+      std::vector<uint8_t> zeros(std::max(data_bytes, scale_bytes), 0);
+      NSData *data_blob = make_blob(zeros.data(), data_bytes);
+      NSData *scale_blob = make_blob(zeros.data(), scale_bytes);
+      zeros.clear();
+      zeros.shrink_to_fit();
+      BOOL staged =
+          [[int8_linear_mil(input_dim, output_dim, sequence_length)
+              dataUsingEncoding:NSUTF8StringEncoding]
+              writeToFile:[source stringByAppendingPathComponent:@"model.mil"]
+               atomically:YES] &&
+          [data_blob
+              writeToFile:[weights
+                              stringByAppendingPathComponent:@"weight_data.bin"]
+               atomically:YES] &&
+          [scale_blob
+              writeToFile:[weights stringByAppendingPathComponent:
+                                       @"weight_scale.bin"]
+               atomically:YES];
+      if (!staged) {
+        cleanup();
+        return 0;
+      }
+
+      // InputNetworks must be an array of per-network dictionaries; the flat
+      // NetworkPlist keys alone are rejected as an unsupported feature.
+      NSDictionary *inputs = @{
+        @"InputNetworks" : @[ @{
+          @"NetworkPlistName" : @"model.mil",
+          @"NetworkPlistPath" : [source stringByAppendingString:@"/"],
+        } ],
+        @"OutputFileName" : @"model.hwx",
+        @"OutputFilePath" : [output stringByAppendingString:@"/"],
+      };
+      NSDictionary *options = @{
+        @"TargetArchitecture" : target,
+        @"scratchPadPath" : NSTemporaryDirectory(),
+      };
+      __block int status = -1;
+      const int result = compile((__bridge CFDictionaryRef)inputs,
+                                 (__bridge CFDictionaryRef)options,
+                                 ^(int code, CFDictionaryRef) { status = code; });
+      size_t bytes = 0;
+      if (result == 0 && status == 0) {
+        NSDictionary *attributes = [files
+            attributesOfItemAtPath:[output
+                                       stringByAppendingPathComponent:
+                                           @"model.hwx"]
+                             error:nil];
+        bytes = static_cast<size_t>([attributes fileSize]);
+      }
+      cleanup();
+      return bytes;
+    } catch (...) {
+      return 0;
+    }
+  }
+}
+
 void qwen35_ane_profile_set_enabled(bool enabled) {
   g_ane_profile_override.store(enabled ? 1 : 0, std::memory_order_relaxed);
 }

--- a/omlx/custom_kernels/qwen35_prefill/fast.py
+++ b/omlx/custom_kernels/qwen35_prefill/fast.py
@@ -353,6 +353,29 @@ def qwen35_ane_available() -> bool:
     )
 
 
+def qwen35_ane_program_bytes(
+    input_dim: int, output_dim: int, sequence_length: int
+) -> int:
+    """Compiled size of one INT8 linear projection, or 0 when unavailable.
+
+    This is what the driver wires when the program loads, so it prices a bank
+    before the load commits the memory. It costs one compile, and the result
+    depends only on the geometry, so one call covers every layer of a shape.
+    The compile stages a zero-filled blob of the projection's weight shape,
+    so callers should cache the result rather than repeat it per layer.
+    """
+    if _ext is None or not hasattr(_ext, "qwen35_ane_program_bytes"):
+        return 0
+    try:
+        return int(
+            _ext.qwen35_ane_program_bytes(
+                int(input_dim), int(output_dim), int(sequence_length)
+            )
+        )
+    except Exception:
+        return 0
+
+
 def qwen35_ane_hybrid_nax_enabled() -> bool:
     """Whether ANE hybrid GPU suffixes currently select bundled NAX QMM."""
     return bool(

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -23,6 +23,7 @@ import time
 from collections import OrderedDict
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, replace
+from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
@@ -75,10 +76,45 @@ def _positive_int(value: object) -> int:
     return parsed if parsed > 0 else 0
 
 
-def _aligned_share_rows(outputs: int, fraction: float) -> int:
-    if outputs <= 0 or fraction <= 0:
+def _aligned_share_rows(outputs: int, fraction: float, alignment: int = 64) -> int:
+    if outputs <= 0 or fraction <= 0 or alignment <= 0:
         return 0
-    return min(outputs, (int(outputs * fraction) // 64) * 64)
+    return min(outputs, (int(outputs * fraction) // alignment) * alignment)
+
+
+def _load_model_config(model_path: str) -> dict | None:
+    """Return the parsed ``config.json``, or ``None`` when it cannot be read."""
+    try:
+        config = json.loads((Path(model_path) / "config.json").read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return config if isinstance(config, dict) else None
+
+
+def _qwen35_text_config(config: dict) -> dict | None:
+    """Return the text config when this is a Qwen3.5/3.6/3.8 checkpoint."""
+    text = config.get("text_config")
+    if not isinstance(text, dict):
+        text = config
+    model_type = str(text.get("model_type") or config.get("model_type") or "")
+    if not any(token in model_type for token in ("qwen3_5", "qwen3_6", "qwen3_8")):
+        return None
+    return text
+
+
+def _qwen35_gdn_layer_count(text: dict, settings: object) -> int:
+    """Count the GDN layers charged for, clamped by the configured maximum."""
+    layer_types = text.get("layer_types")
+    if isinstance(layer_types, list):
+        layers = sum("linear" in str(layer_type).lower() for layer_type in layer_types)
+    else:
+        # Qwen hybrid checkpoints use full attention periodically. Without the
+        # explicit map, charging every layer is the safe estimate.
+        layers = _positive_int(text.get("num_hidden_layers"))
+    return min(
+        layers,
+        max(0, int(getattr(settings, "qwen35_ane_prefill_gdn_max_layers", 48) or 0)),
+    )
 
 
 def _qwen35_cpu_share_estimated_bytes(
@@ -102,18 +138,11 @@ def _qwen35_cpu_share_estimated_bytes(
     ):
         return 0
 
-    config_path = Path(model_path) / "config.json"
-    try:
-        config = json.loads(config_path.read_text())
-    except (OSError, json.JSONDecodeError):
+    config = _load_model_config(model_path)
+    if config is None:
         return None
-    if not isinstance(config, dict):
-        return None
-    text = config.get("text_config")
-    if not isinstance(text, dict):
-        text = config
-    model_type = str(text.get("model_type") or config.get("model_type") or "")
-    if not any(token in model_type for token in ("qwen3_5", "qwen3_6", "qwen3_8")):
+    text = _qwen35_text_config(config)
+    if text is None:
         return 0
 
     hidden = _positive_int(text.get("hidden_size"))
@@ -163,25 +192,113 @@ def _qwen35_cpu_share_estimated_bytes(
             qkv_outputs,
             _aligned_share_rows(qkv_outputs + z_outputs, gdn_fraction),
         )
-        layer_types = text.get("layer_types")
-        if isinstance(layer_types, list):
-            gdn_layers = sum(
-                "linear" in str(layer_type).lower() for layer_type in layer_types
-            )
-        else:
-            # Qwen hybrid checkpoints use full attention periodically. Without
-            # the explicit map, charging every layer is the safe estimate.
-            gdn_layers = _positive_int(text.get("num_hidden_layers"))
-        gdn_layers = min(
-            gdn_layers,
-            max(
-                0,
-                int(getattr(settings, "qwen35_ane_prefill_gdn_max_layers", 48) or 0),
-            ),
+        extra += (
+            _qwen35_gdn_layer_count(text, settings) * gdn_rows * hidden * _FP16_BYTES
         )
-        extra += gdn_layers * gdn_rows * hidden * _FP16_BYTES
 
     return int(extra * _CPU_SHARE_MATERIALIZATION_HEADROOM)
+
+
+@lru_cache(maxsize=32)
+def _ane_program_bytes(input_dim: int, output_dim: int, sequence_length: int) -> int:
+    """Cache one compile per geometry; the size does not depend on the weights."""
+    try:
+        from .custom_kernels.qwen35_prefill import fast
+    except Exception:
+        return 0
+    return fast.qwen35_ane_program_bytes(input_dim, output_dim, sequence_length)
+
+
+def _recurrent_safe_gdn_rows(
+    z_outputs: int, qkv_outputs: int, fraction: float, alignment: int
+) -> int:
+    """Ask the backend itself where its GDN slice stops, so the two cannot drift."""
+    try:
+        from .patches.qwen35_ane_prefill import _recurrent_safe_gdn_ane_outputs
+    except Exception:
+        return 0
+    return _recurrent_safe_gdn_ane_outputs(z_outputs, qkv_outputs, fraction, alignment)
+
+
+def _qwen35_ane_bank_estimated_bytes(
+    model_path: str,
+    settings: object | None,
+) -> int:
+    """Estimate the bytes the Qwen ANE prefill banks wire.
+
+    A resident bank is charged to the kernel's neural ledger and excluded from
+    ``phys_footprint``, so the ordinary accounting cannot see it and admission
+    has never charged for it.
+
+    The size of one program is measured rather than guessed: it is read from a
+    compile of that geometry, which matches what the driver wires, and it does
+    not depend on the weight values, so one compile covers every layer sharing
+    a shape. What stays an estimate is how many layers to charge for -- layers
+    the backend later declines for dtype or row alignment are counted anyway,
+    so the total errs high, which is the safe direction here.
+
+    Returns 0 when the private compiler is unavailable, keeping the previous
+    behaviour.
+    """
+
+    if settings is None or not bool(
+        getattr(settings, "qwen35_ane_prefill_enabled", False)
+    ):
+        return 0
+    config = _load_model_config(model_path)
+    if config is None:
+        return 0
+    text = _qwen35_text_config(config)
+    if text is None:
+        return 0
+
+    hidden = _positive_int(text.get("hidden_size"))
+    intermediate = _positive_int(text.get("intermediate_size"))
+    layer_count = _positive_int(text.get("num_hidden_layers"))
+    sequence_length = _positive_int(
+        getattr(settings, "qwen35_ane_prefill_sequence_length", 2048)
+    )
+    if not hidden or not intermediate or not layer_count or not sequence_length:
+        return 0
+
+    # Dual pins one program per physical ANE and halves each slice, so the
+    # aligned width differs between the two modes.
+    alignment = (
+        128 if bool(getattr(settings, "qwen35_ane_prefill_dual_ane", True)) else 64
+    )
+
+    total = 0
+    mlp_layers = min(
+        layer_count,
+        max(0, int(getattr(settings, "qwen35_ane_prefill_max_layers", 64) or 0)),
+    )
+    mlp_rows = _aligned_share_rows(
+        intermediate,
+        float(getattr(settings, "qwen35_ane_prefill_fraction", 0.0) or 0.0),
+        alignment,
+    )
+    if mlp_layers and mlp_rows:
+        # Gate and up are combined into one program per accelerated layer.
+        total += mlp_layers * _ane_program_bytes(hidden, 2 * mlp_rows, sequence_length)
+
+    if bool(getattr(settings, "qwen35_ane_prefill_gdn", True)):
+        value_heads = _positive_int(text.get("linear_num_value_heads"))
+        value_dim = _positive_int(text.get("linear_value_head_dim"))
+        key_heads = _positive_int(text.get("linear_num_key_heads"))
+        key_dim = _positive_int(text.get("linear_key_head_dim"))
+        z_outputs = value_heads * value_dim
+        qkv_outputs = 2 * key_heads * key_dim + z_outputs
+        gdn_rows = _recurrent_safe_gdn_rows(
+            z_outputs,
+            qkv_outputs,
+            float(getattr(settings, "qwen35_ane_prefill_gdn_fraction", 0.0) or 0.0),
+            alignment,
+        )
+        gdn_layers = _qwen35_gdn_layer_count(text, settings)
+        if gdn_layers and gdn_rows:
+            total += gdn_layers * _ane_program_bytes(hidden, gdn_rows, sequence_length)
+
+    return total
 
 
 @dataclass
@@ -434,7 +551,19 @@ class EnginePool:
                 base = estimate_offload_admission_bytes(
                     entry.model_path, base, fraction
                 )
-        return base + extra
+        banks = (
+            _qwen35_ane_bank_estimated_bytes(entry.model_path, runtime_settings)
+            if include_ane_reservation
+            and ane_prefill_backend(entry.config_model_type) == "qwen"
+            else 0
+        )
+        if banks > 0:
+            logger.info(
+                "Qwen ANE prefill banks add %s to the projected memory for %s",
+                format_size(banks),
+                entry.model_id,
+            )
+        return base + extra + banks
 
     def _qwen4_ple_offload_status(
         self,

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -13,6 +13,7 @@ import pytest
 from omlx.engine_pool import (
     EngineEntry,
     EnginePool,
+    _qwen35_ane_bank_estimated_bytes,
     _qwen35_cpu_share_estimated_bytes,
 )
 from omlx.exceptions import (
@@ -607,11 +608,19 @@ class TestQwenCpuShareMemoryEstimate:
         gdn = 2 * 64 * 256 * 2
         assert estimated == int((gate + down + gdn) * 1.5)
 
-    def test_runtime_estimate_feeds_resident_memory_accounting(self, tmp_path):
+    def test_runtime_estimate_feeds_resident_memory_accounting(
+        self, tmp_path, monkeypatch
+    ):
         from omlx.model_settings import ModelSettings
 
         model = tmp_path / "qwen"
         self._write_config(model)
+        # This test is about the CPU-share term reaching the projection, so
+        # price the ANE banks at zero. Left unpatched it asks the real
+        # compiler, which makes the assertion host-dependent: hosts with
+        # ANECompiler.framework add a bank price the expectation omits, and
+        # hosts without it get 0 and pass.
+        monkeypatch.setattr("omlx.engine_pool._ane_program_bytes", lambda *_a: 0)
         settings = ModelSettings(
             qwen35_ane_prefill_enabled=True,
             qwen35_ane_prefill_cpu_enabled=True,
@@ -876,6 +885,108 @@ class TestQwenCpuShareMemoryEstimate:
         assert entry.runtime_estimated_size == 400
         signature = dict(entry.runtime_settings_signature or ())
         assert signature["deepseek_v41_engram_ssd_offload"] == "False"
+
+
+class TestQwenAneBankMemoryEstimate:
+    @staticmethod
+    def _settings(**overrides):
+        from omlx.model_settings import ModelSettings
+
+        base = {
+            "qwen35_ane_prefill_enabled": True,
+            "qwen35_ane_prefill_dual_ane": False,
+            "qwen35_ane_prefill_sequence_length": 2048,
+            "qwen35_ane_prefill_max_layers": 3,
+            "qwen35_ane_prefill_fraction": 0.5,
+            "qwen35_ane_prefill_gdn": True,
+            "qwen35_ane_prefill_gdn_max_layers": 2,
+            "qwen35_ane_prefill_gdn_fraction": 0.5,
+        }
+        base.update(overrides)
+        return ModelSettings(**base)
+
+    @staticmethod
+    def _price_by_output(monkeypatch):
+        """Stub the compiler so each program's price names its own width."""
+        calls = []
+
+        def fake(input_dim, output_dim, sequence_length):
+            calls.append((input_dim, output_dim, sequence_length))
+            return output_dim * 1000
+
+        monkeypatch.setattr("omlx.engine_pool._ane_program_bytes", fake)
+        return calls
+
+    def test_estimate_charges_every_mlp_and_gdn_program(self, tmp_path, monkeypatch):
+        model = tmp_path / "qwen"
+        TestQwenCpuShareMemoryEstimate._write_config(model)
+        calls = self._price_by_output(monkeypatch)
+
+        estimated = _qwen35_ane_bank_estimated_bytes(str(model), self._settings())
+
+        # Gate and up share one program per layer, so the MLP width is 2x the
+        # aligned slice; GDN is capped at its 128 token-local z rows.
+        assert calls == [(256, 512, 2048), (256, 128, 2048)]
+        assert estimated == 3 * 512 * 1000 + 2 * 128 * 1000
+
+    def test_estimate_caps_gdn_at_the_z_boundary(self, tmp_path, monkeypatch):
+        model = tmp_path / "qwen"
+        TestQwenCpuShareMemoryEstimate._write_config(model)
+        calls = self._price_by_output(monkeypatch)
+
+        _qwen35_ane_bank_estimated_bytes(
+            str(model), self._settings(qwen35_ane_prefill_gdn_fraction=0.9)
+        )
+
+        # A 0.9 request aligns to 320 of 384 rows; recurrent qkv stays on GPU.
+        assert calls[1] == (256, 128, 2048)
+
+    def test_estimate_skips_gdn_below_the_z_boundary(self, tmp_path, monkeypatch):
+        model = tmp_path / "qwen"
+        TestQwenCpuShareMemoryEstimate._write_config(model)
+        calls = self._price_by_output(monkeypatch)
+
+        _qwen35_ane_bank_estimated_bytes(
+            str(model), self._settings(qwen35_ane_prefill_gdn_fraction=0.3)
+        )
+
+        # 64 aligned rows cannot reach z, so the backend offloads no GDN at
+        # all and there is nothing to charge for.
+        assert calls == [(256, 512, 2048)]
+
+    def test_dual_widens_the_alignment(self, tmp_path, monkeypatch):
+        model = tmp_path / "qwen"
+        TestQwenCpuShareMemoryEstimate._write_config(model)
+        calls = self._price_by_output(monkeypatch)
+
+        _qwen35_ane_bank_estimated_bytes(
+            str(model),
+            self._settings(
+                qwen35_ane_prefill_dual_ane=True, qwen35_ane_prefill_fraction=0.4
+            ),
+        )
+
+        # 204 aligned rows fall to 192 at 64 and to 128 at 128.
+        assert calls[0] == (256, 2 * 128, 2048)
+
+    def test_estimate_is_zero_without_the_private_compiler(self, tmp_path, monkeypatch):
+        model = tmp_path / "qwen"
+        TestQwenCpuShareMemoryEstimate._write_config(model)
+        monkeypatch.setattr("omlx.engine_pool._ane_program_bytes", lambda *_args: 0)
+
+        assert _qwen35_ane_bank_estimated_bytes(str(model), self._settings()) == 0
+
+    def test_estimate_is_zero_when_ane_prefill_is_off(self, tmp_path, monkeypatch):
+        model = tmp_path / "qwen"
+        TestQwenCpuShareMemoryEstimate._write_config(model)
+        calls = self._price_by_output(monkeypatch)
+
+        estimated = _qwen35_ane_bank_estimated_bytes(
+            str(model), self._settings(qwen35_ane_prefill_enabled=False)
+        )
+
+        assert estimated == 0
+        assert calls == []
 
 
 class TestApplySettingsOverrides:


### PR DESCRIPTION
**This is a draft because I am not sure the approach is right.** The code works and is tested. It uses a private compiler to get an exact number, and a rougher number that needs no such dependency may be the better trade-off.

The memory guard cannot see the ANE prefill banks. A resident bank is charged to the kernel's neural ledger and excluded from `phys_footprint`, so RSS, `vmmap` and MLX's own accounting are all blind to it, and admission charges **zero** for it today. For Qwen3.8-27B at the default fraction the real figure is **7.06 GB** — 64 MLP programs of about 90 MB each, and 48 GDN programs of about 30 MB.

#2841 reports this model aborting requests and evicting itself on a 32 GB machine with ANE prefill on and completing fine with it off, and asks for exactly this accounting; it even names the shape, 5120→18432 across 64 layers. This charges the banks at model admission rather than in the per-request preflight the report suggests, because the banks are resident for the life of the model rather than transient.

## How the number is obtained

The compiled program size is what the driver wires. Compiling one projection ahead of time produces a file whose byte count equals the `wiredMemory` the driver logs at program-create, in every geometry tried — two contractions, four output widths, two dtypes, five chunk widths, from 5.77 MB to 94.37 MB.

That is the property worth the code: it reads a size off disk **before anything is loaded**, rather than inferring it after the fact from accounting that structurally cannot see it. Size depends on the geometry and not on the weight values, so one compile prices every layer sharing a shape, and this model is two shapes.

## A check from a different model, chip and instrument

Gemma 4 12B on an M1 with a single ANE die and 16 GiB. The compiler prices one gate/up projection of 3840→3072 — the f = 0.20 share — at 11,878,400 bytes, so gate and up across 8 layers come to 181.2 MB. Measuring that same configuration on that machine through the kernel's neural ledger, the only instrument that sees a bank at all, gives 181.0 MB. They agree to 0.1%, across a different model family, a different chip generation, one die instead of two, and an instrument with no relationship to the compiler.

The same machine shows what charging zero costs. At f = 0.60 a 4,096-token prefill is refused against a dynamic ceiling of 10.23 GB with current usage at 7.08 GB and 3.69 GB reclaimable. The 3.18 GB of banks are what closed that gap. Admission charged none of it, so the ceiling is held down by memory the usage term cannot see: the refusal is right, for a reason the guard is unable to state, and the fraction that triggers it looks free from the inside.

## Exact, or close enough?

The size can also just be calculated. `ceil_16K(O*C*bits/8 + 2*O)` gets over 99% of it, and the remainder is a small per-program overhead that varies with the output width. Fitting that from measurements and doing arithmetic would land within about 0.2% of a real load, with no private framework, no probe cost, and nothing new to break.

On the Gemma 4 geometry that form runs 0.55% low at output widths 3072, 4608 and 6144, and 0.41% low at 9216. Expressed in 16 KiB pages the residual is 4, 6, 8 and 9 — linear in the width across the first three, and then not, where a fit anchored on them predicts 12. That is a single geometry and not a refutation of fitting, but it is the shape of the difficulty: the overhead is small enough that arithmetic gets close, and irregular enough that a constant fitted from a handful of widths is not reliably close.

That fit would not stay right on its own, either. The overhead is a handful of measured points against an undocumented compiler with no closed form, and this ground has already retired two per-program constants that looked settled. A compile stays correct when the compiler changes; a fitted constant goes quietly wrong.

Given the guard currently charges zero, either beats what is there now, and I do not think 0.2% is what should decide this.

## Trade-off

`ANECCompile` is reached by `dlsym`, and `ANECompiler.framework` is not the framework the ANE prefill path already uses. So this adds a second private dependency to a feature that already carries one, and that is the part I am least sure about.

## Notes

The per-program size is measured, but the total is still a prediction: it multiplies that size by the layers expected to be accelerated, and layers the backend later declines for dtype or row alignment are counted anyway. The total therefore errs high, which is the safe direction for a guard.

The two Qwen sizing helpers in `engine_pool` shared their config parsing and layer counting, so rather than copy it I lifted the common part into three helpers both call.

Without the framework or the symbol the price is 0 and admission behaves exactly as it does today. The target architecture is read from the device's own `aneArchitectureType`, so there is no chip table to maintain.

`_entry_runtime_resident_size` returns the bank price on top of the CPU share, which the pre-existing `test_runtime_estimate_feeds_resident_memory_accounting` does not account for. Left unpatched that test asks the real compiler and so passes only on hosts without `ANECompiler.framework`, where the price is 0. It prices the banks at zero explicitly now, keeping its assertion about the term it is named for.

## Testing

The full suite on this branch is 11,404 passed, 81 skipped, 6 failed. The same 6 fail on `main` on this host: three in `test_decode_fast_sdpa`, one in `test_glm_moe_dsa_patch` and two in `test_mlx_vlm_qwen4_exp_compat`, all float-tolerance comparisons in custom kernels this branch does not touch.
