### PR TITLE
feat(cli): add 'ps' command to show model status and memory usage

### DIFF
--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -5,6 +5,7 @@ CLI for oMLX.
 
 Commands:
     omlx serve --model-dir /path/to/models    Start multi-model server
+    omlx ps                                   Show model status and memory usage
 
 Usage:
     # Multi-model serving
@@ -12,6 +13,10 @@ Usage:
 
     # With pinned models
     omlx serve --model-dir /path/to/models --pin llama-3b,qwen-7b
+
+    # Show status of the running server
+    omlx ps
+    omlx ps --json
 """
 
 import argparse
@@ -371,6 +376,148 @@ def serve_command(args):
         # after bind succeeds but before the server takes ownership.
         for sock in serve_sockets:
             sock.close()
+
+
+def _format_bytes(size) -> str:
+    try:
+        size = float(size)
+    except (TypeError, ValueError):
+        return "-"
+    if size <= 0:
+        return "-"
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if size < 1000:
+            return f"{size:.1f} {unit}"
+        size /= 1000
+    return f"{size:.1f} PB"
+
+
+def _format_relative_time(epoch_seconds) -> str:
+    import time
+
+    try:
+        last = float(epoch_seconds)
+    except (TypeError, ValueError):
+        return "never"
+    if last <= 0:
+        return "never"
+    delta = max(time.time() - last, 0)
+    if delta < 60:
+        return "just now"
+    if delta < 3600:
+        return f"{int(delta // 60)}m ago"
+    if delta < 86400:
+        hours = delta / 3600
+        return f"{hours:.1f}h ago"
+    days = delta / 86400
+    return f"{days:.1f}d ago"
+
+
+def _format_context(context) -> str:
+    """Format a context window in human-readable units (131072 -> "128k").
+
+    Mirrors the admin dashboard's ``clusterTokens``: exact division for
+    multiples of 1024, nearest-1000 rounding otherwise.
+    """
+    try:
+        ctx = int(context)
+    except (TypeError, ValueError):
+        return "-"
+    if ctx <= 0:
+        return "-"
+    if ctx >= 1024 and ctx % 1024 == 0:
+        return f"{ctx // 1024}k"
+    if ctx >= 1000:
+        return f"{round(ctx / 1000)}k"
+    return str(ctx)
+
+
+def ps_command(args) -> int:
+    """Show model status and memory usage of the running oMLX server.
+
+    Queries ``GET /v1/models/status`` and renders a table of models plus
+    a server memory summary line.
+    """
+    import json
+
+    import requests
+
+    from .settings import GlobalSettings
+
+    settings = GlobalSettings.load()
+    host = args.host or settings.server.host
+    port = args.port or settings.server.port
+
+    # host may be a comma-separated list of bind addresses; pick the first
+    # one for connecting. Wildcard addresses (0.0.0.0, ::) are valid bind
+    # targets but not connectable — fall back to localhost in that case.
+    first_bind = [h.strip() for h in host.split(",") if h.strip()][0] if host else ""
+    connect_host = (
+        first_bind if first_bind not in ("", "0.0.0.0", "::") else "127.0.0.1"
+    )
+    base_url = f"http://{connect_host}:{port}"
+    api_key = getattr(args, "api_key", None) or settings.auth.api_key or ""
+
+    headers = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    try:
+        resp = requests.get(f"{base_url}/v1/models/status", headers=headers, timeout=5)
+    except Exception:
+        print(f"oMLX server is not running at {base_url}")
+        print("Start the server first: omlx start")
+        return 1
+
+    if resp.status_code == 401:
+        print(f"Authentication required at {base_url}")
+        print("Pass the API key: omlx ps --api-key <key>")
+        return 1
+    if not resp.ok:
+        print(f"oMLX server returned an error at {base_url}: HTTP {resp.status_code}")
+        return 1
+
+    data = resp.json()
+
+    if getattr(args, "json", False):
+        print(json.dumps(data, indent=2))
+        return 0
+
+    final_ceiling = data.get("final_ceiling") or 0
+    current_memory = data.get("current_model_memory") or 0
+    models = data.get("models", [])
+
+    summary = f"Memory: {_format_bytes(current_memory)}"
+    if final_ceiling > 0:
+        summary += f" / {_format_bytes(final_ceiling)} (guard ceiling)"
+    print(summary)
+    print()
+
+    header = (
+        f"{'NAME':<40} {'TYPE':<10} {'SIZE':>10} {'CONTEXT':>10} "
+        f"{'STATUS':<8} {'PINNED':<7} {'LAST USED':<14}"
+    )
+    print(header)
+    for model in models:
+        # Loading wins over loaded: a model being reloaded briefly reports both.
+        if model.get("is_loading"):
+            status, size = "loading", model.get("estimated_size")
+        elif model.get("loaded"):
+            status, size = "loaded", (
+                model.get("actual_size") or model.get("estimated_size")
+            )
+        else:
+            status, size = "-", model.get("estimated_size")
+        pinned = "pinned" if model.get("pinned") else "-"
+        print(
+            f"{model.get('id', '')[:40]:<40} "
+            f"{(model.get('model_type') or '-')[:10]:<10} "
+            f"{_format_bytes(size):>10} "
+            f"{_format_context(model.get('max_context_window')):>10} "
+            f"{status:<8} {pinned:<7} "
+            f"{_format_relative_time(model.get('last_access')):<14}"
+        )
+    return 0
 
 
 def launch_command(args, extra_args: list[str] | None = None):
@@ -1302,6 +1449,48 @@ Example directory structure:
         ),
     )
 
+    # Ps command (status of the running server)
+    ps_parser = subparsers.add_parser(
+        "ps",
+        help="List models and memory usage of the running oMLX server",
+        description=(
+            "Show which models are loaded in memory, their sizes, context "
+            "windows, and last-use times. Queries the running server's "
+            "/v1/models/status endpoint."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  omlx ps\n"
+            "  omlx ps --json\n"
+            "  omlx ps --host 127.0.0.1 --port 8999\n"
+            "  omlx ps --api-key <key>\n"
+        ),
+    )
+    ps_parser.add_argument(
+        "--host",
+        type=str,
+        default=None,
+        help="oMLX server host (default: from settings or 127.0.0.1)",
+    )
+    ps_parser.add_argument(
+        "--port",
+        type=int,
+        default=None,
+        help="oMLX server port (default: from settings or 8000)",
+    )
+    ps_parser.add_argument(
+        "--api-key",
+        type=str,
+        default=None,
+        help="API key for oMLX server authentication",
+    )
+    ps_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON",
+    )
+
     # Diagnose command
     diagnose_parser = subparsers.add_parser(
         "diagnose",
@@ -1475,6 +1664,8 @@ Example directory structure:
             sys.exit(diagnose_command(args))
         elif args.command == "cluster":
             sys.exit(cluster_command(args))
+        elif args.command == "ps":
+            sys.exit(ps_command(args))
         else:
             parser.print_help()
             sys.exit(1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1207,6 +1207,310 @@ class TestServeCommandFunctions:
         assert captured["socket_name"][1] > 0
 
 
+class TestPsCommand:
+    """Tests for the `omlx ps` command."""
+
+    @staticmethod
+    def _status_payload(**overrides):
+        models = overrides.pop(
+            "models",
+            [
+                {
+                    "id": "qwen-tts",
+                    "model_type": "audio_tts",
+                    "loaded": True,
+                    "is_loading": False,
+                    "actual_size": 3_000_000_000,
+                    "estimated_size": 2_500_000_000,
+                    "max_context_window": 131072,
+                    "last_access": 1_000_000.0,
+                    "pinned": False,
+                },
+                {
+                    "id": "qwen-asr",
+                    "model_type": "audio_stt",
+                    "loaded": False,
+                    "is_loading": False,
+                    "estimated_size": 2_400_000_000,
+                    "max_context_window": 131072,
+                    "last_access": None,
+                    "pinned": False,
+                },
+                {
+                    "id": "qwen-llm-pinned",
+                    "model_type": "llm",
+                    "loaded": True,
+                    "is_loading": False,
+                    "actual_size": 4_000_000_000,
+                    "estimated_size": 3_800_000_000,
+                    "max_context_window": 65536,
+                    "last_access": 1_000_000.0,
+                    "pinned": True,
+                },
+            ],
+        )
+        payload = {
+            "final_ceiling": 12_000_000_000,
+            "current_model_memory": 2_500_000_000,
+            "model_count": 3,
+            "loaded_count": 2,
+            "models": models,
+        }
+        payload.update(overrides)
+        return payload
+
+    @staticmethod
+    def _make_args(**overrides):
+        defaults = {
+            "host": None,
+            "port": None,
+            "api_key": None,
+            "json": False,
+        }
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    @staticmethod
+    def _mock_response(payload, status_code=200):
+        response = MagicMock()
+        response.status_code = status_code
+        response.ok = status_code < 400
+        response.json.return_value = payload
+        return response
+
+    @staticmethod
+    def _patch_settings(monkeypatch, host="127.0.0.1", port=8000):
+        settings = SimpleNamespace(
+            server=SimpleNamespace(host=host, port=port),
+            auth=SimpleNamespace(api_key=None),
+        )
+        monkeypatch.setattr(
+            "omlx.settings.GlobalSettings.load", lambda: settings
+        )
+
+    def test_ps_table_output(self, monkeypatch, capsys):
+        from omlx import cli
+
+        self._patch_settings(monkeypatch, port=8000)
+        response = self._mock_response(self._status_payload())
+
+        with patch("requests.get", return_value=response) as mock_get:
+            assert cli.ps_command(self._make_args(port=8000)) == 0
+
+        url = mock_get.call_args.args[0]
+        assert url == "http://127.0.0.1:8000/v1/models/status"
+
+        out = capsys.readouterr().out
+        assert "Memory: 2.5 GB / 12.0 GB (guard ceiling)" in out
+        assert "NAME" in out and "TYPE" in out and "SIZE" in out
+        assert "CONTEXT" in out and "STATUS" in out and "LAST USED" in out
+        assert "PINNED" in out
+        assert "qwen-tts" in out
+        assert "audio_tts" in out
+        assert "3.0 GB" in out
+        assert "128k" in out
+        assert "loaded" in out
+        assert "audio_stt" in out
+        assert "never" in out
+        assert "qwen-llm-pinned" in out
+        assert "4.0 GB" in out
+        assert "64k" in out
+
+    def test_ps_format_context_human_readable(self):
+        from omlx import cli
+
+        assert cli._format_context(131072) == "128k"
+        assert cli._format_context(65536) == "64k"
+        assert cli._format_context(4096) == "4k"
+        assert cli._format_context(262144) == "256k"
+        assert cli._format_context(1500) == "2k"
+        assert cli._format_context(999) == "999"
+        assert cli._format_context(0) == "-"
+        assert cli._format_context(None) == "-"
+
+    def test_ps_json_output(self, monkeypatch, capsys):
+        import json
+
+        from omlx import cli
+
+        self._patch_settings(monkeypatch, port=8000)
+        payload = self._status_payload()
+        response = self._mock_response(payload)
+
+        with patch("requests.get", return_value=response):
+            assert cli.ps_command(self._make_args(port=8000, json=True)) == 0
+
+        out = capsys.readouterr().out
+        assert json.loads(out) == payload
+
+    def test_ps_server_down_exits_1(self, monkeypatch, capsys):
+        from omlx import cli
+
+        self._patch_settings(monkeypatch, port=8000)
+
+        with patch("requests.get", side_effect=ConnectionError()):
+            assert cli.ps_command(self._make_args(port=8000)) == 1
+
+        out = capsys.readouterr().out
+        assert "oMLX server is not running at http://127.0.0.1:8000" in out
+        assert "Start the server first: omlx start" in out
+
+    def test_ps_sends_bearer_header_when_api_key(self, monkeypatch, capsys):
+        from omlx import cli
+
+        self._patch_settings(monkeypatch, port=8000)
+        response = self._mock_response(self._status_payload(models=[]))
+
+        with patch("requests.get", return_value=response) as mock_get:
+            assert cli.ps_command(
+                self._make_args(port=8000, api_key="secret-key")
+            ) == 0
+
+        headers = mock_get.call_args.kwargs.get("headers", {})
+        assert headers.get("Authorization") == "Bearer secret-key"
+
+    def test_ps_unauthorized_suggests_api_key(self, monkeypatch, capsys):
+        from omlx import cli
+
+        self._patch_settings(monkeypatch, port=8000)
+        response = self._mock_response({}, status_code=401)
+
+        with patch("requests.get", return_value=response):
+            assert cli.ps_command(self._make_args(port=8000)) == 1
+
+        out = capsys.readouterr().out
+        assert "Authentication required" in out
+        assert "--api-key" in out
+
+    def test_ps_wildcard_host_falls_back_to_localhost(self, monkeypatch, capsys):
+        from omlx import cli
+
+        self._patch_settings(monkeypatch, host="0.0.0.0", port=8000)
+        response = self._mock_response(self._status_payload(models=[]))
+
+        with patch("requests.get", return_value=response) as mock_get:
+            assert cli.ps_command(self._make_args()) == 0
+
+        assert mock_get.call_args.args[0] == (
+            "http://127.0.0.1:8000/v1/models/status"
+        )
+
+    def test_ps_pinned_flag_parsing(self, monkeypatch, capsys):
+        """Pin column parses varied /v1/models/status payloads."""
+        from omlx import cli
+
+        scenarios = [
+            # (model payload, whether "pinned" should appear in the row)
+            (
+                {"pinned": True, "loaded": True},
+                True,
+            ),  # pinned and loaded
+            (
+                {"pinned": True, "loaded": False},
+                True,
+            ),  # pinned but unloaded: still visible
+            (
+                {"pinned": False, "loaded": True},
+                False,
+            ),  # unpinned and loaded
+            (
+                {"pinned": None, "loaded": False},
+                False,
+            ),  # explicit null renders as "-"
+        ]
+        for index, (extra, expect_pinned) in enumerate(scenarios):
+            model = {
+                "id": f"pin-model-{index}",
+                "model_type": "llm",
+                "is_loading": False,
+                "estimated_size": 1_000_000_000,
+                "max_context_window": 131072,
+                "last_access": None,
+            }
+            model.update(extra)
+            payload = self._status_payload(models=[model])
+
+            self._patch_settings(monkeypatch, port=8000)
+            response = self._mock_response(payload)
+            with patch("requests.get", return_value=response):
+                assert cli.ps_command(self._make_args(port=8000)) == 0
+
+            out = capsys.readouterr().out
+            assert f"pin-model-{index}" in out
+            if expect_pinned:
+                assert "pinned" in out
+            else:
+                assert "pinned" not in out
+
+    def test_ps_pinned_key_missing_is_tolerated(self, monkeypatch, capsys):
+        """Older servers may omit the pinned field entirely; render as '-'."""
+        from omlx import cli
+
+        self._patch_settings(monkeypatch, port=8000)
+        payload = self._status_payload(
+            models=[
+                {
+                    "id": "legacy-model",
+                    "model_type": "llm",
+                    "loaded": True,
+                    "is_loading": False,
+                    "estimated_size": 2_000_000_000,
+                    "max_context_window": 131072,
+                    "last_access": None,
+                }
+            ]
+        )
+        response = self._mock_response(payload)
+
+        with patch("requests.get", return_value=response):
+            assert cli.ps_command(self._make_args(port=8000)) == 0
+
+        out = capsys.readouterr().out
+        assert "legacy-model" in out
+        assert "PINNED" in out
+        assert "pinned" not in out.replace("PINNED", "")
+
+    def test_ps_loading_state_shown(self, monkeypatch, capsys):
+        from omlx import cli
+
+        self._patch_settings(monkeypatch, port=8000)
+        payload = self._status_payload(
+            models=[
+                {
+                    "id": "big-model",
+                    "model_type": "llm",
+                    "loaded": False,
+                    "is_loading": True,
+                    "estimated_size": 7_000_000_000,
+                    "max_context_window": 65536,
+                    "last_access": None,
+                    "pinned": False,
+                }
+            ]
+        )
+        response = self._mock_response(payload)
+
+        with patch("requests.get", return_value=response):
+            assert cli.ps_command(self._make_args(port=8000)) == 0
+
+        out = capsys.readouterr().out
+        assert "big-model" in out
+        assert "loading" in out
+
+    def test_ps_cli_args_override_settings(self, monkeypatch, capsys):
+        from omlx import cli
+
+        self._patch_settings(monkeypatch, host="127.0.0.1", port=8000)
+        response = self._mock_response(self._status_payload(models=[]))
+
+        with patch("requests.get", return_value=response) as mock_get:
+            assert cli.ps_command(self._make_args(host="10.0.0.5", port=9000)) == 0
+
+        assert mock_get.call_args.args[0] == (
+            "http://10.0.0.5:9000/v1/models/status"
+        )
+
+
 class TestHasCliOverrides:
     """Tests for _has_cli_overrides() — detects explicitly passed CLI args."""
 


### PR DESCRIPTION
## Motivation

When operating oMLX on a remote Mac over SSH or mosh, there is no quick way to check which models are loaded and how much memory they use.

- The admin dashboard shows this, but exposing it securely from a remote machine takes real effort (Cloudflare Tunnel, VPN, or similar).
- The data is already available via `GET /v1/models/status` — as pointed out in #1535 — but crafting the URL and auth headers by hand for every check, then parsing the JSON, is tedious.

`omlx ps` is a single read-only command that queries this endpoint, following the `ollama ps` / `lms ps` convention.

The command resolves the server address automatically (`~/.omlx/settings.json`, the macOS app's bootstrap file, and `OMLX_*` environment variables) — the same way `launch` does.

## What changed

### 1. New `omlx ps` subcommand (`omlx/cli.py`)

`omlx ps` queries the running server's `GET /v1/models/status` endpoint and renders a memory summary plus a model table. Output from a live server — the STT model is pinned (preloaded on startup), the others are not:

```console
$ omlx ps
Memory: 2.6 GB / 11.9 GB (guard ceiling)

NAME                                     TYPE             SIZE    CONTEXT STATUS   PINNED  LAST USED
mlx-community--Qwen3-ASR-1.7B-8bit       audio_stt      2.5 GB       128k loaded   pinned  3m ago
mlx-community--Qwen3-TTS-12Hz-1.7B-Custo audio_tts      2.5 GB       128k -        -       never
mlx-community--Qwen3-TTS-12Hz-1.7B-Voice audio_tts      2.5 GB       128k -        -       never
mlx-community--gemma-4-e2b-it-qat-OptiQ- vlm            4.5 GB       128k -        -       never
```

Toggling the pin off (and back on) flips the column immediately — captured from the same server:

```console
$ omlx ps              # pin off
NAME                                     TYPE             SIZE    CONTEXT STATUS   PINNED  LAST USED
mlx-community--gemma-4-e2b-it-qat-OptiQ- vlm            4.5 GB       128k -        -       never

$ omlx ps              # pin on
NAME                                     TYPE             SIZE    CONTEXT STATUS   PINNED  LAST USED
mlx-community--gemma-4-e2b-it-qat-OptiQ- llm            4.8 GB       128k loaded   pinned  just now
```

| Column | Source |
|---|---|
| `SIZE` | `actual_size` when loaded, `estimated_size` otherwise |
| `CONTEXT` | `max_context_window` in human-readable units — `131072` → `128k` |
| `STATUS` | `loaded` / `loading` (`is_loading`) / `-` (unloaded) |
| `PINNED` | `pinned` / `-` from `is_pinned` — preloaded on server start, never evicted by LRU/TTL |
| `LAST USED` | relative time from `last_access` (`5m ago`, `never`) |
| Summary line | `current_model_memory` vs the memory guard's `final_ceiling` |

Context windows render in human-readable units — `131072` → `128k` — matching the admin dashboard's `clusterTokens` formatter (exact `k` for multiples of 1024, nearest-1000 rounding otherwise). `--json` emits the raw payload instead. The table lists every model the server has discovered, including downloaded-but-never-loaded entries marked with a `-` status.

The `PINNED` column surfaces oMLX's residency model — from the README: *"I wanted to pin everyday models in memory, auto-swap heavier ones on demand."* Pinned models are preloaded on startup and never evicted by LRU/TTL; the flag stays visible even while the model is unloaded, matching the admin dashboard's Pin column.

### 2. Flags

| Flag | Purpose |
|---|---|
| `--json` | Emit the raw `/v1/models/status` payload for scripting |
| `--host` / `--port` / `--api-key` | Override the resolved settings |

`ps` follows `launch`'s resolution order: CLI flags > `OMLX_*` env vars > `settings.json` > defaults; wildcard bind hosts (`0.0.0.0`, `::`) fall back to `127.0.0.1`.

### 3. Error handling

`ps` exits 1 with a helpful hint in these cases:

| Situation | Behavior |
|---|---|
| Server unreachable | `oMLX server is not running at <url>` (same UX as `launch`) |
| 401 | a hint to pass `--api-key` |

### 4. Help text (`--help`)

`ps` is listed in the top-level help and has its own help text:

```console
$ omlx --help
...
  ps                  List models and memory usage of the running oMLX
                      server

$ omlx ps --help
Show which models are loaded in memory, their sizes, context windows,
and last-use times. Queries the running server's /v1/models/status
endpoint.

Examples:
  omlx ps
  omlx ps --json
  omlx ps --host 127.0.0.1 --port 8999
  omlx ps --api-key <key>
```

The module docstring's `Commands:`/`Usage:` sections list `omlx ps` as well. argparse rejects unknown commands with the full command list (`invalid choice: 'bogus' (choose from 'start', ..., 'ps', ...)`), so `ps` is discoverable there too.

## Validation & tests

Tests in `tests/test_cli.py` — `TestPsCommand`, 11 tests: table output, human-readable context formatting (`131072` → `128k`), pinned-flag parsing (pinned+loaded, pinned-but-unloaded, explicit null, field omitted), `--json`, server-down exit code, Bearer header, 401 hint, wildcard-host fallback, `loading` state, CLI flag precedence.

| Check | Result |
|---|---|
| `pytest tests/test_cli.py -q` | ✅ **80 passed** (69 pre-existing + 11 new) |
| `pytest -m "not slow"` (full fast suite) | ✅ **10665 passed, 156 skipped** |
| `ruff check` | ✅ no new findings (baseline unchanged) |

Manual checks against a live Homebrew-installed server (port 8999):

- ✅ `omlx ps` picked up host/port from `~/.omlx/settings.json` with no flags
- ✅ `OMLX_PORT=9999 omlx ps` overrode the port → not-running message + exit 1
- ✅ `--host 0.0.0.0` fell back to `127.0.0.1` for connecting, same as `launch`
- ✅ `--json` round-tripped the status payload unchanged

> [!NOTE]
> **Scope:** intentionally read-only. Load/unload and settings management already exist as API endpoints; deferred to follow-up PRs if needed.