### PR TITLE
fix(m5): segment oversized sorted gather_qmm calls instead of demoting them

### DIFF
--- a/benchmarks/bench_m5_sorted_gather_chunk.py
+++ b/benchmarks/bench_m5_sorted_gather_chunk.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-layer MoE prefill cost vs chunk width on M5 (sorted gather_qmm paths).
+
+Reproduces one routed-expert MoE layer at a configurable geometry (default:
+Qwen4-Exp, 512 experts / top-10 / hidden 2560 / inter 640, 4-bit gs64 with
+the fused gate+up layout) and times the sorted SwitchGLU path for several
+prefill chunk widths under three dispatch modes:
+
+- ``sorted``      raw ``sorted_indices=True`` (NAX rhs kernel; corrupt past
+                  32768 rows on mlx <= 0.32.2, timed for reference only)
+- ``unsorted``    what the pre-segmenting M5 reroute did past the row cap
+- ``segmented``   the oMLX reroute with <=32768-row sorted slices
+
+Prints ms per layer call and derived tokens/s so the chunk-width policy can
+be judged on numbers. Run from a checkout with the reroute installed::
+
+    python benchmarks/bench_m5_sorted_gather_chunk.py --chunks 2048 4096 8192
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import mlx.core as mx
+from mlx_lm.models.switch_layers import _gather_sort, _scatter_unsort
+
+import omlx.patches.m5_gather_qmm as reroute
+
+
+def _build(experts, hidden, inter, bits, group_size, key):
+    k1, k2 = mx.random.split(key)
+    gate_up = mx.random.normal((experts, 2 * inter, hidden), key=k1) * 0.02
+    down = mx.random.normal((experts, hidden, inter), key=k2) * 0.02
+    gu = mx.quantize(gate_up.astype(mx.bfloat16), group_size=group_size, bits=bits)
+    dn = mx.quantize(down.astype(mx.bfloat16), group_size=group_size, bits=bits)
+    mx.eval(*gu, *dn)
+    return gu, dn
+
+
+def _layer(x, inds, gu, dn, bits, group_size, sorted_flag, gather_qmm):
+    x5 = mx.expand_dims(x, (-2, -3))
+    xs, idx, inv = _gather_sort(x5, inds)
+    h = gather_qmm(
+        xs,
+        *gu,
+        rhs_indices=idx,
+        transpose=True,
+        group_size=group_size,
+        bits=bits,
+        sorted_indices=sorted_flag,
+    )
+    g, u = mx.split(h, 2, axis=-1)
+    a = mx.sigmoid(g) * g * u
+    y = gather_qmm(
+        a,
+        *dn,
+        rhs_indices=idx,
+        transpose=True,
+        group_size=group_size,
+        bits=bits,
+        sorted_indices=sorted_flag,
+    )
+    return _scatter_unsort(y, inv, inds.shape).squeeze(-2)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--experts", type=int, default=512)
+    ap.add_argument("--topk", type=int, default=10)
+    ap.add_argument("--hidden", type=int, default=2560)
+    ap.add_argument("--inter", type=int, default=640)
+    ap.add_argument("--bits", type=int, default=4)
+    ap.add_argument("--group-size", type=int, default=64)
+    ap.add_argument("--chunks", type=int, nargs="+", default=[2048, 4096, 8192])
+    ap.add_argument("--iters", type=int, default=5)
+    ap.add_argument("--modes", nargs="+", default=["sorted", "unsorted", "segmented"])
+    args = ap.parse_args()
+
+    reroute.apply_m5_gather_qmm_workaround()
+    raw = reroute._original_gather_qmm or mx.gather_qmm
+    print(
+        f"mlx {mx.__version__}  device {mx.device_info().get('device_name')}  "
+        f"sorted rhs kernel defective: {reroute._sorted_gather_qmm_defective()}"
+    )
+    gu, dn = _build(
+        args.experts,
+        args.hidden,
+        args.inter,
+        args.bits,
+        args.group_size,
+        mx.random.key(0),
+    )
+    print(
+        f"geometry: E={args.experts} topk={args.topk} hidden={args.hidden} "
+        f"inter={args.inter} q{args.bits}/gs{args.group_size}"
+    )
+    print(f"{'chunk':>6} {'rows':>7} {'mode':>10} {'ms/layer':>9} {'tok/s':>10}")
+    for chunk in args.chunks:
+        kx, ki = mx.random.split(mx.random.key(chunk))
+        x = mx.random.normal((1, chunk, args.hidden), key=kx).astype(mx.bfloat16)
+        inds = mx.random.randint(0, args.experts, (1, chunk, args.topk), key=ki)
+        inds = inds.astype(mx.uint32)
+        mx.eval(x, inds)
+        for mode in args.modes:
+            if mode == "sorted":
+                sorted_flag, gather = True, raw
+            elif mode == "unsorted":
+                sorted_flag, gather = False, raw
+            elif mode == "segmented":
+                sorted_flag, gather = True, reroute._gather_qmm_rerouted
+            else:
+                raise SystemExit(f"unknown mode {mode}")
+
+            def fn(x=x, inds=inds, sorted_flag=sorted_flag, gather=gather):
+                return _layer(
+                    x, inds, gu, dn, args.bits, args.group_size, sorted_flag, gather
+                )
+
+            for _ in range(2):
+                mx.eval(fn())
+            mx.synchronize()
+            t0 = time.perf_counter()
+            for _ in range(args.iters):
+                mx.eval(fn())
+            mx.synchronize()
+            ms = (time.perf_counter() - t0) / args.iters * 1e3
+            print(
+                f"{chunk:>6} {chunk * args.topk:>7} {mode:>10} {ms:>9.2f} "
+                f"{chunk / ms * 1e3:>10.0f}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/omlx/patches/m5_gather_qmm.py
+++ b/omlx/patches/m5_gather_qmm.py
@@ -17,14 +17,28 @@ output through mlx 0.32.2:
   and the mxfp4 variant carries the same tail bug.
 - Row offsets: the int16 fix that landed in mlx 0.32.0 still misses this
   kernel, so sorted row counts above 32768 overflow the row offset
-  (ml-explore/mlx#3856). Reachable in production: a 4097+ token prefill
-  chunk of a top-8 MoE crosses the boundary.
+  (ml-explore/mlx#3856, fixed upstream by ml-explore/mlx#3922 after the
+  0.32.2 release). Reachable in production: a 4097+ token prefill chunk
+  of a top-8 MoE crosses the boundary, and a top-10 MoE (Qwen4-Exp)
+  crosses it at 3277 tokens.
 
-``sorted_indices`` is a pure performance hint, so the wrapper simply
-drops it for calls that match a defect condition. The unsorted gather
-path guards ``K % 64 == 0`` before entering NAX and falls back to the
-verified steel kernels, at some prefill-throughput cost for the
-affected shapes only.
+``sorted_indices`` is a pure performance hint, so the wrapper can always
+fall back to dropping it. The two defects get different treatment:
+
+- ``K % 64 != 0`` drops the flag: the unsorted gather path guards
+  ``K % 64 == 0`` before entering NAX and falls back to the verified
+  steel kernels, at some prefill-throughput cost for the affected
+  shapes only.
+- Row overflow keeps the flag and splits the call instead. The rhs
+  kernel is only wrong because a *single* call exceeds 32768 rows, so
+  an oversized call is issued as balanced ``<= 32768``-row slices of
+  the (already sorted) activations and indices and the partial outputs
+  are concatenated. Each slice stays on the NAX rhs kernel, which is
+  what makes wide prefill chunks (4096+ tokens on a top-8/top-10 MoE)
+  keep their tensor-unit throughput instead of dropping to the
+  per-row gather kernel. Slices are balanced rather than cut at the
+  cap so every slice still clears mlx's ``rows / experts >= 4`` gate
+  for the batched rhs path.
 
 The wrapper self-arms: the first matching call runs a tiny canary
 against an fp32 dequantized reference and only intervenes when the
@@ -44,6 +58,11 @@ logger = logging.getLogger(__name__)
 
 # ml-explore/mlx#3856: sorted row offsets overflow int16 past this count.
 _MAX_SORTED_ROWS = 32768
+
+# Advertises to callers (e.g. the scheduler's prefill-chunk policy) that
+# oversized sorted calls are segmented rather than demoted to the unsorted
+# kernel, so a wide chunk keeps the NAX rhs path.
+SEGMENTS_SORTED_ROWS = True
 
 _original_gather_qmm = None
 _defective: bool | None = None
@@ -83,12 +102,16 @@ def _sorted_gather_qmm_defective() -> bool:
     if _defective:
         logger.warning(
             "sorted gather_qmm corrupts on this machine (canary max err "
-            "%.3g); rerouting K %% 64 != 0 and >%d-row sorted calls to the "
-            "unsorted path (issue #2267)",
+            "%.3g); rerouting K %% 64 != 0 sorted calls to the unsorted "
+            "path and segmenting >%d-row sorted calls (issue #2267)",
             err,
             _MAX_SORTED_ROWS,
         )
     return _defective
+
+
+def _rhs_indices(args, kwargs):
+    return args[3] if len(args) > 3 else kwargs.get("rhs_indices")
 
 
 def _needs_reroute(x, args, kwargs) -> bool:
@@ -99,7 +122,7 @@ def _needs_reroute(x, args, kwargs) -> bool:
     # rhs_indices, transpose, group_size, bits, mode. sorted_indices is
     # keyword-only.
     lhs = args[2] if len(args) > 2 else kwargs.get("lhs_indices")
-    rhs = args[3] if len(args) > 3 else kwargs.get("rhs_indices")
+    rhs = _rhs_indices(args, kwargs)
     transpose = args[4] if len(args) > 4 else kwargs.get("transpose", True)
     # The rhs kernel is only selected for the rhs-indices-only sorted
     # path with transposed weights (x @ w.T).
@@ -110,8 +133,43 @@ def _needs_reroute(x, args, kwargs) -> bool:
     return rhs.size * x.shape[-2] > _MAX_SORTED_ROWS
 
 
+def _segment_bounds(rows: int) -> list[tuple[int, int]]:
+    """Balanced ``[start, stop)`` slices with at most ``_MAX_SORTED_ROWS`` each."""
+    count = -(-rows // _MAX_SORTED_ROWS)
+    size = -(-rows // count)
+    return [(start, min(start + size, rows)) for start in range(0, rows, size)]
+
+
+def _segmented_sorted_gather_qmm(x, w, args, kwargs):
+    """Issue an oversized sorted rhs call as ``<= 32768``-row slices.
+
+    Only the layout the MoE sorted path produces is handled: a 3-D
+    ``[rows, 1, K]`` activation with a flat sorted ``rhs_indices`` of the
+    same row count. Anything else returns None and the caller falls back
+    to dropping ``sorted_indices``.
+    """
+    rhs = _rhs_indices(args, kwargs)
+    if x.ndim != 3 or x.shape[1] != 1 or rhs.ndim != 1 or rhs.shape[0] != x.shape[0]:
+        return None
+    rows = int(x.shape[0])
+    outputs = []
+    for start, stop in _segment_bounds(rows):
+        seg_args = list(args)
+        seg_kwargs = kwargs
+        if len(args) > 3:
+            seg_args[3] = rhs[start:stop]
+        else:
+            seg_kwargs = dict(kwargs, rhs_indices=rhs[start:stop])
+        outputs.append(_original_gather_qmm(x[start:stop], w, *seg_args, **seg_kwargs))
+    return mx.concatenate(outputs, axis=0)
+
+
 def _gather_qmm_rerouted(x, w, *args, **kwargs):
     if _needs_reroute(x, args, kwargs) and _sorted_gather_qmm_defective():
+        if x.shape[-1] % 64 == 0:
+            out = _segmented_sorted_gather_qmm(x, w, args, kwargs)
+            if out is not None:
+                return out
         kwargs = dict(kwargs, sorted_indices=False)
     return _original_gather_qmm(x, w, *args, **kwargs)
 

--- a/tests/test_m5_gather_qmm.py
+++ b/tests/test_m5_gather_qmm.py
@@ -96,6 +96,67 @@ def test_wrapper_drops_sorted_flag_only_when_defective(monkeypatch):
     assert captured["sorted_indices"] is True
 
 
+def test_segment_bounds_are_balanced_and_capped():
+    cap = patch_mod._MAX_SORTED_ROWS
+    assert patch_mod._segment_bounds(cap) == [(0, cap)]
+    bounds = patch_mod._segment_bounds(cap + 1)
+    assert bounds == [(0, cap // 2 + 1), (cap // 2 + 1, cap + 1)]
+    rows = 40960  # 4096-token chunk of a top-10 MoE
+    bounds = patch_mod._segment_bounds(rows)
+    assert bounds == [(0, 20480), (20480, 40960)]
+    assert all(stop - start <= cap for start, stop in bounds)
+    rows = 3 * cap + 5
+    bounds = patch_mod._segment_bounds(rows)
+    assert len(bounds) == 4
+    assert bounds[0][0] == 0 and bounds[-1][1] == rows
+    assert all(b[1] == n[0] for b, n in zip(bounds, bounds[1:]))
+    sizes = [stop - start for start, stop in bounds]
+    assert max(sizes) - min(sizes) < len(bounds)
+
+
+def test_wrapper_segments_oversized_sorted_calls(monkeypatch):
+    """Aligned K past the row cap stays sorted, split into <=32768-row calls."""
+    seen = []
+
+    def spy(x, w, *args, **kwargs):
+        rhs = args[3] if len(args) > 3 else kwargs["rhs_indices"]
+        seen.append((int(x.shape[0]), int(rhs.shape[0]), kwargs["sorted_indices"]))
+        return mx.zeros((x.shape[0], 1, 4), dtype=x.dtype)
+
+    assert apply_m5_gather_qmm_workaround()
+    monkeypatch.setattr(patch_mod, "_original_gather_qmm", spy)
+    monkeypatch.setattr(patch_mod, "_defective", True)
+
+    rows = 70000
+    x = mx.zeros((rows, 1, 128), dtype=mx.bfloat16)
+    idx = mx.zeros((rows,), dtype=mx.uint32)
+    out = mx.gather_qmm(x, x, x, rhs_indices=idx, sorted_indices=True)
+    assert out.shape == (rows, 1, 4)
+    assert len(seen) == 3
+    assert all(sorted_flag for _, _, sorted_flag in seen)
+    assert all(n <= patch_mod._MAX_SORTED_ROWS for n, _, _ in seen)
+    assert all(n == m for n, m, _ in seen)
+    assert sum(n for n, _, _ in seen) == rows
+
+    # Positional rhs_indices (scales, biases, lhs, rhs) segments the same way.
+    seen.clear()
+    out = mx.gather_qmm(x, x, x, x, None, idx, sorted_indices=True)
+    assert out.shape == (rows, 1, 4)
+    assert len(seen) == 3 and all(s for _, _, s in seen)
+
+    # Unaligned K cannot use the rhs kernel at all: one unsorted call.
+    seen.clear()
+    x96 = mx.zeros((rows, 1, 96), dtype=mx.bfloat16)
+    mx.gather_qmm(x96, x96, x96, rhs_indices=idx, sorted_indices=True)
+    assert seen == [(rows, rows, False)]
+
+    # A layout the segmenter does not understand drops the flag instead.
+    seen.clear()
+    x2 = mx.zeros((rows // 2, 2, 128), dtype=mx.bfloat16)
+    mx.gather_qmm(x2, x2, x2, rhs_indices=idx[: rows // 2], sorted_indices=True)
+    assert seen == [(rows // 2, rows // 2, False)]
+
+
 def _kernel_defective_here() -> bool:
     if not mx.metal.is_available():
         return False
@@ -142,3 +203,36 @@ def test_reroute_restores_correct_output_on_defective_hardware():
     )
     err = mx.abs(out.astype(mx.float32) - ref).max().item()
     assert err < 0.2, f"still corrupt through the reroute: max err {err}"
+
+
+@pytest.mark.skipif(
+    not _kernel_defective_here(),
+    reason="sorted gather_qmm NAX kernel is healthy on this machine",
+)
+def test_segmented_sorted_call_matches_reference_past_row_cap():
+    """>32768 sorted rows stay on the NAX rhs kernel and still match fp32."""
+    assert apply_m5_gather_qmm_workaround()
+
+    n, e, out_dim, k = patch_mod._MAX_SORTED_ROWS + 4096, 8, 64, 64
+    keys = mx.random.split(mx.random.key(3856), 3)
+    w = mx.random.normal((e, out_dim, k), key=keys[0]).astype(mx.bfloat16)
+    wq, scales, biases = mx.quantize(w, group_size=64, bits=4)
+    x = (mx.random.normal((n, 1, k), key=keys[1]) * 0.5).astype(mx.bfloat16)
+    idx = mx.sort(mx.random.randint(0, e, (n,), key=keys[2]).astype(mx.uint32))
+    wd = mx.dequantize(wq, scales, biases, group_size=64, bits=4)
+    ref = x.astype(mx.float32) @ wd[idx].swapaxes(-1, -2).astype(mx.float32)
+
+    out = mx.gather_qmm(
+        x,
+        wq,
+        scales,
+        biases,
+        rhs_indices=idx,
+        transpose=True,
+        group_size=64,
+        bits=4,
+        sorted_indices=True,
+    )
+    assert out.shape == ref.shape
+    err = mx.abs(out.astype(mx.float32) - ref).max().item()
+    assert err < 0.2, f"segmented sorted call is corrupt: max err {err}"


### PR DESCRIPTION
## Summary
- The M5 sorted-gather reroute (issue #2267) dropped `sorted_indices` for sorted rhs `gather_qmm` calls above 32768 rows to avoid the int16 row-offset overflow in the NAX rhs kernel (ml-explore/mlx#3856; fixed upstream by ml-explore/mlx#3922 only after 0.32.2 shipped).
- The unsorted gather path is ~8x slower per MoE layer on M5 Max, so any prefill chunk past the cap (4097+ tokens on top-8, 3277+ on top-10 / Qwen4-Exp) lost far more than the wider chunk saved.
- Keep the flag and issue oversized calls as balanced `<= 32768`-row sorted slices, concatenating the partial outputs. Only the layout the MoE sorted path produces (`[rows, 1, K]` activations + flat sorted `rhs_indices`) is segmented; `K % 64 != 0` and other layouts keep the existing demotion.
- Exposes `SEGMENTS_SORTED_ROWS = True` so a chunk-width policy can key off it. (A Qwen4 4096-chunk floor was A/B tested on top of this and found end-to-end neutral on M5 Max, so no scheduler change is proposed.)

## Measurements
`benchmarks/bench_m5_sorted_gather_chunk.py`, one Qwen4-Exp MoE layer (512 experts, top-10, 2560/640, q4 gs64, fused gate+up), M5 Max / mlx 0.32.2, ms per layer call:

| chunk | rows | sorted (raw, corrupt past cap) | unsorted (old reroute) | segmented (this PR) |
|---|---|---|---|---|
| 2048 | 20480 | 23.8 | 189.8 | 24.7 |
| 4096 | 40960 | 38.8 | 337.6 | 31.0 |
| 8192 | 81920 | 48.9 | 512.2 | 58.2 |

## Test plan
- [x] `tests/test_m5_gather_qmm.py`: segment bounds, wrapper splits positional/keyword `rhs_indices`, unaligned K and unknown layouts still demote, and on defective hardware a 36864-row sorted call matches the fp32 reference
- [x] `tests/test_qwen35_moe_gate_up.py`, `tests/test_deepseek_v4_patch.py`, `tests/test_qwen35_moe_weighted_sum.py` pass

## End-to-end (oMLX server, Qwen4-Exp 180B-A10B mixed AWQ, M5 Max 128 GB, 16k prompt, 3 interleaved rounds)
| arm | prompt tok/s |
|---|---|
| baseline, default 2048 chunks | 1196-1227 |
| baseline forced to 4096 chunks (old reroute demotes to unsorted) | **447-458** |
| this PR forced to 4096 chunks (segmented sorted) | 1259-1273 |

Per-chunk trace: a 3968-token chunk took 9.2 s on the old reroute vs 3.1 s segmented. Default Qwen4 chunks (2048) never cross the cap, so this is a cliff fix for wider chunk configurations rather than a default-path speedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUwVt6F1YHbTLvNvmAGEvU