### PR TITLE
feat(qwen35_prefill): instantiate the MoE weighted-sum kernel for top-k 10

### DIFF
--- a/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_prefill.cpp
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_prefill.cpp
@@ -744,7 +744,9 @@ class Qwen35MoeWeightedSumPrimitive : public Primitive {
       return true;
     }
     const int topk = scores.shape(-1);
-    if ((topk != 6 && topk != 8) || x_sorted.shape(0) != scores.size() ||
+    // Instantiated top-k widths: Qwen3.5/3.6 (8), GLM-style 6, Qwen4-Exp (10).
+    if ((topk != 6 && topk != 8 && topk != 10) ||
+        x_sorted.shape(0) != scores.size() ||
         inv_order.size() != scores.size()) {
       return true;
     }

--- a/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_qmm.metal
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_qmm.metal
@@ -182,3 +182,5 @@ instantiate_qwen35_moe_weighted_sum_tiled(float16_t, float, 8, 256);
 instantiate_qwen35_moe_weighted_sum_tiled(bfloat16_t, float, 8, 256);
 instantiate_qwen35_moe_weighted_sum_tiled(float16_t, float, 6, 256);
 instantiate_qwen35_moe_weighted_sum_tiled(bfloat16_t, float, 6, 256);
+instantiate_qwen35_moe_weighted_sum_tiled(float16_t, float, 10, 256);
+instantiate_qwen35_moe_weighted_sum_tiled(bfloat16_t, float, 10, 256);

--- a/omlx/patches/qwen35_moe_weighted_sum.py
+++ b/omlx/patches/qwen35_moe_weighted_sum.py
@@ -6,6 +6,10 @@ outputs, scatters back to ``[B, T, topk, D]``, and then applies router scores.
 For Qwen MoE prefill we can consume the sorted expert output directly with the
 existing native weighted-sum kernel, avoiding the scatter and expanded
 intermediate. Decode and target-verify paths keep the original implementation.
+
+The native kernel is instantiated for top-k 6, 8 and 10; the last covers the
+512-expert Qwen4-Exp MoE (``num_experts_per_tok=10``), whose block inherits
+the Qwen3.5-MoE class and previously fell through to the stock path.
 """
 
 from __future__ import annotations
@@ -55,7 +59,7 @@ def _should_route(self: Any, x: mx.array, target_verify: bool, min_tokens: int) 
         return False
     if getattr(self, "sharding_group", None) is not None:
         return False
-    if getattr(self, "top_k", None) not in (6, 8):
+    if getattr(self, "top_k", None) not in (6, 8, 10):
         return False
     if x.shape[-2] * int(getattr(self, "top_k", 0)) < 64:
         return False

--- a/tests/test_qwen35_moe_weighted_sum.py
+++ b/tests/test_qwen35_moe_weighted_sum.py
@@ -66,6 +66,12 @@ def test_moe_weighted_sum_route_gate(monkeypatch):
     assert not patch._should_route(_Block(), x[:, :1], False, min_tokens=1024)
     assert not patch._should_route(_Block(), x, True, min_tokens=1024)
 
+    # Qwen4-Exp routes ten experts per token (issue: the kernel used to gate
+    # on 6/8 only, silently leaving Qwen4 on the stock scatter path).
+    qwen4_topk = _Block()
+    qwen4_topk.top_k = 10
+    assert patch._should_route(qwen4_topk, x, False, min_tokens=1024)
+
     bad_topk = _Block()
     bad_topk.top_k = 2
     assert not patch._should_route(bad_topk, x, False, min_tokens=1024)
@@ -196,3 +202,92 @@ def test_qwen3_moe_patch_matches_stock_and_skips_decode(monkeypatch):
     y_decode = block(x[:, :1])
     mx.eval(y_decode)
     assert calls["count"] == 0
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="Metal is required")
+@pytest.mark.parametrize("topk", [6, 8, 10])
+def test_native_weighted_sum_matches_reference_for_each_topk(topk):
+    """Every instantiated top-k width (incl. Qwen4-Exp's 10) matches fp32."""
+    from omlx.custom_kernels.qwen35_prefill import fast
+
+    if not fast.has_symbol("qwen35_moe_weighted_sum"):
+        pytest.skip("qwen35_moe_weighted_sum native kernel unavailable")
+
+    tokens, dim = 64, 256
+    rows = tokens * topk
+    keys = mx.random.split(mx.random.key(topk), 3)
+    x_sorted = mx.random.normal((rows, 1, dim), key=keys[0]).astype(mx.bfloat16)
+    inv_order = mx.random.permutation(rows, key=keys[1]).astype(mx.uint32)
+    scores = mx.softmax(mx.random.normal((tokens, topk), key=keys[2]), axis=-1)
+
+    out = fast.qwen35_moe_weighted_sum(x_sorted, inv_order, scores)
+    ref = (
+        x_sorted[inv_order].reshape(tokens, topk, dim).astype(mx.float32)
+        * scores[..., None]
+    ).sum(axis=1)
+    assert out.shape == (tokens, dim)
+    err = mx.abs(out.astype(mx.float32) - ref).max().item()
+    assert err < 2e-2, f"topk={topk}: max err {err}"
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="Metal is required")
+def test_qwen4_shaped_top10_block_routes_and_matches_stock(monkeypatch):
+    """A Qwen4-Exp style top-10 Qwen3.5-MoE VLM block takes the native path."""
+    try:
+        from mlx_vlm.models.qwen3_5_moe import language as q35_moe
+    except Exception:  # noqa: BLE001
+        pytest.skip("mlx_vlm qwen3_5_moe unavailable")
+
+    from omlx.custom_kernels.qwen35_prefill import fast
+    from omlx.patches.qwen35_moe_weighted_sum import (
+        apply_qwen35_moe_weighted_sum_patch,
+    )
+
+    if not fast.has_symbol("qwen35_moe_weighted_sum"):
+        pytest.skip("qwen35_moe_weighted_sum native kernel unavailable")
+
+    cls = q35_moe.Qwen3_5MoeSparseMoeBlock
+    orig_call = cls.__call__
+    monkeypatch.setenv("OMLX_QWEN35_MOE_WEIGHTED_SUM", "1")
+    monkeypatch.setenv("OMLX_QWEN35_MOE_WEIGHTED_SUM_MIN_TOKENS", "16")
+
+    args = types.SimpleNamespace(
+        hidden_size=128,
+        moe_intermediate_size=64,
+        shared_expert_intermediate_size=64,
+        num_experts=32,
+        num_experts_per_tok=10,
+    )
+    block = cls(args)
+    x = mx.random.normal((1, 64, 128), key=mx.random.key(10)).astype(mx.bfloat16)
+    y_ref = orig_call(block, x)
+    mx.eval(y_ref)
+
+    calls = {"count": 0}
+    orig_weighted_sum = fast.qwen35_moe_weighted_sum
+
+    def spy(*a, **kw):
+        calls["count"] += 1
+        return orig_weighted_sum(*a, **kw)
+
+    monkeypatch.setattr(fast, "qwen35_moe_weighted_sum", spy)
+    try:
+        assert apply_qwen35_moe_weighted_sum_patch() is True
+        y = block(x)
+        mx.eval(y)
+        assert calls["count"] == 1
+        diff = mx.abs(y.astype(mx.float32) - y_ref.astype(mx.float32))
+        assert mx.max(diff).item() <= 2e-2
+
+        calls["count"] = 0
+        y_verify = block(x, target_verify=True)
+        mx.eval(y_verify)
+        assert calls["count"] == 0
+    finally:
+        cls.__call__ = orig_call
+        for name in (
+            "_omlx_qwen_moe_weighted_sum_patched",
+            "_omlx_qwen_moe_weighted_sum_original_call",
+        ):
+            if hasattr(cls, name):
+                delattr(cls, name)


### PR DESCRIPTION
## Summary
- The native `qwen35_moe_weighted_sum` kernel (consumes sorted expert output directly, skipping scatter-unsort and the `[B, T, topk, D]` intermediate) was instantiated for top-k 6 and 8 only, and the Python route gate mirrored that.
- Qwen4-Exp routes 10 of 512 experts through the inherited `Qwen3_5MoeSparseMoeBlock`, so all 48 of its MoE layers silently used the stock scatter path on prefill.
- The `moe_weighted_sum_tiled` template is generic in TOPK: add the 10-wide fp16/bf16 instantiations, accept 10 in the primitive's shape gate, widen the patch gate.

## Test plan
- [x] Kernel vs fp32 reference at top-k 6/8/10
- [x] Qwen4-shaped top-10 `Qwen3_5MoeSparseMoeBlock` takes the native path, matches stock, and stays off it for target-verify
- [x] `tests/test_qwen35_q4_mlp.py`, `tests/test_qwen35_moe_gate_up.py`, `tests/test_nax.py` pass with the rebuilt extension

## End-to-end
Prefill throughput on Qwen4-Exp / M5 Max is within noise of baseline (1185-1281 vs 1196-1227 tok/s at 16k); the change removes the scatter but that is a small share of the layer. Value is correctness of the native path for top-10 models plus fewer intermediates, not measurable throughput.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUwVt6F1YHbTLvNvmAGEvU