### PR TITLE
fix(qwen35_prefill): drop the wrong NAX qmm tile variant 6, add a tile benchmark

### DIFF
--- a/benchmarks/bench_qwen35_nax_qmm_variants.py
+++ b/benchmarks/bench_qwen35_nax_qmm_variants.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Stock vs oMLX NAX qmm tiles for Qwen hybrid-layer projections on M5.
+
+The Qwen q4/q8 prefill-linear patch routes affine `QuantizedLinear` prefill
+matmuls through the bundled `qwen35_q{bits}_affine_qmm_t` op, which on M5
+selects a NAX tile chosen by `OMLX_QWEN35_QMM_NAX_VARIANT` (0 = the tile
+stock MLX ships). This benchmark times stock `mx.quantized_matmul` against
+each bundled NAX tile variant (``fast.NAX_QMM_VARIANTS``) at the projection shapes of a Qwen4-Exp GDN /
+attention layer, so the variant default and the q8 min-token threshold
+(`OMLX_QWEN35_Q8_LINEAR_MIN_TOKENS`, 16384) can be set from numbers.
+
+    python benchmarks/bench_qwen35_nax_qmm_variants.py --bits 8 --tokens 2048 8192
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import mlx.core as mx
+
+from omlx.custom_kernels.qwen35_prefill import fast
+
+# (name, N, K) — Qwen4-Exp hidden 2560, GDN 48v/16k heads x 128, attn 24q/2kv x 256
+SHAPES = [
+    ("gdn.in_proj_qkv", 10240, 2560),
+    ("gdn.in_proj_z", 6144, 2560),
+    ("gdn.out_proj", 2560, 6144),
+    ("attn.q_proj", 12288, 2560),
+    ("attn.o_proj", 2560, 6144),
+]
+
+
+def _time(fn, iters):
+    for _ in range(2):
+        mx.eval(fn())
+    mx.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        mx.eval(fn())
+    mx.synchronize()
+    return (time.perf_counter() - t0) / iters * 1e3
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--bits", type=int, default=8)
+    ap.add_argument("--group-size", type=int, default=64)
+    ap.add_argument("--tokens", type=int, nargs="+", default=[2048, 4096, 8192, 16384])
+    ap.add_argument(
+        "--variants", type=int, nargs="+", default=list(fast.NAX_QMM_VARIANTS)
+    )
+    ap.add_argument("--iters", type=int, default=10)
+    ap.add_argument("--shapes", nargs="+", default=[s[0] for s in SHAPES])
+    args = ap.parse_args()
+
+    if not fast.is_native_available():
+        raise SystemExit(f"native extension unavailable: {fast.import_error()}")
+    native = getattr(fast, f"qwen35_q{args.bits}_affine_qmm_t")
+    print(
+        f"mlx {mx.__version__}  {mx.device_info().get('device_name')}  "
+        f"nax={fast.is_nax_available()} native_nax_qmm={fast._qmm_use_nax()}  "
+        f"q{args.bits}/gs{args.group_size}"
+    )
+    print(
+        f"{'shape':>16} {'N':>6} {'K':>5} {'T':>6} {'mode':>10} {'ms':>8} {'GFLOP/s':>9} {'maxerr':>8}"
+    )
+    for name, n, k in SHAPES:
+        if name not in args.shapes:
+            continue
+        w = (mx.random.normal((n, k), key=mx.random.key(n * k)) * 0.02).astype(
+            mx.bfloat16
+        )
+        wq, sc, bi = mx.quantize(w, group_size=args.group_size, bits=args.bits)
+        mx.eval(wq, sc, bi)
+        for t in args.tokens:
+            x = mx.random.normal((1, t, k), key=mx.random.key(t)).astype(mx.bfloat16)
+            mx.eval(x)
+            flop = 2.0 * t * n * k
+
+            def stock(x=x, wq=wq, sc=sc, bi=bi):
+                return mx.quantized_matmul(
+                    x,
+                    wq,
+                    sc,
+                    bi,
+                    transpose=True,
+                    group_size=args.group_size,
+                    bits=args.bits,
+                )
+
+            ref = stock()
+            mx.eval(ref)
+            ms = _time(stock, args.iters)
+            print(
+                f"{name:>16} {n:>6} {k:>5} {t:>6} {'stock':>10} {ms:>8.2f} {flop / ms / 1e6:>9.0f} {'-':>8}"
+            )
+            for v in args.variants:
+                fast.QMM_NAX_VARIANT = v
+
+                def mine(x=x, wq=wq, sc=sc, bi=bi):
+                    return native(x, wq, sc, bi, 8, args.group_size)
+
+                try:
+                    out = mine()
+                    mx.eval(out)
+                except Exception as exc:  # noqa: BLE001
+                    print(
+                        f"{name:>16} {n:>6} {k:>5} {t:>6} {'nax v' + str(v):>10} {'error':>8} {exc}"
+                    )
+                    continue
+                err = (
+                    mx.abs(out.astype(mx.float32) - ref.astype(mx.float32)).max().item()
+                )
+                ms = _time(mine, args.iters)
+                print(
+                    f"{name:>16} {n:>6} {k:>5} {t:>6} {'nax v' + str(v):>10} {ms:>8.2f} {flop / ms / 1e6:>9.0f} {err:>8.3g}"
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_prefill.cpp
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_prefill.cpp
@@ -131,8 +131,10 @@ QwenQAffineNaxVariant qwen_q_affine_nax_variant(int variant) {
       return {/* bm = */ 64, /* bk = */ 32, /* bn = */ 64, 2, 2};
     case 5:
       return {/* bm = */ 64, /* bk = */ 64, /* bn = */ 64, 4, 1};
-    case 6:
-      return {/* bm = */ 64, /* bk = */ 64, /* bn = */ 64, 1, 4};
+    // (64, 64, 64, wm=1, wn=4) was variant 6: a 16-column per-simdgroup N
+    // tile that returns wrong output on M5 Max / mlx 0.32.2 (max abs err 5-8
+    // against stock at every shape and bit width; the other tiles match
+    // exactly). Rejected rather than kept as an opt-in footgun.
     default: {
       std::ostringstream msg;
       msg << "Unsupported Qwen affine qmm NAX variant " << variant << ".";

--- a/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_qmm_nax.metal
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_qmm_nax.metal
@@ -99,11 +99,7 @@
   instantiate_qwen35_q_affine_qmm_t_nax(                                     \
       bits, group_suffix, float16_t, 64, 64, 64, 4, 1);                       \
   instantiate_qwen35_q_affine_qmm_t_nax(                                     \
-      bits, group_suffix, bfloat16_t, 64, 64, 64, 4, 1);                      \
-  instantiate_qwen35_q_affine_qmm_t_nax(                                     \
-      bits, group_suffix, float16_t, 64, 64, 64, 1, 4);                       \
-  instantiate_qwen35_q_affine_qmm_t_nax(                                     \
-      bits, group_suffix, bfloat16_t, 64, 64, 64, 1, 4)
+      bits, group_suffix, bfloat16_t, 64, 64, 64, 4, 1)
 
 define_qwen35_q_affine_qmm_t_nax(4, 64, )
 define_qwen35_q_affine_qmm_t_nax(5, 64, )

--- a/omlx/custom_kernels/qwen35_prefill/fast.py
+++ b/omlx/custom_kernels/qwen35_prefill/fast.py
@@ -824,7 +824,35 @@ _nax_available_cache: bool | None = None
 _stock_nax_cache: bool | None = None
 _qmm_nax_cache: bool | None = None
 
-QMM_NAX_VARIANT = int(os.environ.get("OMLX_QWEN35_QMM_NAX_VARIANT", "0"))
+# Bundled NAX tiles (must match qwen_q_affine_nax_variant in qwen35_prefill.cpp):
+#   0: 64x64x64 wm2 wn2 (stock MLX tile, default)   1: bm 32   2: bm 128
+#   3: bn 128   4: bk 32   5: wm4 wn1
+# benchmarks/bench_qwen35_nax_qmm_variants.py compares them against stock.
+NAX_QMM_VARIANTS = range(6)
+_qmm_nax_variant_warned = False
+
+
+def _resolve_qmm_nax_variant() -> int:
+    global _qmm_nax_variant_warned
+    raw = os.environ.get("OMLX_QWEN35_QMM_NAX_VARIANT", "0").strip()
+    try:
+        variant = int(raw)
+    except ValueError:
+        variant = -1
+    if variant in NAX_QMM_VARIANTS:
+        return variant
+    if not _qmm_nax_variant_warned:
+        _qmm_nax_variant_warned = True
+        logger.warning(
+            "OMLX_QWEN35_QMM_NAX_VARIANT=%r is not a bundled NAX tile "
+            "(valid: 0-%d); using variant 0",
+            raw,
+            NAX_QMM_VARIANTS[-1],
+        )
+    return 0
+
+
+QMM_NAX_VARIANT = _resolve_qmm_nax_variant()
 
 
 def _nax_available_fallback(

--- a/tests/test_nax.py
+++ b/tests/test_nax.py
@@ -136,3 +136,53 @@ def test_ane_hybrid_nax_capability_reports_native_state(monkeypatch):
 def test_ane_hybrid_nax_capability_is_false_for_older_extension(monkeypatch):
     monkeypatch.setattr(fast, "_ext", types.SimpleNamespace())
     assert fast.qwen35_ane_hybrid_nax_enabled() is False
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [("0", 0), ("5", 5), ("6", 0), ("-1", 0), ("junk", 0), (" 2 ", 2)],
+)
+def test_qmm_nax_variant_env_is_validated(monkeypatch, raw, expected):
+    monkeypatch.setenv("OMLX_QWEN35_QMM_NAX_VARIANT", raw)
+    monkeypatch.setattr(fast, "_qmm_nax_variant_warned", False)
+    assert fast._resolve_qmm_nax_variant() == expected
+
+
+def _nax_qmm_ready() -> bool:
+    return (
+        fast.is_native_available()
+        and fast.is_nax_available()
+        and fast.nax_qmm_kernels_built()
+        and fast._qmm_use_nax()
+    )
+
+
+@pytest.mark.skipif(not _nax_qmm_ready(), reason="bundled NAX qmm kernels unavailable")
+@pytest.mark.parametrize("bits", [4, 8])
+@pytest.mark.parametrize("group_size", [64, 128])
+@pytest.mark.parametrize("variant", list(fast.NAX_QMM_VARIANTS))
+def test_every_bundled_nax_qmm_tile_matches_stock(
+    monkeypatch, bits, group_size, variant
+):
+    """Each opt-in tile must reproduce stock MLX (the dropped wn=4 tile did not)."""
+    import mlx.core as mx
+
+    n, k, t = 640, 512, 320
+    keys = mx.random.split(mx.random.key(bits * 100 + variant), 2)
+    w = (mx.random.normal((n, k), key=keys[0]) * 0.05).astype(mx.bfloat16)
+    wq, scales, biases = mx.quantize(w, group_size=group_size, bits=bits)
+    x = mx.random.normal((1, t, k), key=keys[1]).astype(mx.bfloat16)
+    ref = mx.quantized_matmul(
+        x, wq, scales, biases, transpose=True, group_size=group_size, bits=bits
+    )
+    monkeypatch.setattr(fast, "QMM_NAX_VARIANT", variant)
+    native = getattr(fast, f"qwen35_q{bits}_affine_qmm_t")
+    out = native(x, wq, scales, biases, 8, group_size)
+    ref32 = ref.astype(mx.float32)
+    err = mx.abs(out.astype(mx.float32) - ref32).max().item()
+    scale = mx.abs(ref32).max().item()
+    # Reduction order costs at most a bf16 ulp or two; the dropped wn=4 tile
+    # was off by whole units (err ~ scale).
+    assert err <= 0.02 * scale, (
+        f"variant {variant} q{bits}/gs{group_size}: max err {err} (scale {scale})"
+    )


### PR DESCRIPTION
## Summary
- `OMLX_QWEN35_QMM_NAX_VARIANT=6` (64x64x64, wm=1/wn=4) returns wrong output on M5 Max / mlx 0.32.2: max abs error 5-8 against stock `quantized_matmul` at every tested shape, q4/q8, gs64/gs128, while variants 0-5 agree to a bf16 ulp. Remove the tile.
- Validate the env knob in Python: out-of-range or non-numeric values warn once and use variant 0 instead of raising from inside a prefill.
- Add `benchmarks/bench_qwen35_nax_qmm_variants.py` (stock vs each bundled tile at Qwen4-Exp GDN/attention projection shapes) and a hardware test covering every remaining tile.

## Measurements (M5 Max, ms per call, T=8192)
| shape | q8 stock | q8 v0 | q8 v2 | q4 stock | q4 v0 | q4 v2 |
|---|---|---|---|---|---|---|
| gdn.in_proj_qkv 10240x2560 | 18.97 | 18.14 | 15.01 | 8.14 | 7.99 | 8.96 |
| attn.q_proj 12288x2560 | 19.57 | 19.38 | 17.16 | 17.24 | 17.11 | 15.96 |
| attn.o_proj 2560x6144 | 10.06 | 10.17 | 9.76 | 8.46 | 8.58 | 8.13 |

Variant 2 (bm=128) wins 5-20% at 8-bit but is mixed at 4-bit, so the default stays at variant 0.

## Test plan
- [x] `tests/test_nax.py`: env validation cases; every bundled tile vs stock for q4/q8 x gs64/gs128 (52 pass)
- [x] `tests/test_qwen35_q4_mlp.py`, `tests/test_qwen35_ane_prefill.py`, `tests/test_qwen35_moe_weighted_sum.py` pass with the rebuilt extension

## End-to-end
Variant 0 vs 2 with the q8 route forced on at 2048 tokens: 1208-1223 vs 1204-1273 tok/s at 16k, indistinguishable. The PR is the variant-6 correctness fix plus tooling; no default change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUwVt6F1YHbTLvNvmAGEvU