### PR TITLE
feat(qwen4-exp): stream MoE routed-expert weights off the wired/phys budget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,11 @@ packaging/_export/
 packaging/_build/
 *.dmg
 
+# Out-of-tree custom-kernel dev build dirs (CMakeCache.txt, CMakeFiles/,
+# Makefile, libnanobind-static.a, .o -- never committed). Distinct name from
+# the already-ignored build/, so it needs its own rule.
+build_dev/
+
 # Generated engine commit metadata (build-time artifact)
 omlx/_engine_commits.json
 

--- a/Formula/omlx.rb
+++ b/Formula/omlx.rb
@@ -1,5 +1,5 @@
 class Omlx < Formula
-  CUSTOM_KERNELS = %w[bonsai decode_fast glm_moe_dsa minimax_m3 qwen35_prefill].freeze
+  CUSTOM_KERNELS = %w[bonsai decode_fast glm_moe_dsa minimax_m3 qwen35_prefill qwen4_moe_stream].freeze
 
   desc "LLM inference server optimized for Apple Silicon"
   homepage "https://github.com/jundot/omlx"

--- a/omlx/custom_kernels/__init__.py
+++ b/omlx/custom_kernels/__init__.py
@@ -11,6 +11,7 @@ NATIVE_KERNEL_PACKAGES = (
     "glm_moe_dsa",
     "minimax_m3",
     "qwen35_prefill",
+    "qwen4_moe_stream",
 )
 
 

--- a/omlx/custom_kernels/qwen4_moe_stream/__init__.py
+++ b/omlx/custom_kernels/qwen4_moe_stream/__init__.py
@@ -1,0 +1,3 @@
+from . import fast
+
+__all__ = ["fast"]

--- a/omlx/custom_kernels/qwen4_moe_stream/csrc/CMakeLists.txt
+++ b/omlx/custom_kernels/qwen4_moe_stream/csrc/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.27)
+project(qwen4_moe_stream LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+find_package(Python 3.8 COMPONENTS Interpreter Development.Module REQUIRED)
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
+find_package(nanobind CONFIG REQUIRED)
+
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -m mlx --cmake-dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE MLX_ROOT)
+find_package(MLX CONFIG REQUIRED)
+
+# No custom Metal kernels: this extension only wraps mmap'd buffers as mx.arrays;
+# all compute stays on stock mlx::core::gather_qmm. NB_DOMAIN mlx is load-bearing
+# -- it must match the domain the mlx wheel was built with or the mx.array type
+# caster is isolated and abi_probe fails (fast.py then disables the native path).
+nanobind_add_module(_ext
+  NB_STATIC STABLE_ABI LTO NOMINSIZE
+  NB_DOMAIN mlx
+  ${CMAKE_CURRENT_LIST_DIR}/bindings.cpp)
+target_include_directories(_ext PRIVATE ${MLX_INCLUDE_DIRS})
+target_link_libraries(_ext PRIVATE mlx
+  "-framework Metal" "-framework Foundation" "-framework IOSurface")
+
+if(BUILD_SHARED_LIBS)
+  target_link_options(_ext PRIVATE
+    -Wl,-rpath,@loader_path
+    -Wl,-rpath,@loader_path/../../../mlx/lib)  # resolve the mlx wheel's libmlx.dylib
+endif()

--- a/omlx/custom_kernels/qwen4_moe_stream/csrc/bindings.cpp
+++ b/omlx/custom_kernels/qwen4_moe_stream/csrc/bindings.cpp
@@ -1,0 +1,184 @@
+// qwen4_moe_stream: stream qwen4_exp MoE routed-expert (switch_mlp) weights off
+// the wired/phys budget by wrapping a page-aligned mmap'd artifact in MLX arrays.
+//
+// No custom Metal kernel: the wrapped arrays feed the STOCK mlx::core::gather_qmm
+// path unchanged (validated bit-exact, 2-bit + 4-bit, decode + sorted-prefill).
+// This module only (1) mmaps the streaming artifact, (2) hands out mx.array views
+// over individual page-aligned tensor regions via allocator::make_buffer, and
+// (3) tears the mapping down on unload. make_buffer wrappers MUST be released with
+// allocator::release (mlx/allocator.h) -- a no-op deleter leaks one wrapper handle
+// per wrapped tensor per load/unload cycle. release() frees only the lightweight
+// MTL::Buffer wrapper object, never the mmap'd bytes (the mapping owns those).
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <cstring>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
+
+#include "mlx/allocator.h"
+#include "mlx/array.h"
+
+namespace omlx::qwen4_moe_stream {
+namespace mx = mlx::core;
+
+constexpr size_t kPage = 16384;  // artifact page size (must match repack.py PAGE)
+
+static size_t align_up(size_t n, size_t a = kPage) { return (n + a - 1) / a * a; }
+
+struct Mapping {
+  void* base = nullptr;
+  size_t size = 0;
+  int fd = -1;
+  long refcount = 0;    // outstanding wrapped arrays pointing into this mapping
+  bool closed = false;  // close_artifact called; unmap deferred until refcount 0
+};
+
+static std::mutex g_mu;
+static std::unordered_map<int, Mapping> g_maps;
+static int g_next_id = 1;
+
+// Tear down a mapping (must hold g_mu). Safe no-op if already gone.
+static void unmap_locked(std::unordered_map<int, Mapping>::iterator it) {
+  ::munmap(it->second.base, it->second.size);
+  ::close(it->second.fd);
+  g_maps.erase(it);
+}
+
+// Called by each wrapped array's deleter when it is destroyed: drop one ref and,
+// if close_artifact already ran and this was the last live array, unmap now.
+static void release_ref(int id) {
+  std::lock_guard<std::mutex> lk(g_mu);
+  auto it = g_maps.find(id);
+  if (it == g_maps.end()) return;
+  if (it->second.refcount > 0) it->second.refcount--;
+  if (it->second.closed && it->second.refcount == 0) unmap_locked(it);
+}
+
+// mmap the artifact read-only/shared; returns an opaque id used by wrap_tensor.
+// No madvise: the default policy is left in place. Experts are gathered sparsely
+// at serving time, but the initial warm-up/canary sweep faults in sequentially,
+// and MADV_RANDOM would penalize that first pass -- default advice measured well
+// (3.1-4.3 GB/s fault-in). Revisit under Phase-A measurement if needed.
+int mmap_artifact(const std::string& path) {
+  int fd = ::open(path.c_str(), O_RDONLY);
+  if (fd < 0) throw std::runtime_error("mmap_artifact: open failed: " + path);
+  struct stat st{};
+  if (::fstat(fd, &st) != 0) {
+    ::close(fd);
+    throw std::runtime_error("mmap_artifact: fstat failed: " + path);
+  }
+  void* base = ::mmap(nullptr, static_cast<size_t>(st.st_size), PROT_READ,
+                      MAP_SHARED, fd, 0);
+  if (base == MAP_FAILED) {
+    ::close(fd);
+    throw std::runtime_error("mmap_artifact: mmap failed: " + path);
+  }
+  std::lock_guard<std::mutex> lk(g_mu);
+  int id = g_next_id++;
+  g_maps[id] = Mapping{base, static_cast<size_t>(st.st_size), fd, 0, false};
+  return id;
+}
+
+// Mark the mapping closed. Unmap immediately only if no wrapped arrays still
+// point into it; otherwise defer the munmap to the last array's deleter. This
+// removes the close-while-alive hazard: a GPU touch of a wrapped array after
+// close() can no longer fault on unmapped memory (Fable review 2, issue 4).
+void close_artifact(int id) {
+  std::lock_guard<std::mutex> lk(g_mu);
+  auto it = g_maps.find(id);
+  if (it == g_maps.end()) return;
+  it->second.closed = true;
+  if (it->second.refcount == 0) unmap_locked(it);
+}
+
+// Total bytes currently mmap'd across all live artifacts. The Python side feeds
+// this to the enforcer's register_external_wired_provider() as the worst-case
+// externally-wired figure (all expert pages resident under sustained serving).
+size_t mapped_bytes() {
+  std::lock_guard<std::mutex> lk(g_mu);
+  size_t total = 0;
+  for (auto& kv : g_maps) total += kv.second.size;
+  return total;
+}
+
+static mx::Dtype dtype_from_str(const std::string& s) {
+  if (s == "uint32" || s == "U32") return mx::uint32;
+  if (s == "bfloat16" || s == "BF16") return mx::bfloat16;
+  if (s == "float16" || s == "F16") return mx::float16;
+  if (s == "uint16" || s == "U16") return mx::uint16;
+  if (s == "uint8" || s == "U8") return mx::uint8;
+  throw std::runtime_error("wrap_tensor: unsupported dtype: " + s);
+}
+
+// Return an mx.array viewing [offset, offset+len) of artifact `id` as `shape`/
+// `dtype`, backed by external mmap memory (no copy). offset MUST be page-aligned
+// (guaranteed by repack.py) so the underlying pointer is page-aligned for
+// newBufferWithBytesNoCopy. The MTLBuffer is created over a page-rounded length
+// (each tensor's region is page-padded in the artifact, so the rounded span
+// stays inside the file and never overlaps the next tensor); the array itself
+// only ever addresses the logical `length` bytes described by shape*itemsize.
+mx::array wrap_tensor(int id, size_t offset, size_t length,
+                      std::vector<int> shape, const std::string& dtype) {
+  void* base = nullptr;
+  size_t buf_len = align_up(length);
+  {
+    std::lock_guard<std::mutex> lk(g_mu);
+    auto it = g_maps.find(id);
+    if (it == g_maps.end())
+      throw std::runtime_error("wrap_tensor: unknown artifact id");
+    if (it->second.closed)
+      throw std::runtime_error("wrap_tensor: artifact already closed");
+    if (offset % kPage != 0)
+      throw std::runtime_error("wrap_tensor: offset not page-aligned");
+    if (offset + buf_len > it->second.size)
+      throw std::runtime_error("wrap_tensor: region out of bounds");
+    base = it->second.base;
+    it->second.refcount++;  // one ref per wrapped array; deleter drops it
+  }
+  mx::allocator::Buffer buf =
+      mx::allocator::make_buffer(static_cast<char*>(base) + offset, buf_len);
+  mx::Shape sh(shape.begin(), shape.end());
+  // Sanctioned single-step constructor: array(Buffer, Shape, Dtype, Deleter).
+  // Marks the array available; no set_status needed. The deleter releases the
+  // make_buffer wrapper AND drops this mapping's refcount (deferred-unmap safe).
+  return mx::array(buf, std::move(sh), dtype_from_str(dtype),
+                   [id](mx::allocator::Buffer b) {
+                     mx::allocator::release(b);
+                     release_ref(id);
+                   });
+}
+
+}  // namespace omlx::qwen4_moe_stream
+
+namespace nb = nanobind;
+using namespace nb::literals;
+
+NB_MODULE(_ext, m) {
+  m.doc() = "qwen4_exp MoE expert weight streaming (mmap'd page-aligned artifact)";
+
+  // ABI canary (matches glm_moe_dsa/qwen35_prefill): if the nanobind ABI does
+  // not match the mlx wheel, passing an mx.array here fails and fast.py disables
+  // the native path instead of crashing.
+  m.def(
+      "abi_probe",
+      [](const mlx::core::array& a) { return static_cast<int64_t>(a.size()); },
+      "a"_a);
+
+  m.def("mmap_artifact", &omlx::qwen4_moe_stream::mmap_artifact, "path"_a);
+  m.def("close_artifact", &omlx::qwen4_moe_stream::close_artifact, "id"_a);
+  m.def("mapped_bytes", &omlx::qwen4_moe_stream::mapped_bytes);
+  m.def("wrap_tensor", &omlx::qwen4_moe_stream::wrap_tensor, "id"_a, "offset"_a,
+        "length"_a, "shape"_a, "dtype"_a);
+}

--- a/omlx/custom_kernels/qwen4_moe_stream/fast.py
+++ b/omlx/custom_kernels/qwen4_moe_stream/fast.py
@@ -1,0 +1,90 @@
+"""Native wrappers for qwen4_exp MoE expert weight streaming.
+
+Thin, ABI-guarded surface over the ``_ext`` nanobind module. If the native
+extension is absent or built against a mismatched nanobind ABI, every entry
+point degrades gracefully: :func:`is_native_available` returns ``False`` and the
+loader falls back to resident weights (no streaming). This mirrors the
+glm_moe_dsa / qwen35_prefill pattern (per-module ``fast.py`` + ``abi_probe``).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())
+logger = logging.getLogger(__name__)
+
+try:
+    from . import _ext  # type: ignore
+except Exception as exc:  # noqa: BLE001
+    _ext = None
+    _IMPORT_ERROR: Exception | None = exc
+    if any(Path(__file__).parent.glob("_ext*.so")):
+        logger.warning(
+            "qwen4_moe_stream native extension is present but failed to load; "
+            "expert streaming disabled: %s",
+            exc,
+        )
+else:
+    _IMPORT_ERROR = None
+
+_ABI_OK: bool | None = None
+
+
+def _verify_abi() -> bool:
+    """One-shot nanobind-ABI canary: pass an mx.array through the native
+    boundary. A mismatched nanobind isolates the ``mlx`` NB_DOMAIN and this
+    raises, so we disable the native path instead of risking a hard crash."""
+    global _ABI_OK
+    if _ABI_OK is not None:
+        return _ABI_OK
+    if _ext is None:
+        _ABI_OK = False
+        return False
+    try:
+        import mlx.core as mx
+
+        probe = mx.zeros((3,), dtype=mx.uint32)
+        _ABI_OK = int(_ext.abi_probe(probe)) == 3
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("qwen4_moe_stream ABI probe failed; disabling: %s", exc)
+        _ABI_OK = False
+    return _ABI_OK
+
+
+def is_native_available() -> bool:
+    return _ext is not None and _verify_abi()
+
+
+def import_error() -> Exception | None:
+    return _IMPORT_ERROR
+
+
+def mmap_artifact(path: str) -> int:
+    """mmap a page-aligned streaming artifact; returns an opaque id."""
+    if not is_native_available():
+        raise RuntimeError("qwen4_moe_stream native extension unavailable")
+    return int(_ext.mmap_artifact(str(path)))
+
+
+def close_artifact(artifact_id: int) -> None:
+    if _ext is not None:
+        _ext.close_artifact(int(artifact_id))
+
+
+def mapped_bytes() -> int:
+    """Total bytes currently mmap'd across all live artifacts (worst-case
+    externally-wired figure for the enforcer's external-wired provider)."""
+    if _ext is None:
+        return 0
+    return int(_ext.mapped_bytes())
+
+
+def wrap_tensor(artifact_id: int, offset: int, length: int, shape, dtype: str):
+    """Return an mx.array viewing a page-aligned tensor region of the artifact,
+    backed by external mmap memory (no copy)."""
+    if not is_native_available():
+        raise RuntimeError("qwen4_moe_stream native extension unavailable")
+    return _ext.wrap_tensor(int(artifact_id), int(offset), int(length),
+                            [int(d) for d in shape], str(dtype))

--- a/omlx/custom_kernels/qwen4_moe_stream/loader.py
+++ b/omlx/custom_kernels/qwen4_moe_stream/loader.py
@@ -1,0 +1,264 @@
+"""qwen4_exp MoE expert weight streaming -- load-time interception.
+
+Streams the ~46.87 GB of routed-expert (``switch_mlp``) weights off the wired /
+phys memory budget by binding them as mmap-backed mx.arrays over a page-aligned
+artifact (built by ``moe_repack``), instead of loading them resident.
+
+Interception seam (critical): we replace the ``switch_mlp.*`` entries in the
+weights list **before** ``model.load_weights`` -> ``mx.eval(model.parameters())``.
+Because safetensors weights are loaded lazily, swapping the value before that
+eval means the original resident arrays are *never materialized* -- that is the
+entire point (a post-load module walk would first spike ~46.87 GB resident, then
+free it, defeating streaming). The wrapped arrays are already "available"
+(external buffer), so the eval over them is a no-op copy.
+
+Key matching is canonical -- (is_mtp, layer_idx, projection, suffix) -- so it is
+robust to the MTP prefix differing between the checkpoint key
+(``language_model.mtp.layers.N...``) and the bound module path (``mtp.layers.N...``).
+
+Quantization params (bits/group_size/mode) are NOT touched here: they live on the
+``QuantizedSwitchLinear`` module and drive gather_qmm; we only swap the three
+arrays (weight/scales/biases), whose shapes/dtypes match the module slots.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import struct
+from pathlib import Path
+from typing import Optional
+
+from omlx.utils import proc_memory
+
+from . import fast
+
+logger = logging.getLogger(__name__)
+
+# Registry name for the external-wired provider (see omlx/utils/proc_memory.py).
+# Name-keyed + replace-on-register => registering on every load is idempotent.
+_PROVIDER_NAME = "qwen4_moe_stream"
+
+# ...layers.{i}.mlp.switch_mlp.{proj}.{suffix}  (proj in gate/up/down_proj,
+# suffix in weight/scales/biases). Matches both the regular and MTP forms.
+_CANON_RE = re.compile(
+    r"layers\.(\d+)\.mlp\.switch_mlp\."
+    r"(gate_proj|up_proj|down_proj)\.(weight|scales|biases)$"
+)
+
+
+def canonical_key(key: str) -> Optional[tuple[bool, int, str, str]]:
+    """Parse a state-dict / manifest key into (is_mtp, layer_idx, proj, suffix),
+    or None if it is not a switch_mlp expert tensor."""
+    m = _CANON_RE.search(key)
+    if m is None:
+        return None
+    is_mtp = ".mtp." in key or key.startswith("mtp.")
+    return (is_mtp, int(m.group(1)), m.group(2), m.group(3))
+
+
+class StreamingArtifact:
+    """Owns the mmap of a streaming artifact and hands out wrapped mx.arrays,
+    indexed by canonical key so lookups survive prefix differences."""
+
+    def __init__(self, path: str):
+        self.path = str(path)
+        with open(self.path, "rb") as f:
+            mlen = struct.unpack("<Q", f.read(8))[0]
+            manifest = json.loads(f.read(mlen))
+        self.page_size = int(manifest.get("page_size", 16384))
+        # canonical tuple -> manifest tensor entry
+        self._by_canon: dict[tuple, dict] = {}
+        for k, entry in manifest["tensors"].items():
+            canon = canonical_key(k)
+            if canon is None:
+                continue
+            self._by_canon[canon] = entry
+        self._id: Optional[int] = None
+
+    def __len__(self) -> int:
+        return len(self._by_canon)
+
+    def open(self) -> None:
+        if self._id is None:
+            self._id = fast.mmap_artifact(self.path)
+            # Register the enforcer external-wired provider exactly once (by
+            # name; replace-on-register makes repeated opens harmless). The
+            # provider reports the GLOBAL mmap'd total, so it must never be
+            # registered per-open under an append-only API -- proc_memory's
+            # name-keyed registry guarantees that. Never unregistered: it
+            # returns 0 once nothing is mapped.
+            proc_memory.register_external_wired_provider(
+                _PROVIDER_NAME, fast.mapped_bytes
+            )
+
+    def close(self) -> None:
+        if self._id is not None:
+            fast.close_artifact(self._id)
+            self._id = None
+
+    def has(self, canon: tuple) -> bool:
+        return canon in self._by_canon
+
+    def wrap(self, canon: tuple):
+        """Return the mmap-backed mx.array for a canonical key."""
+        if self._id is None:
+            self.open()
+        e = self._by_canon[canon]
+        return fast.wrap_tensor(self._id, e["offset"], e["length"],
+                                e["shape"], e["dtype"])
+
+    def provider(self) -> Callable[[], int]:
+        """Enforcer external-wired provider: bytes currently mmap'd (global sum
+        across all live artifacts). Cheap, non-blocking, never touches MLX."""
+        return fast.mapped_bytes
+
+
+def stream_weight_items(items, artifact: StreamingArtifact, *, expect_all: bool = False):
+    """Transform a ``[(key, array), ...]`` weights list, replacing every
+    switch_mlp expert tensor the artifact provides with its mmap-backed array.
+
+    MUST run POST-sanitize: the vendored ``sanitize`` renames keys (e.g.
+    ``language_model.mtp.*`` -> ``mtp.*``) and can restack expert layouts. Run
+    pre-sanitize and canonical matching silently finds nothing -- every tensor
+    passes through and the model loads fully resident with no error (the
+    pass-through design hides it). ``expect_all`` closes that trap: when the
+    caller knows the full artifact must be consumed (the live wire-in), it hard
+    -fails on any shortfall so silent-resident is impossible.
+
+    Returns ``(new_items, n_swapped, n_missing)``. Non-expert entries and any
+    expert the artifact lacks or that shape/dtype-mismatches pass through
+    untouched (partial artifact / stray tensor degrades to resident, not crash).
+    """
+    new_items = []
+    n_swapped = 0
+    n_missing = 0
+    for key, value in items:
+        canon = canonical_key(key)
+        if canon is None:
+            new_items.append((key, value))
+            continue
+        if not artifact.has(canon):
+            n_missing += 1
+            new_items.append((key, value))
+            continue
+        wrapped = artifact.wrap(canon)
+        # Shape/dtype must match the slot the checkpoint value would fill.
+        if list(wrapped.shape) != list(value.shape) or wrapped.dtype != value.dtype:
+            logger.warning(
+                "qwen4_moe_stream: shape/dtype mismatch for %s "
+                "(wrapped %s/%s vs checkpoint %s/%s); keeping resident",
+                key, wrapped.shape, wrapped.dtype, value.shape, value.dtype,
+            )
+            new_items.append((key, value))
+            continue
+        new_items.append((key, wrapped))
+        n_swapped += 1
+
+    # Mandatory telemetry: silent-resident must be impossible to miss.
+    expected = len(artifact)
+    if n_swapped == expected:
+        logger.info(
+            "qwen4_moe_stream: streamed %d/%d expert tensors (all resident "
+            "expert weight materialization avoided)", n_swapped, expected,
+        )
+    else:
+        logger.warning(
+            "qwen4_moe_stream: streamed only %d/%d expert tensors "
+            "(%d missing from artifact) -- the rest load RESIDENT. If this is "
+            "the full wire-in, the swap likely ran in the wrong place "
+            "(must be POST-sanitize).", n_swapped, expected, n_missing,
+        )
+        if expect_all:
+            raise RuntimeError(
+                f"qwen4_moe_stream: expected to stream all {expected} expert "
+                f"tensors but only swapped {n_swapped} (missing {n_missing}). "
+                f"Refusing silent-resident load; check swap runs post-sanitize."
+            )
+    return new_items, n_swapped, n_missing
+
+
+# Provider registration is now handled by StreamingArtifact.open() via the
+# name-keyed proc_memory registry (idempotent by construction). The former
+# id(enforcer)-guarded ensure_provider_registered() was removed: object-id reuse
+# after enforcer teardown could silently skip registration for a new enforcer at
+# a recycled address (Fable review 2, issue 5).
+
+
+def default_artifact_path(model_dir: str) -> Optional[str]:
+    """The PLE-style artifact sits next to the checkpoint."""
+    p = Path(model_dir) / "moe_experts_streaming.artifact"
+    return str(p) if p.exists() else None
+
+
+def streaming_offload_bytes(model_dir: str) -> int:
+    """Bytes that MoE expert streaming would take off the resident weight budget
+    for this model, or 0 if streaming would not engage. Mirrors the wire-in
+    gating (``_stream_qwen4_exp_experts_on_load``) EXACTLY so admission's
+    resident estimate matches whether streaming actually happens: native ext
+    available, ``OMLX_QWEN4_MOE_STREAM`` not disabled, artifact present. Returns
+    the artifact file size (== worst-case ``mapped_bytes`` once loaded). Cheap:
+    a single ``stat``, no mmap.
+    """
+    import os
+
+    if os.environ.get("OMLX_QWEN4_MOE_STREAM", "1").strip().lower() in (
+        "0", "false", "no", "off",
+    ):
+        return 0
+    if not fast.is_native_available():
+        return 0
+    path = default_artifact_path(str(model_dir))
+    if path is None:
+        return 0
+    try:
+        return int(os.path.getsize(path))
+    except OSError:
+        return 0
+
+
+def run_load_canary(artifact: StreamingArtifact, *, window: int = 4096) -> None:
+    """Load-time bit-exactness canary: force MLX to read a window of one wrapped
+    expert tensor through its external Metal buffer and compare, byte-for-byte,
+    against an independent CPU (numpy) read of the same artifact bytes. Raises on
+    any mismatch -- a silent wrong-bytes read (the page-alignment trap that
+    started this whole effort) becomes a hard, immediate load failure.
+
+    Picks the first available tensor deterministically; cheap (one small slice).
+    """
+    import mlx.core as mx
+    import numpy as np
+
+    if len(artifact) == 0:
+        raise RuntimeError("qwen4_moe_stream canary: artifact has no tensors")
+    canon = sorted(artifact._by_canon.keys())[0]
+    entry = artifact._by_canon[canon]
+    # Reinterpret through the integer storage dtype so numpy compares raw bytes
+    # exactly (BF16 has no numpy dtype; view it as uint16).
+    store_mx, store_np = (
+        (mx.uint16, np.uint16) if entry["dtype"] == "BF16" else (mx.uint32, np.uint32)
+    )
+    itemsize = np.dtype(store_np).itemsize
+    n = min(window, entry["length"] // itemsize)
+
+    # GPU/external path: force MLX to read a flat window through the ext buffer.
+    wrapped = artifact.wrap(canon)
+    raw = wrapped.reshape(-1)[:n].view(store_mx)
+    gpu_bytes = np.array(raw).tobytes()
+
+    # Independent CPU reference: raw bytes straight from the artifact file.
+    with open(artifact.path, "rb") as f:
+        f.seek(entry["offset"])
+        ref = f.read(n * itemsize)
+
+    if gpu_bytes != ref:
+        raise RuntimeError(
+            f"qwen4_moe_stream canary FAILED for {canon}: external buffer read "
+            f"does not match the artifact bytes (page-alignment / wrap bug). "
+            f"Refusing to serve wrong weights."
+        )
+    logger.info(
+        "qwen4_moe_stream: load-time bit-exactness canary passed (%s, %d %s vals)",
+        canon, n, entry["dtype"],
+    )

--- a/omlx/custom_kernels/qwen4_moe_stream/repack.py
+++ b/omlx/custom_kernels/qwen4_moe_stream/repack.py
@@ -1,0 +1,199 @@
+"""Repack qwen4_exp MoE expert (switch_mlp) tensors into a page-aligned,
+mmap-streaming artifact (PLE-artifact-style, separate file, non-destructive).
+
+Every tensor's data starts at a 16 KB page boundary so the streaming loader can
+create a page-aligned bytesNoCopy MTLBuffer and address each tensor via a
+page-aligned `set_buffer` offset (Metal requires >=4-byte offset alignment; ~80%
+of this checkpoint's shards are non-4-aligned in absolute file offset).
+
+Artifact layout:
+  [8-byte little-endian manifest_len][manifest JSON, then zero-pad to PAGE]
+  [tensor 0 data, zero-pad to PAGE][tensor 1 data, zero-pad to PAGE]...
+Manifest: {"page_size":N,
+           "tensors":{key:{offset,length,dtype,shape,bits,group_size,mode}}}
+
+Quantization params (bits/group_size/mode) are carried explicitly per tensor,
+read from config.json["quantization"] (global default + per-module overrides) --
+NEVER inferred from tensor shape. This checkpoint is NOT uniform: the 48 layer
+blocks are oQ2 2-bit gs32 but the MTP block's switch_mlp is 4-bit gs32 (packed
+dim 320 vs 160). Shape-inference of bits/gs is provably ambiguous, so the loader
+must consume these manifest fields directly.
+
+Usage: repack.py <out_path> [--model-dir DIR] [--subset N] [--verify]
+
+The source checkpoint directory is resolved (highest precedence first) from
+``--model-dir DIR``, then the ``OMLX_QWEN4_MODEL_DIR`` env var, then the example
+default below. It is NOT hardcoded -- point it at wherever the oQ2-MTP checkpoint
+lives on your machine.
+"""
+import json
+import os
+import struct
+import sys
+
+PAGE = 16384
+# Example checkpoint this artifact format was authored against. Override via
+# --model-dir or OMLX_QWEN4_MODEL_DIR; do not rely on this literal path.
+DEFAULT_MODEL_DIR = (
+    "/Users/alytaphoenix/.omlx/models/Vontra/Qwen3.8-Flash-Next-MLX-oQ2-MTP"
+)
+D = os.environ.get("OMLX_QWEN4_MODEL_DIR", DEFAULT_MODEL_DIR)
+
+
+def _align(n, a=PAGE):
+    return (n + a - 1) // a * a
+
+
+def _load_quant_config():
+    """config.json quantization block: global bits/group_size/mode + per-module
+    overrides (keyed by module path, e.g. '...switch_mlp.gate_proj')."""
+    q = json.load(open(os.path.join(D, "config.json")))["quantization"]
+    return q, q["bits"], q["group_size"], q["mode"]
+
+
+_QCFG = None
+
+
+def _quant_params(tensor_key):
+    """(bits, group_size, mode) for a tensor, from config -- never shape-inferred.
+    Override keys are MODULE paths, so strip the trailing .weight/.scales/.biases."""
+    global _QCFG
+    if _QCFG is None:
+        _QCFG = _load_quant_config()
+    q, gb, gg, gm = _QCFG
+    o = q.get(tensor_key.rsplit(".", 1)[0])
+    if isinstance(o, dict):
+        return int(o["bits"]), int(o["group_size"]), o.get("mode", gm)
+    return gb, gg, gm
+
+
+def _shard_header(path):
+    with open(path, "rb") as f:
+        n = struct.unpack("<Q", f.read(8))[0]
+        return json.loads(f.read(n)), 8 + n
+
+
+def enumerate_experts():
+    """Return [(key, shard_path, abs_offset, length, dtype, shape)] for every
+    switch_mlp tensor across all 49 MoE blocks (48 layers + MTP), grouped so a
+    subset takes whole blocks."""
+    idx = json.load(open(os.path.join(D, "model.safetensors.index.json")))["weight_map"]
+    headers = {}
+    out = []
+    for key, fn in idx.items():
+        if ".switch_mlp." not in key:
+            continue
+        path = os.path.join(D, fn)
+        if fn not in headers:
+            headers[fn] = _shard_header(path)
+        hdr, data_start = headers[fn]
+        e = hdr[key]
+        s, en = e["data_offsets"]
+        out.append((key, path, data_start + s, en - s, e["dtype"], e["shape"]))
+    # sort by (layer index parsed from key, key) for deterministic block grouping
+    import re
+
+    def layer_of(k):
+        m = re.search(r"layers\.(\d+)\.", k)
+        return int(m.group(1)) if m else 9999  # MTP block (no layers.N) sorts last
+
+    out.sort(key=lambda t: (layer_of(t[0]), t[0]))
+    return out
+
+
+def repack(out_path, subset=None, verify=False):
+    tensors = enumerate_experts()
+    if subset is not None:
+        # keep whole blocks: 9 tensors/block, so subset*9 tensors
+        tensors = tensors[: subset * 9]
+    print(f"repacking {len(tensors)} tensors "
+          f"({len(tensors)//9} blocks) -> {out_path}")
+
+    # Build manifest with page-aligned offsets (after the manifest block).
+    manifest = {"page_size": PAGE, "tensors": {}}
+    # placeholder to size the manifest; offsets depend on manifest length, so
+    # do a two-pass: assume a generous manifest size, then place data.
+    # Simpler: reserve one page for length header + manifest up to (blocks*~1KB).
+    def _entry(cur, key, length, dtype, shape):
+        bits, gs, mode = _quant_params(key)
+        return {"offset": cur, "length": length, "dtype": dtype, "shape": shape,
+                "bits": bits, "group_size": gs, "mode": mode}
+
+    est_manifest = 8 + len(json.dumps({
+        "page_size": PAGE,
+        "tensors": {k: _entry(0, k, ln, dt, sh)
+                    for (k, _, _, ln, dt, sh) in tensors},
+    }).encode()) + 4096
+    data_start = _align(est_manifest)
+
+    cur = data_start
+    for (key, _path, _off, length, dtype, shape) in tensors:
+        manifest["tensors"][key] = _entry(cur, key, length, dtype, shape)
+        cur += _align(length)
+    total = cur
+    mb = json.dumps(manifest).encode()
+    assert 8 + len(mb) <= data_start, "manifest bigger than reserved region"
+
+    # Write.
+    written = 0
+    with open(out_path, "wb") as w:
+        w.write(struct.pack("<Q", len(mb)))
+        w.write(mb)
+        w.write(b"\x00" * (data_start - 8 - len(mb)))  # pad to data_start
+        for (key, path, off, length, dtype, shape) in tensors:
+            tgt = manifest["tensors"][key]["offset"]
+            assert w.tell() == tgt, (w.tell(), tgt, key)
+            with open(path, "rb") as src:
+                src.seek(off)
+                remaining = length
+                while remaining:
+                    chunk = src.read(min(1 << 22, remaining))
+                    w.write(chunk)
+                    remaining -= len(chunk)
+            pad = _align(length) - length
+            if pad:
+                w.write(b"\x00" * pad)
+            written += 1
+            if written % 45 == 0:
+                print(f"  {written}/{len(tensors)} ({cur/1024**3:.1f}GB target)")
+    print(f"wrote {total/1024**3:.2f} GB")
+
+    if verify:
+        import mmap
+        import numpy as np
+        NPD = {"U32": np.uint32, "BF16": np.uint16}
+        with open(out_path, "rb") as af:
+            mm = mmap.mmap(af.fileno(), 0, access=mmap.ACCESS_READ)
+        mlen = struct.unpack("<Q", mm[:8])[0]
+        man = json.loads(mm[8:8 + mlen])
+        bad = 0
+        for (key, path, off, length, dtype, shape) in tensors:
+            t = man["tensors"][key]
+            assert t["offset"] % PAGE == 0, f"{key} not page-aligned"
+            a = np.frombuffer(mm[t["offset"]: t["offset"] + length], dtype=NPD[dtype])
+            with open(path, "rb") as src:
+                src.seek(off)
+                b = np.frombuffer(src.read(length), dtype=NPD[dtype])
+            if not np.array_equal(a, b):
+                bad += 1
+                print(f"  MISMATCH {key}")
+        print(f"verify: {len(tensors)-bad}/{len(tensors)} tensors byte-identical, "
+              f"all page-aligned")
+    return manifest
+
+
+if __name__ == "__main__":
+    out = sys.argv[1]
+    subset = None
+    if "--subset" in sys.argv:
+        subset = int(sys.argv[sys.argv.index("--subset") + 1])
+    if "--model-dir" in sys.argv:
+        # Reassign the module global read by _load_quant_config/enumerate_experts.
+        D = sys.argv[sys.argv.index("--model-dir") + 1]
+    if not os.path.isdir(D):
+        raise SystemExit(
+            f"model dir not found: {D!r}\n"
+            "Pass --model-dir DIR or set OMLX_QWEN4_MODEL_DIR to the oQ2-MTP "
+            "checkpoint directory."
+        )
+    repack(out, subset=subset, verify="--verify" in sys.argv)

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1128,6 +1128,135 @@ def _force_qwen4_exp_sanitize_on_load(model_dir: Path):
 
 
 @contextlib.contextmanager
+def _stream_qwen4_exp_experts_on_load(model_dir: Path):
+    """Stream qwen4_exp MoE routed-expert (switch_mlp) weights off the wired/phys
+    budget: bind them as mmap-backed arrays over a page-aligned artifact next to
+    the checkpoint instead of loading ~46.87 GB resident.
+
+    Runs POST-sanitize by construction -- mlx-vlm's load_model does
+    sanitize -> nn.quantize -> load_weights, so the load_weights patch here sees
+    final (post-sanitize, incl. ``mtp.*``-renamed) keys. Swapping the values in
+    the weights list BEFORE mlx-vlm's ``mx.eval`` means the originals are never
+    materialized. ``expect_all=True`` hard-fails on any shortfall, so a
+    mis-ordered / silent-resident load is impossible. A load-time bit-exactness
+    canary then guards against a wrong-bytes read.
+
+    No-op (resident fallback) unless: model_type is qwen4_exp, the native
+    extension is available, the artifact exists next to the checkpoint, and
+    streaming is not force-disabled via ``OMLX_QWEN4_MOE_STREAM=0``.
+    """
+    import os
+
+    if _read_config_model_type(model_dir) != "qwen4_exp":
+        yield
+        return
+    if os.environ.get("OMLX_QWEN4_MOE_STREAM", "1").strip().lower() in (
+        "0", "false", "no", "off",
+    ):
+        yield
+        return
+    try:
+        from omlx.custom_kernels.qwen4_moe_stream import fast as _qms_fast
+        from omlx.custom_kernels.qwen4_moe_stream import loader as _qms
+    except Exception as exc:  # noqa: BLE001
+        logger.info("qwen4_moe_stream import failed (%s); resident expert load", exc)
+        yield
+        return
+    if not _qms_fast.is_native_available():
+        logger.info(
+            "qwen4_moe_stream native extension unavailable; loading experts resident"
+        )
+        yield
+        return
+    artifact_path = _qms.default_artifact_path(str(model_dir))
+    if artifact_path is None:
+        logger.info(
+            "qwen4_moe_stream artifact not found next to %s; resident expert load",
+            model_dir.name,
+        )
+        yield
+        return
+
+    artifact = _qms.StreamingArtifact(artifact_path)
+    artifact.open()  # mmaps + registers the external-wired provider (idempotent)
+
+    import mlx.nn as _nn
+
+    original_load_weights = _nn.Module.load_weights
+    swapped_total = 0
+
+    def _patched_load_weights(self, weights_items, *args, **kwargs):
+        nonlocal swapped_total
+        if isinstance(weights_items, str):
+            return original_load_weights(self, weights_items, *args, **kwargs)
+        items = list(weights_items)
+        # Only the top-level model load carries the full switch_mlp set; any
+        # submodule load_weights lacks expert keys -> pass straight through.
+        has_experts = any(
+            isinstance(it, (tuple, list))
+            and len(it) >= 2
+            and isinstance(it[0], str)
+            and _qms.canonical_key(it[0]) is not None
+            for it in items
+        )
+        if not has_experts:
+            return original_load_weights(self, items, *args, **kwargs)
+        new_items, n_swapped, _n_missing = _qms.stream_weight_items(
+            items, artifact, expect_all=True
+        )
+        swapped_total += n_swapped
+        # Keep the mapping alive for the model's lifetime (wrapped arrays point
+        # into it); enables a future unload-time close.
+        try:
+            self._qwen4_moe_streaming_artifact = artifact
+        except Exception:  # noqa: BLE001
+            pass
+        return original_load_weights(self, new_items, *args, **kwargs)
+
+    _nn.Module.load_weights = _patched_load_weights
+    load_failed = False
+    try:
+        yield
+    except BaseException:
+        # The load body raised AFTER the weight swap (e.g. OOM during mx.eval).
+        # Record it so the finally block skips the success path: running the
+        # canary here would (a) mask this real failure if the canary itself
+        # raised (raise-inside-finally), and (b) log a false streaming success
+        # for a load that never completed.
+        load_failed = True
+        raise
+    finally:
+        _nn.Module.load_weights = original_load_weights
+        if load_failed:
+            # Failed load: no engine will hold the model, so the unload-time
+            # close never fires -- close here to release the ~47 GB mapping (a
+            # retry would otherwise double-map). Guard the close: an exception
+            # is already propagating and a raising close() would mask it.
+            try:
+                artifact.close()
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "qwen4_moe_stream: artifact.close() failed after a failed "
+                    "load; mapping may leak until process exit", exc_info=True
+                )
+        elif swapped_total > 0:
+            try:
+                _qms.run_load_canary(artifact)
+            except Exception:
+                artifact.close()  # never serve unverified/wrong weights
+                raise
+            logger.info(
+                "qwen4_moe_stream: streaming %d expert tensors for %s "
+                "(~%.1f GB off the resident budget)",
+                swapped_total, model_dir.name, artifact.provider()() / 1024**3,
+            )
+        else:
+            # Streaming never engaged -> drop the mapping so we don't pin ~47 GB
+            # of page cache behind a resident load.
+            artifact.close()
+
+
+@contextlib.contextmanager
 def _remap_nested_visual_on_load(model_dir: Path):
     """Remap ``language_model.model.visual.*`` → ``vision_tower.*`` during
     ``load_model`` for MLX-format models where sanitize is skipped.
@@ -1682,6 +1811,7 @@ class VLMBatchedEngine(BaseEngine):
                 _drop_gemma4_mlx_shared_kv_extras_on_load(Path(self._model_name)),
                 _force_minimax_m3_moe_sanitize_on_load(Path(self._model_name)),
                 _force_qwen4_exp_sanitize_on_load(Path(self._model_name)),
+                _stream_qwen4_exp_experts_on_load(Path(self._model_name)),
                 _remap_nested_visual_on_load(Path(self._model_name)),
                 _transpose_qwen35_mlx_vision_patch_embed_on_load(
                     Path(self._model_name)

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -52,7 +52,7 @@ from .exceptions import (
 )
 from .model_discovery import discover_models, format_size, is_realtime_stt_model
 from .scheduler import SchedulerConfig
-from .utils.proc_memory import get_phys_footprint
+from .utils.proc_memory import discount_external_wired, get_phys_footprint
 
 logger = logging.getLogger(__name__)
 
@@ -322,8 +322,93 @@ class EnginePool:
             return None
         return registry.get_for_model(entry.model_path)
 
+    def _qwen4_moe_streaming_offload_bytes(self, entry: EngineEntry) -> int:
+        """Bytes MoE expert streaming takes off this entry's resident weight
+        budget (0 if streaming would not engage). Mirrors the vlm wire-in gating
+        so the admission estimate agrees with reality."""
+        model_type = (entry.config_model_type or "").replace("-", "_").lower()
+        if model_type != "qwen4_exp":
+            return 0
+        try:
+            from .custom_kernels.qwen4_moe_stream import loader as _qms
+
+            return int(_qms.streaming_offload_bytes(entry.model_path))
+        except Exception:  # noqa: BLE001
+            return 0
+
+    def _extract_qwen4_streaming_artifact(self, engine):
+        """Return the MoE expert-streaming artifact attached to an engine's model
+        (see vlm._stream_qwen4_exp_experts_on_load), or None. The isinstance
+        check is load-bearing: Mock engines in tests auto-vivify a truthy
+        ``_qwen4_moe_streaming_artifact`` attribute, so only a genuine
+        StreamingArtifact must trigger the unload-close path."""
+        if engine is None:
+            return None
+        model = getattr(engine, "_model", None) or getattr(engine, "_vlm_model", None)
+        if model is None:
+            return None
+        artifact = getattr(model, "_qwen4_moe_streaming_artifact", None)
+        if artifact is None:
+            return None
+        try:
+            from .custom_kernels.qwen4_moe_stream.loader import StreamingArtifact
+        except Exception:  # noqa: BLE001
+            return None
+        return artifact if isinstance(artifact, StreamingArtifact) else None
+
+    async def _close_qwen4_streaming_artifact(self, model_id: str, artifact) -> None:
+        """Close a streaming artifact on unload, freeing the ~46.9GB mmap so the
+        ceiling recovers (LIVE TEST 1 issue C: eviction left it mapped, keeping
+        external_wired high and the ceiling collapsed).
+
+        Ordering (Fable): model refs already dropped (stop + settle above) ->
+        drain GPU -> close -> verify mapped_bytes()==0. The refcounted deferred
+        unmap keeps this safe even if a wrapped array outlives this point: the
+        munmap then completes when that last array is freed.
+        """
+        loop = asyncio.get_running_loop()
+        try:
+            from .custom_kernels.qwen4_moe_stream import fast as _qms_fast
+
+            # Run deleters + drain the GPU so no in-flight command reads the
+            # buffers before a (possible) immediate unmap.
+            await loop.run_in_executor(
+                get_mlx_executor(), lambda: (gc.collect(), mx.synchronize())
+            )
+            artifact.close()
+            remaining = _qms_fast.mapped_bytes()
+            if remaining == 0:
+                logger.info(
+                    "qwen4_moe_stream: unmapped streaming artifact for %s "
+                    "(ceiling restored)",
+                    model_id,
+                )
+            else:
+                logger.warning(
+                    "qwen4_moe_stream: %s streaming artifact still %s mapped "
+                    "after close (a wrapped array outlived unload; deferred "
+                    "unmap will finish when it frees)",
+                    model_id,
+                    format_size(remaining),
+                )
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "qwen4_moe_stream: error closing streaming artifact for %s",
+                model_id,
+                exc_info=True,
+            )
+
     def _entry_resident_size(self, entry: EngineEntry) -> int:
         """Return this process's planned weights, not the full cluster model."""
+
+        # MoE expert streaming makes the routed experts reclaimable page cache,
+        # off the resident WEIGHT budget: resident weights ~= full model minus
+        # the streamed artifact. This must win over runtime_estimated_size (the
+        # PLE-era estimate that is streaming-unaware) or reload is refused
+        # against a footprint that is no longer resident (LIVE TEST 1).
+        streamed = self._qwen4_moe_streaming_offload_bytes(entry)
+        if streamed > 0 and entry.estimated_size:
+            return max(0, entry.estimated_size - streamed)
 
         if entry.runtime_estimated_size is not None:
             return entry.runtime_estimated_size
@@ -1655,7 +1740,7 @@ class EnginePool:
                     # large model load without evicting the first, over-
                     # committing past the ceiling (#1623).
                     current = max(
-                        mx.get_active_memory(),
+                        discount_external_wired(mx.get_active_memory()),
                         get_phys_footprint(),
                         self._current_model_memory,
                     )
@@ -1706,7 +1791,8 @@ class EnginePool:
                         # keep trusting phys_footprint because it may be
                         # unrelated process pressure rather than model residue.
                         committed = max(
-                            mx.get_active_memory(), self._current_model_memory
+                            discount_external_wired(mx.get_active_memory()),
+                            self._current_model_memory,
                         )
                         committed_projected = committed + admission_size
                         if committed_projected <= ceiling:
@@ -2022,7 +2108,12 @@ class EnginePool:
                 )
 
             while True:
-                active = mx.get_active_memory()
+                # discount_external_wired: the mmap'd MoE streaming artifact
+                # inflates mx.get_active_memory() but not phys_footprint (or
+                # real memory pressure) -- see proc_memory.py. Undiscounted,
+                # this loop would see phantom usage and evict/reclaim against
+                # a model that isn't actually short on real memory.
+                active = discount_external_wired(mx.get_active_memory())
                 footprint = get_phys_footprint()
                 current = max(active, footprint, self._current_model_memory)
                 if current + predicted <= target:
@@ -2327,7 +2418,13 @@ class EnginePool:
         logger.info(f"Unloading model: {model_id} (immediate abort)")
         distributed = self._distributed_deployment_for_entry(entry) is not None
         resident_size = self._entry_resident_size(entry)
-        pre_unload_active = 0 if distributed else mx.get_active_memory()
+        pre_unload_active = (
+            0 if distributed else discount_external_wired(mx.get_active_memory())
+        )
+        # Capture any MoE expert-streaming artifact BEFORE stop() releases the
+        # model; it is closed after the GPU settle/drain below (Fable ordering:
+        # drop model refs -> drain -> close -> verify mapped_bytes==0).
+        streaming_artifact = self._extract_qwen4_streaming_artifact(entry.engine)
 
         try:
             await entry.engine.stop()
@@ -2429,7 +2526,12 @@ class EnginePool:
         settled = False
         settle_indeterminate = False
         for _settle_round in range(10):
-            active_now = mx.get_active_memory()
+            # Discount external-wired bytes at the same instant as the sample
+            # (pre_unload_active was discounted too, so the delta is consistent).
+            # If a streaming artifact's munmap lands between this sample and the
+            # discount, one poll's freed-figure is skewed by the external total;
+            # the settle loop self-corrects on the next tick.
+            active_now = discount_external_wired(mx.get_active_memory())
             actual_freed = pre_unload_active - active_now
             if actual_freed >= min_expected_freed:
                 settled = True
@@ -2501,7 +2603,7 @@ class EnginePool:
                     lambda: (mx.synchronize(), mx.clear_cache()),
                 )
                 await asyncio.sleep(1.0)
-            active_after = mx.get_active_memory()
+            active_after = discount_external_wired(mx.get_active_memory())
             if active_after > self._current_model_memory + 5 * 1024**3:
                 logger.error(
                     f"Emergency reclaim failed for '{model_id}': "
@@ -2514,6 +2616,9 @@ class EnginePool:
                     f"Emergency reclaim succeeded: "
                     f"active_memory={format_size(active_after)}"
                 )
+
+        if streaming_artifact is not None:
+            await self._close_qwen4_streaming_artifact(model_id, streaming_artifact)
 
         self._wake_process_memory_enforcer()
 
@@ -2552,7 +2657,10 @@ class EnginePool:
                     get_mlx_executor(),
                     lambda: (mx.synchronize(), mx.clear_cache()),
                 )
-                current = max(mx.get_active_memory(), get_phys_footprint())
+                current = max(
+                    discount_external_wired(mx.get_active_memory()),
+                    get_phys_footprint(),
+                )
                 if current <= target:
                     logger.info(
                         f"Reclaimed memory after failed load of '{model_id}': "
@@ -2607,7 +2715,9 @@ class EnginePool:
         entry_detached = False
         entry.abort_loading = False
         resident_size = self._entry_resident_size(entry)
-        pre_load_memory = max(mx.get_active_memory(), get_phys_footprint())
+        pre_load_memory = max(
+            discount_external_wired(mx.get_active_memory()), get_phys_footprint()
+        )
         try:
             effective_type = entry.engine_type
             if force_lm and effective_type == "vlm":
@@ -3012,7 +3122,9 @@ class EnginePool:
                 lambda: (mx.synchronize(), mx.clear_cache()),
             )
 
-            post_load_memory = max(mx.get_active_memory(), get_phys_footprint())
+            post_load_memory = max(
+                discount_external_wired(mx.get_active_memory()), get_phys_footprint()
+            )
             observed_delta = max(0, post_load_memory - pre_load_memory)
             entry.actual_size = observed_delta or resident_size
 

--- a/omlx/process_memory_enforcer.py
+++ b/omlx/process_memory_enforcer.py
@@ -41,7 +41,11 @@ import mlx.core as mx
 from . import settings as _settings
 from .engine.base import BaseNonStreamingEngine
 from .utils import psutil_compat
-from .utils.proc_memory import get_phys_footprint
+from .utils.proc_memory import (
+    discount_external_wired,
+    external_wired_bytes,
+    get_phys_footprint,
+)
 
 if TYPE_CHECKING:
     from .engine_pool import EnginePool
@@ -382,6 +386,12 @@ class ProcessMemoryEnforcer:
         self._prefill_headroom_safety = self._get_prefill_headroom_safety()
         self._prefill_safe_zone_ratio = prefill_safe_zone_ratio
         self._prefill_min_chunk_tokens = prefill_min_chunk_tokens
+        # Gate 2 (docs/qwen4exp-streaming-alternatives-investigation.md):
+        # Externally-wired byte accounting (e.g. mmap'd MoE expert
+        # weights that Metal/phys_footprint cannot see) lives in the
+        # process-global, name-keyed registry in omlx.utils.proc_memory;
+        # the enforcer reads it via external_wired_bytes(). No
+        # per-instance provider registry.
         self._task: asyncio.Task | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         self._wake_event: asyncio.Event | None = None
@@ -597,6 +607,28 @@ class ProcessMemoryEnforcer:
         vm_stat fallback only if the fast host_statistics64 path is unavailable.
         If all telemetry is unavailable, fall back to the static ceiling so
         server health endpoints and the enforcer keep running.
+
+        Gate 2 (revised, LIVE TEST 2 2026-08-31, Fable-reviewed GO): this used
+        to subtract external-wired bytes from the reclaimable estimate
+        whenever idle, on the theory that idle artifact pages sit in
+        free/inactive/active and would otherwise be double-counted as
+        reclaimable headroom. Live measurement falsified that: the registered
+        qwen4_moe_stream provider (fast.mapped_bytes) reports the mmap'd
+        artifact's LOAD-TIME-CONSTANT total size (~43.7 GiB), not how much of
+        it is actually resident right now, and _has_active_requests() is False
+        the instant a load completes -- before the model ever serves a
+        request. Subtracting that constant collapsed the dynamic ceiling to
+        <1 GB against ~34 GB of real usage and force-evicted a model that fit
+        fine, the exact self-defeating pattern already fixed for metal_cap
+        (LIVE TEST 1, Fix A): reserving/subtracting the full artifact size
+        treats streaming as if the experts were fully resident. Nothing real
+        is lost: genuine wired pressure already shows up live via free-bucket
+        depletion (wired pages are disjoint from free/inactive/active in
+        vm_stat), with zero provider involvement -- so external_wired is now
+        off-budget on the dynamic-ceiling side too; it stays in the breakdown
+        dict for observability only. If the ladder later shows real wired
+        contention the lever is mx.set_wired_limit, not this admission
+        ceiling.
         """
         if self._memory_guard_tier == "custom":
             return max(0, self._memory_guard_custom_ceiling_bytes)
@@ -661,6 +693,26 @@ class ProcessMemoryEnforcer:
         else:
             dynamic_ceiling = self._get_dynamic_ceiling()
         metal_cap = self._get_effective_metal_cap_bytes()
+        # Gate 2 (revised, LIVE TEST 1 2026-08-31): external-wired bytes (the
+        # mmap'd MoE expert-streaming artifact) are RECLAIMABLE file-backed
+        # page cache, NOT a hard wired reservation. Subtracting them from
+        # metal_cap collapsed the hard ceiling below the model's real
+        # resident footprint and force-evicted a model that fit fine -- and
+        # reserving the full payload defeats streaming's whole benefit (the
+        # driver wires only bounded per-command expert subsets, never the
+        # full payload at once; on a 64GB box full simultaneous wiring is
+        # physically impossible anyway: backbone ~25.6GB + experts ~46.9GB >
+        # RAM). So external is OFF-BUDGET on the ceiling side; it is retained
+        # in the breakdown below for observability only. It is no longer
+        # subtracted from ANY ceiling: not from metal_cap here (Fix A) and
+        # not from the dynamic ceiling (Fix D removed that idle-only
+        # subtraction). It is observability-only in /health now; real wired
+        # pressure is caught live via vm_stat free-bucket depletion instead
+        # (wired pages are disjoint from free/inactive/active), so nothing
+        # here credits or charges it. If the ladder later shows real wired
+        # contention the lever is mx.set_wired_limit (shrinking MLX's own
+        # share), not this admission ceiling.
+        external_wired = self._get_external_wired_bytes()
         candidates = [static_ceiling, dynamic_ceiling]
         if metal_cap > 0:
             candidates.append(metal_cap)
@@ -668,6 +720,7 @@ class ProcessMemoryEnforcer:
             "static": static_ceiling,
             "dynamic": dynamic_ceiling,
             "metal_cap": metal_cap,
+            "external_wired": external_wired,
             "hard_limit": min(candidates),
         }
 
@@ -804,9 +857,25 @@ class ProcessMemoryEnforcer:
         so idle/status accounting remains as precise as before.
         """
         phys = get_phys_footprint()
+        # external_wired is NOT charged against any ceiling as of Fix D
+        # (LIVE TEST 2, 2026-08-31, Fable-reviewed) -- it is purely
+        # observational in the /health breakdown now (both metal_cap, Fix A,
+        # and the dynamic ceiling, Fix D, stopped subtracting it; real wired
+        # pressure shows up live via vm_stat free-bucket depletion instead).
+        # This discount below is separate and still correct: it is
+        # measurement hygiene, removing MLX's phantom accounting of mmap'd
+        # bytes from mx.get_active_memory() (which counts them; phys_footprint
+        # does not), not budget charging. Discount ONCE, at the sample site,
+        # split by path to avoid double-discount:
         if self._has_active_requests():
-            return max(self._cached_executor_active_memory_bytes(), phys)
-        return max(mx.get_active_memory(), phys)
+            # cached scheduler sample is ALREADY external-discounted
+            # upstream (Scheduler._current_usage_bytes) -- do NOT discount
+            # again here.
+            active = self._cached_executor_active_memory_bytes()
+            return max(active, phys)
+        # idle path: discount the direct sample here.
+        active = discount_external_wired(mx.get_active_memory())
+        return max(active, phys)
 
     def _is_emergency_pressure(self, current: int, ceiling: int) -> bool:
         """Return True only for pressure beyond the configured ceiling.
@@ -837,6 +906,8 @@ class ProcessMemoryEnforcer:
 
     def _has_active_requests(self) -> bool:
         """Best-effort active-request detection without touching MLX."""
+        if self._engine_pool is None:
+            return False
         for entry in self._engine_pool._entries.values():
             engine = getattr(entry, "engine", None)
             if engine is None:
@@ -850,6 +921,16 @@ class ProcessMemoryEnforcer:
             except Exception:
                 return True
         return False
+
+    def _get_external_wired_bytes(self) -> int:
+        """Worst-case externally-wired bytes from the process-global
+        registry in omlx.utils.proc_memory (mmap'd MoE expert weights,
+        etc.). NOT charged against any ceiling as of Fix D -- metal_cap
+        (Fix A) and the dynamic ceiling (Fix D) both stopped subtracting
+        it; it is purely observational, surfaced in the /health breakdown
+        only. Real wired pressure is caught live via vm_stat free-bucket
+        depletion instead."""
+        return external_wired_bytes()
 
     def _cached_executor_active_memory_bytes(self) -> int:
         """Max MLX active-memory sample recorded by scheduler executor threads."""

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -79,7 +79,7 @@ from .utils.metal_sync import (
     _sync_and_clear_cache,
     clear_thread_streams,
 )
-from .utils.proc_memory import get_phys_footprint
+from .utils.proc_memory import discount_external_wired, get_phys_footprint
 from .utils.sampling import make_sampler as omlx_make_sampler
 from .utils.tokenizer import create_streaming_detokenizer
 
@@ -4575,7 +4575,14 @@ class Scheduler:
         return n
 
     def get_cached_mlx_active_memory_bytes(self) -> int:
-        """Return the last MLX active-memory sample taken on the executor."""
+        """Return the last MLX active-memory sample taken on the executor.
+
+        NOTE: this value is EXTERNAL-WIRED-DISCOUNTED at the sample site (see
+        ``_current_usage_bytes``) -- it excludes mmap'd externally-wired bytes
+        (e.g. the MoE expert-streaming artifact) that ``mx.get_active_memory()``
+        counts but phys_footprint does not. Consumers (e.g. the process memory
+        enforcer's cached-executor path) must NOT discount it again.
+        """
         return self._last_mlx_active_memory_bytes
 
     def _hot_cache_cpu_bytes(self) -> int:
@@ -4630,7 +4637,12 @@ class Scheduler:
         """
         active = self._last_mlx_active_memory_bytes
         if refresh_mlx_active:
-            active = max(0, int(mx.get_active_memory()))
+            # Discount external-wired bytes (e.g. mmap'd MoE expert-streaming
+            # artifact) AT THE SAMPLE SITE: mx.get_active_memory() counts them
+            # but phys_footprint / the real budget do not. The cache thus stores
+            # a PRE-DISCOUNTED value -- consumers of _last_mlx_active_memory_bytes
+            # / get_cached_mlx_active_memory_bytes() must NOT discount again.
+            active = discount_external_wired(max(0, int(mx.get_active_memory())))
             self._last_mlx_active_memory_bytes = active
         hot_cache_cpu_bytes = getattr(self, "_hot_cache_cpu_bytes", None)
         if callable(hot_cache_cpu_bytes):

--- a/omlx/utils/proc_memory.py
+++ b/omlx/utils/proc_memory.py
@@ -21,6 +21,8 @@ import ctypes
 import logging
 import os
 import sys
+import threading
+from typing import Callable
 
 logger = logging.getLogger(__name__)
 
@@ -140,3 +142,71 @@ def get_lifetime_max_phys_footprint(pid: int | None = None) -> int:
     if rc != 0:
         return 0
     return info.ri_lifetime_max_phys_footprint
+
+
+# --------------------------------------------------------------------------- #
+# Externally-wired byte accounting                                            #
+# --------------------------------------------------------------------------- #
+# Some memory this process holds is wired OUTSIDE MLX's allocator tracking --
+# notably the qwen4_exp MoE expert-streaming artifact, mmap'd and bound via
+# ``newBufferWithBytesNoCopy``. Such bytes ARE counted by
+# ``mx.get_active_memory()`` but NOT by the phys_footprint ledger above. Any
+# consumer comparing an active-memory sample against a phys/ceiling budget
+# (admission, throttle, OOM, load-delta sizing) over-reports usage by that
+# external total unless it discounts them.
+#
+# Contract (load-bearing): DISCOUNT AT THE SAMPLE SITE; caches store discounted
+# values; no consumer discounts twice. This module never samples MLX (and never
+# imports mlx) -- it is pure arithmetic over a lock-snapshotted provider
+# registry, safe from any thread/async context, so each call site keeps its own
+# already-correct sampling discipline. Providers are snapshotted under the lock
+# but CALLED outside it (a slow provider cannot stall unrelated call sites) and
+# must be cheap, non-blocking, and never touch MLX; exceptions are swallowed.
+
+_EXTERNAL_WIRED_LOCK = threading.Lock()
+_EXTERNAL_WIRED_PROVIDERS: dict[str, Callable[[], int]] = {}
+
+
+def register_external_wired_provider(name: str, provider: Callable[[], int]) -> None:
+    """Register (or replace) a worst-case externally-wired byte provider.
+
+    Name-keyed and replace-on-register, so registration is idempotent by
+    construction: re-registering the same name replaces its provider (callers
+    may register on every model load without accumulating duplicates, which
+    would multiply the count). No object-identity guards.
+    """
+    with _EXTERNAL_WIRED_LOCK:
+        _EXTERNAL_WIRED_PROVIDERS[name] = provider
+
+
+def unregister_external_wired_provider(name: str) -> None:
+    """Remove a provider by name (rarely needed: a provider that returns 0 when
+    nothing is wired can stay registered for the process lifetime)."""
+    with _EXTERNAL_WIRED_LOCK:
+        _EXTERNAL_WIRED_PROVIDERS.pop(name, None)
+
+
+def external_wired_bytes() -> int:
+    """Best-effort sum of every registered provider's current worst-case bytes.
+
+    Providers are snapshotted under the lock and called OUTSIDE it; each is
+    guarded so a failing/slow provider neither crashes nor stalls the sum.
+    """
+    with _EXTERNAL_WIRED_LOCK:
+        providers = list(_EXTERNAL_WIRED_PROVIDERS.values())
+    total = 0
+    for provider in providers:
+        try:
+            total += max(0, int(provider()))
+        except Exception:
+            continue
+    return total
+
+
+def discount_external_wired(sample_bytes: int) -> int:
+    """Discount the externally-wired total from a raw active-memory sample.
+
+    Call at the sample site, wrapping ONLY the ``mx.get_active_memory()`` term
+    (never phys_footprint, which already excludes external bytes). Clamped >= 0.
+    """
+    return max(0, int(sample_bytes) - external_wired_bytes())

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,10 @@ def _custom_kernel_build_kwargs() -> dict:
                 "omlx.custom_kernels.qwen35_prefill._ext",
                 sourcedir="omlx/custom_kernels/qwen35_prefill/csrc",
             ),
+            extension.CMakeExtension(
+                "omlx.custom_kernels.qwen4_moe_stream._ext",
+                sourcedir="omlx/custom_kernels/qwen4_moe_stream/csrc",
+            ),
         ],
         "cmdclass": {"build_ext": extension.CMakeBuild},
     }

--- a/tests/test_qwen4_moe_stream.py
+++ b/tests/test_qwen4_moe_stream.py
@@ -1,0 +1,405 @@
+# SPDX-License-Identifier: Apache-2.0
+"""qwen4_exp MoE expert weight streaming loader.
+
+Covers the canonical key parser, the StreamingArtifact manifest index, the
+weights-list interception (``stream_weight_items``), the idempotent enforcer
+provider registration, and -- gated on the real artifact + native extension --
+a bit-exact round-trip of a wrapped expert tensor through the actual
+``QuantizedSwitchLinear.load_weights`` seam and ``gather_qmm`` forward.
+
+The native-extension / real-artifact tests skip cleanly when either is absent so
+the suite still runs in environments without the built ``_ext`` or the 46.87 GB
+artifact.
+"""
+from __future__ import annotations
+
+import json
+import os
+import struct
+from pathlib import Path
+
+import mlx.core as mx
+import pytest
+
+from omlx.custom_kernels.qwen4_moe_stream import fast, loader
+
+# Real 46.87 GB streaming artifact. Machine-specific; override with
+# OMLX_QWEN4_MOE_STREAM_ARTIFACT. The @_has_artifact guard skips the
+# artifact-dependent tests cleanly when it is absent, so the default path is
+# only an example, not a requirement.
+_ARTIFACT = os.environ.get(
+    "OMLX_QWEN4_MOE_STREAM_ARTIFACT",
+    "/Users/alytaphoenix/.omlx/models/Vontra/"
+    "Qwen3.8-Flash-Next-MLX-oQ2-MTP/moe_experts_streaming.artifact",
+)
+
+_native = pytest.mark.skipif(
+    not fast.is_native_available(), reason="qwen4_moe_stream native ext unavailable"
+)
+_has_artifact = pytest.mark.skipif(
+    not Path(_ARTIFACT).exists(), reason="streaming artifact not present"
+)
+
+
+# --------------------------------------------------------------------------- #
+# canonical_key                                                               #
+# --------------------------------------------------------------------------- #
+def test_canonical_key_regular_layer():
+    k = "language_model.model.layers.7.mlp.switch_mlp.gate_proj.weight"
+    assert loader.canonical_key(k) == (False, 7, "gate_proj", "weight")
+
+
+def test_canonical_key_mtp_both_prefixes():
+    # checkpoint form (language_model.mtp....) and bound-module form (mtp....)
+    a = "language_model.mtp.layers.0.mlp.switch_mlp.down_proj.scales"
+    b = "mtp.layers.0.mlp.switch_mlp.down_proj.scales"
+    assert loader.canonical_key(a) == (True, 0, "down_proj", "scales")
+    assert loader.canonical_key(b) == (True, 0, "down_proj", "scales")
+
+
+def test_canonical_key_non_expert_returns_none():
+    for k in (
+        "language_model.model.layers.0.self_attn.q_proj.weight",
+        "language_model.model.layers.0.mlp.shared_expert.gate_proj.weight",
+        "language_model.model.embed_tokens.weight",
+    ):
+        assert loader.canonical_key(k) is None
+
+
+# --------------------------------------------------------------------------- #
+# stream_weight_items (no native ext / artifact needed -- uses a fake artifact) #
+# --------------------------------------------------------------------------- #
+class _FakeArtifact:
+    """Stand-in for StreamingArtifact: knows a canon set, wraps to a marker."""
+
+    def __init__(self, canons, shape=(2, 2, 2), dtype=mx.uint32):
+        self._canons = set(canons)
+        self._shape = shape
+        self._dtype = dtype
+
+    def __len__(self):
+        return len(self._canons)
+
+    def has(self, canon):
+        return canon in self._canons
+
+    def wrap(self, canon):
+        # A fresh array; the swap is detected by object identity in the test.
+        return mx.zeros(self._shape, dtype=self._dtype)
+
+
+def test_stream_weight_items_swaps_only_experts():
+    canon = (False, 0, "gate_proj", "weight")
+    art = _FakeArtifact({canon}, shape=(2, 2, 2), dtype=mx.uint32)
+    expert_key = "language_model.model.layers.0.mlp.switch_mlp.gate_proj.weight"
+    other_key = "language_model.model.layers.0.self_attn.q_proj.weight"
+    items = [
+        (expert_key, mx.zeros((2, 2, 2), dtype=mx.uint32)),
+        (other_key, mx.ones((3, 3))),
+    ]
+    new_items, n_swapped, n_missing = loader.stream_weight_items(items, art)
+    assert n_swapped == 1 and n_missing == 0
+    by_key = dict(new_items)
+    # expert entry replaced (object identity differs from the input value)
+    assert by_key[expert_key] is not items[0][1]
+    # non-expert untouched
+    assert by_key[other_key] is items[1][1]
+
+
+def test_stream_weight_items_missing_and_mismatch_pass_through():
+    canon = (False, 0, "gate_proj", "weight")
+    # artifact wraps a DIFFERENT shape than the checkpoint value -> keep resident
+    art = _FakeArtifact({canon}, shape=(9, 9, 9), dtype=mx.uint32)
+    expert_key = "language_model.model.layers.0.mlp.switch_mlp.gate_proj.weight"
+    missing_key = "language_model.model.layers.1.mlp.switch_mlp.up_proj.scales"
+    orig_val = mx.zeros((2, 2, 2), dtype=mx.uint32)
+    items = [
+        (expert_key, orig_val),  # shape mismatch -> kept
+        (missing_key, mx.zeros((2, 2, 2), dtype=mx.bfloat16)),  # not in artifact
+    ]
+    new_items, n_swapped, n_missing = loader.stream_weight_items(items, art)
+    assert n_swapped == 0
+    assert n_missing == 1
+    assert dict(new_items)[expert_key] is orig_val  # mismatch left resident
+
+
+# --------------------------------------------------------------------------- #
+# proc_memory registry: name-keyed idempotency + discount arithmetic          #
+# --------------------------------------------------------------------------- #
+def test_proc_memory_name_keyed_idempotent():
+    from omlx.utils import proc_memory
+
+    name = "__test_qwen4_moe_stream__"
+    try:
+        proc_memory.register_external_wired_provider(name, lambda: 100)
+        # re-register same name REPLACES (no accumulation -> no double count)
+        proc_memory.register_external_wired_provider(name, lambda: 250)
+        assert proc_memory.external_wired_bytes() >= 250
+        # discount subtracts the external total, clamped at 0
+        assert proc_memory.discount_external_wired(1000) == 1000 - proc_memory.external_wired_bytes()
+        assert proc_memory.discount_external_wired(10) == 0  # clamp
+    finally:
+        proc_memory.unregister_external_wired_provider(name)
+
+
+def test_proc_memory_provider_exception_swallowed():
+    from omlx.utils import proc_memory
+
+    name = "__test_qwen4_moe_stream_bad__"
+    try:
+        proc_memory.register_external_wired_provider(name, lambda: 1 / 0)
+        # a throwing provider is skipped, not propagated
+        assert proc_memory.external_wired_bytes() >= 0
+    finally:
+        proc_memory.unregister_external_wired_provider(name)
+
+
+# --------------------------------------------------------------------------- #
+# Real artifact: StreamingArtifact + bit-exact load_weights round-trip        #
+# --------------------------------------------------------------------------- #
+# --------------------------------------------------------------------------- #
+# vlm wire-in context manager: gating / no-op fallbacks                        #
+# --------------------------------------------------------------------------- #
+def _write_config(tmp_path, model_type):
+    (tmp_path / "config.json").write_text(
+        json.dumps({"model_type": model_type}), encoding="utf-8"
+    )
+    return tmp_path
+
+
+def _load_weights_is_unpatched():
+    import mlx.nn as nn
+
+    return "_patched_load_weights" not in getattr(
+        nn.Module.load_weights, "__name__", ""
+    )
+
+
+def test_wirein_noop_for_non_qwen4_model(tmp_path):
+    from omlx.engine import vlm
+
+    _write_config(tmp_path, "llama")
+    with vlm._stream_qwen4_exp_experts_on_load(tmp_path):
+        assert _load_weights_is_unpatched()  # never touches load_weights
+
+
+def test_wirein_noop_when_disabled(tmp_path, monkeypatch):
+    from omlx.engine import vlm
+
+    _write_config(tmp_path, "qwen4_exp")
+    monkeypatch.setenv("OMLX_QWEN4_MOE_STREAM", "0")
+    with vlm._stream_qwen4_exp_experts_on_load(tmp_path):
+        assert _load_weights_is_unpatched()
+
+
+def test_wirein_noop_when_artifact_missing(tmp_path, monkeypatch):
+    from omlx.engine import vlm
+
+    _write_config(tmp_path, "qwen4_exp")
+    monkeypatch.setenv("OMLX_QWEN4_MOE_STREAM", "1")
+    # qwen4_exp but no artifact next to the (empty) tmp model dir -> resident.
+    with vlm._stream_qwen4_exp_experts_on_load(tmp_path):
+        assert _load_weights_is_unpatched()
+
+
+def test_entry_resident_size_streaming_discount():
+    """_entry_resident_size subtracts the streamed payload from the full model
+    and this WINS over the stale runtime_estimated_size (LIVE TEST 1 fix B: the
+    reload block was that streaming-unaware 50GB estimate)."""
+    from types import SimpleNamespace
+
+    from omlx import engine_pool as ep
+
+    entry = SimpleNamespace(
+        estimated_size=70 * 1024**3,
+        runtime_estimated_size=50 * 1024**3,
+    )
+
+    class _FakeStreaming:
+        def _qwen4_moe_streaming_offload_bytes(self, e):
+            return 40 * 1024**3
+
+        def _distributed_deployment_for_entry(self, e):
+            return None
+
+    got = ep.EnginePool._entry_resident_size(_FakeStreaming(), entry)
+    assert got == 30 * 1024**3  # 70 full - 40 streamed, not the stale 50
+
+    class _NoStreaming(_FakeStreaming):
+        def _qwen4_moe_streaming_offload_bytes(self, e):
+            return 0
+
+    # No streaming -> unchanged: falls back to runtime_estimated_size.
+    got2 = ep.EnginePool._entry_resident_size(_NoStreaming(), entry)
+    assert got2 == 50 * 1024**3
+
+
+@_native
+@_has_artifact
+def test_streaming_artifact_index_and_provider():
+    art = loader.StreamingArtifact(_ARTIFACT)
+    assert len(art) == 441  # 48 layers * 9 + MTP * 9
+    # a known 2-bit layer tensor and a 4-bit MTP tensor are both present
+    assert art.has((False, 0, "gate_proj", "weight"))
+    assert art.has((True, 0, "down_proj", "biases"))
+    art.open()
+    try:
+        assert art.provider()() > 40 * 1024**3  # ~46.87 GB mapped
+        w = art.wrap((False, 0, "gate_proj", "weight"))
+        assert w.dtype == mx.uint32 and tuple(w.shape) == (512, 640, 160)
+    finally:
+        art.close()
+
+
+def _manifest(path):
+    with open(path, "rb") as f:
+        mlen = struct.unpack("<Q", f.read(8))[0]
+        return json.loads(f.read(mlen))["tensors"]
+
+
+@_native
+@_has_artifact
+def test_streaming_offload_bytes_gating(monkeypatch):
+    """streaming_offload_bytes returns the artifact size when streaming would
+    engage and 0 when disabled -- admission's resident estimate must agree with
+    whether streaming actually happens (LIVE TEST 1 fix B)."""
+    import os
+
+    model_dir = str(Path(_ARTIFACT).parent)
+    monkeypatch.setenv("OMLX_QWEN4_MOE_STREAM", "1")
+    got = loader.streaming_offload_bytes(model_dir)
+    assert got == os.path.getsize(_ARTIFACT) > 40 * 1024**3
+    monkeypatch.setenv("OMLX_QWEN4_MOE_STREAM", "0")
+    assert loader.streaming_offload_bytes(model_dir) == 0
+    # Non-model dir -> 0 even when enabled.
+    monkeypatch.setenv("OMLX_QWEN4_MOE_STREAM", "1")
+    assert loader.streaming_offload_bytes("/nonexistent/model/dir") == 0
+
+
+@_native
+@_has_artifact
+def test_deferred_unmap_completes_on_free():
+    """close() with a live wrapped array defers the munmap; once the array is
+    freed the deferred unmap fires and mapped_bytes drops to 0 (LIVE TEST 1
+    fix C relies on this to recover the ceiling on unload)."""
+    import gc
+
+    # Delta-based (other tests may leave mappings settling): baseline first.
+    for _ in range(20):
+        gc.collect()
+        mx.synchronize()
+        mx.clear_cache()
+    base = fast.mapped_bytes()
+
+    man = _manifest(_ARTIFACT)
+    e = man["language_model.model.layers.0.mlp.switch_mlp.gate_proj.scales"]
+    aid = fast.mmap_artifact(_ARTIFACT)
+    w = fast.wrap_tensor(aid, e["offset"], e["length"], e["shape"], e["dtype"])
+    assert fast.mapped_bytes() > base
+    fast.close_artifact(aid)  # deferred (w still alive)
+    assert fast.mapped_bytes() > base  # not yet unmapped
+    del w
+    dropped = False
+    for _ in range(20):
+        gc.collect()
+        mx.synchronize()
+        mx.clear_cache()
+        if fast.mapped_bytes() <= base:
+            dropped = True
+            break
+    assert dropped, "deferred unmap did not complete after freeing the array"
+
+
+@_native
+@_has_artifact
+def test_close_while_alive_defers_unmap():
+    """close_artifact with a live wrapped array must defer the munmap: a GPU
+    touch after close must not fault, and a fresh wrap on the closed id is
+    refused (Fable review 2, issue 4 -- refcounted deferred unmap)."""
+    man = _manifest(_ARTIFACT)
+    e = man["language_model.model.layers.0.mlp.switch_mlp.gate_proj.scales"]
+    aid = fast.mmap_artifact(_ARTIFACT)
+    w = fast.wrap_tensor(aid, e["offset"], e["length"], e["shape"], e["dtype"])
+    assert fast.mapped_bytes() > 0
+    fast.close_artifact(aid)  # marks closed; unmap deferred (w still alive)
+    # GPU touch AFTER close must complete without faulting on unmapped memory.
+    total = float(mx.sum(w.astype(mx.float32)))
+    assert total == total  # finite / not a fault artifact
+    # A new wrap on the closed mapping is refused (no use-after-close).
+    with pytest.raises(Exception):
+        fast.wrap_tensor(aid, e["offset"], e["length"], e["shape"], e["dtype"])
+    del w  # last ref -> deleter drops refcount -> deferred munmap runs
+
+
+@_native
+@_has_artifact
+@pytest.mark.parametrize(
+    "pfx,is_mtp",
+    [
+        ("language_model.model.layers.0.mlp.switch_mlp", False),
+        ("language_model.mtp.layers.0.mlp.switch_mlp", True),
+    ],
+)
+def test_load_weights_roundtrip_bit_exact(pfx, is_mtp):
+    """Wrapped arrays load through the real QuantizedSwitchLinear.load_weights
+    seam and produce bit-exact gather_qmm output vs a resident-read reference."""
+    from mlx_lm.models.switch_layers import QuantizedSwitchLinear
+
+    man = _manifest(_ARTIFACT)
+    art = loader.StreamingArtifact(_ARTIFACT)
+    art.open()
+    try:
+        proj = "gate_proj"
+        we = man[f"{pfx}.{proj}.weight"]
+        se = man[f"{pfx}.{proj}.scales"]
+        bits, gs = we["bits"], we["group_size"]
+        n_exp, out_dim, _ = we["shape"]
+        in_dim = se["shape"][2] * gs
+
+        canon_w = (is_mtp, 0, proj, "weight")
+        canon_s = (is_mtp, 0, proj, "scales")
+        canon_b = (is_mtp, 0, proj, "biases")
+
+        # Build the module and load the WRAPPED (streamed) arrays into it.
+        mod = QuantizedSwitchLinear(
+            in_dim, out_dim, n_exp, bias=False, group_size=gs, bits=bits, mode="affine"
+        )
+        mod.load_weights(
+            [
+                ("weight", art.wrap(canon_w)),
+                ("scales", art.wrap(canon_s)),
+                ("biases", art.wrap(canon_b)),
+            ],
+            strict=True,
+        )
+
+        # Reference: GENUINE resident load via numpy read of the artifact bytes
+        # (NOT another wrapped array) -- this is what actually proves
+        # streamed == resident, closing Fable review-2 issue 2.
+        import numpy as np
+
+        def resident(canon):
+            e = man[f"{pfx}.{canon[2]}.{canon[3]}"]
+            npd = {"U32": np.uint32, "BF16": np.uint16}[e["dtype"]]
+            with open(_ARTIFACT, "rb") as fp:
+                fp.seek(e["offset"])
+                buf = fp.read(e["length"])
+            arr = mx.array(np.frombuffer(buf, dtype=npd).reshape(e["shape"]))
+            return arr.view(mx.bfloat16) if e["dtype"] == "BF16" else arr
+
+        ref_w = resident(canon_w)
+        ref_s = resident(canon_s)
+        ref_b = resident(canon_b)
+
+        T = 72
+        x = mx.random.normal((T, 1, in_dim)).astype(mx.bfloat16)
+        idx = mx.array([(t * 37) % n_exp for t in range(T)], dtype=mx.uint32).reshape(T, 1)
+
+        y_mod = mod(x, idx, sorted_indices=False)
+        y_ref = mx.gather_qmm(
+            x, ref_w, ref_s, ref_b, rhs_indices=idx, transpose=True,
+            group_size=gs, bits=bits, mode="affine", sorted_indices=False,
+        )
+        assert float(mx.max(mx.abs(y_mod.astype(mx.float32) - y_ref.astype(mx.float32)))) == 0.0
+    finally:
+        art.close()


### PR DESCRIPTION
## What

Stream the ~46.87 GB of qwen4_exp routed-expert (`switch_mlp`) weights off the
wired/phys budget: bind them as mmap-backed, page-aligned arrays over a side-car
artifact next to the checkpoint instead of loading them resident. This lets
**Qwen3.8-Flash-Next-MLX-oQ2-MTP** load and serve long context on a 64 GB M4 Pro
mini, where the fully-resident path does not fit (backbone ~25.6 GB + experts
~46.9 GB > RAM).

Streaming engages only when the artifact exists next to the checkpoint **and**
the native extension is available; otherwise it is a clean fully-resident no-op.

**Kill switch:** `OMLX_QWEN4_MOE_STREAM` defaults to enabled whenever the
streaming artifact is present on disk; set it to `0` to force the old
fully-resident path.

## This is a measured tradeoff, not an unqualified win

Streaming buys the ability to run this model at all on 64 GB, at a real prefill
cost. Live single-request ladder measured (103,019 real prompt tokens,
929.7 s total):

| Prompt depth | Streaming throughput | Non-streaming baseline (comparable depth) |
|---|---|---|
| ~40k | ~178 tok/s | ~223 tok/s-class |
| ~76k | ~124 tok/s | — |
| ~96k | ~111 tok/s | — |

At the **top of the tested range this is roughly ~2x slower prefill** than the
project's earlier non-streaming baseline (~223 tok/s-class). This corrects an
earlier design-doc framing that overstated the regression as "~15x slower" —
the real number is ~2x, not an order of magnitude.

## Real context ceiling: ~121–122k, not the ~200k+ originally projected

The earlier design doc projected a ~200k+ context ceiling under streaming. **That
projection is walked back.** Live testing puts the real ceiling at **~121–122k
tokens**. At that point real *chunked-prefill transient* memory (not anything
this feature's own accounting touches) hits the hard watermark and the enforcer
**gracefully aborts just that one request while keeping the model loaded** —
verified clean, not a crash or an eviction.

**Production config (decided, now live on the mini):** `max_context_window:
120000`, accepting that requests very near the ~121–122k wall may occasionally
get a graceful per-request abort rather than always succeeding.

## Open item

All live testing so far is **single-request**. No concurrent-traffic run under
streaming has been done yet — flagged as an open item, not a proven gap.

## How it works

- `omlx/custom_kernels/qwen4_moe_stream/`: native `_ext` (bytesNoCopy MTLBuffer
  wrap of page-aligned tensors, refcounted deferred `munmap`), `StreamingArtifact`
  manifest index + canonical-key parser, weights-list interception, and
  `repack.py` — the artifact producer / format authority (source dir
  parameterized via `--model-dir` / `OMLX_QWEN4_MODEL_DIR`, no hardcoded path).
- `engine/vlm.py`: `_stream_qwen4_exp_experts_on_load` context manager — patches
  `Module.load_weights` post-sanitize to swap expert values before `mx.eval`,
  with `expect_all` hard-fail, a load-time bit-exactness canary, and
  failure-path teardown that closes the mapping and skips the canary/success log
  if the load body raises after the swap.
- `engine_pool.py`: streaming-aware resident-size estimate for admission +
  unload-time artifact close.
- `utils/proc_memory.py`: name-keyed external-wired provider registry +
  `discount_external_wired` measurement hygiene.
- `process_memory_enforcer.py`: external-wired is observability-only in
  `/health`, not subtracted from any ceiling (`metal_cap` per Fix A, dynamic
  ceiling per Fix D); real wired pressure is caught live via `vm_stat`
  free-bucket depletion.

## Provenance

This is a **focused resubmit targeting `main` directly**, per @jundot's request
on #3283 to split the remaining wanted changes into focused PRs off current
main. Full review history and discussion for this feature live on
**alytaphoenix/omlx#2** — this PR is the same feature commit, cherry-picked
cleanly onto current `main` as a single logical commit (the earlier
deploy-branch prereq-port commit it used to stack on is **not needed** — `main`
already independently carries the `engine_pool`/`deployment` symbols it
depended on, so it was dropped).

## Testing

Full `tests/` suite re-run on the rebuilt-onto-`main` branch: **10664 passed,
150 skipped, 77 deselected**. The only failures (13) are pre-existing and
identical on clean `main` in this environment — an MLX patch-version pin in
`test_mlx0322_compat` / `test_sdpa256_attention` (env has MLX 0.32.0, those
tests expect 0.32.2); none are in files this feature touches, so **zero
regressions** vs. the `main` baseline.

The native-extension tests in `tests/test_qwen4_moe_stream.py` were run **for
real against the built `_ext` kernel (not skipped)**: **17/17 passed**,
including the bit-exact `load_weights` round-trip, deferred-`munmap`, and
canonical-key native paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FR1CuCS9onnMPzwTTkFU4r
