### PR TITLE
fix(scheduler): refuse prefix reuse for unreconstructible cache classes

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -8188,12 +8188,109 @@ class Scheduler:
         )
         return True
 
+    # Legacy class-name aliases explicitly supported by reconstruction.
+    _EXTRA_RECONSTRUCTIBLE_CACHE_TYPES = frozenset({"SizedArraysCache"})
+
+    def _prefix_reuse_supports_cache_class(self, class_name: str) -> bool:
+        """True when ``class_name`` has a recognized reconstruction path.
+
+        Reconstruction dispatches on the stored ``type(cache).__name__`` through
+        ``CacheTypeRegistry``. Preserve existing handling for registered names
+        and explicitly supported sliceable classes. Registration is a trust
+        boundary, not proof that a handler preserves every field: handler-level
+        round-trip tests are still required.
+
+        An *unregistered* class is the problem. ``detect_cache_type`` falls back
+        to structural sniffing, so any ``KVCache`` subclass looks like a plain
+        ``KVCache``, gets ``DefaultCacheHandler`` (``supports_block_slicing =
+        True``) and is rebuilt as a vanilla ``KVCache`` with its extra state
+        dropped. Only that case is refused here.
+        """
+        if class_name in _KNOWN_SLICEABLE_CACHE_TYPES:
+            return True
+        if class_name in self._EXTRA_RECONSTRUCTIBLE_CACHE_TYPES:
+            return True
+        if HAS_CACHE_TYPE_HANDLERS and CacheTypeRegistry is not None:
+            return class_name in CacheTypeRegistry.list_known_class_names()
+        # Without the registry nothing beyond the plainly sliceable set can be
+        # rebuilt, so treat everything else as unsupported.
+        return False
+
+    def _cache_layer_is_reconstructible(self, layer: Any) -> bool:
+        """Recursive per-layer form of :meth:`_prefix_reuse_supports_cache_class`."""
+        if layer is None:
+            return True
+        # Test doubles carry no real cache contract.
+        if type(layer).__module__.startswith("unittest.mock"):
+            return True
+        sub_caches = getattr(layer, "caches", None)
+        if isinstance(sub_caches, (list, tuple)):
+            # CacheList itself round-trips, but only if every sub-cache does:
+            # its handler stores sub-class names and re-dispatches per name.
+            if not self._prefix_reuse_supports_cache_class(type(layer).__name__):
+                return False
+            return all(self._cache_layer_is_reconstructible(sub) for sub in sub_caches)
+        return self._prefix_reuse_supports_cache_class(type(layer).__name__)
+
+    def _model_has_unreconstructible_cache(self) -> bool:
+        """True when ``model.make_cache()`` builds cache layers of a class the
+        paged prefix round trip silently downgrades.
+
+        Unlimited-OCR's ``RingSlidingKVCache`` subclasses ``KVCache`` and is not
+        in the registry, so it is sniffed as a plain ``KVCache``, rebuilt as one,
+        and loses ``window_size`` / ``prefill_length`` / ``_ring_pos``. The model
+        then attends over an unbounded history, which can alter generation.
+        The pre-existing rotating guard cannot catch it:
+        it runs only for *exact* prefix hits and inspects the *already
+        reconstructed* cache, which is a plain ``KVCache`` by then.
+
+        Probed once per scheduler and memoized. A probe that raises is **not**
+        memoized and refuses reuse for that request, so a transient failure can
+        never be recorded as "safe" and then silently reused.
+        """
+        cached = getattr(self, "_unreconstructible_cache_model", None)
+        if cached is not None:
+            return cached
+
+        try:
+            layers = make_prompt_cache(self.model) or []
+        except Exception as e:
+            logger.warning(
+                "Could not probe model cache classes (%s: %s); refusing prefix cache "
+                "reuse for this request rather than risking a silent downgrade",
+                type(e).__name__,
+                e,
+            )
+            logger.debug("Cache probe failure traceback:", exc_info=True)
+            return True
+
+        result = False
+        for layer in layers:
+            if not self._cache_layer_is_reconstructible(layer):
+                logger.info(
+                    "Prefix cache reuse disabled: model builds %s layers, which "
+                    "have no cache-type handler and would be rebuilt as plain "
+                    "KVCache, dropping their state",
+                    type(layer).__name__,
+                )
+                result = True
+                break
+
+        self._unreconstructible_cache_model = result
+        return result
+
     def _prepare_prefix_cache_for_request(self, request: Request) -> None:
         if request.request_id in self._prefix_cache_prepared:
             return
 
-        # Check prefix cache for cached KV state
-        if self.block_aware_cache is not None:
+        # Check prefix cache for cached KV state. Models whose cache layers do
+        # not survive reconstruction skip the lookup entirely and fall through
+        # to full prefill below — including on partial hits, which bypass the
+        # exact-hit guard further down.
+        if (
+            self.block_aware_cache is not None
+            and not self._model_has_unreconstructible_cache()
+        ):
             # Use paged cache
             block_table, remaining = self.block_aware_cache.fetch_cache(
                 request.request_id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,18 @@ class MockModel:
         """Return model parameters."""
         return self._parameters
 
+    def make_cache(self) -> list:
+        """Build the per-layer prompt cache, like a real mlx-lm model.
+
+        The scheduler probes this to decide whether a stored prefix can be
+        rebuilt faithfully, so the double has to answer it. A plain llama-style
+        model builds ``KVCache`` layers; tests that need another cache class
+        override this attribute.
+        """
+        from mlx_lm.models.cache import KVCache
+
+        return [KVCache() for _ in range(self.config.num_hidden_layers)]
+
 
 @pytest.fixture
 def mock_tokenizer() -> MockTokenizer:

--- a/tests/test_prefix_cache_gdn_split.py
+++ b/tests/test_prefix_cache_gdn_split.py
@@ -20,6 +20,11 @@ class _HybridModel:
     def __init__(self):
         self.layers = [MagicMock(), MagicMock()]
 
+    def make_cache(self):
+        from mlx_lm.models.cache import ArraysCache, KVCache
+
+        return [KVCache(), ArraysCache(size=2)]
+
 
 def _hybrid_extracted(token_count: int, recurrent_value: float):
     return [
@@ -618,6 +623,7 @@ def test_split_exact_prefix_fails_closed_before_placeholder_allocation(tmp_path)
 def test_scheduler_exact_split_hit_reprefills_only_last_block():
     """Exact GDN hits walk back one block before reconstruction (N-1 safety)."""
     scheduler = Scheduler.__new__(Scheduler)
+    scheduler.model = _HybridModel()
     scheduler.config = SchedulerConfig(
         paged_cache_block_size=BLOCK_SIZE,
         gdn_ssd_split_enabled=True,

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -611,6 +611,183 @@ class TestSchedulerAddRequest:
             "req-rotating"
         )
 
+    def test_partial_hit_refused_when_model_builds_unregistered_cache(
+        self, mock_model, mock_tokenizer
+    ):
+        """A model whose own make_cache() returns an *unregistered* cache class
+        must not reuse a paged prefix at all — not even a partial one.
+
+        An unregistered ``KVCache`` subclass is sniffed structurally, handed the
+        default handler and rebuilt as a plain ``KVCache``, silently dropping its
+        window state (Unlimited-OCR's ``RingSlidingKVCache`` carries
+        window_size/prefill_length/_ring_pos). The pre-existing rotating guard
+        only covers *exact* hits and inspects the already-reconstructed cache,
+        so a partial hit slipped through and corrupted generation.
+        """
+        from omlx.cache.paged_cache import BlockTable
+
+        RingSlidingKVCache = type("RingSlidingKVCache", (), {})
+        mock_model.make_cache = lambda: [RingSlidingKVCache()]
+
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        scheduler.block_aware_cache = MagicMock()
+        scheduler.paged_cache_manager = MagicMock()
+
+        # Partial hit: 2 of 4 tokens cached, so the exact-hit guard cannot fire.
+        block_table = BlockTable(request_id="req-ring", block_ids=[7], num_tokens=2)
+        scheduler.block_aware_cache.fetch_cache.return_value = (block_table, [43, 44])
+        # Reconstruction hands back a plain KVCache — the ring class is lost.
+        scheduler.block_aware_cache.reconstruct_cache.return_value = [MagicMock()]
+
+        request = Request(
+            request_id="req-ring",
+            prompt=[41, 42, 43, 44],
+            sampling_params=SamplingParams(max_tokens=16),
+        )
+
+        scheduler.add_request(request)
+        scheduler._prepare_prefix_cache_for_request(request)
+
+        assert request.cached_tokens == 0
+        assert request.remaining_tokens == [41, 42, 43, 44]
+        assert request.prompt_cache is None
+        scheduler.block_aware_cache.fetch_cache.assert_not_called()
+
+    def test_plain_kvcache_model_still_uses_prefix_cache(
+        self, mock_model, mock_tokenizer
+    ):
+        """The guard must not disable prefix reuse for ordinary KVCache models."""
+        from omlx.cache.paged_cache import BlockTable
+
+        KVCache = type("KVCache", (), {})
+        mock_model.make_cache = lambda: [KVCache()]
+
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        scheduler.block_aware_cache = MagicMock()
+        scheduler.paged_cache_manager = MagicMock()
+
+        block_table = BlockTable(request_id="req-plain", block_ids=[8], num_tokens=2)
+        scheduler.block_aware_cache.fetch_cache.return_value = (block_table, [53, 54])
+        scheduler.block_aware_cache.reconstruct_cache.return_value = [MagicMock()]
+
+        request = Request(
+            request_id="req-plain",
+            prompt=[51, 52, 53, 54],
+            sampling_params=SamplingParams(max_tokens=16),
+        )
+
+        scheduler.add_request(request)
+        scheduler._prepare_prefix_cache_for_request(request)
+
+        scheduler.block_aware_cache.fetch_cache.assert_called_once()
+        assert request.cached_tokens == 2
+
+    @pytest.mark.parametrize(
+        "cache_class_name",
+        [
+            # Registered: reconstruction re-dispatches on the stored class name
+            # and the boundary-snapshot path preserves the extra state.
+            "RotatingKVCache",
+            "ArraysCache",
+            "MiniMaxM3KVCache",
+            # Plainly sliceable, round-trips by block slicing.
+            "ChunkedKVCache",
+            "TurboQuantKVCache",
+        ],
+    )
+    def test_supported_non_plain_cache_models_keep_prefix_cache(
+        self, mock_model, mock_tokenizer, cache_class_name
+    ):
+        """The guard must only refuse classes the round trip cannot rebuild.
+
+        Rotating/arrays/MiniMax layers have registry handlers and chunked and
+        TurboQuant layers are block-sliceable, so all of them keep prefix reuse.
+        Refusing them would cost a full re-prefill on every request for no
+        correctness gain.
+        """
+        from omlx.cache.paged_cache import BlockTable
+
+        mock_model.make_cache = lambda: [type(cache_class_name, (), {})()]
+
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        scheduler.block_aware_cache = MagicMock()
+        scheduler.paged_cache_manager = MagicMock()
+
+        block_table = BlockTable(
+            request_id="req-supported", block_ids=[11], num_tokens=2
+        )
+        scheduler.block_aware_cache.fetch_cache.return_value = (block_table, [63, 64])
+        scheduler.block_aware_cache.reconstruct_cache.return_value = [MagicMock()]
+
+        request = Request(
+            request_id="req-supported",
+            prompt=[61, 62, 63, 64],
+            sampling_params=SamplingParams(max_tokens=16),
+        )
+
+        scheduler.add_request(request)
+        scheduler._prepare_prefix_cache_for_request(request)
+
+        assert scheduler._model_has_unreconstructible_cache() is False
+        scheduler.block_aware_cache.fetch_cache.assert_called_once()
+
+    def test_cache_list_refused_when_a_sub_cache_is_unregistered(
+        self, mock_model, mock_tokenizer
+    ):
+        """CacheList round-trips per sub-cache, so one unknown sub-cache is fatal."""
+        cache_list = type(
+            "CacheList",
+            (),
+            {"caches": (type("KVCache", (), {})(), type("RingSlidingKVCache", (), {})())},
+        )
+        mock_model.make_cache = lambda: [cache_list()]
+
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        scheduler.block_aware_cache = MagicMock()
+
+        assert scheduler._model_has_unreconstructible_cache() is True
+
+    def test_cache_list_allowed_when_every_sub_cache_is_supported(
+        self, mock_model, mock_tokenizer
+    ):
+        """A CacheList of known sub-caches keeps prefix reuse."""
+        cache_list = type(
+            "CacheList",
+            (),
+            {"caches": (type("KVCache", (), {})(), type("RotatingKVCache", (), {})())},
+        )
+        mock_model.make_cache = lambda: [cache_list()]
+
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        scheduler.block_aware_cache = MagicMock()
+
+        assert scheduler._model_has_unreconstructible_cache() is False
+
+    def test_probe_failure_refuses_reuse_and_is_not_memoized(
+        self, mock_model, mock_tokenizer
+    ):
+        """A failed probe must fail closed and stay retryable.
+
+        Memoizing a transient failure as "safe" would restore exactly the silent
+        downgrade this guard exists to prevent, so the failure path refuses reuse
+        and records nothing.
+        """
+
+        def _boom():
+            raise RuntimeError("cannot build cache")
+
+        mock_model.make_cache = _boom
+
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        scheduler.block_aware_cache = MagicMock()
+
+        assert scheduler._model_has_unreconstructible_cache() is True
+        assert getattr(scheduler, "_unreconstructible_cache_model", None) is None
+
+        # Once the underlying cause clears, the model is probed again.
+        mock_model.make_cache = lambda: [type("KVCache", (), {})()]
+        assert scheduler._model_has_unreconstructible_cache() is False
+
     def test_add_request_under_pressure_skips_hot_cache_preload_and_promotion(
         self, mock_model, mock_tokenizer
     ):


### PR DESCRIPTION
### Summary

Refuse paged prefix lookup when a model builds cache classes without a recognized reconstruction path. This prevents an unregistered KV-like subclass from being silently restored as plain KVCache; unsupported layouts instead recompute the prompt.

Closes #3445.

- Probe the model's cache layout and check supported reconstruction class names.
- Preserve reuse for supported sliceable classes and registered handlers.
- Recursively inspect composite members, not just their outer wrapper.
- Refuse reuse when cache construction raises; do not memoize transient failures as safe.
- Check before lookup, including partial hits.

### Scope and trade-off

Unsupported layouts lose prefix reuse, avoiding the unregistered-class downgrade described in #3445. This does not add ring batching, new cache handlers, image controls, or sampling changes. Registration remains a trust boundary: each handler still needs round-trip tests. In particular, this guard does not address #2496, whose Kimi-Linear cache classes are already registered.

The check runs before lookup only; completion-time storage is unchanged. Unsupported layouts can therefore still write blocks they cannot reuse, wasting work and retaining those entries on SSD across restarts. Later registering a class makes those pre-registration entries eligible for lookup; the new handler must not silently accept incompatible old state.

A capability follow-up must invalidate those entries or reject them safely as cache misses. Alternatively, this PR could also skip storage for unsupported layouts. The current implementation keeps the guard minimal; maintainer feedback on extending it to storage is welcome. The migration requirement must be recorded when this guard lands, not discovered only when capability is restored.

The scheduler safety issue is addressed even though directly calling the unsupported registry fallback still yields a generic cache. Hardening that registry API separately need not block the fail-safe.

### Verification

- Upstream base `e467261e`: 243 scheduler tests passed before applying the change.
- Standalone PR tree: 1069 targeted scheduler/cache tests passed, 3 deselected. This includes the 10 added regression cases, cache handlers, singleton handling, paged/SSD storage, hybrid layouts, and GDN reconstruction.
- Confirmed the new partial-hit test fails against the original upstream lookup method: it incorrectly reuses two cached tokens. The test passes with this guard.
- Weight-free probes using real native `RingSlidingKVCache`, registered KV/Arrays layers, and a nested `CacheList` confirmed refusal/allowance and successful-probe memoization.
- An existing GDN test constructed `Scheduler` without a model. Its fixture now supplies its intended KV/Arrays cache layout; all existing walkback assertions remain unchanged.
- Syntax and diff-whitespace checks passed. Independent review found no blocking issues after the fixture adaptation and comment corrections.

The CI-style full suite stopped after three MiniMax compatibility failures: 5777 passed, 106 skipped, 77 deselected. Each failing case reproduces on unchanged upstream `e467261e` with the same environment (missing `_build_sparse_decode_indices`, missing `minimax_m3_vl.msa`, and unsupported `pack_shared_expert`). The full suite did not complete; this is not a full-suite pass. No unrelated compatibility fix is included.

Test host: macOS 26.6.2, Apple M4 Max, Python 3.12.11, MLX 0.32.2, mlx-lm 0.31.3, mlx-vlm 0.6.3. No model weights or OCR HTTP replay were used for this PR's verification; ring-capability replay results are not attributed to this guard.

Targeted command:

```sh
python -m pytest tests/test_scheduler*.py tests/test_cache_type_handlers.py tests/test_singleton_cache_passthrough.py tests/test_prefix_cache.py tests/test_prefix_cache_cachelist_mixed.py tests/test_prefix_cache_cachelist_per_member.py tests/test_rotating_cache_contract.py tests/test_store_cache_gate.py tests/test_paged_cache.py tests/test_paged_ssd_cache.py tests/test_hybrid_cache.py tests/test_cache_factory.py tests/test_cache_ntuple_state.py tests/test_prefix_cache_dedup_backfill.py tests/test_prefix_cache_gdn_split.py tests/test_prefix_cache_rotating_tip_strip.py -q
```