### PR TITLE
fix(vlm): preserve Unlimited-OCR ring caches through prefix reuse

### DIFF
--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -822,6 +822,19 @@ class BlockAwarePrefixCache(CacheManager):
                 layer_state.get("meta_state", ()) for layer_state in cache_data
             ]
 
+        if is_tensor_data:
+            # The OCR handler exports only intact prompt KV, not overwritten
+            # decode slots. Do not label it with the full generated sequence
+            # or allocate blocks past its valid prefix (including partials).
+            for idx, type_name in enumerate(layer_cache_types or []):
+                if type_name in ("RingSlidingKVCache", "OMLXRingSlidingKVCache"):
+                    keys = cache_data[idx]["state"][0]
+                    if keys is None:
+                        return None
+                    tokens = tokens[: keys.shape[2]]
+            if not tokens:
+                return None
+
         split_gdn_layout = self._gdn_split_layout_supported(layer_cache_types)
 
         # Get or create block table
@@ -3377,6 +3390,41 @@ class BlockAwarePrefixCache(CacheManager):
                     cache_type_name = layer_cache_types[layer_idx]
 
                 handler = CacheTypeRegistry.get_handler_by_class_name(cache_type_name)
+
+                if cache_type_name in (
+                    "RingSlidingKVCache", "OMLXRingSlidingKVCache"
+                ):
+                    # A deduplicated chain may start with a valid prefill
+                    # capture and end with old overwritten decode-ring slots.
+                    # Validate every block, not just the first block's metadata
+                    # passed to reconstruct_cache for ordinary sliceable KV.
+                    window = None
+                    prefix_end = 0
+                    for block_idx, data in enumerate(all_block_data):
+                        metadata = all_block_meta_states[block_idx]
+                        block_window, stored_length = handler.validate_prefix_metadata(
+                            metadata[layer_idx] if metadata else None
+                        )
+                        keys, values = data[layer_idx]
+                        expected_length = self.paged_cache.blocks[
+                            block_table.block_ids[block_idx]
+                        ].token_count
+                        if (
+                            keys is None
+                            or values is None
+                            or keys.ndim != 4
+                            or values.ndim != 4
+                            or keys.shape[:3] != values.shape[:3]
+                            or keys.shape[0] != 1
+                            or keys.shape[2] != expected_length
+                        ):
+                            raise ValueError("Invalid Unlimited-OCR prefix block length")
+                        prefix_end += expected_length
+                        if stored_length < prefix_end or (
+                            window is not None and block_window != window
+                        ):
+                            raise ValueError("Incompatible Unlimited-OCR prefix blocks")
+                        window = block_window
 
                 # === CacheList: dedicated branch (before standard 2-tuple unpack) ===
                 if cache_type_name == "CacheList":

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -827,7 +827,7 @@ class BlockAwarePrefixCache(CacheManager):
             # decode slots. Do not label it with the full generated sequence
             # or allocate blocks past its valid prefix (including partials).
             for idx, type_name in enumerate(layer_cache_types or []):
-                if type_name in ("RingSlidingKVCache", "OMLXRingSlidingKVCache"):
+                if CacheTypeRegistry.is_ring_family(type_name):
                     if idx >= len(cache_data):
                         # Refuse incomplete captures before allocating blocks.
                         return None
@@ -3405,9 +3405,7 @@ class BlockAwarePrefixCache(CacheManager):
 
                 handler = CacheTypeRegistry.get_handler_by_class_name(cache_type_name)
 
-                if cache_type_name in (
-                    "RingSlidingKVCache", "OMLXRingSlidingKVCache"
-                ):
+                if CacheTypeRegistry.is_ring_family(cache_type_name):
                     # A deduplicated chain may start with a valid prefill
                     # capture and end with old overwritten decode-ring slots.
                     # Validate every block, not just the first block's metadata
@@ -3415,14 +3413,49 @@ class BlockAwarePrefixCache(CacheManager):
                     window = None
                     prefix_end = 0
                     for block_idx, data in enumerate(all_block_data):
+                        if block_idx >= len(block_table.block_ids):
+                            raise ValueError(
+                                f"Missing Unlimited-OCR block ID at index {block_idx}"
+                            )
+                        block_id = block_table.block_ids[block_idx]
+                        block = self.paged_cache.allocated_blocks.get(block_id)
+                        if block is None:
+                            raise ValueError(
+                                f"Unlimited-OCR block {block_id} is no longer allocated"
+                            )
+                        if block_idx >= len(all_block_meta_states):
+                            raise ValueError(
+                                f"Missing Unlimited-OCR metadata for block {block_idx}"
+                            )
                         metadata = all_block_meta_states[block_idx]
+                        if (
+                            not isinstance(metadata, (list, tuple))
+                            or layer_idx >= len(metadata)
+                        ):
+                            raise ValueError(
+                                f"Missing Unlimited-OCR metadata for layer {layer_idx} "
+                                f"in block {block_idx}"
+                            )
                         block_window, stored_length = handler.validate_prefix_metadata(
-                            metadata[layer_idx] if metadata else None
+                            metadata[layer_idx]
                         )
+                        if (
+                            not isinstance(data, (list, tuple))
+                            or layer_idx >= len(data)
+                        ):
+                            raise ValueError(
+                                f"Missing Unlimited-OCR layer {layer_idx} in block {block_idx}"
+                            )
+                        if (
+                            not isinstance(data[layer_idx], (list, tuple))
+                            or len(data[layer_idx]) != 2
+                        ):
+                            raise ValueError(
+                                f"Invalid Unlimited-OCR K/V pair for layer {layer_idx} "
+                                f"in block {block_idx}"
+                            )
                         keys, values = data[layer_idx]
-                        expected_length = self.paged_cache.blocks[
-                            block_table.block_ids[block_idx]
-                        ].token_count
+                        expected_length = block.token_count
                         if (
                             keys is None
                             or values is None

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -828,6 +828,9 @@ class BlockAwarePrefixCache(CacheManager):
             # or allocate blocks past its valid prefix (including partials).
             for idx, type_name in enumerate(layer_cache_types or []):
                 if type_name in ("RingSlidingKVCache", "OMLXRingSlidingKVCache"):
+                    if idx >= len(cache_data):
+                        # Refuse incomplete captures before allocating blocks.
+                        return None
                     keys = cache_data[idx]["state"][0]
                     if keys is None:
                         return None

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -784,13 +784,13 @@ class BlockAwarePrefixCache(CacheManager):
         if not tokens:
             return None
 
-        # Check if cache_data contains extracted tensor states
+        # Recognize extracted payloads even when the first state is missing,
+        # so malformed ring captures cannot bypass validation below.
         is_tensor_data = (
             cache_data
             and isinstance(cache_data, list)
             and len(cache_data) > 0
             and isinstance(cache_data[0], dict)
-            and "state" in cache_data[0]
         )
 
         # Extract cache type information for SSD storage
@@ -831,8 +831,19 @@ class BlockAwarePrefixCache(CacheManager):
                     if idx >= len(cache_data):
                         # Refuse incomplete captures before allocating blocks.
                         return None
-                    keys = cache_data[idx]["state"][0]
-                    if keys is None:
+                    state = cache_data[idx].get("state")
+                    if not isinstance(state, (tuple, list)) or len(state) != 2:
+                        return None
+                    keys, values = state
+                    # Match the reconstruction contract before slicing or
+                    # allocating blocks. K/V feature widths may differ.
+                    if (
+                        getattr(keys, "ndim", None) != 4
+                        or getattr(values, "ndim", None) != 4
+                        or keys.shape[:3] != values.shape[:3]
+                        or keys.shape[0] != 1
+                        or keys.shape[2] <= 0
+                    ):
                         return None
                     tokens = tokens[: keys.shape[2]]
             if not tokens:

--- a/omlx/cache/type_handlers.py
+++ b/omlx/cache/type_handlers.py
@@ -43,6 +43,7 @@ class CacheType(Enum):
     QWEN4_QSA_KVCACHE = "QSAKVCache"
     QWEN4_QSA_QUANTIZED_KVCACHE = "QSAQuantizedKVCache"
     QWEN4_BATCH_QSA_KVCACHE = "BatchQSAKVCache"
+    RING_SLIDING_KVCACHE = "RingSlidingKVCache"
 
 
 @dataclass

--- a/omlx/cache/type_registry.py
+++ b/omlx/cache/type_registry.py
@@ -24,6 +24,7 @@ from .type_handlers import (
     RotatingKVCacheHandler,
     SizedArraysCache,
 )
+from .unlimited_ocr_handler import RingSlidingKVCacheHandler
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +80,8 @@ class CacheTypeRegistry:
         "QSAKVCache": CacheType.QWEN4_QSA_KVCACHE,
         "QSAQuantizedKVCache": CacheType.QWEN4_QSA_QUANTIZED_KVCACHE,
         "BatchQSAKVCache": CacheType.QWEN4_BATCH_QSA_KVCACHE,
+        "RingSlidingKVCache": CacheType.RING_SLIDING_KVCACHE,
+        "OMLXRingSlidingKVCache": CacheType.RING_SLIDING_KVCACHE,
     }
 
     # Default handler instance
@@ -272,6 +275,7 @@ def _initialize_default_handlers() -> None:
     CacheTypeRegistry.register(Qwen4QSAKVCacheHandler())
     CacheTypeRegistry.register(Qwen4QSAQuantizedKVCacheHandler())
     CacheTypeRegistry.register(Qwen4BatchQSAKVCacheHandler())
+    CacheTypeRegistry.register(RingSlidingKVCacheHandler())
 
 
 # Initialize handlers when module is imported

--- a/omlx/cache/type_registry.py
+++ b/omlx/cache/type_registry.py
@@ -162,6 +162,15 @@ class CacheTypeRegistry:
         return cls._class_name_map.get(class_name) == CacheType.ARRAYS_CACHE
 
     @classmethod
+    def is_ring_family(cls, class_name: str) -> bool:
+        """Match registered ring layouts, not arbitrary KVCache subclasses.
+
+        Family membership permits ring-handler dispatch; it does not imply
+        oMLX's adapted-only set_prefill_end or singleton interfaces.
+        """
+        return cls._class_name_map.get(class_name) == CacheType.RING_SLIDING_KVCACHE
+
+    @classmethod
     def detect_cache_type(cls, cache_obj: Any) -> CacheType:
         """Detect cache type from object.
 

--- a/omlx/cache/unlimited_ocr.py
+++ b/omlx/cache/unlimited_ocr.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native Unlimited-OCR ring cache on oMLX's serial generation lane.
+
+Import lazily after the Unlimited-OCR compatibility loader has run: the pinned
+mlx-vlm may obtain the native model package from oMLX's vendor namespace.
+"""
+
+from mlx_vlm.models.unlimited_ocr.language import RingSlidingKVCache
+
+
+class OMLXRingSlidingKVCache(RingSlidingKVCache):
+    """Keep the native attention layout; reject lossy batch conversions."""
+
+    @classmethod
+    def merge(cls, caches):
+        if len(caches) != 1:
+            raise ValueError("Unlimited-OCR ring caches require serial requests")
+        return caches[0]
+
+    def to_batch(self, left_padding):
+        if list(left_padding) != [0]:
+            raise ValueError(
+                "Unlimited-OCR ring caches require serial unpadded requests"
+            )
+        return self
+
+    def filter(self, batch_indices):
+        indices = list(batch_indices)
+        if indices == [0]:
+            return
+        if not indices:
+            self.keys = self.values = None
+            self.offset = 0
+            self.prefill_length = None
+            self._ring_pos = 0
+            return
+        raise ValueError("Unlimited-OCR ring caches require serial requests")
+
+    def extract(self, idx):
+        if int(idx) != 0:
+            raise IndexError("Unlimited-OCR ring cache only has row 0")
+        return self
+
+    def extend(self, other):
+        raise ValueError("Unlimited-OCR ring caches require serial requests")
+
+    def is_trimmable(self):
+        # Prefill prefixes are contiguous; decode has overwritten history.
+        return self.prefill_length is None
+
+    def trim(self, n):
+        if not self.is_trimmable():
+            raise ValueError("Cannot trim a decoded Unlimited-OCR ring cache")
+        return super().trim(n)

--- a/omlx/cache/unlimited_ocr.py
+++ b/omlx/cache/unlimited_ocr.py
@@ -5,11 +5,33 @@ Import lazily after the Unlimited-OCR compatibility loader has run: the pinned
 mlx-vlm may obtain the native model package from oMLX's vendor namespace.
 """
 
+from mlx_vlm.models.cache import KVCache
 from mlx_vlm.models.unlimited_ocr.language import RingSlidingKVCache
 
 
 class OMLXRingSlidingKVCache(RingSlidingKVCache):
     """Keep the native attention layout; reject lossy batch conversions."""
+
+    def __init__(self, window_size):
+        super().__init__(window_size)
+        self._prefill_end = None
+
+    def set_prefill_end(self, end):
+        """Declare the N-1 boundary before any size-one prefill chunks."""
+        if self.prefill_length is not None or end < self.offset:
+            raise ValueError("Cannot reopen or move back the ring prefill boundary")
+        self._prefill_end = end
+
+    def update_and_fetch(self, keys, values):
+        if self._prefill_end is not None:
+            if self.offset < self._prefill_end:
+                if self.offset + keys.shape[2] > self._prefill_end:
+                    raise ValueError("Prefill chunk crosses the ring decode boundary")
+                # Native ring code treats every size-one call as decode. The
+                # scheduler knows whether it is still processing prompt KV.
+                return KVCache.update_and_fetch(self, keys, values)
+            self._prefill_end = None
+        return super().update_and_fetch(keys, values)
 
     @classmethod
     def merge(cls, caches):
@@ -33,6 +55,7 @@ class OMLXRingSlidingKVCache(RingSlidingKVCache):
             self.offset = 0
             self.prefill_length = None
             self._ring_pos = 0
+            self._prefill_end = None
             return
         raise ValueError("Unlimited-OCR ring caches require serial requests")
 

--- a/omlx/cache/unlimited_ocr_handler.py
+++ b/omlx/cache/unlimited_ocr_handler.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Persist the intact prompt prefix, never overwritten OCR decode-ring slots."""
+
+from .type_handlers import CacheType, KVCacheHandler
+
+
+class RingSlidingKVCacheHandler(KVCacheHandler):
+    @property
+    def cache_type(self):
+        return CacheType.RING_SLIDING_KVCACHE
+
+    def serialize_state(self, cache_obj):
+        keys, values = cache_obj.state
+        if keys is None or values is None:
+            return keys, values
+        prefix_length = cache_obj.prefill_length
+        end = (
+            min(cache_obj.offset, prefix_length)
+            if prefix_length is not None
+            else cache_obj.offset
+        )
+        return keys[:, :, :end, :], values[:, :, :end, :]
+
+    def serialize_meta_state(self, cache_obj):
+        keys, _ = self.serialize_state(cache_obj)
+        length = 0 if keys is None else keys.shape[2]
+        # Storage is a prefill prefix, even when captured after decoding.
+        return (str(cache_obj.window_size), "-1", str(length), "0")
+
+    def extract_state(self, cache_obj):
+        keys, values = self.serialize_state(cache_obj)
+        return {
+            "keys": keys,
+            "values": values,
+            "offset": 0 if keys is None else keys.shape[2],
+            "cache_type": self.cache_type.value,
+        }
+
+    @staticmethod
+    def validate_prefix_metadata(meta_state):
+        """Return window/length only for intact, not post-decode, captures."""
+        if not isinstance(meta_state, (list, tuple)) or len(meta_state) != 4:
+            raise ValueError("Missing or invalid Unlimited-OCR ring metadata")
+        window, prefix_length, stored_length, ring_pos = map(int, meta_state)
+        if window <= 0 or prefix_length != -1 or ring_pos != 0 or stored_length <= 0:
+            raise ValueError("Invalid Unlimited-OCR intact-prefix metadata")
+        return window, stored_length
+
+    def reconstruct_cache(self, state, meta_state=None):
+        from .unlimited_ocr import OMLXRingSlidingKVCache
+
+        window, _ = self.validate_prefix_metadata(meta_state)
+        keys, values = state.get("keys"), state.get("values")
+        if (
+            keys is None
+            or values is None
+            or keys.ndim != 4
+            or values.ndim != 4
+            or keys.shape[:3] != values.shape[:3]
+            or keys.shape[0] != 1
+            or keys.shape[2] <= 0
+        ):
+            raise ValueError("Invalid Unlimited-OCR intact-prefix cache state")
+        cache = OMLXRingSlidingKVCache(window)
+        # Deduplicated chains use the first block's capture metadata. Its
+        # stored_length may be shorter than this extended, concatenated prefix;
+        # per-block tensor-length validation already happens in prefix_cache.
+        cache.state = (keys, values)
+        # Do not restore the old decode boundary. The request may extend this
+        # prefix; the native cache establishes its boundary on first decode.
+        return cache

--- a/omlx/models/vlm.py
+++ b/omlx/models/vlm.py
@@ -174,6 +174,23 @@ class VLMModelAdapter(nn.Module):
             return self._language_model.args
         return self.config
 
+    @property
+    def requires_serial_decode(self) -> bool:
+        """Unlimited-OCR's native ring cache has no safe multi-row conversion."""
+        return self.model_type == "unlimited-ocr"
+
+    def is_prefix_cache_compatible(self, caches: List[Any]) -> bool:
+        """Reject legacy full-KV OCR prefixes, including text-only requests."""
+        if self.model_type != "unlimited-ocr":
+            return True
+        expected = self.make_cache()
+        return len(caches) == len(expected) and all(
+            type(actual) is type(fresh)
+            and getattr(actual, "window_size", None)
+            == getattr(fresh, "window_size", None)
+            for actual, fresh in zip(caches, expected)
+        )
+
     def make_cache(self) -> List[Any]:
         """
         Create KV cache using the language model's make_cache().
@@ -183,7 +200,17 @@ class VLMModelAdapter(nn.Module):
         per layer if the language model doesn't define make_cache().
         """
         if hasattr(self._language_model, "make_cache"):
-            return self._language_model.make_cache()
+            caches = self._language_model.make_cache()
+            if self.requires_serial_decode:
+                from ..cache.unlimited_ocr import OMLXRingSlidingKVCache
+
+                caches = [
+                    OMLXRingSlidingKVCache(c.window_size)
+                    if type(c).__name__ == "RingSlidingKVCache"
+                    else c
+                    for c in caches
+                ]
+            return caches
         from mlx_lm.models.cache import KVCache
         return [KVCache() for _ in range(len(self.layers))]
 

--- a/omlx/models/vlm.py
+++ b/omlx/models/vlm.py
@@ -176,7 +176,16 @@ class VLMModelAdapter(nn.Module):
 
     @property
     def requires_serial_decode(self) -> bool:
-        """Unlimited-OCR's native ring cache has no safe multi-row conversion."""
+        """Unlimited-OCR's native ring cache has no safe multi-row conversion.
+
+        EngineCore's single-worker executor serializes scheduler execution;
+        the scheduler additionally admits only one running/prefilling request
+        for this model. Fresh/restored caches belong to individual requests,
+        not the shared weights. EngineCore registers model-object ownership;
+        forced transfer resets the previous owner's scheduler but does not
+        stop its engine loop. Other engines with separate models may still
+        run concurrently.
+        """
         return self.model_type == "unlimited-ocr"
 
     def is_prefix_cache_compatible(self, caches: List[Any]) -> bool:

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1782,6 +1782,11 @@ class Scheduler:
                 "Llama 4 detected; serializing requests because ChunkedKVCache "
                 "does not support multi-row batching yet"
             )
+        if getattr(model, "requires_serial_decode", False) is True:
+            logger.info(
+                "Unlimited-OCR detected; serializing requests to preserve "
+                "native ring-cache attention"
+            )
 
         # Load additional EOS tokens from generation_config.json.
         # Some models (e.g. GLM-4.6V) define multiple EOS tokens there
@@ -3288,6 +3293,8 @@ class Scheduler:
             return False
 
         def _ok(c: Any) -> bool:
+            if type(c).__name__ in ("RingSlidingKVCache", "OMLXRingSlidingKVCache"):
+                return False
             if isinstance(c, KVCache):
                 return True
             if isinstance(c, ArraysCache):
@@ -8033,6 +8040,8 @@ class Scheduler:
                         "QSAKVCache",
                         "QSAQuantizedKVCache",
                         "BatchQSAKVCache",
+                        "RingSlidingKVCache",
+                        "OMLXRingSlidingKVCache",
                     ):
                         state = handler.serialize_state(layer_cache)
                         meta = handler.serialize_meta_state(layer_cache)
@@ -8542,6 +8551,16 @@ class Scheduler:
                     reconstructed = self.block_aware_cache.reconstruct_cache(
                         block_table
                     )
+                validate_prefix = getattr(self.model, "is_prefix_cache_compatible", None)
+                if (
+                    reconstructed
+                    and callable(validate_prefix)
+                    and not validate_prefix(reconstructed)
+                ):
+                    logger.warning(
+                        "Discarding incompatible prefix cache for %s", request.request_id
+                    )
+                    reconstructed = None
                 if reconstructed:
                     request.prompt_cache = reconstructed
                     request.block_table = block_table
@@ -9794,7 +9813,11 @@ class Scheduler:
     def _effective_max_num_seqs(self) -> int:
         """Current admission cap, narrowed for models that require serial decode."""
         self._refresh_generation_overflow_recovery_ids()
-        if self._serialize_llama4_requests or self._generation_overflow_recovery_ids:
+        if (
+            self._serialize_llama4_requests
+            or self._generation_overflow_recovery_ids
+            or getattr(self.model, "requires_serial_decode", False) is True
+        ):
             return 1
         return max(1, self.config.max_num_seqs)
 

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -3448,6 +3448,13 @@ class Scheduler:
         ]
         return all(routes) if routes else predicted
 
+    @staticmethod
+    def _set_ring_prefill_end(cache: list[Any], remaining_tokens: int) -> None:
+        """Keep size-one prompt chunks out of the native OCR decode ring."""
+        for layer in cache:
+            if type(layer).__name__ == "OMLXRingSlidingKVCache":
+                layer.set_prefill_end(layer.offset + max(0, remaining_tokens - 1))
+
     def _do_external_prefill(
         self,
         request: "Request",
@@ -3499,6 +3506,8 @@ class Scheduler:
             prompt_cache = existing_cache
         else:
             prompt_cache = make_prompt_cache(self.model)
+
+        self._set_ring_prefill_end(prompt_cache, n_tokens)
 
         # Fresh TurboQuant requests run fp16 during the cold prefill loop and
         # are quantized once at the end. Restored TurboQuant prefix caches stay
@@ -5308,6 +5317,7 @@ class Scheduler:
             if existing_cache is not None
             else make_prompt_cache(self.model)
         )
+        self._set_ring_prefill_end(prompt_cache, len(tokens))
 
         block_size = self.config.paged_cache_block_size
         boundary_enabled = (

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -3287,13 +3287,17 @@ class Scheduler:
         """
         from mlx_lm.models.cache import ArraysCache, CacheList, KVCache
 
+        if CacheTypeRegistry is None:
+            # Without layout classification, do not risk converting a custom
+            # KVCache subclass as ordinary dense KV.
+            return False
         if self._model_uses_mla():
             return False
         if self._model_uses_attention_sinks():
             return False
 
         def _ok(c: Any) -> bool:
-            if type(c).__name__ in ("RingSlidingKVCache", "OMLXRingSlidingKVCache"):
+            if CacheTypeRegistry.is_ring_family(type(c).__name__):
                 return False
             if isinstance(c, KVCache):
                 return True
@@ -3450,7 +3454,18 @@ class Scheduler:
 
     @staticmethod
     def _set_ring_prefill_end(cache: list[Any], remaining_tokens: int) -> None:
-        """Keep size-one prompt chunks out of the native OCR decode ring."""
+        """Declare the absolute end of this request's N-1 prefill.
+
+        remaining_tokens includes the final prompt token reserved for the
+        BatchGenerator kickoff. Both _do_external_prefill and _begin_prefill
+        process tokens[:-1] as prefill and pass tokens[-1:] to insert(); keep
+        this boundary in sync if either split changes. Chunking and VLM
+        embeddings do not change the number of reserved kickoff tokens.
+
+        The final prompt token enters the decode ring, not the permanent
+        prefix. This preserves oMLX's existing split, not native full-prompt
+        parity. Size-one chunks before the boundary must remain prefill.
+        """
         for layer in cache:
             if type(layer).__name__ == "OMLXRingSlidingKVCache":
                 layer.set_prefill_end(layer.offset + max(0, remaining_tokens - 1))
@@ -8044,14 +8059,15 @@ class Scheduler:
                     continue
 
                 if hasattr(layer_cache, "state"):
-                    if handler is not None and class_name in (
-                        "MiniMaxM3KVCache",
-                        "MiniMaxM3BatchKVCache",
-                        "QSAKVCache",
-                        "QSAQuantizedKVCache",
-                        "BatchQSAKVCache",
-                        "RingSlidingKVCache",
-                        "OMLXRingSlidingKVCache",
+                    if handler is not None and (
+                        class_name in (
+                            "MiniMaxM3KVCache",
+                            "MiniMaxM3BatchKVCache",
+                            "QSAKVCache",
+                            "QSAQuantizedKVCache",
+                            "BatchQSAKVCache",
+                        )
+                        or CacheTypeRegistry.is_ring_family(class_name)
                     ):
                         state = handler.serialize_state(layer_cache)
                         meta = handler.serialize_meta_state(layer_cache)
@@ -9821,7 +9837,14 @@ class Scheduler:
         self._generation_overflow_recovery_ids.intersection_update(active_ids)
 
     def _effective_max_num_seqs(self) -> int:
-        """Current admission cap, narrowed for models that require serial decode."""
+        """Current admission cap, narrowed for models that require serial decode.
+
+        _schedule_waiting counts running plus prefilling requests, not just
+        rows in the current decode batch. EngineCore runs this scheduler on
+        its single-worker executor; the cap prevents overlapping admission,
+        while that executor prevents overlapping step() calls. This does not
+        make direct concurrent calls to Scheduler.step() safe.
+        """
         self._refresh_generation_overflow_recovery_ids()
         if (
             self._serialize_llama4_requests

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -3507,7 +3507,7 @@ class Scheduler:
         else:
             prompt_cache = make_prompt_cache(self.model)
 
-        self._set_ring_prefill_end(prompt_cache, n_tokens)
+        Scheduler._set_ring_prefill_end(prompt_cache, n_tokens)
 
         # Fresh TurboQuant requests run fp16 during the cold prefill loop and
         # are quantized once at the end. Restored TurboQuant prefix caches stay
@@ -5317,7 +5317,7 @@ class Scheduler:
             if existing_cache is not None
             else make_prompt_cache(self.model)
         )
-        self._set_ring_prefill_end(prompt_cache, len(tokens))
+        Scheduler._set_ring_prefill_end(prompt_cache, len(tokens))
 
         block_size = self.config.paged_cache_block_size
         boundary_enabled = (

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -617,8 +617,10 @@ class TestSchedulerAddRequest:
         """Reject unknown cache classes before a partial hit loses their state."""
         from omlx.cache.paged_cache import BlockTable
 
-        RingSlidingKVCache = type("RingSlidingKVCache", (), {})
-        mock_model.make_cache = lambda: [RingSlidingKVCache()]
+        # The real ring class is now registered; keep this a genuinely
+        # unsupported layout so capability additions cannot weaken the test.
+        UnregisteredRingCache = type("UnregisteredRingCache", (), {})
+        mock_model.make_cache = lambda: [UnregisteredRingCache()]
 
         scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
         scheduler.block_aware_cache = MagicMock()
@@ -723,7 +725,7 @@ class TestSchedulerAddRequest:
         cache_list = type(
             "CacheList",
             (),
-            {"caches": (type("KVCache", (), {})(), type("RingSlidingKVCache", (), {})())},
+            {"caches": (type("KVCache", (), {})(), type("UnregisteredRingCache", (), {})())},
         )
         mock_model.make_cache = lambda: [cache_list()]
 

--- a/tests/test_unlimited_ocr_cache.py
+++ b/tests/test_unlimited_ocr_cache.py
@@ -51,6 +51,28 @@ def test_unsafe_multirow_merge_is_rejected():
         _patched_merge_caches([[make_filled_cache()], [make_filled_cache()]])
 
 
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("RingSlidingKVCache", True),
+        ("OMLXRingSlidingKVCache", True),
+        ("KVCache", False),
+        ("RotatingKVCache", False),
+        ("UnregisteredRingSlidingKVCache", False),
+    ],
+)
+def test_ring_family_requires_registered_ring_type(name, expected):
+    assert CacheTypeRegistry.is_ring_family(name) is expected
+
+
+def test_ring_family_does_not_imply_adapted_prefill_interface():
+    native = adapter()._language_model.make_cache()[0]
+    append(native, [0, 1])
+    assert CacheTypeRegistry.is_ring_family(type(native).__name__)
+    Scheduler._set_ring_prefill_end([native], 3)
+    assert native.offset == 2 and native.prefill_length is None
+
+
 def test_ring_prefix_serialization_does_not_export_overwritten_slots():
     cache = make_filled_cache()
     handler = CacheTypeRegistry.get_handler_for_object(cache)
@@ -115,6 +137,18 @@ def test_scheduler_exports_only_intact_prefix(mock_model, mock_tokenizer):
 def test_ring_is_not_turboquant_convertible(mock_model, mock_tokenizer):
     scheduler = Scheduler(mock_model, mock_tokenizer)
     assert not scheduler._turboquant_eligible([make_filled_cache()])
+
+
+def test_turboquant_refuses_cache_when_registry_is_unavailable(
+    monkeypatch, mock_model, mock_tokenizer
+):
+    from mlx_lm.models.cache import KVCache
+
+    import omlx.scheduler as scheduler_module
+
+    scheduler = Scheduler(mock_model, mock_tokenizer)
+    monkeypatch.setattr(scheduler_module, "CacheTypeRegistry", None)
+    assert not scheduler._turboquant_eligible([KVCache()])
 
 
 def test_stale_plain_kv_prefix_is_incompatible():
@@ -316,6 +350,53 @@ def test_store_accepts_ring_kv_with_distinct_feature_dimensions(
         ssd.close()
 
 
+def test_restored_unequal_width_ring_matches_native_decode_after_wrap(
+    tmp_path, mock_model, mock_tokenizer
+):
+    # Native KVCache allocates K and V widths separately. Verify the restored
+    # ring preserves that contract through decode and actual MLX attention.
+    native = adapter()._language_model.make_cache()[0]
+    keys = mx.broadcast_to(mx.arange(4)[None, None, :, None], (1, 1, 4, 192))
+    values = mx.broadcast_to(
+        mx.arange(100, 104)[None, None, :, None], (1, 1, 4, 128)
+    )
+    native.update_and_fetch(keys.astype(mx.float32), values.astype(mx.float32))
+    scheduler = Scheduler(mock_model, mock_tokenizer)
+    payload, config = scheduler._extract_cache_states([native])
+    prefix, paged, ssd = make_ssd_stack(tmp_path, 2)
+    try:
+        table = prefix.store_cache(
+            "unequal-decode", list(range(4)), payload, model_cache_config=config
+        )
+        assert table is not None and table.num_tokens == 4
+        restored_layers = prefix.reconstruct_cache(table)
+        assert restored_layers is not None
+        restored = restored_layers[0]
+        assert restored is not native
+        query = mx.ones((1, 1, 1, 192))
+        for token in range(4, 10):
+            keys = mx.full((1, 1, 1, 192), float(token))
+            values = mx.full((1, 1, 1, 128), float(100 + token))
+            expected_keys, expected_values = native.update_and_fetch(keys, values)
+            actual_keys, actual_values = restored.update_and_fetch(keys, values)
+            assert mx.array_equal(actual_keys, expected_keys).item()
+            assert mx.array_equal(actual_values, expected_values).item()
+            expected = mx.fast.scaled_dot_product_attention(
+                query, expected_keys, expected_values, scale=192**-0.5
+            )
+            actual = mx.fast.scaled_dot_product_attention(
+                query, actual_keys, actual_values, scale=192**-0.5
+            )
+            assert actual.shape == (1, 1, 1, 128)
+            assert mx.allclose(actual, expected, atol=1e-5, rtol=1e-5).item()
+        # Four prompt tokens stay permanent; the two-slot ring wrapped twice.
+        assert restored.offset == 10 and restored.prefill_length == 4
+        assert actual_keys[0, 0, :, 0].tolist() == [0, 1, 2, 3, 8, 9]
+        assert actual_values[0, 0, :, 0].tolist() == [100, 101, 102, 103, 108, 109]
+    finally:
+        ssd.close()
+
+
 def test_scheduler_discards_legacy_ocr_prefix(mock_model, mock_tokenizer):
     from unittest.mock import MagicMock
 
@@ -475,7 +556,16 @@ def test_scheduler_prefill_boundary_matches_cold_past_ring_window(
                 # Chunked prefill yields to the scheduler's fairness timer.
                 if not request.is_finished():
                     time.sleep(0.001)
-            assert request.is_finished()
+            state = scheduler._prefill_states.get(request.request_id)
+            assert request.is_finished(), (
+                f"{label}: scheduler did not finish within 10s; "
+                f"status={request.status.name}, "
+                f"generated={len(request.output_token_ids)}/132, "
+                f"cached_tokens={request.cached_tokens}, "
+                f"chunked={use_chunks}, step_size={step}, "
+                f"prefill_processed={state.tokens_processed if state else 'inactive'}, "
+                f"prefill_remaining={state.tokens_remaining.size if state else 'inactive'}"
+            )
             assert len(request.output_token_ids) == 132
             assert request.get_finish_reason() == "length"
             assert all(b.ref_count == 0 for b in paged.blocks if not b.is_null)
@@ -790,5 +880,79 @@ def test_ring_block_tensor_length_must_match_token_count(
         assert prefix.reconstruct_cache(table) is None
         paged.delete_block_table("warm-short")
         assert all(b.ref_count == 0 for b in paged.blocks if not b.is_null)
+    finally:
+        ssd.close()
+
+
+@pytest.mark.parametrize(
+    "corruption, diagnostic",
+    [
+        ("metadata", "Missing Unlimited-OCR metadata for layer 1 in block 1"),
+        ("layer", "Missing Unlimited-OCR layer 1 in block 1"),
+        ("allocation", "is no longer allocated"),
+    ],
+)
+def test_ring_reconstruction_missing_entries_report_context_and_release_refs(
+    tmp_path, mock_model, mock_tokenizer, monkeypatch, caplog, corruption, diagnostic
+):
+    from omlx.request import Request, SamplingParams
+
+    scheduler = Scheduler(mock_model, mock_tokenizer)
+    caches = [make_filled_cache(), make_filled_cache()]
+    payload, config = scheduler._extract_cache_states(caches)
+    prefix, paged, ssd = make_ssd_stack(tmp_path, 2, num_layers=2)
+    try:
+        table = prefix.store_cache(
+            "seed", list(range(4)), payload, model_cache_config=config
+        )
+        assert table is not None and table.num_tokens == 4
+        tail_hash = paged.blocks[table.block_ids[-1]].block_hash
+        paged.delete_block_table("seed")
+        load = ssd.load_block_with_metadata
+
+        def load_incomplete_tail(block_hash, **kwargs):
+            data, metadata = load(block_hash, **kwargs)
+            if block_hash == tail_hash:
+                if corruption == "metadata":
+                    metadata = dict(metadata)
+                    metadata["layer_meta_states"] = metadata["layer_meta_states"][:1]
+                elif corruption == "layer":
+                    data = data[:1]
+                else:
+                    # Simulate a missing allocation on the validation lookup
+                    # only. Keep the real owned blocks available for cleanup.
+                    class MissingValidationLookup(dict):
+                        missing = True
+
+                        def get(self, key, default=None):
+                            block = super().get(key, default)
+                            if (
+                                block is not None
+                                and block.block_hash == tail_hash
+                                and self.missing
+                            ):
+                                self.missing = False
+                                return None
+                            return block
+
+                    monkeypatch.setattr(
+                        paged,
+                        "allocated_blocks",
+                        MissingValidationLookup(paged.allocated_blocks),
+                    )
+            return data, metadata
+
+        monkeypatch.setattr(ssd, "load_block_with_metadata", load_incomplete_tail)
+        scheduler.block_aware_cache = prefix
+        scheduler.paged_cache_manager = paged
+        request = Request("incomplete-tail", list(range(6)), SamplingParams(max_tokens=4))
+        scheduler.add_request(request)
+        scheduler._prepare_prefix_cache_for_request(request)
+        assert request.cached_tokens == 0
+        assert request.prompt_cache is None and request.block_table is None
+        assert request.remaining_tokens == list(range(6))
+        assert paged.get_block_table(request.request_id) is None
+        assert all(b.ref_count == 0 for b in paged.blocks if not b.is_null)
+        assert diagnostic in caplog.text
     finally:
         ssd.close()

--- a/tests/test_unlimited_ocr_cache.py
+++ b/tests/test_unlimited_ocr_cache.py
@@ -205,6 +205,28 @@ def test_ssd_store_and_restore_only_prompt_blocks(
         ssd.close()
 
 
+def test_store_refuses_missing_ring_layer_before_allocating_blocks(
+    tmp_path, mock_model, mock_tokenizer
+):
+    scheduler = Scheduler(mock_model, mock_tokenizer)
+    payload, config = scheduler._extract_cache_states(
+        [make_filled_cache(), make_filled_cache()]
+    )
+    prefix, paged, ssd = make_ssd_stack(tmp_path, 2)
+    try:
+        # The model declares two ring layers, but only the first was captured.
+        table = prefix.store_cache(
+            "incomplete", list(range(12)), payload[:1], model_cache_config=config
+        )
+        assert table is None
+        assert paged.get_block_table("incomplete") is None
+        assert "incomplete" not in prefix._request_tables
+        assert all(b.ref_count == 0 for b in paged.blocks if not b.is_null)
+        assert all(b.block_hash is None for b in paged.blocks if not b.is_null)
+    finally:
+        ssd.close()
+
+
 def test_scheduler_discards_legacy_ocr_prefix(mock_model, mock_tokenizer):
     from unittest.mock import MagicMock
 

--- a/tests/test_unlimited_ocr_cache.py
+++ b/tests/test_unlimited_ocr_cache.py
@@ -280,6 +280,152 @@ class TinyRingLanguageModel:
         return mx.broadcast_to(mx.array([0.0, 0.0, 10.0, 0.0]), (*input_ids.shape, 4))
 
 
+class RetentionLogitsModel(TinyRingLanguageModel):
+    """Make an early ring overwrite observable in generated token IDs."""
+
+    def __init__(self):
+        self.boundaries = []
+
+    def make_cache(self):
+        from mlx_vlm.models.unlimited_ocr.language import RingSlidingKVCache
+
+        return [RingSlidingKVCache(128)]
+
+    def __call__(self, input_ids, cache=None, **kwargs):
+        tensor = input_ids.astype(mx.float32)[:, None, :, None]
+        keys, _ = cache[0].update_and_fetch(tensor, tensor)
+        self.boundaries.append(cache[0].prefill_length)
+        token = 3 + int(mx.sum(keys).item()) % 20
+        logits = mx.where(mx.arange(32) == token, 10.0, -10.0)
+        return mx.broadcast_to(logits, (*input_ids.shape, 32))
+
+
+@pytest.mark.parametrize(
+    "prompt_length,stored_length,step_size,chunked",
+    [
+        (8, 8, 2048, False),  # exact hit trims to N-1
+        (9, 8, 2048, False),  # one uncached token is kickoff, not prefill
+        (8, 6, 2048, False),  # two uncached tokens split into prefill + kickoff
+        (8, 0, 2, False),  # synchronous prefill ends in a single-token chunk
+        (8, 0, 2, True),  # the same tail across scheduler step() calls
+        (8, 4, 2, True),  # chunked continuation from a partial prefix
+        (8, 0, 1, True),  # every prefill chunk is a single token
+    ],
+)
+def test_scheduler_prefill_boundary_matches_cold_past_ring_window(
+    tmp_path,
+    mock_model,
+    mock_tokenizer,
+    prompt_length,
+    stored_length,
+    step_size,
+    chunked,
+):
+    import time
+
+    from omlx.request import Request, SamplingParams
+
+    prompt = list(range(10, 10 + prompt_length))
+
+    def run(label, stored, step, use_chunks):
+        model = adapter()
+        language = RetentionLogitsModel()
+        model._language_model = language
+        scheduler = Scheduler(
+            mock_model,
+            mock_tokenizer,
+            SchedulerConfig(prefill_step_size=step, chunked_prefill=use_chunks),
+        )
+        scheduler.model = model
+        prefix, paged, ssd = make_ssd_stack(tmp_path / label, 2)
+        scheduler.block_aware_cache = prefix
+        scheduler.paged_cache_manager = paged
+        try:
+            if stored:
+                cache = model.make_cache()[0]
+                append(cache, prompt[:stored])
+                payload, config = scheduler._extract_cache_states([cache])
+                table = prefix.store_cache(
+                    "seed", prompt[:stored], payload, model_cache_config=config
+                )
+                assert table is not None
+                paged.delete_block_table("seed")
+            request = Request(
+                label, prompt, SamplingParams(max_tokens=132, temperature=0)
+            )
+            scheduler.add_request(request)
+            scheduler._prepare_prefix_cache_for_request(request)
+            assert request.cached_tokens == (
+                stored - 1 if stored == prompt_length else stored
+            )
+            deadline = time.monotonic() + 10
+            while not request.is_finished() and time.monotonic() < deadline:
+                scheduler.step()
+                # Chunked prefill yields to the scheduler's fairness timer.
+                if not request.is_finished():
+                    time.sleep(0.001)
+            assert request.is_finished()
+            assert len(request.output_token_ids) == 132
+            assert request.get_finish_reason() == "length"
+            assert all(b.ref_count == 0 for b in paged.blocks if not b.is_null)
+            return request.output_token_ids, language.boundaries
+        finally:
+            if scheduler.batch_generator is not None:
+                scheduler.batch_generator.close()
+            ssd.close()
+
+    cold, _ = run("cold-reference", 0, 2048, False)
+    actual, boundaries = run("candidate", stored_length, step_size, chunked)
+    # Preserve this serving engine's N-1 kickoff, not native full-prompt parity.
+    assert {b for b in boundaries if b is not None} == {prompt_length - 1}
+    assert actual == cold
+
+
+def test_explicit_prefill_end_survives_singletons_and_resume():
+    cache = adapter().make_cache()[0]
+    cache.set_prefill_end(4)
+    append(cache, [0, 1])
+    # Resume after a scheduler yield, still before the same absolute boundary.
+    cache.set_prefill_end(4)
+    append(cache, [2])
+    assert cache.prefill_length is None
+    assert cache.is_trimmable()
+    append(cache, [3])
+    assert cache.prefill_length is None
+    for token in range(4, 12):
+        values = append(cache, [token])
+    assert cache.prefill_length == 4
+    assert values == [0, 1, 2, 3, 10, 11]
+
+
+def test_prefill_end_rejects_crossing_or_reopening_decode():
+    cache = adapter().make_cache()[0]
+    with pytest.raises(ValueError):
+        cache.set_prefill_end(-1)
+    cache.set_prefill_end(2)
+    with pytest.raises(ValueError):
+        append(cache, [0, 1, 2])
+    assert cache.offset == 0
+    append(cache, [0, 1])
+    with pytest.raises(ValueError):
+        cache.set_prefill_end(1)
+    append(cache, [2])
+    with pytest.raises(ValueError):
+        cache.set_prefill_end(5)
+
+
+def test_empty_filter_discards_request_prefill_end():
+    cache = adapter().make_cache()[0]
+    cache.set_prefill_end(100)
+    append(cache, [0, 1])
+    cache.filter([])
+    append(cache, [10, 11])
+    for token in range(12, 18):
+        values = append(cache, [token])
+    assert cache.prefill_length == 2
+    assert values == [10, 11, 16, 17]
+
+
 def test_guard_refuses_native_ring_until_registration(
     monkeypatch, mock_model, mock_tokenizer
 ):

--- a/tests/test_unlimited_ocr_cache.py
+++ b/tests/test_unlimited_ocr_cache.py
@@ -227,6 +227,95 @@ def test_store_refuses_missing_ring_layer_before_allocating_blocks(
         ssd.close()
 
 
+@pytest.mark.parametrize("with_config", [False, True])
+@pytest.mark.parametrize("layer_idx", [0, 1])
+@pytest.mark.parametrize(
+    "malformed_payload",
+    [
+        pytest.param(lambda k, v: {}, id="missing-state"),
+        pytest.param(lambda k, v: {"state": None}, id="none-state"),
+        pytest.param(lambda k, v: {"state": ()}, id="empty-state"),
+        pytest.param(lambda k, v: {"state": 7}, id="scalar-state"),
+        pytest.param(lambda k, v: {"state": (k,)}, id="missing-value"),
+        pytest.param(lambda k, v: {"state": (k, v, v)}, id="extra-element"),
+        pytest.param(lambda k, v: {"state": (None, v)}, id="none-key"),
+        pytest.param(lambda k, v: {"state": (k, None)}, id="none-value"),
+        pytest.param(lambda k, v: {"state": (7, v)}, id="non-tensor-key"),
+        pytest.param(lambda k, v: {"state": (k, 7)}, id="non-tensor-value"),
+        pytest.param(lambda k, v: {"state": (k[0, 0], v)}, id="rank-two-key"),
+        pytest.param(lambda k, v: {"state": (k, v[0])}, id="rank-three-value"),
+        pytest.param(lambda k, v: {"state": (k[None], v)}, id="rank-five-key"),
+        pytest.param(lambda k, v: {"state": (k, v[:, :, :2])}, id="short-value"),
+        pytest.param(
+            lambda k, v: {"state": (k, mx.concatenate([v, v], axis=1))},
+            id="head-count-mismatch",
+        ),
+        pytest.param(
+            lambda k, v: {
+                "state": (mx.concatenate([k, k]), mx.concatenate([v, v]))
+            },
+            id="multi-row",
+        ),
+        pytest.param(
+            lambda k, v: {"state": (k[:, :, :0], v[:, :, :0])},
+            id="empty-prefix",
+        ),
+    ],
+)
+def test_store_refuses_malformed_ring_state_before_allocating_blocks(
+    tmp_path, mock_model, mock_tokenizer, malformed_payload, layer_idx, with_config
+):
+    scheduler = Scheduler(mock_model, mock_tokenizer)
+    payload, config = scheduler._extract_cache_states(
+        [make_filled_cache(), make_filled_cache()]
+    )
+    keys, values = payload[layer_idx].pop("state")
+    payload[layer_idx].update(malformed_payload(keys, values))
+    prefix, paged, ssd = make_ssd_stack(tmp_path, 2, num_layers=2)
+    try:
+        table = prefix.store_cache(
+            "malformed",
+            list(range(12)),
+            payload,
+            model_cache_config=config if with_config else None,
+        )
+        assert table is None
+        assert paged.get_block_table("malformed") is None
+        assert "malformed" not in prefix._request_tables
+        assert all(b.ref_count == 0 for b in paged.blocks if not b.is_null)
+        assert all(b.block_hash is None for b in paged.blocks if not b.is_null)
+    finally:
+        ssd.close()
+
+
+@pytest.mark.parametrize("with_config", [False, True])
+@pytest.mark.parametrize("state_type", [tuple, list])
+def test_store_accepts_ring_kv_with_distinct_feature_dimensions(
+    tmp_path, mock_model, mock_tokenizer, with_config, state_type
+):
+    scheduler = Scheduler(mock_model, mock_tokenizer)
+    payload, config = scheduler._extract_cache_states([make_filled_cache()])
+    keys = mx.arange(8, dtype=mx.float32).reshape(1, 1, 4, 2)
+    values = mx.arange(12, dtype=mx.float32).reshape(1, 1, 4, 3)
+    payload[0]["state"] = state_type((keys, values))
+    prefix, paged, ssd = make_ssd_stack(tmp_path, 2)
+    try:
+        table = prefix.store_cache(
+            "valid",
+            list(range(12)),
+            payload,
+            model_cache_config=config if with_config else None,
+        )
+        assert table is not None and table.num_tokens == 4
+        restored = prefix.reconstruct_cache(table)
+        assert restored is not None and restored[0].offset == 4
+        restored_keys, restored_values = restored[0].state
+        assert mx.array_equal(restored_keys, keys).item()
+        assert mx.array_equal(restored_values, values).item()
+    finally:
+        ssd.close()
+
+
 def test_scheduler_discards_legacy_ocr_prefix(mock_model, mock_tokenizer):
     from unittest.mock import MagicMock
 
@@ -254,7 +343,7 @@ def test_scheduler_discards_legacy_ocr_prefix(mock_model, mock_tokenizer):
     scheduler.paged_cache_manager.delete_block_table.assert_called_once_with("legacy")
 
 
-def make_ssd_stack(directory, block_size):
+def make_ssd_stack(directory, block_size, num_layers=1):
     from omlx.cache.paged_cache import PagedCacheManager
     from omlx.cache.paged_ssd_cache import PagedSSDCacheManager
     from omlx.cache.prefix_cache import BlockAwarePrefixCache
@@ -264,7 +353,7 @@ def make_ssd_stack(directory, block_size):
         max_size_bytes=1024**2,
         hot_cache_max_bytes=0,
         expected_model_name="ocr",
-        expected_num_layers=1,
+        expected_num_layers=num_layers,
         expected_block_size=block_size,
     )
     paged = PagedCacheManager(
@@ -272,7 +361,7 @@ def make_ssd_stack(directory, block_size):
     )
     paged.set_paged_ssd_cache_manager(ssd)
     prefix = BlockAwarePrefixCache(
-        model=SimpleNamespace(layers=[None]),
+        model=SimpleNamespace(layers=[None] * num_layers),
         paged_cache_manager=paged,
         paged_ssd_cache_manager=ssd,
     )

--- a/tests/test_unlimited_ocr_cache.py
+++ b/tests/test_unlimited_ocr_cache.py
@@ -1,0 +1,537 @@
+"""The OCR decode ring must survive oMLX cache boundaries unchanged."""
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+
+from omlx.cache.type_registry import CacheTypeRegistry
+from omlx.models.vlm import VLMModelAdapter
+from omlx.scheduler import Scheduler, SchedulerConfig, _patched_merge_caches
+
+
+def adapter():
+    from omlx.patches.mlx_vlm_unlimited_ocr_compat import (
+        apply_mlx_vlm_unlimited_ocr_compat_patch,
+    )
+
+    apply_mlx_vlm_unlimited_ocr_compat_patch()
+    from mlx_vlm.models.unlimited_ocr.language import RingSlidingKVCache
+
+    return VLMModelAdapter(
+        SimpleNamespace(
+            config=SimpleNamespace(model_type="unlimited-ocr"),
+            language_model=SimpleNamespace(make_cache=lambda: [RingSlidingKVCache(2)]),
+        )
+    )
+
+
+def append(cache, values):
+    tensor = mx.array(values, dtype=mx.float32).reshape(1, 1, -1, 1)
+    return cache.update_and_fetch(tensor, tensor)[0].reshape(-1).tolist()
+
+
+def make_filled_cache():
+    cache = adapter().make_cache()[0]
+    append(cache, [0, 1, 2, 3])
+    for token in range(4, 12):
+        append(cache, [token])
+    return cache
+
+
+def test_singleton_merge_keeps_native_ring():
+    cache = make_filled_cache()
+    merged = _patched_merge_caches([[cache]])[0]
+    assert append(merged, [12]) == [0, 1, 2, 3, 12, 11]
+    assert merged.offset == 13
+
+
+def test_unsafe_multirow_merge_is_rejected():
+    with pytest.raises(ValueError, match="serial"):
+        _patched_merge_caches([[make_filled_cache()], [make_filled_cache()]])
+
+
+def test_ring_prefix_serialization_does_not_export_overwritten_slots():
+    cache = make_filled_cache()
+    handler = CacheTypeRegistry.get_handler_for_object(cache)
+    state = handler.serialize_state(cache)
+    assert state[0].reshape(-1).tolist() == [0, 1, 2, 3]
+    assert state[1].shape == (1, 1, 4, 1)
+
+
+def test_restored_partial_prefix_reestablishes_ring_boundary():
+    cache = make_filled_cache()
+    handler = CacheTypeRegistry.get_handler_for_object(cache)
+    state = {"keys": cache.keys[:, :, :2], "values": cache.values[:, :, :2]}
+    restored = handler.reconstruct_cache(state, handler.serialize_meta_state(cache))
+    append(restored, [2, 3])
+    for token in range(4, 12):
+        result = append(restored, [token])
+    assert result == [0, 1, 2, 3, 10, 11]
+    assert restored.offset == 12
+
+
+@pytest.mark.parametrize(
+    "meta",
+    [
+        None,
+        (),
+        ("0", "-1", "4", "0"),
+        ("2", "4", "99", "0"),
+        ("2", "4", "4", "0", "extra"),
+    ],
+)
+def test_bad_ring_metadata_rejected(meta):
+    cache = make_filled_cache()
+    handler = CacheTypeRegistry.get_handler_for_object(cache)
+    state = {"keys": cache.keys[:, :, :4], "values": cache.values[:, :, :4]}
+    with pytest.raises(ValueError):
+        handler.reconstruct_cache(state, meta)
+
+
+def test_scheduler_serializes_only_ring_model(mock_model, mock_tokenizer):
+    scheduler = Scheduler(mock_model, mock_tokenizer, SchedulerConfig(max_num_seqs=8))
+    assert scheduler._effective_max_num_seqs() == 8
+    scheduler.model = adapter()
+    assert scheduler._effective_max_num_seqs() == 1
+
+
+def test_scheduler_exports_only_intact_prefix(mock_model, mock_tokenizer):
+    scheduler = Scheduler(mock_model, mock_tokenizer)
+    payload, config = scheduler._extract_cache_states([make_filled_cache()])
+    assert payload[0]["state"][0].reshape(-1).tolist() == [0, 1, 2, 3]
+    handler = CacheTypeRegistry.get_handler_by_class_name(
+        config.layer_configs[0].class_name
+    )
+    restored = handler.reconstruct_cache(
+        {"keys": payload[0]["state"][0], "values": payload[0]["state"][1]},
+        payload[0]["meta_state"],
+    )
+    for token in range(4, 12):
+        values = append(restored, [token])
+    assert values == [0, 1, 2, 3, 10, 11]
+
+
+def test_ring_is_not_turboquant_convertible(mock_model, mock_tokenizer):
+    scheduler = Scheduler(mock_model, mock_tokenizer)
+    assert not scheduler._turboquant_eligible([make_filled_cache()])
+
+
+def test_stale_plain_kv_prefix_is_incompatible():
+    from mlx_lm.models.cache import KVCache
+
+    model = adapter()
+    assert not model.is_prefix_cache_compatible([KVCache()])
+    assert model.is_prefix_cache_compatible(model.make_cache())
+
+
+def test_singleton_protocol_and_trim():
+    cache = adapter().make_cache()[0]
+    append(cache, [0, 1, 2, 3])
+    assert cache.to_batch([0]) is cache
+    assert cache.extract(0) is cache
+    cache.filter([0])
+    assert cache.is_trimmable()
+    assert cache.trim(1) == 1
+    assert cache.offset == 3
+    append(cache, [3])
+    assert not cache.is_trimmable()
+    with pytest.raises(ValueError, match="trim"):
+        cache.trim(1)
+    with pytest.raises(ValueError, match="serial"):
+        cache.to_batch([1])
+    with pytest.raises(ValueError, match="serial"):
+        cache.extend(cache)
+    cache.filter([])
+    assert cache.offset == 0 and cache.keys is None
+
+
+@pytest.mark.parametrize("block_size", [2, 3])
+def test_ssd_store_and_restore_only_prompt_blocks(
+    tmp_path, mock_model, mock_tokenizer, caplog, block_size
+):
+    from omlx.cache.paged_cache import PagedCacheManager
+    from omlx.cache.paged_ssd_cache import PagedSSDCacheManager
+    from omlx.cache.prefix_cache import BlockAwarePrefixCache
+
+    ssd = PagedSSDCacheManager(
+        cache_dir=tmp_path,
+        max_size_bytes=1024**2,
+        expected_model_name="ocr",
+        expected_num_layers=1,
+        expected_block_size=block_size,
+    )
+    paged = PagedCacheManager(
+        block_size=block_size, max_blocks=32, initial_blocks=32, model_name="ocr"
+    )
+    paged.set_paged_ssd_cache_manager(ssd)
+    prefix = BlockAwarePrefixCache(
+        model=SimpleNamespace(layers=[None]),
+        paged_cache_manager=paged,
+        paged_ssd_cache_manager=ssd,
+    )
+    scheduler = Scheduler(mock_model, mock_tokenizer)
+    payload, config = scheduler._extract_cache_states([make_filled_cache()])
+    try:
+        table = prefix.store_cache(
+            "cold", list(range(12)), payload, model_cache_config=config
+        )
+        assert table is not None
+        assert table.num_tokens == 4 // block_size * block_size
+        assert "Rejecting block" not in caplog.text
+        restored = prefix.reconstruct_cache(table)[0]
+        if table.num_tokens < 4:
+            # Append a multi-token suffix so it remains prefill, not decode.
+            append(restored, list(range(table.num_tokens, 5)))
+            expected_prefix = list(range(5))
+        else:
+            expected_prefix = list(range(4))
+        for token in range(len(expected_prefix), 12):
+            values = append(restored, [token])
+        assert values[: len(expected_prefix)] == expected_prefix
+        assert sorted(values[len(expected_prefix) :]) == [10, 11]
+
+        # The first blocks retain the first capture's metadata after dedup.
+        extended = adapter().make_cache()[0]
+        append(extended, list(range(8)))
+        payload, config = scheduler._extract_cache_states([extended])
+        table = prefix.store_cache(
+            "extended", list(range(8)), payload, model_cache_config=config
+        )
+        restored = prefix.reconstruct_cache(table)
+        assert restored is not None
+        assert restored[0].offset == 8 // block_size * block_size
+    finally:
+        ssd.close()
+
+
+def test_scheduler_discards_legacy_ocr_prefix(mock_model, mock_tokenizer):
+    from unittest.mock import MagicMock
+
+    from mlx_lm.models.cache import KVCache
+
+    from omlx.cache.paged_cache import BlockTable
+    from omlx.request import Request, SamplingParams
+
+    scheduler = Scheduler(mock_model, mock_tokenizer)
+    scheduler.model = adapter()
+    scheduler.block_aware_cache = MagicMock()
+    scheduler.paged_cache_manager = MagicMock()
+    table = BlockTable(request_id="legacy", block_ids=[1], num_tokens=2)
+    scheduler.block_aware_cache.fetch_cache.return_value = (table, [12, 13])
+    scheduler.block_aware_cache.reconstruct_cache.return_value = [KVCache()]
+    request = Request(
+        request_id="legacy",
+        prompt=[10, 11, 12, 13],
+        sampling_params=SamplingParams(max_tokens=4),
+    )
+    scheduler.add_request(request)
+    scheduler._prepare_prefix_cache_for_request(request)
+    assert request.cached_tokens == 0 and request.prompt_cache is None
+    assert request.remaining_tokens == [10, 11, 12, 13]
+    scheduler.paged_cache_manager.delete_block_table.assert_called_once_with("legacy")
+
+
+def make_ssd_stack(directory, block_size):
+    from omlx.cache.paged_cache import PagedCacheManager
+    from omlx.cache.paged_ssd_cache import PagedSSDCacheManager
+    from omlx.cache.prefix_cache import BlockAwarePrefixCache
+
+    ssd = PagedSSDCacheManager(
+        cache_dir=directory,
+        max_size_bytes=1024**2,
+        hot_cache_max_bytes=0,
+        expected_model_name="ocr",
+        expected_num_layers=1,
+        expected_block_size=block_size,
+    )
+    paged = PagedCacheManager(
+        block_size=block_size, max_blocks=32, initial_blocks=32, model_name="ocr"
+    )
+    paged.set_paged_ssd_cache_manager(ssd)
+    prefix = BlockAwarePrefixCache(
+        model=SimpleNamespace(layers=[None]),
+        paged_cache_manager=paged,
+        paged_ssd_cache_manager=ssd,
+    )
+    return prefix, paged, ssd
+
+
+class TinyRingLanguageModel:
+    """Weight-free model exercising real scheduler prefill and EOS completion."""
+
+    layers = [None]
+
+    def __init__(self):
+        self.seen_tokens = []
+
+    def make_cache(self):
+        from mlx_vlm.models.unlimited_ocr.language import RingSlidingKVCache
+
+        return [RingSlidingKVCache(2)]
+
+    def __call__(self, input_ids, cache=None, **kwargs):
+        self.seen_tokens.extend(input_ids.reshape(-1).tolist())
+        tensor = input_ids.astype(mx.float32)[:, None, :, None]
+        for layer in cache or []:
+            layer.update_and_fetch(tensor, tensor)
+        # The tokenizer fixture's EOS is 2. Return real logits, not a mocked
+        # scheduler/BatchGenerator response, so fallback must actually run.
+        return mx.broadcast_to(mx.array([0.0, 0.0, 10.0, 0.0]), (*input_ids.shape, 4))
+
+
+def test_guard_refuses_native_ring_until_registration(
+    monkeypatch, mock_model, mock_tokenizer
+):
+    model = adapter()
+    native_model = model._language_model
+    with monkeypatch.context() as unregistered:
+        for name in ("RingSlidingKVCache", "OMLXRingSlidingKVCache"):
+            unregistered.delitem(CacheTypeRegistry._class_name_map, name)
+        before = Scheduler(mock_model, mock_tokenizer)
+        before.model = native_model
+        assert before._model_has_unreconstructible_cache()
+    after = Scheduler(mock_model, mock_tokenizer)
+    after.model = model
+    assert not after._model_has_unreconstructible_cache()
+
+
+@pytest.mark.parametrize("block_size", [2, 3])
+@pytest.mark.parametrize("legacy_layout", ["native-decode", "plain-kv"])
+def test_persisted_legacy_entries_release_real_references_after_restart(
+    tmp_path, mock_model, mock_tokenizer, block_size, legacy_layout, monkeypatch
+):
+    from mlx_lm.models.cache import KVCache
+
+    from omlx.cache.hybrid_cache import ModelCacheConfig
+    from omlx.request import Request, SamplingParams
+
+    # Capture the old writer's raw state/meta contract, before the ring handler
+    # exported prompt-only tensors. No production image/hash salt is involved.
+    native = adapter()._language_model.make_cache()[0]
+    append(native, [0, 1, 2, 3])
+    for token in range(4, 12):
+        append(native, [token])
+    if legacy_layout == "plain-kv":
+        old = KVCache()
+        old.state = native.state
+    else:
+        old = native
+        assert old.meta_state == ("2", "4", "12", "0")
+    payload = [
+        {
+            "state": old.state,
+            "meta_state": old.meta_state,
+            "class_name": type(old).__name__,
+            "cache_type": "KVCache",
+        }
+    ]
+    prefix, paged, ssd = make_ssd_stack(tmp_path, block_size)
+    try:
+        with monkeypatch.context() as unregistered:
+            for name in ("RingSlidingKVCache", "OMLXRingSlidingKVCache"):
+                unregistered.delitem(CacheTypeRegistry._class_name_map, name)
+            config = ModelCacheConfig.from_cache_list([old])
+            table = prefix.store_cache(
+                "old-writer", list(range(12)), payload, model_cache_config=config
+            )
+        assert table is not None and table.num_tokens == 6
+    finally:
+        ssd.close()
+    assert list(tmp_path.rglob("*.safetensors")), "fixture must reach disk"
+
+    prefix, paged, ssd = make_ssd_stack(tmp_path, block_size)
+    scheduler = Scheduler(mock_model, mock_tokenizer)
+    scheduler.model = adapter()
+    language_model = TinyRingLanguageModel()
+    scheduler.model._language_model = language_model
+    scheduler.block_aware_cache = prefix
+    scheduler.paged_cache_manager = paged
+    try:
+        # Prove the unchanged identity actually hits the old persisted chain.
+        table, remaining = prefix.fetch_cache("probe", list(range(8)))
+        assert table is not None and table.num_tokens == 6
+        assert remaining == [6, 7]
+        if legacy_layout == "native-decode":
+            # Exercise handler metadata refusal, not just the adapter's
+            # different-class check for a plain-KV reconstruction.
+            assert prefix.reconstruct_cache(table) is None
+        else:
+            assert type(prefix.reconstruct_cache(table)[0]) is KVCache
+        old_block_ids = tuple(table.block_ids)
+        paged.delete_block_table("probe")
+        for attempt in range(3):
+            request = Request(
+                request_id=f"legacy-{attempt}",
+                prompt=list(range(8)),
+                sampling_params=SamplingParams(max_tokens=4),
+            )
+            scheduler.add_request(request)
+            scheduler._prepare_prefix_cache_for_request(request)
+            if attempt == 0:
+                assert request.cached_tokens == 0
+                assert request.prompt_cache is None and request.block_table is None
+                assert request.remaining_tokens == list(range(8))
+                assert paged.get_block_table(request.request_id) is None
+                assert all(paged.blocks[i].ref_count == 0 for i in old_block_ids)
+                assert all(b.ref_count == 0 for b in paged.blocks if not b.is_null)
+                assert paged.free_block_queue.num_free_blocks == 31
+                expected_prefill = list(range(8))
+            else:
+                # Completion rewrites the rejected entries with safe prompt
+                # captures. Subsequent requests must reuse those, not keep
+                # missing forever or inherit the old full-KV attention.
+                assert request.cached_tokens == 6
+                assert scheduler.model.is_prefix_cache_compatible(request.prompt_cache)
+                expected_prefill = [6, 7]
+            language_model.seen_tokens.clear()
+            for _ in range(10):
+                scheduler.step()
+                if request.is_finished():
+                    break
+            assert request.is_finished()
+            assert request.get_finish_reason() == "stop"
+            assert (
+                language_model.seen_tokens[: len(expected_prefill)] == expected_prefill
+            )
+            assert all(
+                token == 2
+                for token in language_model.seen_tokens[len(expected_prefill) :]
+            )
+            assert all(b.ref_count == 0 for b in paged.blocks if not b.is_null)
+    finally:
+        ssd.close()
+
+
+@pytest.mark.parametrize("block_size", [2, 3])
+def test_guarded_reuse_after_restart_preserves_ring(
+    tmp_path, mock_model, mock_tokenizer, block_size
+):
+    from omlx.request import Request, SamplingParams
+
+    scheduler = Scheduler(mock_model, mock_tokenizer)
+    cache = adapter().make_cache()[0]
+    append(cache, list(range(8)))
+    payload, config = scheduler._extract_cache_states([cache])
+    prefix, _, ssd = make_ssd_stack(tmp_path, block_size)
+    try:
+        table = prefix.store_cache(
+            "cold", list(range(8)), payload, model_cache_config=config
+        )
+        assert table is not None
+    finally:
+        ssd.close()
+    prefix, paged, ssd = make_ssd_stack(tmp_path, block_size)
+    scheduler.model = adapter()
+    scheduler.block_aware_cache = prefix
+    scheduler.paged_cache_manager = paged
+    try:
+        request = Request("warm", list(range(10)), SamplingParams(max_tokens=4))
+        scheduler.add_request(request)
+        scheduler._prepare_prefix_cache_for_request(request)
+        assert request.cached_tokens == (8 if block_size == 2 else 6)
+        restored = request.prompt_cache[0]
+        append(restored, request.remaining_tokens)
+        for token in range(10, 16):
+            values = append(restored, [token])
+        assert values == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 14, 15]
+        paged.delete_block_table(request.request_id)
+        assert all(b.ref_count == 0 for b in paged.blocks if not b.is_null)
+    finally:
+        ssd.close()
+
+
+@pytest.mark.parametrize("block_size", [2, 3])
+def test_deduplicated_legacy_prefill_cannot_hide_decoded_tail(
+    tmp_path, monkeypatch, block_size
+):
+    from omlx.cache.hybrid_cache import ModelCacheConfig
+
+    native = adapter()._language_model.make_cache()[0]
+    append(native, [0, 1, 2, 3])
+    prefix, _, ssd = make_ssd_stack(tmp_path, block_size)
+    try:
+        with monkeypatch.context() as unregistered:
+            unregistered.delitem(
+                CacheTypeRegistry._class_name_map, "RingSlidingKVCache"
+            )
+            config = ModelCacheConfig.from_cache_list([native])
+            first = [
+                {
+                    "state": native.state,
+                    "meta_state": native.meta_state,
+                    "class_name": "RingSlidingKVCache",
+                    "cache_type": "KVCache",
+                }
+            ]
+            table = prefix.store_cache(
+                "old-prefill", list(range(4)), first, model_cache_config=config
+            )
+            assert table is not None
+            for token in range(4, 12):
+                append(native, [token])
+            decoded = [
+                {
+                    "state": native.state,
+                    "meta_state": native.meta_state,
+                    "class_name": "RingSlidingKVCache",
+                    "cache_type": "KVCache",
+                }
+            ]
+            table = prefix.store_cache(
+                "old-decode", list(range(12)), decoded, model_cache_config=config
+            )
+            assert table is not None and table.num_tokens == 6
+    finally:
+        ssd.close()
+    prefix, paged, ssd = make_ssd_stack(tmp_path, block_size)
+    try:
+        table, _ = prefix.fetch_cache("warm-mixed", list(range(8)))
+        assert table is not None and table.num_tokens == 6
+        # The first block's metadata is valid prefill; a later block contains
+        # overwritten decode slots [10, 11] falsely labeled as prompt [4, 5].
+        assert prefix.reconstruct_cache(table) is None
+        paged.delete_block_table("warm-mixed")
+        assert all(b.ref_count == 0 for b in paged.blocks if not b.is_null)
+    finally:
+        ssd.close()
+
+
+def test_ring_block_tensor_length_must_match_token_count(
+    tmp_path, mock_model, mock_tokenizer
+):
+    scheduler = Scheduler(mock_model, mock_tokenizer)
+    cache = adapter().make_cache()[0]
+    append(cache, [0, 1, 2, 3])
+    payload, config = scheduler._extract_cache_states([cache])
+    prefix, paged, ssd = make_ssd_stack(tmp_path, 2)
+    try:
+        table = prefix.store_cache(
+            "cold", [0, 1, 2, 3], payload, model_cache_config=config
+        )
+        tail_hash = paged.blocks[table.block_ids[-1]].block_hash
+    finally:
+        ssd.close()
+    prefix, _, ssd = make_ssd_stack(tmp_path, 2)
+    try:
+        short = mx.array([2.0]).reshape(1, 1, 1, 1)
+        assert ssd.save_block(
+            tail_hash,
+            [(short, short)],
+            token_count=2,
+            model_name="ocr",
+            layer_cache_types=["OMLXRingSlidingKVCache"],
+            layer_meta_states=[("2", "-1", "4", "0")],
+            replace_existing=True,
+        )
+    finally:
+        ssd.close()
+    prefix, paged, ssd = make_ssd_stack(tmp_path, 2)
+    try:
+        table, _ = prefix.fetch_cache("warm-short", [0, 1, 2, 3, 4, 5])
+        assert table is not None and table.num_tokens == 4
+        assert prefix.reconstruct_cache(table) is None
+        paged.delete_block_table("warm-short")
+        assert all(b.ref_count == 0 for b in paged.blocks if not b.is_null)
+    finally:
+        ssd.close()


### PR DESCRIPTION
### Summary

On top of the general guard, restore Unlimited-OCR prefix reuse with a tested reconstruction contract. This re-enables a path the guard deliberately disables; it is not the minimal fix for silent downgrades.

Builds on merged [#3447](https://github.com/jundot/omlx/pull/3447). Rebased onto upstream `aa8db734`; the diff now contains only the ring-cache follow-up, not the guard commit. This base also includes the follow-up that skips storage for unsupported cache layouts.

- Add an oMLX-owned native-ring subclass with safe singleton interfaces; reject lossy multi-row conversion.
- Declare the N-1 prefill end explicitly so a single-token prompt chunk cannot start the decode ring early; cover both normal and chunked scheduler prefill.
- Serialize Unlimited-OCR admission while other model engines retain batching.
- Register a ring handler that exports only intact prompt KV and reconstructs a fresh ring with valid prompt-boundary bookkeeping.
- Limit stored token sequences to the exported prefix before allocating blocks; refuse missing ring layers and malformed K/V state, including a missing first-layer state that could otherwise bypass validation.
- Reject legacy ordinary-KV OCR hits, decoded/malformed metadata, inconsistent ring windows, and tensor lengths that disagree with block token counts. Validate every block so deduplication cannot hide an unsafe trailing capture behind valid first-block metadata.
- Centralize registered ring-family checks for storage, reconstruction, extraction, and TurboQuant exclusion; retain exact-class checks for adapted-only interfaces and decline TurboQuant conversion if the registry is unavailable.

### Trade-offs and scope

Concurrent Unlimited-OCR requests queue. This is a per-model throughput regression, not server-wide serialization; the existing Llama 4 ChunkedKVCache serial-admission path is a precedent. This is deliberately not a generic batched-ring implementation. Decoded ring slots are not persisted as a full token history.

No image-mode API, prompt normalization, or image-identity version bump is included. Migration relies on live layout signatures, adapter compatibility checks, and per-block validation that rejects unsafe persisted entries as cache misses. It does not depend on a separate image-controls PR landing first.

Existing N-1 prompt kickoff and block-aligned prefill are unchanged: the final prompt token enters the decode ring rather than the permanent prefix. Exact parity with a native full-prompt generation path remains a follow-up. Serialization relies on the per-engine single-worker executor and an admission cap counting both running and prefilling requests; it does not make direct concurrent Scheduler.step() calls safe. Forced model-ownership transfer resets the previous owner's scheduler but does not stop its engine loop.

### Verification on the guarded split

- 1392 targeted scheduler/QSA/cache/adapter/engine/ownership tests passed, 3 deselected, for `148b959a`, including 121 ring tests. The ring test module passes Ruff and `git diff --check` is clean. This is a local targeted result, not a full-suite CI claim.
- The six-item review follow-up adds real SSD-to-decode coverage with unequal K/V feature widths (192/128), ring wrap, and MLX attention; contextual block/allocation/metadata validation with scheduler fallback and zero-reference cleanup tests; registered ring-family checks; N-1 boundary and serialization documentation; and actionable scheduler-test timeout diagnostics. The missing-allocation fixture injects a lookup failure, not a real deallocation race.
- Three independent reviews accepted the six-item follow-up; the final import-spacing correction and ownership wording clarification are included. No fresh production OCR replay or native full-model parity run was performed for this follow-up. CI for the newly pushed commit is tracked separately.
- Added 68 malformed-state cases spanning missing/null state, invalid pair structure, non-tensor entries, wrong ranks, mismatched K/V dimensions, multi-row state, and empty prefixes. These exercise both layer positions with and without model metadata and verify rejection before request-table or block allocation. Four valid round-trip controls preserve list/tuple payloads and different K/V feature widths.
- Fixed the two QSA reservation integration failures introduced by the prefill-boundary follow-up: both prefill entry points now invoke the static boundary helper through `Scheduler`, preserving lightweight scheduler callers. The previously omitted QSA integration file is included in the passing targeted suite. GitHub CI passed on Python 3.11–3.13 for `7c9fa19c`. That historical CI result does not verify the newly pushed six-item follow-up; its CI status is tracked separately.
- The missing-ring-layer regression failed with `IndexError` before the bounds check and now verifies that storage returns `None` without allocating a request table or referenced/hashed blocks.
- New regressions cover exact hits, one- and two-token suffixes, single-token chunk tails, and chunked continuation through 132 generated tokens with a 128-token ring. Five scheduler cases failed on the premature boundary before the correction and pass afterward. Exact-hit and one-token-suffix controls retain their existing behavior.
- Before the prefill-boundary follow-up, the CI-style local full suite completed with 10842 passed, 155 skipped, 77 deselected, and 10 failures. Four MiniMax compatibility failures reproduced on unchanged upstream `aa8db734` with the same installed dependencies. The other six were caused by an inherited `OMLX_API_KEY`; rerunning both affected settings/server files without that variable passed all 279 tests. The pre-follow-up GitHub CI passed on Python 3.11–3.13. These are historical full-suite results, not a green local full-suite claim for the new follow-up; fresh GitHub CI is separate.
- Verified the guard refuses the native cache before registration and allows the adapted cache after registration.
- Real SSD persistence/reopen tests cover plain-KV legacy entries, decoded native-ring metadata, mixed deduplicated prefill/decode chains, and malformed tensor lengths. Real scheduler/BatchGenerator execution with a tiny weight-free model verifies full-prefill fallback, EOS completion, subsequent safe warm reuse, and zero remaining block references.
- Valid partial and extended deduplicated prefixes retain native prompt-plus-window behavior. Singleton methods, serial admission, trim behavior, and TurboQuant exclusion are covered.
- Independent review found and reproduced mixed-chain and tensor-length gaps. Both now have failing-before/passing-after regressions; re-review found no remaining high-severity issues.
- Static review of the prefill-boundary follow-up inspected scheduler integration, mask behavior, eviction retries, marker lifetime, and reconstruction, but missed the QSA integration failures addressed above; review does not substitute for executable tests.

### Controlled HTTP replay

Repeated all twelve requests with the prefill-boundary correction on 2026-09-06: three pages across cold JSON, warm JSON, concurrent SSE, and a process restart on the same SSD each finished with `stop`. Each page's output was byte-identical across all four conditions and matched the earlier replays, with completion lengths 1794 / 3536 / 900. Cold requests had zero cached tokens; every later request reused 256. The three simultaneous clients queued serially. Restart recovered three SSD files with zero incompatible entries; no request warnings or errors appeared.

Replay used an 8-bit Unlimited-OCR derivative, temperature 0, cap 8192, no repetition guard, and configured concurrency 8. A process-local harness held preprocessing at base mode (`cropping=False, base_size=1024, image_size=1024`) and applied the default template from [mlx-vlm #2164](https://github.com/Blaizzy/mlx-vlm/pull/2164). These controls are outside this patch; they isolate cache behavior and do not verify default gundam behavior.

The replay establishes consistency within the guarded paged path, not OCR accuracy or native unpaged parity. All outputs also match the older combined prototype, but its paged-versus-unpaged numerical differences remain out of scope.

Test host: macOS 26.6.2, Apple M4 Max, Python 3.12.11, MLX 0.32.2, mlx-lm 0.31.3, mlx-vlm 0.6.3. Both temporary servers were stopped; no production deployment was performed.
