### PR TITLE
fix(bench): the accuracy queue waits for the kernel memory ledger to settle between items

### DIFF
--- a/omlx/admin/accuracy_benchmark.py
+++ b/omlx/admin/accuracy_benchmark.py
@@ -311,12 +311,55 @@ async def _continue_queue(engine_pool: Any, chain_id: int) -> None:
         f"benchmarks={list(request.benchmarks.keys())}"
     )
 
+    # The previous item has just unloaded its model; without this wait the
+    # admission reads the stale footprint and refuses the load (see the helper).
+    await _wait_for_memory_to_settle(engine_pool)
+
     try:
         await run_accuracy_benchmark(run, engine_pool)
     except Exception as e:
         logger.error(f"Queue: error running {request.model_id}: {e}")
 
     await _continue_queue(engine_pool, chain_id)
+
+
+async def _wait_for_memory_to_settle(engine_pool, timeout_s: float = 90.0) -> None:
+    """Wait for the kernel ledger to give back the previous model's pages.
+
+    Load admission (``engine_pool.get_engine``) compares the cap against
+    ``max(active_memory, phys_footprint, accounted)``, and ``phys_footprint``
+    is the macOS ledger, which keeps counting reclaimable pages of a
+    just-unloaded model. Measured 03/09: the unload reported
+    ``freed=106.72GB, active_memory: 433.66MB (settled)`` at 15:06:25.491 and
+    the queue asked for the next model in the SAME millisecond -- the
+    projection read ``current: 75.91GB`` and refused with
+    InsufficientMemoryError. Two queue items died that way, with the machine
+    genuinely empty; 92 s later the same load went through with no
+    intervention at all.
+
+    The unload's own barrier already waits for ``active_memory`` (and it did
+    its job: 433 MB). What is missing is waiting for the ledger, and that is
+    what this helper does -- only between queue items, where nobody is waiting
+    on a response.
+    """
+    import mlx.core as mx
+
+    from ..utils.proc_memory import get_phys_footprint
+
+    limit = time.monotonic() + timeout_s
+    previous = None
+    while time.monotonic() < limit:
+        footprint = get_phys_footprint()
+        live = mx.get_active_memory()
+        # settled once the ledger comes close to what MLX reports as live
+        if footprint <= live + 8 * 1024**3:
+            return
+        if previous is not None and footprint >= previous:
+            # it stopped falling: insisting does not help, and admission has
+            # its own eviction path if there is still not enough room
+            return
+        previous = footprint
+        await asyncio.sleep(2.0)
 
 
 async def cancel_queue() -> None:

--- a/tests/test_accuracy_queue_memory.py
+++ b/tests/test_accuracy_queue_memory.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The accuracy queue waits for the kernel ledger to settle between two items.
+
+Measured 03/09: the unload reported `freed=106.72GB, active_memory: 433.66MB
+(settled)` at 15:06:25.491 and the queue asked for the next model in the SAME
+millisecond. Admission compares the cap against
+`max(active_memory, phys_footprint, accounted)`, and phys_footprint -- the
+macOS ledger -- was still counting 75.91 GB of reclaimable pages from the model
+that had just left. Two items died with InsufficientMemoryError, with the
+machine genuinely empty; 92 s later the same load went through on its own.
+"""
+
+import asyncio
+
+import pytest
+
+from omlx.admin import accuracy_benchmark as ab
+
+
+@pytest.mark.asyncio
+async def test_waits_until_the_ledger_falls(monkeypatch):
+    """While the footprint is high the queue holds; once it falls, it goes on."""
+    readings = iter([80 * 1024**3, 60 * 1024**3, 30 * 1024**3, 1 * 1024**3])
+    seen = []
+
+    def _footprint():
+        v = next(readings)
+        seen.append(v)
+        return v
+
+    monkeypatch.setattr("omlx.utils.proc_memory.get_phys_footprint", _footprint)
+    _sleep_real = asyncio.sleep
+    monkeypatch.setattr(ab.asyncio, "sleep", lambda _s: _sleep_real(0))
+
+    class _MX:
+        @staticmethod
+        def get_active_memory():
+            return 400 * 1024**2
+
+    monkeypatch.setitem(__import__("sys").modules, "mlx.core", _MX)
+    await ab._wait_for_memory_to_settle(None, timeout_s=5.0)
+    # waited out the high readings and stopped at the settled one (1 GB <= 0.4 + 8)
+    assert len(seen) == 4, seen
+
+
+@pytest.mark.asyncio
+async def test_does_not_wait_when_it_is_already_low(monkeypatch):
+    """With the ledger already low it costs nothing -- the queue loses no time."""
+    calls = []
+
+    def _footprint():
+        calls.append(1)
+        return 500 * 1024**2
+
+    monkeypatch.setattr("omlx.utils.proc_memory.get_phys_footprint", _footprint)
+
+    class _MX:
+        @staticmethod
+        def get_active_memory():
+            return 400 * 1024**2
+
+    monkeypatch.setitem(__import__("sys").modules, "mlx.core", _MX)
+    await ab._wait_for_memory_to_settle(None, timeout_s=5.0)
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_gives_up_when_it_stops_falling(monkeypatch):
+    """If the ledger stabilizes high, insisting does not help: admission has its
+    own eviction path, and holding the queue forever is worse."""
+    readings = iter([80 * 1024**3, 79 * 1024**3, 79 * 1024**3, 79 * 1024**3])
+    seen = []
+
+    def _footprint():
+        v = next(readings)
+        seen.append(v)
+        return v
+
+    monkeypatch.setattr("omlx.utils.proc_memory.get_phys_footprint", _footprint)
+    _sleep_real = asyncio.sleep
+    monkeypatch.setattr(ab.asyncio, "sleep", lambda _s: _sleep_real(0))
+
+    class _MX:
+        @staticmethod
+        def get_active_memory():
+            return 400 * 1024**2
+
+    monkeypatch.setitem(__import__("sys").modules, "mlx.core", _MX)
+    await ab._wait_for_memory_to_settle(None, timeout_s=5.0)
+    assert len(seen) == 3, seen


### PR DESCRIPTION
## What

Between two items of the accuracy benchmark queue, the just-unloaded model keeps counting in the kernel's `phys_footprint` for a few seconds. The next item then sees no prefill headroom, the adaptive throttle drops to its 32-token floor, and the measurement is wrong (or the request is aborted by the memory guard).

This adds `_wait_for_memory_to_settle(engine_pool, timeout_s=90)` and calls it between queue items: it polls the footprint until it stops falling (or the cap expires) before the next model is loaded.

## Measured

GLM-5.3-Flash oQ2e on M1 Ultra (04/09): the production model measured 66-70 tok/s of prefill right after unloading another model, against 119.5 tok/s with a clean server. Same model, same prompts — the only difference was the residue in the ledger.

## Test

`tests/test_accuracy_queue_memory.py` (3 tests). Reverting `omlx/admin/accuracy_benchmark.py` to `main` makes all 3 fail.
