### PR TITLE
fix(prefill): a cut chunk's sample must not RAISE the per-token transient rate

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -4793,11 +4793,8 @@ class Scheduler:
                 delta,
             )
             return
-        if (
-            getattr(self, "_prefill_speed_priority", False)
-            and requested_step is not None
-            and n_tokens < requested_step
-        ):
+        partial = requested_step is not None and n_tokens < requested_step
+        if partial and getattr(self, "_prefill_speed_priority", False):
             logger.debug(
                 "[throttle:%s] measure rid=%s n=%d delta=%.2fMB "
                 "(skipped: speed partial < requested_step=%d)",
@@ -4808,6 +4805,46 @@ class Scheduler:
                 requested_step,
             )
             return
+        if partial:
+            # Under context priority the partial sample is kept (#2434 scoped
+            # the skip above to speed priority on purpose) — but ONLY when it
+            # does not RAISE the rate. A cut chunk's delta is dominated by the
+            # fixed/pool component, so dividing it by a small n inflates the
+            # per-token rate; feeding that back is a self-reinforcing collapse,
+            # where the inflated rate justifies an even smaller chunk, which
+            # measures worse still. The asymmetry matches the physics: a fixed
+            # cost can only inflate a per-token rate, never deflate it, so a
+            # partial sample that comes in LOWER is trustworthy and still
+            # teaches the tracker.
+            #
+            # Measured 04/09 on GLM-5.3-Flash oQ2e, ONE 110k-token prompt, every
+            # sample past 90k of context already read:
+            #     n=512  ->   333 MB      n=96  ->  912 MB
+            #     n=128  ->  1319 MB      n=64  ->  441 MB
+            # A 128-token chunk reading 4x a 512-token one at the same point in
+            # the text cannot be that chunk's cost. The EWMA rode it from 1073
+            # to 5549 KB/token, the throttle fell to its 32-token floor, and the
+            # prompt ran at 72 tok/s against the 160 it does at 512.
+            #
+            # Real growth is not lost: the predictor takes the MAX with a
+            # kv_len-aware static estimate, and the hard limits read live
+            # memory rather than this rate, so a lower estimate cannot weaken
+            # the abort path.
+            ewma = self._prefill_transient_tracker.bytes_per_token
+            if ewma > 0 and delta / n_tokens > ewma:
+                logger.debug(
+                    "[throttle:%s] measure rid=%s n=%d delta=%.2fMB "
+                    "(skipped: partial < requested_step=%d would raise the rate "
+                    "%.1fKB -> %.1fKB per token)",
+                    loop_label,
+                    request_id,
+                    n_tokens,
+                    delta / 1024**2,
+                    requested_step,
+                    ewma / 1024,
+                    (delta / n_tokens) / 1024,
+                )
+                return
         self._prefill_transient_tracker.update(
             n_tokens,
             delta,

--- a/tests/test_prefill_oom_graceful.py
+++ b/tests/test_prefill_oom_graceful.py
@@ -1273,3 +1273,68 @@ def test_speed_priority_guard_passes_full_chunk_that_fits():
     ns._fake_current = 10 * _GB
     ns._prefill_speed_priority = True
     assert _guard_call(ns, 2048, kv_len=5000) == 2048
+
+
+def test_partial_sample_that_would_raise_the_rate_is_dropped():
+    """O colapso do estrangulador em contexto longo, reproduzido.
+
+    Medido em 04/09 no GLM-5.3-Flash oQ2e, um prompt de 110k tokens, todas as
+    amostras com mais de 90k de contexto já lido: um pedaço de 128 tokens mediu
+    1319 MB enquanto um de 512 mediu 333 MB no mesmo ponto do texto. A taxa por
+    token subiu de 1073 para 5549 KB, o estrangulador desceu ao piso de 32
+    tokens e o preparo caiu de 160 para 72 palavras por segundo.
+
+    O colapso é GRADUAL, e é por isso que a proteção de outlier do rastreador
+    (8x a média) não o pega: cada amostra fica dentro do limite e a média sobe
+    em progressão geométrica (alfa 0,3 · uma amostra a 3x deixa a média 1,6x
+    maior, e a próxima parte de um patamar mais alto).
+    """
+    tracker = PrefillTransientTracker()
+    ns = SimpleNamespace(
+        _prefill_min_chunk_tokens=32,
+        _prefill_speed_priority=False,
+        _prefill_transient_tracker=tracker,
+    )
+    ns._record_chunk_transient = Scheduler._record_chunk_transient.__get__(
+        ns, Scheduler
+    )
+    amostra = lambda n, b: ns._record_chunk_transient(  # noqa: E731
+        n, 0, int(b), request_id="r", loop_label="unit", requested_step=512
+    )
+
+    amostra(512, 333 * 1024**2)  # o pedaço inteiro, a medida honesta
+    taxa_honesta = tracker.bytes_per_token
+    assert taxa_honesta == pytest.approx(333 * 1024**2 / 512)
+
+    # seis pedaços cortados, cada um a 3x a taxa corrente — dentro da proteção
+    # de outlier, que é 8x. Sem o portão a média cresce ~1,6x por amostra.
+    for _ in range(6):
+        n = 128
+        amostra(n, tracker.bytes_per_token * 3 * n)
+
+    assert tracker.bytes_per_token == pytest.approx(taxa_honesta), (
+        f"a taxa subiu de {taxa_honesta / 1024:.0f} para "
+        f"{tracker.bytes_per_token / 1024:.0f} KB por token — é o colapso"
+    )
+
+
+def test_partial_sample_that_lowers_the_rate_still_teaches():
+    """A assimetria é de propósito: custo fixo só sabe inflar a taxa."""
+    tracker = PrefillTransientTracker()
+    ns = SimpleNamespace(
+        _prefill_min_chunk_tokens=32,
+        _prefill_speed_priority=False,
+        _prefill_transient_tracker=tracker,
+    )
+    ns._record_chunk_transient = Scheduler._record_chunk_transient.__get__(
+        ns, Scheduler
+    )
+    ns._record_chunk_transient(
+        512, 0, 333 * 1024**2, request_id="r", loop_label="unit", requested_step=512
+    )
+    antes = tracker.bytes_per_token
+    # metade do tamanho, um QUARTO do custo: a taxa cai e a amostra vale
+    ns._record_chunk_transient(
+        256, 0, 83 * 1024**2, request_id="r", loop_label="unit", requested_step=512
+    )
+    assert tracker.bytes_per_token < antes


### PR DESCRIPTION
## What

The adaptive prefill throttle can feed on itself at long context. When a chunk is cut (throttle, guard, boundary), the measured `phys_footprint` delta is dominated by buffer-pool churn rather than the chunk's work; dividing it by a small `n` yields an inflated per-token rate, which shrinks the next chunk further, which measures worse still. The tracker's outlier guard (8x the EWMA) does not catch it because the climb is gradual — each sample stays under the ratio while the EWMA grows geometrically.

#2434 already skipped partial samples, but only under speed priority. This extends the gate to context priority **asymmetrically**: a partial sample that would raise the rate is dropped; one that lowers it still teaches the tracker (a fixed cost can only inflate a per-token rate, never deflate it). Real growth is not lost — the predictor still takes the MAX with the kv_len-aware static estimate, and the hard limits read live memory, not this rate.

## Measured

GLM-5.3-Flash oQ2e on M1 Ultra (04/09), ONE 110k-token prompt, every sample past 90k of context already read:

```
n=512  ->   333 MB      n=96  ->  912 MB
n=128  ->  1319 MB      n=64  ->  441 MB
```

A 128-token chunk reading 4x a 512-token one at the same point in the text cannot be that chunk's cost. The EWMA went from 1073 to 5549 KB/token, the throttle fell to its 32-token floor, and the prompt ran at 72 tok/s against the 160 it does when it stays at 512.

## Test

`tests/test_prefill_oom_graceful.py::test_partial_sample_that_would_raise_the_rate_is_dropped` reproduces the gradual climb (six cut chunks at 3x the running rate, each under the 8x guard): without the gate the rate goes from 666 to 11,174 KB/token; with it, it stays at 666. `test_partial_sample_that_lowers_the_rate_still_teaches` covers the asymmetry. Reverting `omlx/scheduler.py` to `main` fails the first.

## Caveat measured in the field

The fix closes one of the two roads into the collapse, not both. Re-measured on
a fresh server per arm, same 110k prompt: at the guard's old level (`custom`,
0.90) the gate bought 154 tok/s with the fix against 152 without, and the final
rate was still 3,889 KB/token — because WHOLE chunks also measure inflated near
the soft target, and those samples the gate lets through by design.

What actually kept the 512-token chunks alive at 110k was headroom: the
`aggressive` level ran 163 tok/s with 188 whole 512-chunks and a final rate of
620 KB/token, fix or no fix.

```
110k prompt, fresh server per arm:
  custom, fix on       154 tok/s   22 samples rejected   final rate 3,889 KB/token
  custom, fix off      152 tok/s   12x32 19x64 13x96 … 162x512   final rate 5,454 KB/token
  aggressive, fix off  163 tok/s   188x512                        final rate   620 KB/token
```

The fix closes the cut-chunk road; the headroom closes the other one. They are
complementary, and this PR is only the first.
