### PR TITLE
perf(vlm): load the glm5_next vision tower in float16 (the oQ float16 recipe stores it in float32)

### DIFF
--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -23,6 +23,7 @@ Usage:
     vision API format is transparently handled.
 """
 
+import os
 import asyncio
 import contextlib
 import copy
@@ -1751,6 +1752,25 @@ class VLMBatchedEngine(BaseEngine):
         await loop.run_in_executor(
             get_mlx_executor(), materialize_lazy_state, self._vlm_model
         )
+
+        # glm5_next: the oQ float16 recipe leaves the vision tower in float32
+        # (upstream #1682 rule); on this family float16 is measured 4-5x
+        # closer to float32 than bfloat16 is, and the float32 copy costs ~1 GB
+        # resident. OMLX_VISION_FP16=0 keeps the checkpoint's dtype.
+        if (
+            _read_config_model_type(self._model_name) == "glm5_next"
+            and os.environ.get("OMLX_VISION_FP16", "1") != "0"
+        ):
+            try:
+                from ..utils.model_loading import cast_vision_f32_params_to_fp16
+
+                recast = await loop.run_in_executor(
+                    get_mlx_executor(), cast_vision_f32_params_to_fp16, self._vlm_model
+                )
+                if recast:
+                    logger.info("vision tower dtype: float32 -> float16 (%d tensors)", recast)
+            except Exception:
+                logger.warning("vision fp16 recast failed; staying on float32", exc_info=True)
 
         # t5 ternary: free unused bias tensors to recover ~420 MB RAM.
         # The repacked safetensors carries 2-bit biases for format compat;

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -1302,3 +1302,46 @@ def maybe_load_custom_quantization(
         return None
 
     return model, processor
+
+
+_VISION_SUBTREES = ("vision_model", "vision_tower")
+
+
+def cast_vision_f32_params_to_fp16(model: Any) -> int:
+    """Recast the float32 leaves of a VLM's vision tower to float16.
+
+    The oQ float16 recipe stores vision/audio passthrough tensors in float32
+    (upstream #1682, measured on Gemma 4 with no activation numbers). On
+    GLM-5.3-Flash the tower's SwiGLU is clamped at +-10, its peak activation
+    is ~228 against float16's 65504, and — measured token by token against
+    the float32 tower on real screenshots — float16 lands 4-5x CLOSER to
+    float32 than bfloat16 does (the dtype the model was trained in and that
+    every non-oQ build serves). The float32 copy costs ~1 GB resident on a
+    104 GB model for nothing. Runs in the same bounded chunks as
+    materialize_lazy_state so the float32 originals are released as we go.
+
+    Returns the number of tensors recast.
+    """
+    from mlx.utils import tree_unflatten
+
+    keys = [
+        key
+        for key, value in tree_flatten(model.parameters())
+        if isinstance(value, mx.array)
+        and value.dtype == mx.float32
+        and key.split(".", 1)[0] in _VISION_SUBTREES
+    ]
+    params = dict(tree_flatten(model.parameters()))
+    for start in range(0, len(keys), _MATERIALIZE_EVAL_CHUNK):
+        chunk = [(key, params.pop(key).astype(mx.float16)) for key in keys[start : start + _MATERIALIZE_EVAL_CHUNK]]
+        mx.eval([value for _, value in chunk])
+        model.update(tree_unflatten(chunk))
+        del chunk
+    del params
+    if keys:
+        # Only now are the float32 originals unreferenced. Clearing the pool
+        # with them still held by a local (the first version did) cleared
+        # nothing, and the load-time "actual" read ~1 GB HIGHER (104.9 vs
+        # 103.9 GB, measured 04/09): both copies sat in memory.
+        mx.clear_cache()
+    return len(keys)

--- a/tests/test_cast_vision_fp16.py
+++ b/tests/test_cast_vision_fp16.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+"""O cast da torre de visão na carga: só as folhas float32 da subárvore de visão viram float16.
+
+Medido em 04/09 no GLM-5.3-Flash (visao_f16.py, só a torre): float16 fica 4-5x mais perto do
+float32 do que bfloat16 (o dtype de origem), pico de ativação ~228 contra 65504. O float32 que a
+rotina oQ grava por regra do tronco (#1682, medido no Gemma 4) custa ~1 GB residente à toa.
+"""
+import mlx.core as mx
+import mlx.nn as nn
+
+from omlx.utils.model_loading import cast_vision_f32_params_to_fp16
+
+
+class _Torre(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = nn.Linear(4, 4)
+        self.proj.weight = mx.ones((4, 4), dtype=mx.float32)
+        self.proj.bias = mx.zeros((4,), dtype=mx.float32)
+        self.norm = mx.ones((4,), dtype=mx.float16)   # já float16: fica
+
+
+class _Lingua(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.gate = mx.ones((3, 4), dtype=mx.float32)   # roteador em float32: NÃO é visão, fica
+
+
+class _VLM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.vision_model = _Torre()
+        self.language_model = _Lingua()
+
+
+def test_so_as_folhas_float32_da_visao_viram_float16():
+    m = _VLM()
+    n = cast_vision_f32_params_to_fp16(m)
+    assert n == 2, "proj.weight e proj.bias; a norma já era float16"
+    assert m.vision_model.proj.weight.dtype == mx.float16
+    assert m.vision_model.proj.bias.dtype == mx.float16
+    assert m.vision_model.norm.dtype == mx.float16
+    assert m.language_model.gate.dtype == mx.float32, "o roteador da língua não é tocado"
+    assert float(mx.sum(m.vision_model.proj.weight).item()) == 16.0
+
+
+def test_sem_visao_nao_faz_nada():
+    class _SoTexto(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.language_model = _Lingua()
+    assert cast_vision_f32_params_to_fp16(_SoTexto()) == 0


### PR DESCRIPTION
## What

Implements what #3435 measured. The oQ float16 recipe leaves the vision/audio passthrough tensors in float32 because of the #1682 rule, which was written for Gemma 4 on a hypothesis and never measured. On `glm5_next` float16 is measured 4-5x **closer** to float32 than bfloat16 is (the dtype the model was trained in and that every non-oQ build serves), and the float32 copy costs ~1.1 GB resident (347 tensors: 2.25 GB on disk, 1.12 GB in float16).

At load, `cast_vision_f32_params_to_fp16` recasts the float32 leaves of the vision tower to float16 in the same bounded chunks as `materialize_lazy_state`, handing the float32 copies back to the allocator as it goes. Scoped to `glm5_next`; `OMLX_VISION_FP16=0` keeps the checkpoint's dtype.

## Measured

GLM-5.3-Flash oQ2e on M1 Ultra: resident 104.92 → 103.18 GB on load. Vision-feature outputs on real screenshots, token by token against the float32 tower: float16 within fp16 rounding, bfloat16 4-5x further. Details and numbers in #3435.

## Tests

`tests/test_cast_vision_fp16.py` (only float32 leaves under the vision subtrees are recast; the count is returned; nothing else is touched).