### PR TITLE
perf(glm5_next): the recurrent layer slices itself above 512 positions (bit-identical, 30% faster on long chunks)

### DIFF
--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/language.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/language.py
@@ -207,6 +207,20 @@ class Glm5NextLinearAttention(nn.Module):
             out = inputs @ self._fw.T
         return mx.split(out, self._split_pts, axis=-1)
 
+    # Acima desta largura a camada se fatia sozinha. O kernel gated_delta
+    # escala mal com o comprimento: medido no modelo real (04/09,
+    # prefill_heterogeneo.py) uma camada custa 16,24 ms em S=512, 90,87 em
+    # 2048 e 193,47 em 4096 -- 11,9x de tempo para 8x de tokens. Processar o
+    # mesmo bloco em fatias de 512, encadeadas pelo cache, cai para 63,81 ms
+    # (+29,8%) e 127,48 (+34,1%), e o resultado e BIT A BIT o mesmo
+    # (dif max 0,00e+00 nas tres larguras): a recorrencia ja e sequencial, a
+    # fatia so muda a ordem em que os blocos entram.
+    #
+    # Isto e o que permite ao preparo do prompt usar pedacos maiores que 512
+    # sem pagar a recorrencia: o MoE, que e 59% do tempo do pedaco, rende mais
+    # com largura (177 tok/s em 512 contra 193 em 2048).
+    _FATIA_RECORRENTE = 512
+
     def __call__(
         self,
         inputs: mx.array,
@@ -214,6 +228,30 @@ class Glm5NextLinearAttention(nn.Module):
         cache: Optional[Any] = None,
     ) -> mx.array:
         B, S, _ = inputs.shape
+        if (
+            S > self._FATIA_RECORRENTE
+            and cache is not None
+            and cache.lengths is None
+            and not getattr(cache, "_omlx_captura_desfazer", False)
+        ):
+            # Fatiado apenas no preparo do prompt: com preenchimento a direita
+            # (cache.lengths) a mascara e por sequencia e nao fatia, e com a
+            # captura do desfazer armada quem chama espera os tensores de UMA
+            # passada -- e a janela de verificacao do MTP nunca chega perto de
+            # 512 posicoes.
+            fatia = self._FATIA_RECORRENTE
+            corta = mask is not None and mask.ndim >= 1 and mask.shape[-1] == S
+            return mx.concatenate(
+                [
+                    self(
+                        inputs[:, i : i + fatia],
+                        mask[..., i : i + fatia] if corta else None,
+                        cache,
+                    )
+                    for i in range(0, S, fatia)
+                ],
+                axis=1,
+            )
         has_right_padding = cache is not None and cache.lengths is not None
         if has_right_padding:
             mask = mx.arange(S)[None] < cache.lengths[:, None]

--- a/tests/test_glm5_next_recurrent_slicing.py
+++ b/tests/test_glm5_next_recurrent_slicing.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+"""A camada recorrente do glm5_next (Glm5NextLinearAttention) se fatia sozinha acima de 512 posições.
+
+Medido em 04/09: um bloco de preparo de 2048 posições fica 30% mais rápido quando a recorrente
+processa em fatias de 512 (bit a bit idêntico), e a atenção esparsa continua vendo o bloco
+inteiro. A recursão tem que estar DENTRO do próprio `return` — é assim que a barreira de
+ordenação do arquivo (test_glm5_next_ordering_barrier) a reconhece como saída legítima.
+Lê o arquivo vendorado pelo caminho, como o teste irmão, para não depender do patch de compat.
+"""
+import ast
+import pathlib
+
+ALVO = pathlib.Path(__file__).resolve().parents[1] / (
+    "omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/language.py"
+)
+
+
+def _classe(nome):
+    tree = ast.parse(ALVO.read_text(encoding="utf-8"))
+    return next(n for n in ast.walk(tree) if isinstance(n, ast.ClassDef) and n.name == nome)
+
+
+def test_o_limite_da_fatia_existe_e_e_512():
+    classe = _classe("Glm5NextLinearAttention")
+    limites = [
+        n for n in classe.body if isinstance(n, ast.Assign)
+        and any(isinstance(t, ast.Name) and t.id == "_FATIA_RECORRENTE" for t in n.targets)
+    ]
+    assert limites and ast.literal_eval(limites[0].value) == 512
+
+
+def test_a_chamada_fatia_por_recursao_dentro_do_return():
+    classe = _classe("Glm5NextLinearAttention")
+    call = next(n for n in classe.body if isinstance(n, ast.FunctionDef) and n.name == "__call__")
+    fatiamentos = [
+        n for n in ast.walk(call)
+        if isinstance(n, ast.Return) and isinstance(n.value, ast.Call)
+        and "concatenate" in ast.unparse(n.value.func)
+        and any(isinstance(c, ast.Call) and ast.unparse(c.func) == "self" for c in ast.walk(n.value))
+    ]
+    assert fatiamentos, "o __call__ não fatia por recursão dentro de um return"
+    guarda = next(
+        n for n in ast.walk(call)
+        if isinstance(n, ast.If) and "_FATIA_RECORRENTE" in ast.unparse(n.test)
+    )
+    assert "cache is not None" in ast.unparse(guarda.test), "o fatiamento tem que exigir cache"


### PR DESCRIPTION
## What

`Glm5NextLinearAttention.__call__` splits a prefill chunk longer than 512 positions into 512-position slices when a cache is present, feeding the recurrent state through the slices and concatenating the outputs — inside the same `return`, so the layer's ordering barrier still sees a single exit. The sparse-attention layers are untouched and keep seeing the whole chunk.

Output is **bit-identical** to the unsliced path (the recurrence is sequential by construction; the slicing only changes how much is materialized at once).

## Measured

M1 Ultra, GLM-5.3-Flash oQ2e, offline bench on the vendored model: with a 2048-position prefill chunk, the recurrent layers run ~30% faster sliced (the 2048-wide intermediates of the gated delta rule stop dominating), and the layer output matches the unsliced run bit for bit. Below 512 positions (today's default block for this family) the path is not taken and nothing changes. It is what makes larger hybrid blocks worth measuring at long context (110k tokens: 181 tok/s with a 1024 block against 163 with 512 — companion PR).

## Test

`tests/test_glm5_next_recurrent_slicing.py` reads the vendored file and checks: the slice limit exists and is 512, the `__call__` slices by recursion **inside a `return`** (`mx.concatenate([... self(...)])`), and the guard requires a cache. Fails on `main` (no slicing), passes with this change.