### PR TITLE
perf(qwen4_exp): reserve QSA indexer capacity for known prefill lengths

### DIFF
--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -159,7 +159,20 @@ class _QSAIndexerCache:
         self._index_position_ids = None
         self._index_offset = 0
         self._index_capacity_managed = True
+        self._index_reserved_tokens = 0
         self._invalidate_pooled_indexer()
+
+    def reserve_index_capacity(self, tokens: int) -> None:
+        """Hint the final sequence length so capacity lands on it once.
+
+        Capacity doubling is the right policy when the final length is unknown
+        (decode). A prefill knows it up front, and doubling there costs a full
+        reallocate + memset + copy of the indexer mid-prefill and leaves up to
+        2x the needed capacity resident — past ``max_position_embeddings`` for
+        long prompts. Reservation makes the first grow land exactly on the
+        stepped horizon and switches later grows back to plain steps.
+        """
+        self._index_reserved_tokens = max(0, int(tokens))
 
     @property
     def index_keys(self):
@@ -205,6 +218,30 @@ class _QSAIndexerCache:
         stepped = ((needed + step - 1) // step) * step
         return max(stepped, 2 * current if current else step)
 
+    def _next_capacity(
+        self, current: int, needed: int, step: int, reserve: Optional[int] = None
+    ) -> int:
+        """Single capacity policy shared by the raw arrays and the block bank.
+
+        Without a reservation the horizon is unknown, so doubling amortizes the
+        copies. With a reservation the horizon is known, so doubling is pure
+        waste: land on it on the first grow, then extend in plain steps.
+
+        ``reserve`` is expressed in the same units as ``current``/``needed``
+        (tokens for the raw arrays, blocks for the pooled bank) and defaults to
+        the token-denominated reservation.
+        """
+        if reserve is None:
+            reserve = getattr(self, "_index_reserved_tokens", 0)
+        if not reserve:
+            return self._growth_capacity(current, needed, step)
+        # Known horizon: always grow to at least the reservation, never past it
+        # by doubling. A restored cache below the horizon (prefix hit) needs the
+        # same treatment as a fresh one, or it climbs the doubling ladder chunk
+        # by chunk until it overshoots the prompt twice over.
+        target = needed if current >= reserve else max(needed, reserve)
+        return ((target + step - 1) // step) * step
+
     def _ensure_indexer_capacity(
         self,
         sample_keys: mx.array,
@@ -220,9 +257,14 @@ class _QSAIndexerCache:
             )
         if needed <= current:
             return
-        capacity = ((needed + self.index_step - 1) // self.index_step) * self.index_step
-        if current and self._index_capacity_managed:
-            capacity = max(capacity, 2 * current)
+        if self._index_capacity_managed:
+            capacity = self._next_capacity(current, needed, self.index_step)
+        else:
+            # The backing buffers belong to a restore/reconstruction caller, so
+            # only round up to the step; never second-guess its sizing.
+            capacity = (
+                (needed + self.index_step - 1) // self.index_step
+            ) * self.index_step
         new_keys = mx.zeros(
             (sample_keys.shape[0], capacity, sample_keys.shape[-1]),
             dtype=sample_keys.dtype,
@@ -328,10 +370,12 @@ class _QSAIndexerCache:
             )
             if complete_blocks > current_capacity:
                 block_step = max(1, self.index_step // compress_ratio)
-                capacity = self._growth_capacity(
+                reserved = getattr(self, "_index_reserved_tokens", 0)
+                capacity = self._next_capacity(
                     current_capacity,
                     complete_blocks,
                     block_step,
+                    reserve=(reserved // compress_ratio if reserved else 0),
                 )
                 new_buffer = mx.zeros(
                     (new_pooled.shape[0], capacity, new_pooled.shape[-1]),

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -3575,6 +3575,12 @@ class Scheduler:
 
         emitted_boundaries: dict[int, int] = {}
 
+        # The full prompt length is known here; hand it to the QSA indexer so
+        # its arrays are sized once instead of doubling mid-prefill.
+        self._reserve_qsa_index_capacity(
+            prompt_cache, base_size + int(input_arr.shape[1])
+        )
+
         while input_arr.shape[1] > 0:
             _trace_chunk_start = time.perf_counter()
             _trace_processed_before = processed_tokens
@@ -4510,6 +4516,38 @@ class Scheduler:
                 logger.debug("Failed to read local hot-cache byte counter")
                 return 0
 
+    def _reserve_qsa_index_capacity(self, cache_list: Any, tokens: int) -> int:
+        """Tell QSA indexer caches their final length before the first chunk.
+
+        The indexer's capacity-backed arrays grow by doubling, which is correct
+        when the horizon is unknown (decode) and pure waste when it is known:
+        a doubling mid-prefill reallocates, memsets and copies the whole
+        indexer in one chunk (measured +12.25 GB of phys in the chunk that
+        crossed 196,608 tokens, tripping the enforcer at prefill's finish
+        line) and leaves up to 2x capacity resident — past
+        ``max_position_embeddings`` on long prompts. Reserving lands the
+        allocation on the final stepped size once and switches later grows to
+        plain steps. Non-QSA caches expose no such method and are skipped.
+        """
+        if not cache_list or tokens <= 0:
+            return 0
+        reserved = 0
+        for c in cache_list:
+            reserve = getattr(c, "reserve_index_capacity", None)
+            if reserve is None:
+                continue
+            try:
+                reserve(int(tokens))
+                reserved += 1
+            except Exception:
+                logger.debug("QSA index capacity reservation failed", exc_info=True)
+        if reserved:
+            logger.info(
+                f"Reserved QSA indexer capacity for {int(tokens)} tokens "
+                f"across {reserved} caches (no mid-prefill doubling)"
+            )
+        return reserved
+
     def _current_usage_bytes(self, *, refresh_mlx_active: bool = True) -> int:
         """Current memory usage for scheduler-side guard checks.
 
@@ -5223,6 +5261,13 @@ class Scheduler:
 
         if state.tokens_processed == 0:
             _sync_and_clear_cache(self._stream)
+            # Known horizon: size the QSA indexer once instead of doubling
+            # mid-prefill (see _reserve_qsa_index_capacity).
+            self._reserve_qsa_index_capacity(
+                state.cache,
+                state.total_length
+                or state.base_size + int(state.tokens_remaining.shape[1]),
+            )
 
         # Clamp to the next block boundary so boundary snapshots fire exactly.
         if state.boundary_enabled and state.block_size > 0:

--- a/tests/test_prefill_oom_graceful.py
+++ b/tests/test_prefill_oom_graceful.py
@@ -945,6 +945,7 @@ def test_step_prefill_reclaims_before_first_guard():
         _guard_prefill_chunk=lambda n, **kwargs: events.append("guard") or n,
         _record_chunk_transient=MagicMock(),
         _maybe_record_fixed_state_bytes=MagicMock(),
+        _reserve_qsa_index_capacity=MagicMock(),
     )
     ns.running = {}
     ns._decode_fairness = True

--- a/tests/test_qwen4_qsa_reserved_capacity.py
+++ b/tests/test_qwen4_qsa_reserved_capacity.py
@@ -1,0 +1,141 @@
+"""Reserved-horizon tests for the Qwen4 QSA indexer capacity policy.
+
+Regression guard for the measured mid-prefill spike: the indexer used to
+double its capacity-backed arrays unconditionally, so a long prefill paid a
+full reallocate + memset + copy of the whole indexer at one chunk boundary
+(+12.25 GB of phys in the chunk crossing 196,608 tokens) and kept up to 2x
+capacity resident, past ``max_position_embeddings``. A prefill knows its final
+length, so it now reserves it and doubling is only used when the horizon is
+genuinely unknown (decode).
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib
+
+import mlx.core as mx
+
+from omlx.patches import mlx_vlm_qwen4_exp_compat as compat
+
+compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+language = importlib.import_module("mlx_vlm.models.qwen4_exp.language")
+
+_STEP = 64  # instance override keeps the allocations test-sized
+
+
+def _cache(reserve: int = 0):
+    cache = language.QSAKVCache()
+    cache.index_step = _STEP
+    if reserve:
+        cache.reserve_index_capacity(reserve)
+    return cache
+
+
+def _append(cache, start: int, stop: int) -> None:
+    length = stop - start
+    raw = mx.arange(1 * stop * 8, dtype=mx.float32).reshape(1, stop, 8)
+    cache.update_indexer(raw[:, start:stop], mx.arange(start, stop, dtype=mx.int32)[None])
+
+
+def _capacity(cache) -> int:
+    return 0 if cache._index_keys is None else int(cache._index_keys.shape[1])
+
+
+def test_reservation_lands_the_first_allocation_on_the_final_size():
+    cache = _cache(reserve=200)
+
+    _append(cache, 0, 8)
+
+    # ceil(200 / 64) * 64 — the whole prompt fits in one allocation.
+    assert _capacity(cache) == 256
+
+
+def test_reserved_indexer_never_doubles_past_the_reservation():
+    cache = _cache(reserve=200)
+
+    _append(cache, 0, 8)
+    _append(cache, 8, 200)
+    assert _capacity(cache) == 256  # no grow while staying inside the horizon
+
+    _append(cache, 200, 257)  # decode crossed the reserved horizon
+
+    # A step (256 -> 320), not a doubling (which would be 512).
+    assert _capacity(cache) == 320
+    assert int(cache.index_keys.shape[1]) == 257  # logical view tracks length
+
+
+def test_unreserved_growth_still_doubles():
+    cache = _cache()
+
+    _append(cache, 0, 8)
+    assert _capacity(cache) == _STEP  # seed
+    _append(cache, 8, 65)
+    assert _capacity(cache) == 128
+    _append(cache, 65, 129)
+
+    # Unknown horizon: 128 -> 256 doubling is still the amortizing choice.
+    assert _capacity(cache) == 256
+
+
+def test_reservation_preserves_the_prefix_across_the_single_grow():
+    cache = _cache(reserve=200)
+
+    _append(cache, 0, 8)
+    first = mx.array(cache.index_keys[:, :8, :])
+    _append(cache, 8, 200)
+    mx.eval(first, cache.index_keys)
+
+    assert mx.array_equal(first, mx.array(cache.index_keys[:, :8, :]))
+
+
+def test_restored_cache_below_the_reservation_lands_on_it_not_double():
+    # A prefix hit restores capacity sized for the cached prefix. The legacy
+    # policy doubled from there (measured on a warm 212k turn: 2.84 -> 5.59 GB
+    # in one chunk, capacity for 229,376 tokens on a 212,068-token prompt), and
+    # kept climbing the ladder whenever the prompt outgrew the doubling.
+    cache = _cache(reserve=2000)
+
+    capacity = cache._next_capacity(1088, 1089, _STEP)
+
+    assert capacity == 2048  # ceil(2000 / 64) * 64
+    assert capacity != 2176  # what doubling from 1088 would have produced
+
+
+def test_next_capacity_policy_table():
+    cache = _cache(reserve=200)
+
+    # Tokens, first grow: land on the reservation.
+    assert cache._next_capacity(0, 8, _STEP) == 256
+    # Tokens, past the reservation: plain steps.
+    assert cache._next_capacity(256, 257, _STEP) == 320
+    # Block units (pooled bank): the reservation arrives pre-divided.
+    assert cache._next_capacity(0, 10, 8, reserve=12) == 16
+    assert cache._next_capacity(16, 17, 8, reserve=12) == 24
+    # No reservation: unchanged legacy policy.
+    unreserved = _cache()
+    assert unreserved._next_capacity(64, 65, _STEP) == 128
+
+
+def test_scheduler_reservation_skips_non_qsa_caches():
+    from omlx.scheduler import Scheduler
+
+    class _Plain:
+        pass
+
+    class _QSA:
+        def __init__(self):
+            self.reserved = 0
+
+        def reserve_index_capacity(self, tokens):
+            self.reserved = tokens
+
+    qsa_a, qsa_b = _QSA(), _QSA()
+    count = Scheduler._reserve_qsa_index_capacity(
+        object(), [qsa_a, _Plain(), qsa_b], 12345
+    )
+
+    assert count == 2
+    assert (qsa_a.reserved, qsa_b.reserved) == (12345, 12345)
+    assert Scheduler._reserve_qsa_index_capacity(object(), [qsa_a], 0) == 0


### PR DESCRIPTION
# perf(qwen4_exp): reserve QSA indexer capacity for known prefill lengths

## Summary

The QSA indexer cache grows with the general-purpose "double when short" rule, even though a prefill's final token count is known before its first chunk runs. The doubling therefore fires in the middle of prefill — at the deepest point of the request, where memory headroom is smallest — and each doubling costs a reallocation, a zero-fill and a full copy while the old buffer is still alive.

This PR reserves the capacity the request will actually need, once, at the start. Behavior for requests whose length is not known is unchanged: growth still doubles.

## Root cause

`_ensure_indexer_capacity` grows the indexer cache by stepping up until it covers the current need, which for a cache below the needed size means doubling. For a prefill the needed size is not a guess: the prompt length is known before the loop starts. Measured on a Qwen4-exp hybrid model (48 layers, 12 of them full attention, `max_position_embeddings = 262144`) during a 205k-token prefill, one chunk added **+12.25GB** of resident memory at `kv = 196,608` — the moment with the least headroom. In steady state the cache had been grown to a capacity of **393,216 tokens, larger than the model's own maximum context of 262,144**, because doubling overshoots and there is no upper bound tied to the horizon.

## Change

Model side (`mlx_vlm/models/qwen4_exp/language.py`):

- `reserve_index_capacity(tokens)` records the horizon for the caches a request will use.
- `_next_capacity(current, needed, step, reserve=None)` replaces the doubling *only* when a reservation exists: the target is the reservation, or the need when the cache has already passed it, rounded up to the step. With no reservation the code path is the original stepped growth, so unknown-length requests behave exactly as before.
- The pooled block bank takes the same treatment through `reserve // compress_ratio`.

Scheduler side (`omlx/scheduler.py`): `Scheduler._reserve_qsa_index_capacity(cache_list, tokens)` sets the reservation on every cache that supports it (caches without the method are skipped, so other model families are untouched) and logs one INFO line. It is called before the external-prefill loop with `base_size + remaining`, and in the chunked path on the first chunk with `state.total_length or base + remaining`.

## Measurements

Setup: 128GB Apple Silicon, Qwen4-exp hybrid chat model as above, weights 69.6GB resident. Single request, cold server, identical oMLX configuration in each pair; only the presence of this change differs. Metrics are per-request: `peak phys` = max `phys_footprint` sampled during the request; `Δswap` = delta of `sysctl vm.swapusage` `used` across the request, so the machine's starting state is irrelevant; `wall` = request round trip.

**Cold 205k prompt:**

| | without this change | with this change |
|---|---|---|
| outcome | request rejected with an empty `usage` payload; model unloaded by the memory guard | completed |
| `peak phys` | 102.17GB | **92.37GB** (Δ −9.80GB) |
| indexer cache resident | 10.46GB (capacity 393,216 > 262,144 max context) | **6.77GB** (exactly the reservation) |
| `Δswap` | **+6.2GB** | ≈ 0 |

**Warm 212k prompt (a prefix hit, so the restored cache starts below the reservation):** 115s → **99s**, `cached_tokens = 98,304`, and no memory-guard activity in the log either way at that length.

The warm case is what shaped the fix. An earlier revision only reserved when the cache was empty, so a restored cache below the reservation still fell through to doubling — measurable as +5.87GB of physical growth during the request. The regression test is named for that: `test_restored_cache_below_the_reservation_lands_on_it_not_double`, and `test_unreserved_growth_still_doubles` pins the unchanged unknown-length behavior.

## Testing

`tests/test_qwen4_qsa_reserved_capacity.py` — 7 tests over the capacity arithmetic: an unreserved cache doubles as before; a reservation lands on the rounded step; a need above the reservation wins; a cache already past the reservation is left alone; a restored cache below the reservation lands on the reservation rather than doubling; the pooled block bank scales by the compression ratio; the scheduler helper skips caches that do not implement the hook.

Full fast suite: 267 relevant tests pass. One failure in `test_qwen4_qsa_decode_gather.py` reproduces identically on unmodified cache code, so it is pre-existing and unrelated. `black`/`ruff` report the same findings as the base commit — the new lines add none.

## Relation to other work

- **#3417** (open, three admission-charge bugs in the prefill transient tracker) is a different mechanism on the accounting side; it neither prevents nor reduces the doubling. The two are complementary and touch disjoint files.
- **#3428** and **#3334** (open) modify the same vendor `language.py` for gathered-QSA eligibility and compiled decode respectively. No functional overlap — neither touches indexer capacity — but expect a textual conflict in that file when they merge.
- Measured here as a prefill-time cost, the same indexer cache is also a *retained* cost; this PR bounds the transient overshoot, not the steady-state size, which remains whatever the context length requires.
