### PR TITLE
feat(cache): budget retained boundary checkpoints

### DIFF
--- a/omlx/cache/boundary_retention.py
+++ b/omlx/cache/boundary_retention.py
@@ -1,0 +1,87 @@
+"""Retention policy for per-boundary recurrent-state checkpoints.
+
+Hybrid models (GDN / Mamba / KDA linear-attention layers) can only resume a
+shared prefix from a sequence boundary where the recurrent state was captured,
+so oMLX captures a checkpoint at every block boundary during prefill. That makes
+the retained prefix cost grow linearly with context *on top of* the attention
+KV, and the checkpoint is by far the larger term: measured on
+Qwen3.8-Flash-Next (36 GDN layers, block_size 2048), one 234,070-token prefill
+captured 113 checkpoints of 115.6MB each -- 12.06GB resident for the whole
+prefill, 52.5KB per prompt token against the 27KB of the entire live attention
+cache. On a 128GB machine that resident term is what pushes long-context
+requests into the memory guard.
+
+Restores do not need that density. A restore lands on the deepest retained
+checkpoint at or below the depth it needs and re-prefills the gap: the store path
+already refuses to persist a non-sliceable block without its checkpoint ("storing
+live non-sliceable state would corrupt later prefix hits"), so checkpoints only
+trade memory against gap recompute -- which makes them the right thing to budget.
+
+The budget is spent as an even lattice over the prompt, because uniform spacing
+minimizes the worst-case recompute gap for a fixed budget. It is applied while
+prefilling (the final length is unknown, so the lattice is re-spread over the
+range reached so far each time it overflows) and always keeps the newest
+boundary: an append-only multi-turn conversation resumes from that one alone,
+while the interior ones serve requests that diverge inside the stored prefix.
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+#: Retaining more than this many checkpoints is past the point where the
+#: placement argument holds: the budget exists to bound a per-request resident
+#: cost, and 64 checkpoints of a hybrid model are already gigabytes.
+MAX_RETAINED_BOUNDARIES = 64
+
+
+def select_spaced_boundaries(
+    recorded: Sequence[int], limit: int, block_size: int, keep: int
+) -> set[int]:
+    """Return the boundaries of ``recorded`` that keep a checkpoint.
+
+    ``recorded`` is the ascending boundary token counts captured so far for one
+    request. ``limit`` is the depth the request's cache can still be *stored*
+    and resumed at: the end of prefill while prefilling, and the cacheable
+    prefix while decoding (see the call sites). ``block_size`` is the block size
+    the boundaries are aligned to. The budget ``keep`` counts interior
+    checkpoints; in addition to those the function always retains two
+    boundaries that the caller cannot afford to lose:
+
+    * the deepest recorded boundary at or below ``limit`` -- the depth the next
+      turn of a growing conversation resumes from, and the only boundary the
+      store path can use for its deepest block;
+    * the deepest recorded boundary overall, which is the one the store reads as
+      ``latest_tc``.
+
+    ``keep <= 0`` retains everything, i.e. the pre-existing behavior.
+
+    ``limit`` rather than the newest capture is the reference point because a
+    decoding request keeps capturing boundaries past the prompt, and while
+    speculative decoding and reasoning output push that newest capture further
+    out, anchoring the lattice on it widens the stride and evicts the in-range
+    boundary the next turn needs -- which presents not as a shallower hit but as
+    no hit at all, and on a store whose only surviving boundary is out of range,
+    as a refused store for the whole request.
+    """
+    budget = 0 if keep < 0 else min(int(keep), MAX_RETAINED_BOUNDARIES)
+    if budget == 0 or not recorded or block_size <= 0:
+        return set(recorded)
+
+    # Widening by powers of two keeps the lattices nested: a point on the
+    # ``2 * stride`` lattice was always on the ``stride`` lattice, so growing the
+    # prompt never deletes a checkpoint the wider lattice still needs. Any other
+    # widening leaves holes -- measured, one gap spanning 98% of the prompt.
+    stride = 1
+    while stride * block_size * budget < limit:
+        stride *= 2
+    step = block_size * stride
+
+    within = [tc for tc in recorded if tc <= limit]
+    retained = {tc for tc in within if tc % step == 0}
+    if within:
+        retained.add(within[-1])
+    retained.add(recorded[-1])
+    return retained

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -47,6 +47,7 @@ from mlx_lm.models.cache import (
 )
 from mlx_lm.sample_utils import make_logits_processors
 
+from .cache.boundary_retention import select_spaced_boundaries
 from .cache.observability import BoundarySnapshotDiagnostics, CacheRateTracker
 from .cache.paged_cache import PagedCacheManager
 from .cache.pooling_delta import compact_pooling_cache_snapshot
@@ -1568,6 +1569,9 @@ class SchedulerConfig:
 
     # Paged cache settings (internal defaults)
     paged_cache_block_size: int = 256  # Tokens per block
+    # Interior recurrent-state checkpoints retained per prefill, newest excluded
+    # (it is always retained). 0 = keep every boundary.
+    boundary_snapshot_retention: int = 0
     max_cache_blocks: int | None = (
         None  # Auto-calculated from available KV cache memory
     )
@@ -6435,6 +6439,38 @@ class Scheduler:
             )
             return
 
+        # Budget the retained checkpoints before capturing anything. A restore
+        # lands on the deepest retained checkpoint and re-prefills the gap, so
+        # capturing a boundary that will not be retained costs 115MB of resident
+        # state (measured on a hybrid GDN model at block_size 2048) and buys
+        # nothing: the store path will not persist a non-sliceable block without
+        # its checkpoint anyway. Deciding here also frees the boundaries that
+        # fall out of the budget as prefill runs, which is what bounds the
+        # long-context resident peak.
+        # Duck-typed configs (tests, embedded harnesses) carry only the fields
+        # they care about; an absent budget means the historical behavior.
+        retention = getattr(self.config, "boundary_snapshot_retention", 0)
+        recorded = self._boundary_cache_snapshots[request_id]
+        if retention > 0:
+            retained = select_spaced_boundaries(
+                sorted([*recorded, token_count]),
+                token_count,
+                block_size,
+                retention,
+            )
+            if token_count not in retained:
+                self._boundary_snapshot_diagnostics.record(
+                    "capture_skipped",
+                    reason="retention_thinned",
+                    request_id=request_id,
+                    token_count=token_count,
+                    block_size=block_size,
+                    source="prefill",
+                )
+                return
+            for tc in [tc for tc in recorded if tc not in retained]:
+                del recorded[tc]
+
         # Offload snapshot to SSD if store is available, keeping only a
         # None marker in the dict.  Falls back to in-memory storage when
         # the SSD store is unavailable or the write fails.
@@ -6847,6 +6883,32 @@ class Scheduler:
 
         if request.request_id not in self._boundary_cache_snapshots:
             self._boundary_cache_snapshots[request.request_id] = {}
+
+        # Same budget as the prefill-side recorder: this path captures at every
+        # block boundary crossed while decoding, so without it a long generation
+        # re-accumulates the checkpoints prefill just released. The lattice is
+        # laid out over the cacheable prefix, not over the emitted count: a
+        # decoding request captures past the end of the prompt, and those depths
+        # are not storable (the store filters to the cacheable sequence), so
+        # letting them set the stride evicts the in-range boundary the next turn
+        # resumes from -- which costs every subsequent hit.
+        retention = getattr(self.config, "boundary_snapshot_retention", 0)
+        if retention > 0:
+            recorded = self._boundary_cache_snapshots[request.request_id]
+            if getattr(request, "needs_think_prefix", False):
+                limit = len(request.prompt_token_ids)
+            else:
+                limit = total_tokens
+            retained = select_spaced_boundaries(
+                sorted([*recorded, total_tokens]),
+                limit,
+                block_size,
+                retention,
+            )
+            if total_tokens not in retained:
+                return
+            for tc in [tc for tc in recorded if tc not in retained]:
+                del recorded[tc]
 
         # Offload to SSD with in-memory fallback.
         if self._boundary_snapshot_store is not None:

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -348,6 +348,14 @@ class CacheSettings:
     gdn_ssd_split_enabled: bool | None = None
     gdn_ssd_pending_max_size: str = "512MB"
     gdn_sidecar_state_dtype: str = "fp32"
+    # How many interior recurrent-state checkpoints a prefill retains, in
+    # addition to the newest one (always kept). Hybrid models capture one at
+    # every block boundary -- 115.6MB each on a 36-layer GDN model at
+    # block_size 2048 -- so an unbounded 234k-token prefill holds 12GB of them
+    # for its whole duration. Restores land on the deepest retained checkpoint
+    # and re-prefill the gap, so a small budget trades recompute for that
+    # resident memory. 0 keeps every boundary (the historical behavior).
+    boundary_snapshot_retention: int = 0
 
     def get_gdn_snapshot_storage(self) -> str:
         """Return the user-facing GDN storage policy."""
@@ -439,6 +447,7 @@ class CacheSettings:
             "hot_cache_write_through": self.hot_cache_write_through,
             "ane_compile_cache": self.ane_compile_cache,
             "initial_cache_blocks": self.initial_cache_blocks,
+            "boundary_snapshot_retention": self.boundary_snapshot_retention,
         }
 
     @classmethod
@@ -489,6 +498,9 @@ class CacheSettings:
             ),
             ane_compile_cache=bool(data.get("ane_compile_cache", False)),
             initial_cache_blocks=data.get("initial_cache_blocks", 256),
+            boundary_snapshot_retention=int(
+                data.get("boundary_snapshot_retention", 0)
+            ),
         )
 
 
@@ -1727,6 +1739,7 @@ class GlobalSettings:
                 self.cache.gdn_ssd_pending_max_size
             ),
             gdn_sidecar_state_dtype=self.cache.gdn_sidecar_state_dtype,
+            boundary_snapshot_retention=self.cache.boundary_snapshot_retention,
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/tests/test_boundary_retention.py
+++ b/tests/test_boundary_retention.py
@@ -1,0 +1,121 @@
+"""Retention-policy tests for per-boundary recurrent-state checkpoints.
+
+Regression guard for the measured cost of unbounded retention: one 234,070-token
+prefill of Qwen3.8-Flash-Next captured 113 checkpoints of 115.6MB each -- 12.06GB
+resident for the whole prefill, 52.5KB per prompt token against the 27KB of the
+entire live attention cache. Retention must bound that to the configured budget,
+keep the boundary a continuation resumes from, and spread what it keeps: keeping
+only the deepest checkpoints drives the hit rate of an early-diverging branch to
+zero, and one dominant gap re-prefills most of the prompt.
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from omlx.cache.boundary_retention import (
+    MAX_RETAINED_BOUNDARIES,
+    select_spaced_boundaries,
+)
+
+BLOCK = 2048
+# The boundaries recorded by the measured 234k prefill.
+MEASURED = list(range(BLOCK, 233_472 + BLOCK, BLOCK))  # 114 entries
+LATEST = MEASURED[-1]
+
+
+def test_zero_budget_retains_everything():
+    assert select_spaced_boundaries(MEASURED, LATEST, BLOCK, 0) == set(MEASURED)
+    assert select_spaced_boundaries(MEASURED, LATEST, BLOCK, -1) == set(MEASURED)
+
+
+def test_a_short_prompt_fits_the_budget_untouched():
+    recorded = [BLOCK * i for i in range(1, 5)]
+    assert select_spaced_boundaries(recorded, BLOCK * 4, BLOCK, keep=4) == set(recorded)
+
+
+def test_measured_run_drops_almost_every_checkpoint():
+    retained = select_spaced_boundaries(MEASURED, LATEST, BLOCK, keep=4)
+
+    assert len(retained) <= 4 + 1
+    assert len(MEASURED) - len(retained) >= 108  # ~12GB no longer held resident
+    assert LATEST in retained
+
+
+def test_newest_boundary_is_always_retained():
+    for count in (9, 64, 1024, 8192):
+        recorded = [BLOCK * i for i in range(1, count + 1)]
+        assert recorded[-1] in select_spaced_boundaries(
+            recorded, recorded[-1], BLOCK, 3
+        )
+
+
+def test_cost_is_bounded_independent_of_prefill_length():
+    for count in (9, 64, 1024, 8192, 131_072):
+        recorded = [BLOCK * i for i in range(1, count + 1)]
+        retained = select_spaced_boundaries(recorded, recorded[-1], BLOCK, 3)
+        assert len(retained) <= 3 + 1
+
+
+def test_kept_checkpoints_are_evenly_spaced():
+    keep = 4
+    retained = sorted(select_spaced_boundaries(MEASURED, LATEST, BLOCK, keep=keep))
+
+    step = retained[1] - retained[0]
+    # Uniform interior spacing bounds the worst-case recompute gap at one step.
+    assert [b - a for a, b in zip(retained, retained[1:])][:-1] == [step] * (
+        len(retained) - 2
+    )
+    assert max(b - a for a, b in zip([0, *retained], retained)) <= step
+    assert len(retained) >= 2  # a budget of 4 must not collapse to one point
+
+
+def test_lattice_is_stable_as_the_prompt_grows():
+    # The scheduler prunes in place, so the lattice has to be nested: growing the
+    # prompt must never delete a checkpoint the wider lattice still wants, and
+    # must not leave a hole spanning most of the prompt.
+    recorded: list[int] = []
+    for i in range(1, 513):
+        newest = BLOCK * i
+        recorded = sorted(
+            select_spaced_boundaries([*recorded, newest], newest, BLOCK, keep=4)
+        )
+        assert recorded[-1] == newest
+        assert len(recorded) <= 5
+
+    gaps = [b - a for a, b in zip(recorded, recorded[1:])]
+    assert max(gaps) <= recorded[-1] // 4
+    assert len(recorded) >= 3
+
+
+def test_never_returns_empty_for_a_non_empty_input():
+    assert select_spaced_boundaries([BLOCK], BLOCK, BLOCK, keep=1) == {BLOCK}
+
+
+def test_budget_is_capped_at_a_sane_ceiling():
+    recorded = [BLOCK * i for i in range(1, 5000)]
+    assert (
+        len(select_spaced_boundaries(recorded, recorded[-1], BLOCK, 10_000))
+        <= MAX_RETAINED_BOUNDARIES + 1
+    )
+
+
+def test_the_resume_boundary_survives_a_drifting_reference():
+    """``limit`` is the cacheable depth, not the newest capture.
+
+    A decoding request records boundaries past the end of its prompt, which the
+    store filters out. Spacing the lattice over the cacheable limit instead of
+    the newest capture keeps the boundary the next turn resumes from, even when
+    the newest capture is far beyond it.
+    """
+    recorded = [BLOCK, 2 * BLOCK, 3 * BLOCK]  # 3 interior boundaries in range
+    limit = 3 * BLOCK  # end of the cacheable prompt
+    newest = 8 * BLOCK  # emitted tokens pushed the capture past it
+
+    retained = select_spaced_boundaries(
+        sorted([*recorded, newest]), limit, BLOCK, keep=1
+    )
+
+    assert limit in retained  # the resume point of the next turn
+    assert newest in retained  # the store's latest_tc
+    assert len(retained) <= 1 + 2

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -2425,6 +2425,58 @@ class TestSchedulerRemoveFinishedRequest:
 class TestSchedulerBoundarySnapshots:
     """Tests for boundary cache snapshots on non-sliceable cache models."""
 
+    def test_decode_captures_beyond_the_prompt_keep_the_resume_boundary(
+        self, mock_model, mock_tokenizer
+    ):
+        """A long generation must not evict the boundary the next turn resumes at.
+
+        Regression for the retention budget: it laid the lattice out over the
+        newest capture, but a decoding request captures past the end of the
+        prompt while the store filters those depths out (``cacheable_sequence``).
+        Once the emitted count widened the stride, the deepest in-range boundary
+        was pruned -- leaving a store whose only surviving boundary is unusable
+        (refused: ``reason=boundary_snapshot_unavailable available_boundaries=1``)
+        and a following turn that re-prefills the entire prompt despite matching
+        it token for token. Seen with a 126,670-token prompt emitting a few
+        hundred reasoning tokens per turn; shrunk to block_size 4 here.
+        """
+        config = SchedulerConfig(
+            paged_cache_block_size=4, boundary_snapshot_retention=1
+        )
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer, config=config)
+        scheduler.block_aware_cache = MagicMock()
+        scheduler._boundary_snapshot_required = True
+
+        mock_layer_cache = MagicMock()
+        type(mock_layer_cache).__name__ = "BatchArraysCache"
+        scheduler.batch_generator = MagicMock()
+
+        request = Request(
+            request_id="req-drift",
+            prompt="hello",
+            sampling_params=SamplingParams(),
+        )
+        request.prompt_token_ids = list(range(12))
+        request.num_prompt_tokens = 12
+        request.needs_think_prefix = True  # only the prompt is cacheable
+
+        # Boundaries prefill already captured inside the prompt.
+        scheduler._boundary_cache_snapshots["req-drift"] = {4: "s4", 8: "s8", 12: "s9"}
+
+        for total in (16, 20):
+            mock_layer_cache.offset = total
+            scheduler.batch_generator.extract_cache.return_value = {
+                123: ([mock_layer_cache], list(range(12, total)))
+            }
+            request.output_token_ids = list(range(12, total))
+            scheduler._maybe_capture_boundary_snapshot(request, 123)
+
+        recorded = scheduler._boundary_cache_snapshots["req-drift"]
+        # The depth the next turn resumes from, and the store's only usable one.
+        assert 12 in recorded, recorded
+        # Nothing above the cacheable prompt can serve a store of this request.
+        assert all(tc % 4 == 0 for tc in recorded)
+
     def test_capture_boundary_snapshot_at_block_boundary(
         self, mock_model, mock_tokenizer
     ):
@@ -2463,6 +2515,7 @@ class TestSchedulerBoundarySnapshots:
         assert diagnostics["capture_attempts"] == 1
         assert diagnostics["captures"] == 1
         assert diagnostics["captures_memory"] == 1
+
         snapshot = scheduler._boundary_cache_snapshots["req-boundary"][4]
         # The in-memory fallback pre-extracts eagerly (retaining raw cache
         # objects kept the full KV member of pm-eligible CacheLists alive

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -364,9 +364,7 @@ class TestSchedulerSettings:
         """Defaults on; explicit false round-trips."""
         assert SchedulerSettings.from_dict({}).decode_fairness is True
         assert (
-            SchedulerSettings.from_dict(
-                {"decode_fairness": False}
-            ).decode_fairness
+            SchedulerSettings.from_dict({"decode_fairness": False}).decode_fairness
             is False
         )
 
@@ -467,6 +465,7 @@ class TestCacheSettings:
             "hot_cache_write_through": False,
             "ane_compile_cache": False,
             "initial_cache_blocks": 256,
+            "boundary_snapshot_retention": 0,
         }
 
     def test_from_dict(self):
@@ -504,9 +503,7 @@ class TestCacheSettings:
     def test_from_dict_preserves_legacy_mode_and_fp32_default(
         self, legacy_split, expected_mode
     ):
-        settings = CacheSettings.from_dict(
-            {"gdn_ssd_split_enabled": legacy_split}
-        )
+        settings = CacheSettings.from_dict({"gdn_ssd_split_enabled": legacy_split})
         assert settings.gdn_ssd_split_enabled is legacy_split
         assert settings.get_gdn_snapshot_storage() == expected_mode
         assert settings.gdn_sidecar_state_dtype == "fp32"
@@ -527,7 +524,9 @@ class TestCacheSettings:
             }
         )
         global_settings = GlobalSettings(cache=settings)
-        assert any("gdn_snapshot_storage" in error for error in global_settings.validate())
+        assert any(
+            "gdn_snapshot_storage" in error for error in global_settings.validate()
+        )
 
     def test_auto_policy_embeds_when_cache_is_disabled_or_hot_only(self):
         settings = CacheSettings(enabled=False)
@@ -1564,9 +1563,7 @@ class TestGlobalSettings:
         errors = settings.validate()
         assert not any("gdn_sidecar_state_dtype" in e for e in errors)
 
-    @pytest.mark.parametrize(
-        "dtype", ["fp32", "bf16", "int8", "rht_int8", "rht_int16"]
-    )
+    @pytest.mark.parametrize("dtype", ["fp32", "bf16", "int8", "rht_int8", "rht_int16"])
     def test_validate_accepts_every_dtype_with_split_enabled(self, dtype):
         settings = GlobalSettings()
         settings.cache.gdn_ssd_split_enabled = True
@@ -2282,9 +2279,7 @@ class TestResolveDefaultBasePath:
         self, monkeypatch, tmp_path
     ):
         resolved = tmp_path / "resolved-base"
-        monkeypatch.setattr(
-            "omlx.settings.resolve_default_base_path", lambda: resolved
-        )
+        monkeypatch.setattr("omlx.settings.resolve_default_base_path", lambda: resolved)
 
         settings = GlobalSettings.load()
 
@@ -2813,3 +2808,32 @@ class TestCORSMiddleware:
             assert resp.status_code == 200
             assert "access-control-allow-origin" in resp.headers
             assert resp.headers["access-control-allow-origin"] == "*"
+
+
+def test_boundary_snapshot_retention_survives_settings_round_trip(tmp_path):
+    """The retention budget must reach the scheduler across a restart.
+
+    ``CacheSettings`` persists through an explicit to_dict/from_dict pair rather
+    than ``**data``, so a field added to the dataclass but not to both halves of
+    that pair is accepted in memory and then silently dropped on load. That is
+    what happened on the first real-machine run of this feature: the settings
+    file said 4, the scheduler read 0, and a 261k-token prefill captured all 127
+    checkpoints as if the feature were not installed.
+    """
+    gs = GlobalSettings(base_path=tmp_path)
+    gs.cache.boundary_snapshot_retention = 4
+    gs.save()
+
+    restored = GlobalSettings.load(base_path=tmp_path)
+    assert restored.cache.boundary_snapshot_retention == 4
+    assert restored.to_scheduler_config().boundary_snapshot_retention == 4
+
+
+def test_boundary_snapshot_retention_defaults_to_retaining_everything(tmp_path):
+    """A settings file written before this feature keeps the old behavior."""
+    gs = GlobalSettings(base_path=tmp_path)
+    gs.save()
+
+    restored = GlobalSettings.load(base_path=tmp_path)
+    assert restored.cache.boundary_snapshot_retention == 0
+    assert restored.to_scheduler_config().boundary_snapshot_retention == 0


### PR DESCRIPTION
# feat(cache): budget retained boundary checkpoints

## Summary

Hybrid models can only resume a shared prefix from a sequence boundary where the **recurrent state** was captured, so `Scheduler` captures a checkpoint at **every** block boundary during prefill. That makes the retained-prefix cost grow linearly with context *on top of* the attention KV, and on the models I measured the checkpoint is the dominant term.

This PR adds a budget for those checkpoints. The budget is enforced **at capture time**, so a boundary that will not be retained is never extracted, and boundaries that fall out of the budget are freed **while prefill is still running**. The newest boundary is always retained. Default (`cache.boundary_snapshot_retention = 0`) preserves current behavior exactly.

## Motivation (measured)

Machine: 128GB Apple Silicon. Model: a Qwen4-exp hybrid chat model with 36 GDN linear-attention layers + 12 full-attention layers, `max_position_embeddings = 262144`, weights 69.6GB resident, `paged_cache_block_size = 2048`, `cache.hot_cache_only = true` (SSD cache off). Single request, cold server, serial.

Metric definitions used below — all of them are per-request deltas or maxima, so they do not depend on the state the test machine happened to be in: `peak phys` = max `phys_footprint` sampled during the request; `Δswap` = delta of `sysctl vm.swapusage` `used` across the request; `resident snapshots` = tensor bytes of the boundaries recorded so far, sampled per chunk under `OMLX_PREFILL_MEM_PROBE=1`; pressure events = occurrences of guard rejection / hot-cache shrink / store skip in the log.

A 234,070-token prefill recorded **113 checkpoints of 115.6MB each — 12.06GB, held for the whole prefill**. Per prompt token that is **52.5KB**, versus **27KB for the entire live attention cache**: the retention cost is nearly twice the thing it is caching, and it is resident before any prefix reuse has happened. It is also what pushes a long-context request into the memory guard once the hot cache holds anything at all.

Single 261,075-token prefill, identical configuration, differing only in the budget:

| | `retention = 0` | `retention = 4` | Δ |
|---|---|---|---|
| `resident snapshots` | 13.68GB (127 × 115.6MB) | **0.43GB (4)** | **−13.25GB** |
| `peak phys` | 99.12GB | **85.63GB** | **−13.49GB** |
| `peak MLX active` | 91.9GB | 78.91GB | −13.0GB |
| `Δswap` | ≈ 0 | ≈ 0 | — |
| pressure events | 0 | 0 | — |
| `wall` | 234s | 239s | +2% |

What that headroom buys — same box, hot cache raised to 8GB, one conversation, three consecutive turns (prompts are synthetic, generated by script):

| turn | prompt tokens | `cached_tokens` | `wall` | `Δswap` |
|---|---|---|---|---|
| T1 | 100,067 | 0 (cold) | 90s | ≈ 0 |
| T2 | 212,068 | **98,304** | 101s | ≈ 0 |
| T3 | 234,069 | **210,944** | **24s** | ≈ 0 |

For comparison, with `retention = 0` on the same model the same three turns report `cached_tokens = 0` for all three and T3 takes 207s — and the hot cache has to be limited to 2GB to avoid the memory guard at all. **The reason long-context multi-turn could not reuse prefixes is not that the prefix cache is broken; it is that keeping every checkpoint leaves no room to store the prefix.** Pressure events across the run: 0.

## Why the budget is safe

Restores do not need a dense checkpoint set, and the existing code already assumes it:

- The store path refuses to persist a non-sliceable block without its checkpoint, in its own words: *"storing live non-sliceable state would corrupt later prefix hits"*. So a pruned boundary cannot become a half-populated block — pruning is exactly the supported degradation path, not a new one.
- A restore lands on the deepest retained checkpoint at or below the depth it needs and re-prefills the gap; the restore path already reports how far it walked back (`walkback_blocks`, `chosen_endpoint_tokens`).

That guard protects *correctness*, not *hit rate*, and the first revision of this PR learned the difference the hard way. It spaced the lattice over the newest captured boundary, which for a decoding request runs past the end of the prompt; the store filters to the cacheable sequence, so widening the stride off that moving point evicted the one in-range boundary the store could use. A store then refused outright (`reason=boundary_snapshot_unavailable available_boundaries=1`) and the following turn re-prefilled a 127,493-token prompt that matched its predecessor token for token. Budgeting checkpoints is only safe while the deepest *storable* boundary keeps its checkpoint; the design below makes that an invariant rather than a coincidence.

Verified end to end rather than argued: a 40,031-token base turn, then a **divergence at ~30k where the checkpoint had been pruned**, greedy (`temperature=0`, 48 tokens), compared byte-for-byte against the same prompt run with cross-turn caching disabled.

| request | `cached_tokens` | `wall` | output vs cache-disabled reference |
|---|---|---|---|
| diverged (first) | 16,384 (nearest retained lattice point) | 17s | **identical** |
| diverged (repeat) | 32,768 | 3s | **identical** |
| append (no divergence) | 38,912 (previous turn's deepest storable boundary) | 7s | — |

## Design

`omlx/cache/boundary_retention.py` holds the placement rule; `Scheduler` applies it in both recorders (`_on_prefill_boundary_snapshot` for prefill, `_maybe_capture_boundary_snapshot` for boundaries crossed while decoding — gating only the first lets a long generation re-accumulate what prefill released).

Decisions worth reviewing, each forced by a measured failure:

1. **Enforce at capture, not at store.** Deciding at store time still pays the extraction and keeps every checkpoint resident for the entire prefill, which is the cost being optimized.
2. **The lattice lives in absolute coordinates** (`tc % step == 0`), not as a rank over the boundaries kept so far. Rank-based placement collapses: once the prompt outgrows the survivors, every slot snaps onto the same one, and I measured a single gap spanning **98% of the prompt** — which re-prefills everything the budget was for.
3. **The stride widens by powers of two**, which keeps successive lattices nested: a point on the `2·stride` lattice was always on the `stride` lattice, so growing the prompt never deletes a checkpoint the wider lattice still wants. A non-power-of-two widening is not nested and reproduces the same 98% hole.
4. **Two boundaries are retained outside the budget**, because the store cannot do without them: the deepest recorded boundary *at or below the cacheable depth* (the depth a growing conversation resumes from, and the only boundary its store can use for its deepest block) and the deepest recorded boundary overall (which the store reads as `latest_tc`). A budget that spends the resume point is not a budget, it is a cache disable.
5. **The lattice is laid out over the cacheable depth, not over the newest capture.** For the prefill recorder the two coincide; for the decode recorder they do not, because it captures on `request.num_tokens` — prompt plus output — while the store filters to `cacheable_sequence` (the prompt alone when `needs_think_prefix`, matching the store's own condition). Anchoring on the newest capture therefore lets reasoning output and long generations widen the stride and delete in-range checkpoints. Shrunk to `block_size = 4` in `test_decode_captures_beyond_the_prompt_keep_the_resume_boundary`, which is red on the previous anchoring and green on this one.
6. **Uniform spacing** minimizes the worst-case recompute gap for a fixed budget, matching the placement used elsewhere for this problem (vLLM #45238 fix (a): "retain K checkpoints per request, spread across the prompt", K configurable with a small default of 2–4; the balanced-placement result in arXiv 2605.05219; llama.cpp #19408 is the fixed-interval variant).

`keep <= 0` means "retain everything", and the value is capped at `MAX_RETAINED_BOUNDARIES = 64`.

## Testing

- `tests/test_boundary_retention.py` — 10 tests over the placement rule: default retains everything; cost bounded for prefill lengths up to 131,072 boundaries; newest always retained; interior spacing uniform so no gap dominates; **incremental pruning over 512 arriving boundaries leaves one even step** (this is the test that caught the collapse in both naive variants); never empty; budget capped; the resume boundary and the store's `latest_tc` both survive a newest capture far above the cacheable limit.
- `tests/test_scheduler.py::TestSchedulerBoundarySnapshots::test_decode_captures_beyond_the_prompt_keep_the_resume_boundary` — drives the decode-side recorder through a real `Scheduler` with `needs_think_prefix` set, captures two boundaries past the end of the prompt, and asserts the deepest in-range boundary is still recorded. This is the one that was missing before: every policy-level test stayed green while the call site anchored on the wrong quantity, so a policy test alone could not have caught it.
- `tests/test_settings.py` — round-trip persistence of the new key. This is not boilerplate: `CacheSettings` persists through an explicit `to_dict`/`from_dict` pair rather than `**data`, so the first version of this PR recorded `4` in `settings.json` while the scheduler read `0` — a feature that is installed and inert, invisible in every unit test and only visible on a real run.
- Full fast suite: 10,636 passed. The 8 failures that remain are pre-existing; 7 reproduce on an unmodified `origin/main` worktree, and the 8th (`test_prefill_snapshot_decoupled_from_live_cache`) was a genuine regression from this PR — it drives `Scheduler` with a `SimpleNamespace` config, so the new field is now read through `getattr`, matching the existing convention for duck-typed configs.
- Real-machine numbers in the tables above, from the same binary with the budget flipped. Verified again under an agent-shaped workload (real repository files as tool results, a few hundred tokens generated per turn, next request issued immediately) with the hot cache at 86-99% of its limit and prompts of 252,703 / 260,915 tokens: hits landed on the previous turn's deepest storable boundary every time.

## Out of scope / honest limits

- With a budget of 4 on a 260k prompt the interior lattice step is 65,536 tokens, so a branch that diverges early re-prefills from the nearest lattice point. Measured rather than extrapolated: a 260,946-token turn whose history was edited ~1/3 of the way in resumed at `cached_tokens = 65,536` and re-prefilled 195,410 tokens (256s), where the turns that merely appended resumed at 249,856 and 251,904 and took 21s and 27s. That gap is the inherent price of the budget and is why the value is configurable: 16 retains every 16,384 tokens (~1.9GB of resident checkpoints at 115.6MB each) and cuts the same divergence to a ~20k-token re-prefill. It is strictly better than the alternative today, which is no reuse at all.
- **A larger budget is not better reuse, because the budget competes with the cache
  it protects.** Measured on the same 250k-class agentic transcript: with `keep = 4`
  an appending turn resumed at 251,904 of 253,612 tokens (99.3%) and swap did not
  grow; with `keep = 16` the same protocol missed outright twice on arrival
  (`reused 0`, one run adding 3.1GB of swap), and when the same request was retried
  90s later it resumed only at 81,920 (32%) because the deep blocks had been
  reclaimed meanwhile. At 115.6MB per checkpoint the retained set is 0.46GB at 4 and
  1.85GB at 16, and every store also carries that payload, so the extra checkpoints
  consume both the memory and the store bandwidth the KV chain needs to stay
  resident. The small default is deliberate; anyone raising it should re-measure
  reuse depth, not just the worst-case recompute gap.
- The attention KV is unchanged, and nothing here writes to disk; `hot_cache_only` configurations are the primary beneficiary.
- #3336 compresses *each* checkpoint while this reduces *how many*, so on the GDN term the two are substitutes rather than multiplicative. Measured retained-prefix cost at 234k: 18.7GB today, 12.6GB with that codec alone, **6.9GB with this budget alone**, 6.6GB with both. If only one of the two can land first, this is the larger lever for RAM-only long-context serving; that codec remains the right fix for absolute bytes on the SSD/split path.
- **#2628** (open, tracked under the #2625 large-context investigation) attacks the same
  bytes from the accounting side: it adds the *future* boundary-snapshot bytes to the
  prefill admission estimate so the guard can refuse earlier. That is a different remedy
  for the same cost, and it composes — this PR lowers the number their estimator has to
  reserve for. The per-checkpoint figure measured above (115.6MB at `block_size 2048` on
  a 36-layer GDN Qwen4-exp model) is the constant that estimate needs.
- **#3335** (open) gates the same recorder, `_maybe_capture_boundary_snapshot`, on a
  different criterion: it skips captures the store's alignment filter can never select,
  so a reasoning-model turn stops paying extraction for snapshots that cannot be used.
  This PR budgets how many *usable* checkpoints are retained. The two are independent
  predicates over the same call site, so expect a textual conflict there, not a semantic
  one.
- **#2366** (open) stores the large fp32 snapshot states as int8, i.e. it shrinks each
  checkpoint rather than reducing how many are kept — the same substitute relationship
  described for #3336 above.
- #1887 proposed bounding checkpoints but scoped it to cross-turn tips; this extends the budget to the interior boundaries captured during prefill, where the resident cost actually lives. #3439 lowers the *production rate* by widening `block_size`, which is orthogonal and composes with this.
