### PR TITLE
feat(vlm): unload the glm5_next vision tower for text-only deployments (opt-in, off by default)

### DIFF
--- a/omlx/admin/i18n/en.json
+++ b/omlx/admin/i18n/en.json
@@ -528,6 +528,8 @@
   "settings.advanced.sse_keepalive_mode_chunk": "Chunk (default, OpenClaw / WorkBuddy compatible)",
   "settings.advanced.sse_keepalive_mode_comment": "Comment (legacy : keep-alive)",
   "settings.advanced.sse_keepalive_mode_off": "Off (no keepalive)",
+  "settings.advanced.vision_tower_text_only": "Unload the vision tower (text-only mode)",
+  "settings.advanced.vision_tower_text_only_hint": "For agents that never send images: after the model loads, the vision tower's weights are dropped (GLM-5.3-Flash: 347 tensors, 1.12 GB) and image inputs are refused with a clear error. Measured on M1 Ultra (05/09): a 229k-token prompt met the memory guard's target near 180k tokens by ~0.4 GB and paused twice; this is the cheapest way to stay under it. Applies to the next model load.",
   "settings.language.section_label": "Language",
   "settings.language.label": "Interface Language",
   "settings.language.en": "English",

--- a/omlx/admin/i18n/es.json
+++ b/omlx/admin/i18n/es.json
@@ -528,6 +528,8 @@
   "settings.advanced.sse_keepalive_mode_chunk": "Chunk (default, OpenClaw / WorkBuddy compatible)",
   "settings.advanced.sse_keepalive_mode_comment": "Comment (legacy : keep-alive)",
   "settings.advanced.sse_keepalive_mode_off": "Off (no keepalive)",
+  "settings.advanced.vision_tower_text_only": "Quitar la torre de visión (modo solo texto)",
+  "settings.advanced.vision_tower_text_only_hint": "Para agentes que nunca envían imágenes: tras la carga, los pesos de la torre de visión se liberan (GLM-5.3-Flash: 347 tensores, 1,12 GB) y las entradas con imagen se rechazan con un error claro. Medido en M1 Ultra (05/09): un prompt de 229k tokens tocó el objetivo del guardián de memoria cerca de 180k por ~0,4 GB y pausó dos veces; es la forma más barata de quedarse por debajo. Se aplica en la próxima carga.",
   "settings.language.section_label": "Idioma",
   "settings.language.label": "Idioma de la Interfaz",
   "settings.language.en": "English",

--- a/omlx/admin/i18n/fr.json
+++ b/omlx/admin/i18n/fr.json
@@ -528,6 +528,8 @@
   "settings.advanced.sse_keepalive_mode_chunk": "Chunk (default, OpenClaw / WorkBuddy compatible)",
   "settings.advanced.sse_keepalive_mode_comment": "Comment (legacy : keep-alive)",
   "settings.advanced.sse_keepalive_mode_off": "Off (no keepalive)",
+  "settings.advanced.vision_tower_text_only": "Retirer la tour de vision (mode texte seul)",
+  "settings.advanced.vision_tower_text_only_hint": "Pour les agents qui n'envoient jamais d'image : après le chargement, les poids de la tour de vision sont libérés (GLM-5.3-Flash : 347 tenseurs, 1,12 Go) et les entrées avec image sont refusées avec une erreur claire. Mesuré sur M1 Ultra (05/09) : un prompt de 229k jetons a atteint la cible du garde mémoire vers 180k à ~0,4 Go près et a fait deux pauses ; c'est le moyen le moins cher de rester en dessous. S'applique au prochain chargement.",
   "settings.language.section_label": "Langue",
   "settings.language.label": "Langue de l'interface",
   "settings.language.en": "English",

--- a/omlx/admin/i18n/ja.json
+++ b/omlx/admin/i18n/ja.json
@@ -528,6 +528,8 @@
   "settings.advanced.sse_keepalive_mode_chunk": "Chunk (default, OpenClaw / WorkBuddy compatible)",
   "settings.advanced.sse_keepalive_mode_comment": "Comment (legacy : keep-alive)",
   "settings.advanced.sse_keepalive_mode_off": "Off (no keepalive)",
+  "settings.advanced.vision_tower_text_only": "ビジョンタワーを外す (テキスト専用モード)",
+  "settings.advanced.vision_tower_text_only_hint": "画像を送らないエージェント向け: 読み込み後にビジョンタワーの重みを解放し (GLM-5.3-Flash: 347 テンソル、1.12 GB)、画像入力は明確なエラーで拒否します。M1 Ultra で計測 (05/09): 229k トークンのプロンプトが 180k 付近でメモリガードの目標に約 0.4 GB で達し 2 回停止しました。目標の下に留まる最も安価な方法です。次のモデル読み込みから適用。",
   "settings.language.section_label": "言語",
   "settings.language.label": "インターフェース言語",
   "settings.language.en": "English",

--- a/omlx/admin/i18n/ko.json
+++ b/omlx/admin/i18n/ko.json
@@ -528,6 +528,8 @@
   "settings.advanced.sse_keepalive_mode_chunk": "Chunk (default, OpenClaw / WorkBuddy compatible)",
   "settings.advanced.sse_keepalive_mode_comment": "Comment (legacy : keep-alive)",
   "settings.advanced.sse_keepalive_mode_off": "Off (no keepalive)",
+  "settings.advanced.vision_tower_text_only": "비전 타워 제거(텍스트 전용 모드)",
+  "settings.advanced.vision_tower_text_only_hint": "이미지를 보내지 않는 에이전트용: 로드 후 비전 타워 가중치를 해제하고(GLM-5.3-Flash: 347 텐서, 1.12GB) 이미지 입력은 명확한 오류로 거부합니다. M1 Ultra에서 측정(05/09): 229k 토큰 프롬프트가 180k 근처에서 메모리 가드 목표에 약 0.4GB 차이로 닿아 두 번 멈췄습니다. 목표 아래에 머무는 가장 저렴한 방법입니다. 다음 모델 로드부터 적용.",
   "settings.language.section_label": "언어",
   "settings.language.label": "인터페이스 언어",
   "settings.language.en": "English",

--- a/omlx/admin/i18n/pt-BR.json
+++ b/omlx/admin/i18n/pt-BR.json
@@ -528,6 +528,8 @@
   "settings.advanced.sse_keepalive_mode_chunk": "Chunk (padrão, compatível com OpenClaw / WorkBuddy)",
   "settings.advanced.sse_keepalive_mode_comment": "Comment (legado : keep-alive)",
   "settings.advanced.sse_keepalive_mode_off": "Off (sem keepalive)",
+  "settings.advanced.vision_tower_text_only": "Tirar a torre de visão (modo só-texto)",
+  "settings.advanced.vision_tower_text_only_hint": "Para agentes que nunca mandam imagem: depois da carga, os pesos da torre de visão são liberados (GLM-5.3-Flash: 347 tensores, 1,12 GB) e pedidos com imagem são recusados com erro claro. Medido no M1 Ultra (05/09): um prompt de 229k tokens encostou no alvo do guarda de memória perto dos 180k por ~0,4 GB e pausou duas vezes; esta é a forma mais barata de ficar abaixo dele. Vale a partir da próxima carga do modelo.",
   "settings.language.section_label": "Idioma",
   "settings.language.label": "Idioma da Interface",
   "settings.language.en": "English",

--- a/omlx/admin/i18n/ru.json
+++ b/omlx/admin/i18n/ru.json
@@ -528,6 +528,8 @@
   "settings.advanced.sse_keepalive_mode_chunk": "Chunk (по умолчанию, совместимо с OpenClaw / WorkBuddy)",
   "settings.advanced.sse_keepalive_mode_comment": "Comment (устаревший : keep-alive)",
   "settings.advanced.sse_keepalive_mode_off": "Off (без keep-alive)",
+  "settings.advanced.vision_tower_text_only": "Убрать башню зрения (режим только текст)",
+  "settings.advanced.vision_tower_text_only_hint": "Для агентов, которые не отправляют изображения: после загрузки веса башни зрения освобождаются (GLM-5.3-Flash: 347 тензоров, 1,12 ГБ), а ввод с изображениями отклоняется с понятной ошибкой. Измерено на M1 Ultra (05/09): промпт на 229k токенов упёрся в цель охранника памяти около 180k с запасом ~0,4 ГБ и дважды приостанавливался; это самый дешёвый способ остаться ниже. Применяется при следующей загрузке.",
   "settings.language.section_label": "Язык",
   "settings.language.label": "Язык интерфейса",
   "settings.language.en": "Английский",

--- a/omlx/admin/i18n/zh-TW.json
+++ b/omlx/admin/i18n/zh-TW.json
@@ -528,6 +528,8 @@
   "settings.advanced.sse_keepalive_mode_chunk": "Chunk（預設，相容 OpenClaw / WorkBuddy）",
   "settings.advanced.sse_keepalive_mode_comment": "Comment（舊版 : keep-alive）",
   "settings.advanced.sse_keepalive_mode_off": "關閉（不保持連線）",
+  "settings.advanced.vision_tower_text_only": "卸載視覺塔（純文字模式）",
+  "settings.advanced.vision_tower_text_only_hint": "面向從不傳送圖片的代理：模型載入後釋放視覺塔權重（GLM-5.3-Flash：347 個張量，1.12 GB），圖片輸入以明確錯誤拒絕。在 M1 Ultra 上實測（05/09）：229k 詞元的提示在 180k 附近以約 0.4 GB 之差觸及記憶體守衛目標並暫停兩次；這是留在目標之下最便宜的辦法。下次載入模型時生效。",
   "settings.language.section_label": "語言",
   "settings.language.label": "介面語言",
   "settings.language.en": "English",

--- a/omlx/admin/i18n/zh.json
+++ b/omlx/admin/i18n/zh.json
@@ -528,6 +528,8 @@
   "settings.advanced.sse_keepalive_mode_chunk": "分块（默认，兼容 OpenClaw / WorkBuddy）",
   "settings.advanced.sse_keepalive_mode_comment": "注释（旧版 : keep-alive）",
   "settings.advanced.sse_keepalive_mode_off": "关闭（不保活）",
+  "settings.advanced.vision_tower_text_only": "卸载视觉塔（纯文本模式）",
+  "settings.advanced.vision_tower_text_only_hint": "面向从不发送图片的智能体：模型加载后释放视觉塔权重（GLM-5.3-Flash：347 个张量，1.12 GB），图片输入以明确错误拒绝。在 M1 Ultra 上实测（05/09）：229k 词元的提示在 180k 附近以约 0.4 GB 之差触及内存守卫目标并暂停两次；这是留在目标之下最便宜的办法。下次加载模型时生效。",
   "settings.language.section_label": "语言",
   "settings.language.label": "界面语言",
   "settings.language.en": "English",

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -258,6 +258,7 @@ class GlobalSettingsRequest(BaseModel):
     auto_start_on_launch: bool | None = None
     burst_decode_mode: str | None = None  # "off" / "light" / "balanced" / "aggressive"
     preserve_mid_system_cache: bool | None = None
+    vision_tower_text_only: bool | None = None  # applies on next load
     distributed_inference_enabled: bool | None = None
     max_audio_upload_size: str | None = None
 
@@ -3563,6 +3564,7 @@ async def get_global_settings(is_admin: bool = Depends(require_admin)):
                 "preserve_mid_system_cache",
                 True,
             ),
+            "vision_tower_text_only": getattr(global_settings.server, "vision_tower_text_only", False),
             "distributed_inference_enabled": getattr(
                 global_settings.server,
                 "distributed_inference_enabled",
@@ -3812,6 +3814,14 @@ async def update_global_settings(
     if request.auto_start_on_launch is not None:
         global_settings.server.auto_start_on_launch = request.auto_start_on_launch
         runtime_applied.append("auto_start_on_launch")
+    if request.vision_tower_text_only is not None:
+        global_settings.server.vision_tower_text_only = bool(request.vision_tower_text_only)
+        import os as _os
+
+        if request.vision_tower_text_only:
+            _os.environ["OMLX_VISION_TOWER_TEXT_ONLY"] = "1"
+        else:
+            _os.environ.pop("OMLX_VISION_TOWER_TEXT_ONLY", None)
     if request.preserve_mid_system_cache is not None:
         global_settings.server.preserve_mid_system_cache = (
             request.preserve_mid_system_cache

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -121,7 +121,7 @@
             // Global settings
             globalSettings: {
                 base_path: '',
-                server: { host: '127.0.0.1', port: 8000, log_level: 'info', sse_keepalive_mode: 'chunk', burst_decode_mode: 'balanced', preserve_mid_system_cache: true, distributed_inference_enabled: false, distributed_inference_active: false, max_audio_upload_size: '100MB' },
+                server: { host: '127.0.0.1', port: 8000, log_level: 'info', sse_keepalive_mode: 'chunk', burst_decode_mode: 'balanced', vision_tower_text_only: false, preserve_mid_system_cache: true, distributed_inference_enabled: false, distributed_inference_active: false, max_audio_upload_size: '100MB' },
                 model: { model_dirs: [''], model_fallback: false, hide_helper_models: false },
                 memory: { prefill_memory_guard: true, memory_guard_tier: 'balanced', memory_guard_custom_ceiling_gb: 0 },
                 scheduler: { max_concurrent_requests: 8, embedding_batch_size: 32, chunked_prefill: false, prefill_priority: 'context', decode_fairness: true },
@@ -6706,6 +6706,7 @@
                             log_level: this.globalSettings.server.log_level,
                             sse_keepalive_mode: this.globalSettings.server.sse_keepalive_mode,
                             burst_decode_mode: this.globalSettings.server.burst_decode_mode,
+                            vision_tower_text_only: !!this.globalSettings.server.vision_tower_text_only,
                             preserve_mid_system_cache: this.globalSettings.server.preserve_mid_system_cache,
                             distributed_inference_enabled: this.globalSettings.server.distributed_inference_enabled,
                             max_audio_upload_size: this.globalSettings.server.max_audio_upload_size,

--- a/omlx/admin/templates/dashboard/_settings.html
+++ b/omlx/admin/templates/dashboard/_settings.html
@@ -859,6 +859,19 @@
                                         </div>
                                         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 px-4 sm:px-6 py-4">
                                             <div class="flex-1">
+                                                <label class="text-sm text-neutral-700">{{ t('settings.advanced.vision_tower_text_only') }}</label>
+                                                <p class="text-xs text-neutral-400 mt-0.5">{{ t('settings.advanced.vision_tower_text_only_hint') }}</p>
+                                            </div>
+                                            <button type="button"
+                                                    @click="globalSettings.server.vision_tower_text_only = !globalSettings.server.vision_tower_text_only"
+                                                    :class="globalSettings.server.vision_tower_text_only ? 'bg-black' : 'bg-neutral-200'"
+                                                    class="relative w-11 h-6 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
+                                                <span :class="globalSettings.server.vision_tower_text_only ? 'translate-x-5' : 'translate-x-0'"
+                                                      class="block w-5 h-5 bg-white rounded-full shadow-sm transform transition-transform duration-300 absolute top-0.5 left-0.5"></span>
+                                            </button>
+                                        </div>
+                                        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 px-4 sm:px-6 py-4">
+                                            <div class="flex-1">
                                                 <label class="text-sm text-neutral-700">{{ t('settings.advanced.preserve_mid_system_cache') }}</label>
                                                 <p class="text-xs text-neutral-400 mt-0.5">{{ t('settings.advanced.preserve_mid_system_cache_hint') }}</p>
                                             </div>

--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -117,6 +117,10 @@ def serve_command(args):
     if settings.cache.ane_compile_cache:
         os.environ.setdefault("OMLX_QWEN35_ANE_COMPILE_CACHE", "1")
 
+    # The VLM engine reads this at load; export the saved setting the same way.
+    if bool(getattr(settings.server, "vision_tower_text_only", False)):
+        os.environ.setdefault("OMLX_VISION_TOWER_TEXT_ONLY", "1")
+
     # Register TRACE level (5) — includes full message content
     TRACE = 5
     logging.addLevelName(TRACE, "TRACE")

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -30,6 +30,7 @@ import importlib
 import inspect
 import json
 import logging
+import os
 import threading
 from collections.abc import AsyncIterator
 from pathlib import Path
@@ -1768,6 +1769,30 @@ class VLMBatchedEngine(BaseEngine):
         except Exception:
             logger.debug("t5 bias free skipped", exc_info=True)
 
+        # Text-only deployment: drop the vision tower (1.12 GB on GLM-5.3-Flash) so
+        # a long prompt stops meeting the memory guard's target near 180k tokens
+        # (measured 05/09: the miss was ~0.4 GB). Image inputs are refused with a
+        # clear error while it is out. Off by default; OMLX_VISION_TOWER_TEXT_ONLY=1
+        # (the CLI exports the saved setting).
+        self._vision_tower_freed = False
+        if (
+            _read_config_model_type(self._model_name) == "glm5_next"
+            and os.environ.get("OMLX_VISION_TOWER_TEXT_ONLY", "0") == "1"
+        ):
+            try:
+                from ..utils.model_loading import free_vision_tower
+
+                n_tensors, n_bytes = await loop.run_in_executor(
+                    get_mlx_executor(), free_vision_tower, self._vlm_model
+                )
+                self._vision_tower_freed = True
+                logger.info(
+                    "vision tower unloaded (text-only mode): %d tensors, %.2f GB returned",
+                    n_tensors, n_bytes / 1024**3,
+                )
+            except Exception:
+                logger.warning("vision tower unload failed; tower stays resident", exc_info=True)
+
         # Supported MoE gate+up regroup: concatenate the routed experts'
         # gate and up projections so decode runs 2 gather_qmm launches per
         # MoE layer instead of 3 (issue #2238). Bit-exact; also swaps the
@@ -2442,6 +2467,13 @@ class VLMBatchedEngine(BaseEngine):
             and self._count_content_parts(msg.get("content"), audio_part_types) > 0
             for msg in messages
         )
+
+        if getattr(self, "_vision_tower_freed", False) and (has_explicit_images or num_images > 0):
+            raise ValueError(
+                "This model is serving in text-only mode: the vision tower was unloaded "
+                "to free memory (Settings > Advanced > vision tower text-only, or "
+                "OMLX_VISION_TOWER_TEXT_ONLY). Turn it off and reload the model to send images."
+            )
 
         remaining_images = num_images
         remaining_audios = num_audios

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -175,6 +175,10 @@ class ServerSettings:
     auto_start_on_launch: bool = True
     burst_decode_mode: str = DEFAULT_BURST_DECODE_MODE
     preserve_mid_system_cache: bool = True
+    # Drop the glm5_next vision tower after load (1.12 GB) and refuse image
+    # inputs — for agents that never send images. Off by default. Measured
+    # 05/09: the long-context prefill missed the guard's target by ~0.4 GB.
+    vision_tower_text_only: bool = False
     distributed_inference_enabled: bool = False
     # Human-readable size, same grammar as cache limits ("100MB", "1GB").
     max_audio_upload_size: str = "100MB"
@@ -204,6 +208,7 @@ class ServerSettings:
             auto_start_on_launch=data.get("auto_start_on_launch", True),
             burst_decode_mode=data.get("burst_decode_mode", DEFAULT_BURST_DECODE_MODE),
             preserve_mid_system_cache=data.get("preserve_mid_system_cache", True),
+            vision_tower_text_only=bool(data.get("vision_tower_text_only", False)),
             distributed_inference_enabled=data.get(
                 "distributed_inference_enabled",
                 False,

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -1302,3 +1302,38 @@ def maybe_load_custom_quantization(
         return None
 
     return model, processor
+
+
+_VISION_SUBTREES = ("vision_model", "vision_tower")
+
+
+def free_vision_tower(model: Any) -> tuple[int, int]:
+    """Drop the vision tower's weights for a text-only deployment; returns (tensors, bytes).
+
+    Every leaf under the vision subtrees is replaced by a one-element placeholder
+    of the same dtype, so the module tree stays intact (no attribute errors on
+    introspection) while the memory goes back to the allocator. The engine that
+    calls this must refuse image inputs while the tower is out.
+
+    Why: on GLM-5.3-Flash the float16 tower is 1.12 GB resident (347 tensors), and
+    the long-context prefill meets the memory guard's target by ~0.4 GB near 180k
+    tokens (measured 05/09: two throttle pauses on a 229k prompt). An agent that
+    never sends images pays that 1.12 GB for nothing.
+    """
+    from mlx.utils import tree_unflatten
+
+    pares = [
+        (key, value)
+        for key, value in tree_flatten(model.parameters())
+        if isinstance(value, mx.array) and key.split(".", 1)[0] in _VISION_SUBTREES
+    ]
+    n_tensores = len(pares)
+    liberados = sum(int(v.nbytes) for _, v in pares)
+    for start in range(0, len(pares), _MATERIALIZE_EVAL_CHUNK):
+        chunk = [(k, mx.zeros((1,), dtype=v.dtype)) for k, v in pares[start : start + _MATERIALIZE_EVAL_CHUNK]]
+        mx.eval([v for _, v in chunk])
+        model.update(tree_unflatten(chunk))
+        del chunk
+    del pares
+    mx.clear_cache()
+    return n_tensores, liberados

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -83,6 +83,7 @@ class TestServerSettings:
             "auto_start_on_launch": True,
             "burst_decode_mode": "balanced",
             "preserve_mid_system_cache": True,
+            "vision_tower_text_only": False,
             "distributed_inference_enabled": False,
             "max_audio_upload_size": "100MB",
         }

--- a/tests/test_vision_tower_text_only.py
+++ b/tests/test_vision_tower_text_only.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+"""A torre de visão fora no uso só-texto: libera 1,12 GB no GLM-5.3-Flash e recusa imagem.
+
+Medido em 05/09: um prompt de 229k tokens encostou no alvo do guarda perto dos 180k por ~0,4 GB e
+pausou duas vezes. Desligado de fábrica — quem liga abre mão de mandar imagem para este modelo.
+"""
+import mlx.core as mx
+import mlx.nn as nn
+
+from omlx.utils.model_loading import free_vision_tower
+
+
+class _Torre(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = nn.Linear(64, 64)
+        self.norm = nn.LayerNorm(64)
+
+
+class _Modelo(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.vision_model = _Torre()
+        self.language_model = nn.Linear(64, 64)
+
+
+def test_libera_so_a_torre_e_devolve_a_conta():
+    m = _Modelo()
+    mx.eval(m.parameters())
+    antes_lm = m.language_model.weight
+    n, nbytes = free_vision_tower(m)
+    assert n == 4  # proj.weight, proj.bias, norm.weight, norm.bias
+    assert nbytes == 64 * 64 * 4 + 64 * 4 + 64 * 4 + 64 * 4
+    # a torre virou placeholders de um elemento, a árvore continua inteira
+    assert m.vision_model.proj.weight.shape == (1,)
+    assert m.vision_model.norm.bias.shape == (1,)
+    # a linguagem não foi tocada
+    assert m.language_model.weight is antes_lm
+
+
+def test_desligado_de_fabrica():
+    from omlx.settings import ServerSettings
+
+    assert ServerSettings().vision_tower_text_only is False
+    assert ServerSettings.from_dict({"vision_tower_text_only": True}).vision_tower_text_only is True


### PR DESCRIPTION
## What

An opt-in for agents that never send images. After `glm5_next` loads, `free_vision_tower(model)` replaces every leaf under `vision_model` / `vision_tower` with a one-element placeholder of the same dtype — the module tree stays intact, so introspection keeps working — and the memory goes back to the allocator. On GLM-5.3-Flash that is **347 tensors, 1.05-1.12 GB**. While the tower is out, a chat request carrying an image is refused with a `ValueError` that names the setting and how to turn it off.

**Off by default.** `ServerSettings.vision_tower_text_only` (Settings › Advanced toggle), or `OMLX_VISION_TOWER_TEXT_ONLY=1`; the CLI exports the saved setting so the engine reads one source. Applies to the next model load. Independent of #3453 (float16 tower): that one shrinks the tower, this one removes it.

## Measured

M1 Ultra, GLM-5.3-Flash oQ2e (101 GB resident), cold 229,920-token prompt, block 1024, guard target 112.5 GB, clean server start per arm:

```
                      prefill      pauses   chunks              footprint @197k
tower resident        170.5 tok/s  2        1024 -> 256 cuts    112.9 GB (target met)
tower unloaded        175.3 tok/s  0        224 x 1024, whole   111.4 GB
```

```
vision tower unloaded (text-only mode): 347 tensors, 1.05 GB returned
```

The miss with the tower resident was ~0.4 GB near 180k tokens; removing 1 GB of base line is what turned the two pauses into none.

## Tests

`tests/test_vision_tower_text_only.py`: frees only the vision subtree (language weights untouched), returns the tensor/byte count, placeholders keep the tree intact; setting is off by default and round-trips. Reverting the `model_loading.py` hunk makes the test error out. Settings round-trip in `tests/test_settings.py`.