### PR TITLE
fix(qwen4_exp): bound masked SDPA256 memory pricing

### DIFF
--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -54,6 +54,18 @@ _SDPA_VECTOR_SUPPORTED_HEAD_DIMS = frozenset({64, 96, 128, 256})
 # dim-less path and matches the fp16/bf16 majority of MLX inference models.
 _SDPA_FALLBACK_SCORE_DTYPE_SIZE = 2
 
+# Bytes/elem the unfused head-dim-256 fallback actually materializes on
+# Metal: MLX keeps the attention score matrix in fp32 even for bf16/fp16
+# models (measured ~33GiB IOAccelerator spike on a 160k-token VLM prefill at
+# head_dim=256). Shared by the sdpa256 route gate
+# (patches/sdpa256_attention._tiled_route_required) and the Qwen4 prefill
+# profile so the router and the guard price the real fallback identically.
+# Kept separate from _SDPA_FALLBACK_SCORE_DTYPE_SIZE: that default covers
+# the dim-less generic path where the compute dtype is unknown and the
+# fp16/bf16 majority is the better prior; widening it globally would
+# re-price unrelated models without evidence.
+SDPA256_UNFUSED_SCORE_DTYPE_SIZE = 4
+
 # Head dims whose multi-token prefill is routed to an O(L) tiled/online-softmax
 # kernel instead of the unfused O(L^2) score-matrix fallback. Populated at
 # runtime by the kernel patch that installs the route (see
@@ -68,6 +80,7 @@ class _BoundedSDPAPrefillRoute:
     min_query_len: int
     min_kv_len: int
     kv_tile: int
+    supports_array_mask: bool
 
 
 _SDPA_TILED_PREFILL_HEAD_DIMS: dict[int, tuple[_BoundedSDPAPrefillRoute, ...]] = {}
@@ -79,18 +92,20 @@ def register_tiled_prefill_head_dim(
     min_query_len: int = 2,
     min_kv_len: int = 8192,
     kv_tile: int = 1024,
+    supports_array_mask: bool = False,
 ) -> None:
     """Register a bounded long-context route installed for one head dim.
 
     Multiple native routes may cover the same head dimension at different
-    thresholds. Store them independently so combining two registrations can
-    never invent shape coverage that neither route actually guarantees.
+    thresholds and mask capabilities. Store them independently so combining
+    registrations cannot invent coverage no individual route guarantees.
     """
     head_dim = int(head_dim)
     route = _BoundedSDPAPrefillRoute(
         min_query_len=max(2, int(min_query_len)),
         min_kv_len=max(1, int(min_kv_len)),
         kv_tile=max(1, int(kv_tile)),
+        supports_array_mask=bool(supports_array_mask),
     )
     routes = _SDPA_TILED_PREFILL_HEAD_DIMS.get(head_dim, ())
     if route not in routes:
@@ -1295,13 +1310,44 @@ class _Qwen4ExpPrefillMemoryProfile:
         core_kv = kv_len
         if gathered_core and kv_len > self.indexer_budget:
             core_kv = min(kv_len, self.indexer_budget + self.compress_ratio - 1)
+
+        # The head_dim-256 sdpa256 patch keeps long-context prefill O(L):
+        # consult the same bounded-route registry the generic estimator uses
+        # (issue #2204 follow-up). Without it this profile always charges the
+        # dense Q x kv_len matrix, which made the guard shrink VLM chunks to
+        # crawl speed on 160k-context prefills even though the router forces
+        # a bounded kernel there.
         core = estimate_unfused_sdpa_call_bytes(
             self.num_attention_heads,
             query_tokens,
             core_kv,
             self.head_dim,
-            self.score_dtype_size,
+            SDPA256_UNFUSED_SCORE_DTYPE_SIZE,
         )
+        bounded_routes = _SDPA_TILED_PREFILL_HEAD_DIMS.get(self.head_dim, ())
+        matching_routes = [
+            route
+            for route in bounded_routes
+            if route.supports_array_mask
+            and query_tokens >= route.min_query_len
+            and core_kv >= route.min_kv_len
+        ]
+        if matching_routes:
+            # Match the generic estimator's O(L) bound: fp32 output plus one
+            # fp32 score tile (largest registered tile). The core_kv is the
+            # K width of the real core-attention call, so a gathered QSA call
+            # whose reduced K is below the route floor stays dense-priced.
+            kv_tile = max(route.kv_tile for route in matching_routes)
+            tile_scores = (
+                self.num_attention_heads
+                * query_tokens
+                * min(kv_tile, core_kv)
+                * SDPA256_UNFUSED_SCORE_DTYPE_SIZE
+            )
+            output = (
+                self.num_attention_heads * query_tokens * self.head_dim * 4
+            )
+            core = int(output + tile_scores)
         return indexer + core
 
 

--- a/omlx/patches/sdpa256_attention.py
+++ b/omlx/patches/sdpa256_attention.py
@@ -29,7 +29,10 @@ import weakref
 
 import mlx.core as mx
 
-from omlx.memory_monitor import estimate_unfused_sdpa_call_bytes
+from omlx.memory_monitor import (
+    SDPA256_UNFUSED_SCORE_DTYPE_SIZE,
+    estimate_unfused_sdpa_call_bytes,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -95,6 +98,17 @@ def _parse_force_tiled_env() -> bool | None:
     return None
 
 
+def _notify_bounded_route(provider, active: bool) -> None:
+    """Let the scheduler retire measurements from the previous route."""
+    try:
+        owner = getattr(provider, "__self__", None)
+        callback = getattr(owner, "_sdpa256_bounded_route_changed", None)
+        if callable(callback):
+            callback(active)
+    except Exception:
+        logger.debug("sdpa256 route notification failed", exc_info=True)
+
+
 def _tiled_route_required(queries, keys) -> bool:
     """Decide forced-fused vs default for a matched call (True = force).
 
@@ -102,12 +116,13 @@ def _tiled_route_required(queries, keys) -> bool:
     (issues #2155 / #2204), so force the fused path only when the unfused
     transient would not fit under the guard ceiling — or when no headroom
     info is available, keeping the memory-safe #2025 behavior."""
+    provider = _HEADROOM_PROVIDER() if _HEADROOM_PROVIDER is not None else None
     if _FORCE_TILED is not None:
         if _FORCE_TILED:
             _note_tiled_route("forced", "forced by OMLX_SDPA256_TILED=1")
+        _notify_bounded_route(provider, _FORCE_TILED)
         return _FORCE_TILED
     try:
-        provider = _HEADROOM_PROVIDER() if _HEADROOM_PROVIDER is not None else None
         if provider is None:
             _note_tiled_route(
                 "no-provider",
@@ -122,6 +137,7 @@ def _tiled_route_required(queries, keys) -> bool:
                 "memory ceiling not available (enforcer state not yet "
                 "propagated)",
             )
+            _notify_bounded_route(provider, True)
             return True
         batch, n_q, q_len, _ = queries.shape
         transient = estimate_unfused_sdpa_call_bytes(
@@ -129,17 +145,22 @@ def _tiled_route_required(queries, keys) -> bool:
             q_len,
             keys.shape[-2],
             HEAD_DIM,
-            score_dtype_size=queries.dtype.size,
+            # The unfused fallback materializes fp32 scores even for bf16
+            # inputs (issue #2204 follow-up): pricing it at the query dtype
+            # halves the predicted matrix and admits OOM spikes at long
+            # context. Shared with the guard via the memory_monitor constant.
+            score_dtype_size=SDPA256_UNFUSED_SCORE_DTYPE_SIZE,
         )
-        if transient > headroom:
+        bounded = transient > headroom
+        _notify_bounded_route(provider, bounded)
+        if bounded:
             _note_tiled_route(
                 "insufficient-headroom",
                 f"unfused transient ~{transient / 2**20:.0f}MiB exceeds live "
                 f"guard headroom ~{headroom / 2**20:.0f}MiB at "
                 f"kv_len={keys.shape[-2]}",
             )
-            return True
-        return False
+        return bounded
     except Exception:
         _note_tiled_route("probe-error", "guard headroom probe failed")
         logger.debug("sdpa256 headroom probe failed", exc_info=True)
@@ -233,7 +254,15 @@ def _array_tiled_sdpa256(queries, keys, values, scale, mask, sinks=None):
 
 
 def _flash_sdpa256(queries, keys, values, scale, mask, sinks=None):
-    """Use MLX 0.32.2 native fused SDPA on Metal, portable tiling elsewhere."""
+    """Use MLX 0.32.2 native fused SDPA on Metal, portable tiling elsewhere.
+
+    Explicit array masks never take the native fused call: MLX's fused
+    array-mask support is unproven and may silently fall back to the
+    unfused fp32 score matrix, which is exactly the O(L^2) spike this patch
+    exists to bound. The array-tiled implementation already handles bool and
+    additive masks, so route them there directly."""
+    if isinstance(mask, mx.array):
+        return _array_tiled_sdpa256(queries, keys, values, scale, mask, sinks)
     native_shape = values.shape[-1] == HEAD_DIM and not (
         isinstance(mask, str)
         and mask == "causal"
@@ -297,6 +326,7 @@ def _register_bounded_route(min_kv_len: int) -> bool:
             min_query_len=_SDPA256_MIN_Q_LEN,
             min_kv_len=min_kv_len,
             kv_tile=_KV_TILE,
+            supports_array_mask=True,
         )
     except Exception:
         logger.debug("could not register sdpa256 with memory_monitor", exc_info=True)

--- a/omlx/prefill_transient_tracker.py
+++ b/omlx/prefill_transient_tracker.py
@@ -231,8 +231,15 @@ class PrefillTransientTracker:
         """Footprint released since the last positive chunk measurement."""
         return self._recent_reclaim_bytes
 
+    def reset_history(self, *, gathered_core: bool = False) -> None:
+        """Drop observations for one execution regime."""
+        if gathered_core:
+            self._gathered_history = _TransientHistory()
+        else:
+            self._dense_history = _TransientHistory()
+
     def reset(self) -> None:
         """Drop all observations (e.g. on model reload or after a long idle)."""
-        self._dense_history = _TransientHistory()
-        self._gathered_history = _TransientHistory()
+        self.reset_history()
+        self.reset_history(gathered_core=True)
         self._recent_reclaim_bytes = 0

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1997,6 +1997,7 @@ class Scheduler:
         self._prefill_transient_tracker = PrefillTransientTracker(
             model_id=_tracker_model_id
         )
+        self._sdpa256_bounded_route_active: bool | None = None
         # One-shot probe of the GDN/Mamba fixed recurrent-state footprint,
         # armed by _set_model_info_for_monitor when ArraysCache layers exist
         # and taken after the first prefill chunk's eval.
@@ -4028,6 +4029,14 @@ class Scheduler:
         base_cap = self._memory_abort_limit_bytes or self._memory_hard_limit_bytes
         safety_cap = self._prefill_abort_cap()
         return base_cap, safety_cap, self._prefill_abort_margin
+
+    def _sdpa256_bounded_route_changed(self, active: bool) -> None:
+        """Retire measurements when SDPA256 changes memory regimes."""
+        previous = getattr(self, "_sdpa256_bounded_route_active", None)
+        active = bool(active)
+        self._sdpa256_bounded_route_active = active
+        if previous != active and (previous is not None or active):
+            self._prefill_transient_tracker.reset_history()
 
     def _sdpa256_unfused_headroom(self) -> int:
         """Live headroom (bytes) for one unfused SDPA transient, under the

--- a/tests/test_memory_monitor.py
+++ b/tests/test_memory_monitor.py
@@ -1078,6 +1078,215 @@ class TestDeepSeekV4PrefillMemoryProfile:
         assert make_prefill_memory_profile(config, compute_dtype_size=2) is None
 
 
+class TestQwen4ExpPrefillMemoryProfile:
+    """Qwen4 profile must price the head-dim-256 core through the same
+    bounded-route registry the generic estimator uses: dense Q x kv_len fp32
+    without a registered route, output + one fp32 score tile with one."""
+
+    @staticmethod
+    def _profile():
+        from omlx.memory_monitor import make_prefill_memory_profile
+
+        config = SimpleNamespace(
+            model_type="qwen4_exp",
+            num_hidden_layers=48,
+            num_attention_heads=24,
+            num_key_value_heads=2,
+            head_dim=256,
+            indexer_n_heads=4,
+            indexer_head_dim=128,
+            indexer_budget=2048,
+            indexer_compress_ratio=4,
+            full_attention_interval=4,
+            layer_types=None,
+        )
+        return make_prefill_memory_profile(config, compute_dtype_size=2)
+
+    def _monitor(self, profile):
+        from omlx.memory_monitor import MemoryMonitor
+
+        monitor = MemoryMonitor(max_kv_cache_memory=None, eviction_enabled=False)
+        monitor.set_model_info(
+            num_layers=48,
+            num_kv_heads=2,
+            head_dim=256,
+            dtype_size=2,
+            num_attention_heads=24,
+            compute_dtype_size=2,
+            prefill_memory_profile=profile,
+        )
+        return monitor
+
+    @staticmethod
+    def _indexer_bytes(query_tokens, kv_len):
+        pooled = max(kv_len // 4, 1)
+        return 4 * query_tokens * pooled * 4 + 4 * query_tokens * 128 * 4
+
+    def test_no_registration_prices_dense_fp32_core(self):
+        import omlx.memory_monitor as memory_monitor
+
+        memory_monitor._SDPA_TILED_PREFILL_HEAD_DIMS.pop(256, None)
+        try:
+            profile = self._profile()
+            query_tokens, kv_len = 2048, 160_000
+            estimate = profile.estimate_prefill_transient_bytes(
+                query_tokens, kv_len
+            )
+            # Dense unfused core is priced at the measured fp32 width, not
+            # the bf16 model compute dtype (issue #2204 follow-up).
+            assert estimate == self._indexer_bytes(query_tokens, kv_len) + (
+                24 * query_tokens * kv_len * 4 + 24 * query_tokens * 256 * 4
+            )
+        finally:
+            memory_monitor._SDPA_TILED_PREFILL_HEAD_DIMS.pop(256, None)
+
+    def test_causal_only_registration_keeps_array_mask_core_dense(self):
+        import omlx.memory_monitor as memory_monitor
+
+        memory_monitor._SDPA_TILED_PREFILL_HEAD_DIMS.pop(256, None)
+        memory_monitor.register_tiled_prefill_head_dim(
+            256, min_query_len=16, min_kv_len=2048, kv_tile=1024
+        )
+        try:
+            profile = self._profile()
+            query_tokens, kv_len = 2048, 4096
+            expected = self._indexer_bytes(query_tokens, kv_len) + (
+                24 * query_tokens * kv_len * 4 + 24 * query_tokens * 256 * 4
+            )
+            assert profile.estimate_prefill_transient_bytes(
+                query_tokens, kv_len
+            ) == expected
+        finally:
+            memory_monitor._SDPA_TILED_PREFILL_HEAD_DIMS.pop(256, None)
+
+    def test_matching_registration_prices_output_plus_one_fp32_tile(self):
+        import omlx.memory_monitor as memory_monitor
+
+        memory_monitor._SDPA_TILED_PREFILL_HEAD_DIMS.pop(256, None)
+        memory_monitor.register_tiled_prefill_head_dim(
+            256, min_query_len=16, min_kv_len=8192, kv_tile=1024, supports_array_mask=True
+        )
+        try:
+            profile = self._profile()
+            query_tokens, kv_len = 2048, 160_000
+            estimate = profile.estimate_prefill_transient_bytes(
+                query_tokens, kv_len
+            )
+            # Indexer charge is retained; the core is fp32 output plus one
+            # 1024-wide fp32 score tile — no Q x kv_len matrix.
+            expected = self._indexer_bytes(query_tokens, kv_len) + (
+                24 * query_tokens * 256 * 4 + 24 * query_tokens * 1024 * 4
+            )
+            assert estimate == expected
+            dense = self._indexer_bytes(query_tokens, kv_len) + (
+                24 * query_tokens * kv_len * 4 + 24 * query_tokens * 256 * 4
+            )
+            assert estimate < dense / 10
+        finally:
+            memory_monitor._SDPA_TILED_PREFILL_HEAD_DIMS.pop(256, None)
+
+    def test_threshold_misses_stay_dense(self):
+        import omlx.memory_monitor as memory_monitor
+
+        memory_monitor._SDPA_TILED_PREFILL_HEAD_DIMS.pop(256, None)
+        memory_monitor.register_tiled_prefill_head_dim(
+            256, min_query_len=16, min_kv_len=8192, kv_tile=1024, supports_array_mask=True
+        )
+        try:
+            profile = self._profile()
+            dense_small_kv = self._indexer_bytes(2048, 4096) + (
+                24 * 2048 * 4096 * 4 + 24 * 2048 * 256 * 4
+            )
+            # kv below the route floor -> dense.
+            assert (
+                profile.estimate_prefill_transient_bytes(2048, 4096)
+                == dense_small_kv
+            )
+            # query below the route floor -> dense.
+            dense_short_q = self._indexer_bytes(8, 160_000) + (
+                24 * 8 * 160_000 * 4 + 24 * 8 * 256 * 4
+            )
+            assert (
+                profile.estimate_prefill_transient_bytes(8, 160_000)
+                == dense_short_q
+            )
+        finally:
+            memory_monitor._SDPA_TILED_PREFILL_HEAD_DIMS.pop(256, None)
+
+    def test_crossed_registrations_never_invent_coverage(self):
+        """Two routes whose individual (query, kv) thresholds are not jointly
+        met must not produce a bounded price (mirror of the generic
+        estimator's threshold-independence regression)."""
+        import omlx.memory_monitor as memory_monitor
+
+        memory_monitor._SDPA_TILED_PREFILL_HEAD_DIMS.pop(256, None)
+        memory_monitor.register_tiled_prefill_head_dim(
+            256, min_query_len=16, min_kv_len=8192, kv_tile=1024, supports_array_mask=True
+        )
+        memory_monitor.register_tiled_prefill_head_dim(
+            256, min_query_len=64, min_kv_len=2048, kv_tile=512, supports_array_mask=True
+        )
+        try:
+            profile = self._profile()
+            # q=16 / kv=2048 meets one threshold from each route but no
+            # complete route.
+            dense = self._indexer_bytes(16, 2048) + (
+                24 * 16 * 2048 * 4 + 24 * 16 * 256 * 4
+            )
+            assert profile.estimate_prefill_transient_bytes(16, 2048) == dense
+            # The widest tile among matching routes binds for full matches.
+            bounded = self._indexer_bytes(64, 8192) + (
+                24 * 64 * 256 * 4 + 24 * 64 * 1024 * 4
+            )
+            assert profile.estimate_prefill_transient_bytes(64, 8192) == bounded
+        finally:
+            memory_monitor._SDPA_TILED_PREFILL_HEAD_DIMS.pop(256, None)
+
+    def test_gathered_core_below_route_floor_stays_dense(self):
+        """The route covers the dense core's actual K width. A gathered QSA
+        core attending ~indexer_budget tokens is below the 8192 route floor
+        and must not borrow a bounded price registered for the dense path."""
+        import omlx.memory_monitor as memory_monitor
+
+        memory_monitor._SDPA_TILED_PREFILL_HEAD_DIMS.pop(256, None)
+        memory_monitor.register_tiled_prefill_head_dim(
+            256, min_query_len=16, min_kv_len=8192, kv_tile=1024, supports_array_mask=True
+        )
+        try:
+            profile = self._profile()
+            query_tokens, kv_len = 2048, 160_000
+            core_kv = min(kv_len, 2048 + 4 - 1)
+            dense = self._indexer_bytes(query_tokens, kv_len) + (
+                24 * query_tokens * core_kv * 4 + 24 * query_tokens * 256 * 4
+            )
+            assert (
+                profile.estimate_prefill_transient_bytes(
+                    query_tokens, kv_len, gathered_core=True
+                )
+                == dense
+            )
+        finally:
+            memory_monitor._SDPA_TILED_PREFILL_HEAD_DIMS.pop(256, None)
+
+    def test_bounded_price_reaches_monitor_via_chunk_transient(self):
+        import omlx.memory_monitor as memory_monitor
+
+        memory_monitor._SDPA_TILED_PREFILL_HEAD_DIMS.pop(256, None)
+        memory_monitor.register_tiled_prefill_head_dim(
+            256, min_query_len=16, min_kv_len=8192, kv_tile=1024, supports_array_mask=True
+        )
+        try:
+            profile = self._profile()
+            monitor = self._monitor(profile)
+            direct = profile.estimate_prefill_transient_bytes(2048, 160_000)
+            routed = monitor.estimate_chunk_transient_bytes(
+                2048, 160_000, gathered_core=False
+            )
+            assert routed == direct
+        finally:
+            memory_monitor._SDPA_TILED_PREFILL_HEAD_DIMS.pop(256, None)
+
+
 class TestAnePrefillTransientReserve:
     def test_ane_prefill_transient_is_added_to_the_peak(self):
         # issue #2841: the ANE I/O surfaces are dirtied by the first long

--- a/tests/test_prefill_oom_graceful.py
+++ b/tests/test_prefill_oom_graceful.py
@@ -505,6 +505,62 @@ def test_predicted_transient_zero_without_signals():
     assert ns._predicted_chunk_transient(4, 1000) == 0.0
 
 
+def test_bounded_qwen4_route_drops_unfused_dense_history():
+    """A route flip to bounded array-mask SDPA must retire unfused samples."""
+    from omlx import memory_monitor
+    from omlx.memory_monitor import make_prefill_memory_profile
+
+    config = SimpleNamespace(
+        model_type="qwen4_exp",
+        num_hidden_layers=48,
+        num_attention_heads=24,
+        num_key_value_heads=2,
+        head_dim=256,
+        indexer_n_heads=4,
+        indexer_head_dim=128,
+        indexer_budget=2048,
+        indexer_compress_ratio=4,
+        full_attention_interval=4,
+        layer_types=None,
+    )
+    profile = make_prefill_memory_profile(config, compute_dtype_size=2)
+    monitor = MemoryMonitor(max_kv_cache_memory=_GB, eviction_enabled=False)
+    monitor.set_model_info(
+        num_layers=48,
+        num_kv_heads=2,
+        head_dim=256,
+        dtype_size=2,
+        num_attention_heads=24,
+        prefill_memory_profile=profile,
+    )
+    routes = memory_monitor._SDPA_TILED_PREFILL_HEAD_DIMS.get(256)
+    memory_monitor.register_tiled_prefill_head_dim(
+        256,
+        min_query_len=16,
+        min_kv_len=8192,
+        kv_tile=1024,
+        supports_array_mask=True,
+    )
+    try:
+        tracker = PrefillTransientTracker()
+        tracker.update(2048, int(25.4 * 1024**2 * 2048))
+        ns = _throttle_ctx(
+            current=0, hard=240 * _GB, samples_bpt=None, monitor=monitor
+        )
+        ns._prefill_transient_tracker = tracker
+        Scheduler._sdpa256_bounded_route_changed(ns, False)
+        Scheduler._sdpa256_bounded_route_changed(ns, True)
+
+        predicted = ns._predicted_chunk_transient(2048, 174_000)
+        stale = 25.4 * 1024**2 * 2048 * Scheduler._PREFILL_TRANSIENT_SAFETY
+        assert predicted < stale / 8
+    finally:
+        if routes is None:
+            memory_monitor._SDPA_TILED_PREFILL_HEAD_DIMS.pop(256, None)
+        else:
+            memory_monitor._SDPA_TILED_PREFILL_HEAD_DIMS[256] = routes
+
+
 def test_predicted_transient_drops_dense_ewma_when_qsa_static_is_cheaper():
     """A leftover dense last_delta must not refuse gathered QSA static."""
     from omlx.memory_monitor import make_prefill_memory_profile
@@ -554,11 +610,16 @@ def test_predicted_transient_drops_dense_ewma_when_qsa_static_is_cheaper():
         4096, 233_472, gathered_core=True
     )
     assert next_predicted == pytest.approx(predicted, rel=1e-6)
-    # Without gathered pricing, that same leftover gulp must still bind.
+    # Without gathered pricing, the larger of that gulp and dense fp32 static
+    # pricing must bind.
     dense_predicted = ns._predicted_chunk_transient(
         4096, 233_472, gathered_core=False
     )
-    assert dense_predicted == pytest.approx(dense_poison, rel=1e-3)
+    dense_static = (
+        monitor.estimate_chunk_transient_bytes(4096, 233_472 + 4096)
+        + monitor.estimate_prompt_kv_bytes(4096)
+    ) * Scheduler._PREFILL_TRANSIENT_SAFETY
+    assert dense_predicted == pytest.approx(max(dense_poison, dense_static), rel=1e-3)
 
 
 def test_predicted_transient_keeps_gathered_spike_from_this_request():

--- a/tests/test_qwen4_qsa_prefill_memory.py
+++ b/tests/test_qwen4_qsa_prefill_memory.py
@@ -1,5 +1,7 @@
 """Regression smoke tests for Qwen4 QSA long-prefill memory routing."""
 
+import importlib
+import sys
 from types import SimpleNamespace
 
 import mlx.core as mx
@@ -113,3 +115,130 @@ def test_long_bool_mask_turboquant_prefill_is_tiled_first(monkeypatch):
 
     assert result.shape == queries.shape
     assert calls == ["quantized"]
+
+
+def test_qwen4_mask_dense_seam_reaches_array_tiled_sdpa256(monkeypatch):
+    """Production seam: on the official mask_dense path the QSA indexer
+    builds an explicit array mask; with the sdpa256 patch installed that mask
+    must reach _array_tiled_sdpa256 (bounded) and never the native fused call
+    whose array-mask support could silently unfuse into the O(L^2) fp32
+    score matrix. Uses a real Qwen4ExpAttention at production head_dim=256
+    with gathered attention disabled by non-broadcast MRoPE positions."""
+    from omlx import memory_monitor
+    from omlx.patches import mlx_vlm_qwen4_exp_compat as compat
+    from omlx.patches import sdpa256_attention as sdpa256
+
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models.qwen4_exp import TextConfig
+    from mlx_vlm.models.qwen4_exp.language import QSAKVCache, Qwen4ExpAttention
+
+    cfg = TextConfig(
+        model_type="qwen4_exp_text",
+        hidden_size=512,
+        num_hidden_layers=1,
+        num_attention_heads=8,
+        linear_num_value_heads=4,
+        linear_num_key_heads=2,
+        linear_key_head_dim=8,
+        linear_value_head_dim=8,
+        linear_conv_kernel_dim=3,
+        num_experts=4,
+        num_experts_per_tok=2,
+        shared_expert_intermediate_size=16,
+        moe_intermediate_size=16,
+        rms_norm_eps=1e-6,
+        vocab_size=64,
+        num_key_value_heads=2,
+        max_position_embeddings=4096,
+        hc_count=2,
+        hc_lowrank=8,
+        head_dim=256,
+        layer_types=["full_attention"],
+        ple_layer_ids=[],
+        ple_embed_dim=32,
+        ple_conv_kernel_size=3,
+        ngram_size=3,
+        heads_per_ngram=2,
+        ngram_vocab_size_base=17,
+        make_ngram_vocab_size_divisible_by=4,
+        split_ngram_parts=4,
+        indexer_n_heads=2,
+        indexer_kv_heads=1,
+        indexer_head_dim=128,
+        indexer_budget=16,
+        indexer_compress_ratio=4,
+        eos_token_id=1,
+        rope_parameters={
+            "rope_type": "default",
+            "mrope_section": [2, 1, 1],
+            "rope_theta": 10_000,
+            "partial_rotary_factor": 1.0,
+        },
+    )
+    attn = Qwen4ExpAttention(cfg)
+    mx.eval(attn.parameters())
+
+    # Keep the gathered fast path off so the official mask_dense path runs:
+    # 3-D MRoPE positions with differing planes fail the gathered text
+    # eligibility on both this branch (broadcast check) and upstream main
+    # (2-D-only predicate), unlike the env knob which only exists here.
+    prefill_len = 64  # > indexer_budget(16): the sparse mask engages
+    position_ids = mx.stack(
+        [
+            mx.arange(prefill_len, dtype=mx.int32) * (1 + plane)
+            for plane in range(3)
+        ]
+    ).reshape(3, 1, prefill_len)
+
+    # Fresh sdpa256 install with test-sized KV floor.
+    importlib.import_module("mlx_lm.models.base")
+    importlib.import_module("mlx_vlm.models.base")
+    sdpa_snap = {
+        mod: mod.scaled_dot_product_attention
+        for name, mod in tuple(sys.modules.items())
+        if mod is not None
+        and name.startswith(("mlx_lm.models.", "mlx_vlm.models."))
+        and hasattr(mod, "scaled_dot_product_attention")
+    }
+    min_kv_len_snap = sdpa256._SDPA256_MIN_KV_LEN
+    routes_snap = memory_monitor._SDPA_TILED_PREFILL_HEAD_DIMS.get(256)
+    monkeypatch.setattr(sdpa256, "_PATCHED", False, raising=False)
+    monkeypatch.setattr(sdpa256, "_HEADROOM_PROVIDER", None, raising=False)
+    monkeypatch.setattr(sdpa256, "_FORCE_TILED", None, raising=False)
+    assert sdpa256.apply_sdpa256_attention_patch(min_kv_len=32) is True
+
+    calls = []
+
+    def tiled(queries, keys, values, scale, mask, sinks=None):
+        calls.append(mask)
+        return mx.zeros(queries.shape, queries.dtype)
+
+    def boom(*args, **kwargs):
+        raise AssertionError(
+            "native fused SDPA must not see the Qwen4 explicit array mask"
+        )
+
+    monkeypatch.setattr(sdpa256, "_array_tiled_sdpa256", tiled)
+    monkeypatch.setattr(sdpa256.mx.fast, "scaled_dot_product_attention", boom)
+
+    try:
+        mx.random.seed(7)
+        x = mx.random.normal((1, prefill_len, 512))
+        cache = QSAKVCache()
+        out = attn(x, mask="causal", cache=cache, position_ids=position_ids)
+        mx.eval(out)
+
+        assert out.shape == (1, prefill_len, 512)
+        assert len(calls) == 1
+        mask = calls[0]
+        assert isinstance(mask, mx.array)
+        assert 1 <= mask.ndim <= 4
+    finally:
+        for mod, fn in sdpa_snap.items():
+            mod.scaled_dot_product_attention = fn
+        sdpa256._SDPA256_MIN_KV_LEN = min_kv_len_snap
+        if routes_snap is None:
+            memory_monitor._SDPA_TILED_PREFILL_HEAD_DIMS.pop(256, None)
+        else:
+            memory_monitor._SDPA_TILED_PREFILL_HEAD_DIMS[256] = routes_snap
+        monkeypatch.setattr(sdpa256, "_PATCHED", False, raising=False)

--- a/tests/test_sdpa256_attention.py
+++ b/tests/test_sdpa256_attention.py
@@ -109,7 +109,10 @@ def test_metal_bounded_path_forces_mlx0322_fused_kernel(monkeypatch):
 
 @pytest.mark.parametrize("case", ["boolean", "additive", "sinks"])
 def test_bounded_path_preserves_array_masks_and_sinks(case):
-    """Exercise the real MLX 0.32.2 fused call on Metal when available."""
+    """Array masks route to the bounded portable path on Metal too (native
+    fused array-mask support is unproven and may silently unfuse); causal/
+    no-mask cases exercise the real MLX 0.32.2 fused call when available.
+    All cases stay numerically pinned against the reference SDPA."""
     from omlx.patches.sdpa256_attention import _flash_sdpa256
 
     q, k, v = _qkv(16, 32, n_q=4, n_kv=2)
@@ -129,6 +132,72 @@ def test_bounded_path_preserves_array_masks_and_sinks(case):
     )
     mx.eval(out, ref)
     assert _max_abs(out, ref) < 2e-2
+
+
+@pytest.mark.parametrize("mask_kind", ["boolean", "additive"])
+def test_metal_array_masks_never_reach_native_fused(mask_kind, monkeypatch):
+    """On Metal, an explicit array mask must go straight to the bounded
+    array-tiled kernel — never to mx.fast.scaled_dot_product_attention with
+    force_fused=True, whose array-mask handling could silently unfuse into
+    the O(L^2) fp32 score matrix this patch exists to bound."""
+    from omlx.patches import sdpa256_attention as sdpa256
+
+    calls = []
+
+    def boom(*args, **kwargs):
+        raise AssertionError("native fused SDPA must not see an array mask")
+
+    def tiled(q, k, v, scale, mask, sinks=None):
+        calls.append((mask, sinks))
+        return q
+
+    monkeypatch.setattr(sdpa256.mx.metal, "is_available", lambda: True)
+    monkeypatch.setattr(
+        sdpa256.mx.fast, "scaled_dot_product_attention", boom
+    )
+    monkeypatch.setattr(sdpa256, "_array_tiled_sdpa256", tiled)
+
+    q, k, v = _qkv(16, 32, n_q=4, n_kv=2)
+    if mask_kind == "boolean":
+        mask = mx.arange(32)[None, None, None, :] >= 8
+    else:
+        allowed = mx.arange(32)[None, None, None, :] >= 8
+        mask = mx.where(allowed, 0.0, -1e4).astype(mx.float16)
+    sinks = mx.array([-0.5, 0.0, 0.5, 1.0], dtype=mx.float16)
+
+    out = sdpa256._flash_sdpa256(q, k, v, SCALE_256, mask, sinks)
+    assert out is q
+    # Mask and sinks forwarded unchanged to the bounded kernel.
+    assert len(calls) == 1
+    assert calls[0][0] is mask
+    assert calls[0][1] is sinks
+
+
+@pytest.mark.parametrize("mask", ["causal", None], ids=["causal", "none"])
+def test_metal_causal_and_none_keep_native_fused(mask, monkeypatch):
+    """The router dtype fix must not push the proven causal/no-mask paths off
+    the native fused kernel."""
+    from omlx.patches import sdpa256_attention as sdpa256
+
+    calls = []
+
+    def fake_sdpa(q, k, v, **kwargs):
+        calls.append(kwargs)
+        return q
+
+    def tiled(*args, **kwargs):
+        raise AssertionError("causal/no-mask native shape must stay fused")
+
+    monkeypatch.setattr(sdpa256.mx.metal, "is_available", lambda: True)
+    monkeypatch.setattr(sdpa256.mx.fast, "scaled_dot_product_attention", fake_sdpa)
+    monkeypatch.setattr(sdpa256, "_array_tiled_sdpa256", tiled)
+
+    q, k, v = _qkv(16, 32, n_q=4, n_kv=2)
+    out = sdpa256._flash_sdpa256(q, k, v, SCALE_256, mask)
+    assert out is q
+    assert calls == [
+        {"scale": SCALE_256, "mask": mask, "sinks": None, "force_fused": True}
+    ]
 
 
 @pytest.mark.parametrize("mask_kind", ["boolean", "additive"])
@@ -361,9 +430,13 @@ class _HeadroomOwner:
 
     def __init__(self, value):
         self.value = value
+        self.route_changes = []
 
     def headroom(self):
         return self.value
+
+    def _sdpa256_bounded_route_changed(self, active):
+        self.route_changes.append(active)
 
 
 @pytest.fixture
@@ -379,15 +452,20 @@ def _sdpa256_provider_reset(monkeypatch):
 
 def test_route_prefers_stock_when_unfused_fits(_sdpa256_provider_reset):
     sdpa256 = _sdpa256_provider_reset
-    from omlx.memory_monitor import estimate_unfused_sdpa_call_bytes
+    from omlx.memory_monitor import (
+        SDPA256_UNFUSED_SCORE_DTYPE_SIZE,
+        estimate_unfused_sdpa_call_bytes,
+    )
 
     q, k, _ = _qkv(2048, 16384)
     owner = _HeadroomOwner(1 << 40)  # ~1 TB headroom: unfused clearly fits
     sdpa256.set_unfused_headroom_provider(owner.headroom)
     assert sdpa256._should_route(q, k, None, "causal", None) is False
 
-    # Exactly at the estimated transient the unfused path still fits...
-    need = estimate_unfused_sdpa_call_bytes(24, 2048, 16384, 256, q.dtype.size)
+    # Exactly at the fp32-priced transient the unfused path still fits...
+    need = estimate_unfused_sdpa_call_bytes(
+        24, 2048, 16384, 256, SDPA256_UNFUSED_SCORE_DTYPE_SIZE
+    )
     owner.value = need
     assert sdpa256._should_route(q, k, None, "causal", None) is False
     # ...one byte short -> forced fused.
@@ -397,6 +475,40 @@ def test_route_prefers_stock_when_unfused_fits(_sdpa256_provider_reset):
     # Negative headroom = no active ceiling -> memory-safe default.
     owner.value = -1
     assert sdpa256._should_route(q, k, None, "causal", None) is True
+    assert owner.route_changes == [False, False, True, True]
+
+
+def test_route_prices_bf16_fallback_at_fp32(_sdpa256_provider_reset):
+    """The unfused fallback materializes fp32 scores even for bf16 queries;
+    pricing at the query dtype (2B) admitted the O(L^2) matrix when only the
+    bf16-sized transient fit and produced the ~33GiB VLM prefill spike."""
+    sdpa256 = _sdpa256_provider_reset
+    from omlx.memory_monitor import (
+        SDPA256_UNFUSED_SCORE_DTYPE_SIZE,
+        estimate_unfused_sdpa_call_bytes,
+    )
+
+    q, k, _ = _qkv(2048, 16384, dtype=mx.bfloat16)
+    assert q.dtype.size == 2  # the wrongly-cheap price
+    assert SDPA256_UNFUSED_SCORE_DTYPE_SIZE == 4  # the real materialization
+
+    bf16_price = estimate_unfused_sdpa_call_bytes(
+        24, 2048, 16384, 256, q.dtype.size
+    )
+    fp32_price = estimate_unfused_sdpa_call_bytes(
+        24, 2048, 16384, 256, SDPA256_UNFUSED_SCORE_DTYPE_SIZE
+    )
+    assert fp32_price > bf16_price
+
+    # Headroom fits the bf16-sized matrix but not the real fp32 one -> the
+    # router must force the bounded path.
+    owner = _HeadroomOwner(int((bf16_price + fp32_price) / 2))
+    sdpa256.set_unfused_headroom_provider(owner.headroom)
+    assert sdpa256._should_route(q, k, None, "causal", None) is True
+
+    # Full fp32 headroom restores the faster stock path.
+    owner.value = fp32_price
+    assert sdpa256._should_route(q, k, None, "causal", None) is False
 
 
 def test_route_defaults_to_tiled_when_provider_owner_dies(_sdpa256_provider_reset):
@@ -463,7 +575,9 @@ def test_force_off_does_not_publish_a_bounded_memory_route(monkeypatch):
     monkeypatch.setattr(sdpa256, "_FORCE_TILED", None)
     assert sdpa256._register_bounded_route(8192) is True
     try:
-        assert 256 in mm._SDPA_TILED_PREFILL_HEAD_DIMS
+        routes = mm._SDPA_TILED_PREFILL_HEAD_DIMS[256]
+        assert len(routes) == 1
+        assert routes[0].supports_array_mask is True
     finally:
         mm._SDPA_TILED_PREFILL_HEAD_DIMS.pop(256, None)
 


### PR DESCRIPTION
## Summary

Qwen4-exp long-context prefill could make inconsistent decisions around head-dim-256 SDPA:

- the route gate priced the unfused score matrix at the query dtype, although MLX materializes it as fp32;
- the Qwen4 memory profile kept charging a dense `Q × KV` core after execution had a bounded tiled route;
- route registrations described shape thresholds but not explicit-array-mask support, so Qwen4 could incorrectly trust a causal-only Qwen3.5 route;
- after an unfused-to-bounded route change, old dense EWMA/last-delta measurements could continue shrinking chunks or triggering eviction retries.

This PR makes runtime routing, static admission pricing, and measured throttle history agree on the active memory regime.

## Before

At roughly 180k context, a 2048-token Qwen4 VLM `mask_dense` chunk can require an fp32 score matrix of about **33 GiB**. Pricing that candidate as bf16 could admit the unfused path without enough memory and cause a large footprint spike or OOM.

The opposite mismatch occurred after bounded tiling engaged: static pricing could still assume a full dense matrix, while stale unfused measurements could dominate `max(static, EWMA, last_delta)`. That unnecessarily reduced chunk widths and could cause eviction retries until enough bounded samples decayed the old EWMA.

A separate capability mismatch allowed a causal-only head-dim-256 registration to activate bounded pricing for Qwen4's explicit array mask, even though that route could not execute the call.

## After

- The route gate prices the unfused candidate as an fp32 score matrix plus fp32 output.
- Explicit boolean/additive masks use `_array_tiled_sdpa256`; causal/no-mask Metal calls retain native fused SDPA.
- Bounded-route registrations declare whether they support array masks. Qwen4 uses bounded pricing only when one route covers both the shape and mask capability.
- The bounded Qwen4 estimate includes fp32 output, one fp32 score tile, and the existing indexer charge. Gathered cores below the route floor remain dense-priced at their actual reduced K width.
- An unfused↔bounded transition retires dense EWMA/last-delta history. Gathered history and reclaim accounting remain intact, and bounded measurements seed the new regime.

No public API or setting changes. `OMLX_SDPA256_TILED=1/0` keeps its existing behavior.

## Runtime validation

The release app was rebuilt directly from PR head `ffa19d10` on `main`; its bundled `omlx` source was verified to contain the fp32 gate, array-mask capability registration, and route-change history reset.

### Cold multimodal prefill

A **181,116-token** request placed a 1024×1024 image in a later user turn after 180k text tokens. The server switched to bounded SDPA256 at high context:

```text
sdpa256: ... unfused transient ~19248MiB exceeds live guard headroom ~18101MiB at kv_len=102400
[throttle:external] ... n=2048 kv_len=100352 transient=498.92MB ... samples=1
```

The first line says the fp32 unfused candidate no longer fit and was rejected. The next completed chunk started a fresh transient history instead of inheriting the preceding route's 46 samples. The request reached 181k and generated a token without OOM; peak sampled IOAccelerator allocation was **94.85 GiB**, below the 128 GiB system limit.

This clean-`main` run also encountered the separate eviction/resume bug fixed by [#3414](https://github.com/jundot/omlx/pull/3414): two LRU eviction pauses repeated part of the cold prefill, and later chunks briefly shrank to 1728/1024. Consequently it took **840 seconds**. #3414 is intentionally not included in this standalone PR.

### Cached-prefix continuation

A follow-up request reused **180,224 of 183,165 prompt tokens**, leaving 2,941 tokens including a second image:

```text
paged cache hit, 180224 tokens in 88 blocks, 2941 tokens remaining
[throttle:external] ... n=2048 kv_len=180224 ... samples=1
[throttle:external] ... n=892 kv_len=182272 ... samples=1
Scheduled request ... with 1 tokens to process ... 180224 cached
```

Both remaining chunks ran at their requested widths with no throttle, eviction retry, or OOM. The request completed in **20.1 seconds**. The 2048-token high-context bounded chunk took about **14.2 seconds** after cache reconstruction; this is intentionally a memory-safety fallback, not the preferred fast path. During the cached prefill, sampled IOAccelerator allocation rose from **80.51 GiB to 89.16 GiB**, still far below the rejected ~34 GiB full-score allocation at this context, then fell to **71.80 GiB** after completion.

Together with the deterministic stale-history regression, this verifies both the real array-mask safety route and a real prefix-cached continuation on the standalone PR bundle.

## Reproduce

1. Start oMLX with debug logging and the prefill memory guard enabled.
2. Load a Qwen4-exp VLM with `head_dim=256`.
3. Send a multimodal conversation with enough text to approach the model's context limit, followed by an image in a later user turn. This places a non-broadcast visual MRoPE region in a high-KV prefill chunk.
4. Verify that the logs change from `path=gathered` to `path=mask_dense` and report `unfused transient ... exceeds live guard headroom`.
5. Confirm that full chunk width is retained, memory does not jump by the reported unfused estimate, and no OOM occurs. A prefix-cached continuation can additionally verify that old dense measurements do not throttle the bounded route.

The exact token count needed depends on model geometry, configured memory ceiling, and available unified memory. The route engages when the fp32 unfused estimate exceeds live guard headroom.

## Tests

Key regressions:

```bash
pytest -q tests/test_prefill_oom_graceful.py::test_bounded_qwen4_route_drops_unfused_dense_history
pytest -q tests/test_memory_monitor.py::TestQwen4ExpPrefillMemoryProfile::test_causal_only_registration_keeps_array_mask_core_dense
pytest -q tests/test_qwen4_qsa_prefill_memory.py::test_qwen4_mask_dense_seam_reaches_array_tiled_sdpa256
```

Coverage also includes fp32 route-gate boundaries, dense/bounded/threshold/gathered pricing, boolean and additive masks, causal/no-mask native routing, tiled numerical parity, route notifications, and restoration of patched test state.

Validation:

- **201 passed** across the affected memory-monitor, transient-tracker, graceful-OOM, Qwen4 QSA, and SDPA256 test modules.
- Full local run: **10,667 passed, 149 skipped**. Six numerical-tolerance failures reproduce unchanged on `origin/main`; the affected stale fp32 expectation was updated and passes.
- `git diff --check` clean.
