### PR TITLE
fix(benchmark): add gen_tps to benchmark pp-result logging

### DIFF
--- a/omlx/admin/benchmark.py
+++ b/omlx/admin/benchmark.py
@@ -1954,10 +1954,11 @@ async def run_benchmark(run: BenchmarkRun, engine_pool: Any) -> None:
             )
             metrics["system_metrics"] = _sample_window(run, window_start)
             logger.info(
-                "[benchmark-pp-result] pp=%d processing_tps=%.3f "
+                "[benchmark-pp-result] pp=%d processing_tps=%.3f gen_tps=%.3f "
                 "ttft_ms=%.3f e2e_ms=%.3f cached_tokens=%d",
                 pp_len,
                 float(metrics.get("processing_tps", 0.0) or 0.0),
+                float(metrics.get("gen_tps", 0.0) or 0.0),
                 float(metrics.get("ttft_ms", 0.0) or 0.0),
                 float(metrics.get("e2e_latency_s", 0.0) or 0.0) * 1000.0,
                 int(metrics.get("cached_tokens", 0) or 0),

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -856,6 +856,66 @@ class TestBenchmarkEngineSelection:
         assert pool._scheduler_config.prefill_speed_priority is False
 
     @pytest.mark.asyncio
+    async def test_run_benchmark_logs_gen_tps_in_pp_result(self, caplog):
+        run = BenchmarkRun(
+            bench_id="bench-log-gen-tps",
+            request=BenchmarkRequest(
+                model_id="m",
+                prompt_lengths=[1024],
+                generation_length=1,
+            ),
+        )
+        with (
+            patch("omlx.admin.benchmark._upload_to_omlx_ai", AsyncMock()),
+            caplog.at_level(logging.INFO),
+        ):
+            await run_benchmark(run, _FakeBenchEnginePool())
+
+        pp_logs = [
+            record.getMessage()
+            for record in caplog.records
+            if "[benchmark-pp-result]" in record.getMessage()
+        ]
+        assert pp_logs
+        assert "processing_tps=" in pp_logs[0]
+        assert "gen_tps=" in pp_logs[0]
+
+    @pytest.mark.asyncio
+    async def test_run_benchmark_logs_zero_gen_tps_when_unmeasured(self, caplog):
+        run = BenchmarkRun(
+            bench_id="bench-log-gen-tps-none",
+            request=BenchmarkRequest(
+                model_id="m",
+                prompt_lengths=[1024],
+                generation_length=128,
+            ),
+        )
+        metrics = {
+            "prompt_tokens": 1024,
+            "completion_tokens": 128,
+            "cached_tokens": 0,
+            "ttft_ms": 100.0,
+            "e2e_latency_s": 0.25,
+            "tpot_ms": None,
+            "gen_tps": None,
+            "processing_tps": 500.0,
+        }
+        with (
+            patch("omlx.admin.benchmark._upload_to_omlx_ai", AsyncMock()),
+            patch("omlx.admin.benchmark._run_single_test", AsyncMock(return_value=metrics)),
+            caplog.at_level(logging.INFO),
+        ):
+            await run_benchmark(run, _FakeBenchEnginePool())
+
+        pp_logs = [
+            record.getMessage()
+            for record in caplog.records
+            if "[benchmark-pp-result]" in record.getMessage()
+        ]
+        assert pp_logs
+        assert "gen_tps=0.000" in pp_logs[0]
+
+    @pytest.mark.asyncio
     async def test_batch_request_skips_engine_with_none_scheduler_core(self):
         run = BenchmarkRun(
             bench_id="bench-test",


### PR DESCRIPTION
Benchmark runs were logging prefill throughput (`processing_tps`) but not decode/generation throughput (`gen_tps`), even though `gen_tps` is already computed and surfaced in the UI. This made generation speed unrecoverable from `server.log` alone.

- **Benchmark log payload update**
  - Extended the `[benchmark-pp-result]` format string in `omlx/admin/benchmark.py` to include `gen_tps` immediately after `processing_tps`.
  - Kept existing field order otherwise unchanged (`ttft_ms`, `e2e_ms`, `cached_tokens` remain in place).

- **`None`-safe formatting for generation TPS**
  - Added `float(metrics.get("gen_tps", 0.0) or 0.0)` in log arguments so unmeasurable decode runs (`gen_tps is None`) log as `0.000` instead of failing `%0.3f` formatting.

- **Targeted benchmark logging coverage**
  - Added/updated tests in `tests/test_benchmark.py` to assert:
    - `[benchmark-pp-result]` includes `gen_tps=...`
    - `gen_tps=None` is rendered as `gen_tps=0.000`

```python
logger.info(
    "[benchmark-pp-result] pp=%d processing_tps=%.3f gen_tps=%.3f "
    "ttft_ms=%.3f e2e_ms=%.3f cached_tokens=%d",
    pp_len,
    float(metrics.get("processing_tps", 0.0) or 0.0),
    float(metrics.get("gen_tps", 0.0) or 0.0),
    float(metrics.get("ttft_ms", 0.0) or 0.0),
    float(metrics.get("e2e_latency_s", 0.0) or 0.0) * 1000.0,
    int(metrics.get("cached_tokens", 0) or 0),
)
```

Closes #3464 