### PR TITLE
perf(qwen4_exp): host-side decode optimizations for Qwen3.8-Flash-Next

### DIFF
--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/hc_fused.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/hc_fused.py
@@ -298,9 +298,12 @@ def compatible(module, hyper_input) -> bool:
         and 1 <= hyper_input.shape[0] * hyper_input.shape[1] <= MAX_ROWS
     ):
         return False
-    if hasattr(module, "input_inject_weight") or getattr(
-        module, "_omlx_exact_hybrid_projection", False
-    ):
+    if getattr(module, "_omlx_exact_hybrid_projection", False):
+        # Upstream's exact hybrid projection (installed at load time for serial decode)
+        # keeps its own compiled single-token path; that is a runtime choice, not a
+        # checkpoint layout, so it is not logged.
+        return False
+    if hasattr(module, "input_inject_weight"):
         return _ineligible("combined input projection layout")
     hc_count = getattr(module, "hc_count", None)
     hidden = getattr(module, "hidden_size", None)

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/hc_fused.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/hc_fused.py
@@ -1,0 +1,404 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fused hyper-connection kernels for Qwen4-Exp decode and verify rows.
+
+``Qwen4ExpGatedResidual._forward`` builds ~30 MLX nodes per call (grouped norm,
+three small quantized projections, silu/sigmoid gates, stream mix and mean) and
+runs 97 times per forward. On Apple Silicon the host-side kernel encoding of
+that graph, not its GPU time, dominates a Lightning MTP verify cycle. Three
+row-batched Metal kernels replace it for small row counts:
+
+* ``N`` -- per-stream RMS norm with the ``1 + weight`` scale (bit-identical to
+  ``mx.fast.rms_norm``).
+* ``D`` -- ``input_mix_weight_down`` (320 rows) and ``block_inject_weight``
+  (``hc_count`` rows) projections per token row, split over 4 K-slices, with
+  the ``silu(mix / hc_count)`` and ``2 * sigmoid(inject / hc_count)``
+  epilogues folded in.
+* ``U`` -- ``input_mix_weight_up`` per output element, sigmoid, times the
+  normed stream, mean over streams via simd shuffles.
+
+Rows live in the grid (``batch * seq <= 16``). The affine unpack helpers come
+from :mod:`hc_projection`. Results match the canonical path to a few bf16 ULP
+(fp32 is kept through the epilogues); the path fails closed to ``_forward`` on
+any runtime error. Disable with ``OMLX_QWEN4_HC_FUSED=0``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .hc_projection import _HEADER
+
+logger = logging.getLogger(__name__)
+
+MAX_ROWS = 16
+_GROUP_SIZE = 64
+_SUPPORTED_BITS = (4, 5, 6, 8)
+_DISABLED = os.environ.get("OMLX_QWEN4_HC_FUSED", "1").strip().lower() in {
+    "0",
+    "false",
+    "no",
+    "off",
+}
+_KERNELS: dict[str, object] = {}
+_RUNTIME_FAILED = False
+_FAILURE_LOGGED = False
+
+_N_SOURCE = r"""
+    const uint row = threadgroup_position_in_grid.z;
+    const uint s = threadgroup_position_in_grid.y;
+    const uint t = thread_index_in_threadgroup;
+    const uint sg = simdgroup_index_in_threadgroup;
+    const uint lane = thread_index_in_simdgroup;
+    threadgroup float part[8];
+    constexpr int PER = H / 256;
+    const device T* xp = x + (size_t)row * K + (size_t)s * H;
+    const device T* wp = w + (size_t)s * H;
+    device T* op = xn + (size_t)row * K + (size_t)s * H;
+    float v[PER];
+    float ss = 0.0f;
+    for (int i = 0; i < PER; ++i) {
+        v[i] = float(xp[t + i * 256]);
+        ss += v[i] * v[i];
+    }
+    ss = simd_sum(ss);
+    if (lane == 0) part[sg] = ss;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    float tot = 0.0f;
+    for (int i = 0; i < 8; ++i) tot += part[i];
+    const float inv = metal::rsqrt(tot / float(H) + eps[0]);
+    for (int i = 0; i < PER; ++i) {
+        const int k = t + i * 256;
+        op[k] = T(v[i] * inv * (1.0f + float(wp[k])));
+    }
+"""
+
+_D_SOURCE = r"""
+    const uint tg = threadgroup_position_in_grid.y;
+    const uint row = threadgroup_position_in_grid.z;
+    const uint sg = simdgroup_index_in_threadgroup;
+    const uint lane = thread_index_in_simdgroup;
+    constexpr int KS = 4;
+    constexpr int SLICE = K / KS;
+    constexpr int GROUPS = K / 64;
+    threadgroup float part[KS][8];
+    const device T* x = xn + (size_t)row * K;
+    const int rg = int(sg & 1);
+    const int ks = int(sg >> 1);
+    if (tg < R / 8) {
+        constexpr int PF = hc_pack_factor<BITS_D>();
+        constexpr int BP = hc_bytes_per_pack<BITS_D>();
+        constexpr int ROW_BYTES = K * BP / PF;
+        constexpr int PPT = 2;
+        constexpr int VPT = PF * PPT;
+        constexpr int BLOCK = VPT * 32;
+        constexpr int SCALE_STEP = 64 / VPT;
+        const int out_row = int(tg) * 8 + rg * 4;
+        const device uint8_t* wp = (const device uint8_t*)down_w
+            + out_row * ROW_BYTES + ks * (SLICE * BP / PF) + int(lane) * PPT * BP;
+        const device T* sp = down_s + out_row * GROUPS + ks * (SLICE / 64)
+            + int(lane) / SCALE_STEP;
+        const device T* bp = down_b + out_row * GROUPS + ks * (SLICE / 64)
+            + int(lane) / SCALE_STEP;
+        const device T* xp = x + ks * SLICE + int(lane) * VPT;
+        float result[4] = {0.0f};
+        float xv[VPT];
+        for (int k = 0; k < SLICE; k += BLOCK) {
+            float sum = hc_load_vector<T, VPT, BITS_D>(xp, xv);
+            for (int r = 0; r < 4; ++r) {
+                result[r] += hc_qdot<VPT, BITS_D>(
+                    wp + r * ROW_BYTES, xv,
+                    float(sp[r * GROUPS]), float(bp[r * GROUPS]), sum);
+            }
+            wp += BLOCK * BP / PF;
+            sp += BLOCK / 64;
+            bp += BLOCK / 64;
+            xp += BLOCK;
+        }
+        for (int r = 0; r < 4; ++r) {
+            float v = simd_sum(result[r]);
+            if (lane == 0) part[ks][rg * 4 + r] = v;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (sg < 2 && lane < 4) {
+            const int r = int(lane);
+            float v = part[0][sg * 4 + r] + part[1][sg * 4 + r]
+                + part[2][sg * 4 + r] + part[3][sg * 4 + r];
+            v = v / float(HC);
+            act[(size_t)row * R + int(tg) * 8 + int(sg) * 4 + r]
+                = T(v / (1.0f + metal::exp(-v)));
+        }
+        return;
+    }
+    if (INJ == 0 || rg != 0) return;
+    {
+        constexpr int PF = hc_pack_factor<BITS_I>();
+        constexpr int BP = hc_bytes_per_pack<BITS_I>();
+        constexpr int ROW_BYTES = K * BP / PF;
+        constexpr int PPT = 1;
+        constexpr int VPT = PF;
+        constexpr int BLOCK = VPT * 32;
+        constexpr int SCALE_STEP = 64 / VPT;
+        const device uint8_t* wp = (const device uint8_t*)inject_w
+            + ks * (SLICE * BP / PF) + int(lane) * BP;
+        const device T* sp = inject_s + ks * (SLICE / 64) + int(lane) / SCALE_STEP;
+        const device T* bp = inject_b + ks * (SLICE / 64) + int(lane) / SCALE_STEP;
+        const device T* xp = x + ks * SLICE + int(lane) * VPT;
+        float result[HC] = {0.0f};
+        float xv[VPT];
+        int k = 0;
+        const int last = (ks == KS - 1) ? (SLICE - BLOCK) : SLICE;
+        for (; k < last; k += BLOCK) {
+            float sum = hc_load_vector<T, VPT, BITS_I>(xp, xv);
+            for (int r = 0; r < HC; ++r) {
+                result[r] += hc_qdot<VPT, BITS_I>(
+                    wp + r * ROW_BYTES, xv,
+                    float(sp[r * GROUPS]), float(bp[r * GROUPS]), sum);
+            }
+            wp += BLOCK * BP / PF;
+            sp += BLOCK / 64;
+            bp += BLOCK / 64;
+            xp += BLOCK;
+        }
+        if (ks == KS - 1) {
+            float sum = hc_load_vector<T, VPT, BITS_I>(xp, xv);
+            for (int r = 0; r < HC; ++r) {
+                result[r] += hc_qdot_safe<VPT, BITS_I>(
+                    wp + r * ROW_BYTES, xv,
+                    float(sp[r * GROUPS]), float(bp[r * GROUPS]), sum);
+            }
+        }
+        for (int r = 0; r < HC; ++r) {
+            float v = simd_sum(result[r]);
+            if (lane == 0) part[ks][r] = v;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (sg == 0 && lane < HC) {
+            const int r = int(lane);
+            float v = part[0][r] + part[1][r] + part[2][r] + part[3][r];
+            v = v / float(HC);
+            inj[(size_t)row * HC + r] = T(2.0f / (1.0f + metal::exp(-v)));
+        }
+    }
+"""
+
+_U_SOURCE = r"""
+    const uint g = threadgroup_position_in_grid.y;
+    const uint t = thread_index_in_threadgroup;
+    const int h = int(g) * 64 + int(t >> 2);
+    const int s = int(t & 3);
+    const int n = s * H + h;
+    constexpr int PF = hc_pack_factor<BITS_U>();
+    constexpr int BP = hc_bytes_per_pack<BITS_U>();
+    constexpr int ROW_BYTES = R * BP / PF;
+    constexpr int GROUPS_R = R / 64;
+    constexpr int CH = 2 * PF;
+    constexpr int CPG = 64 / CH;
+    const device uint8_t* w = (const device uint8_t*)up_w + (size_t)n * ROW_BYTES;
+    const device T* sp = up_s + (size_t)n * GROUPS_R;
+    const device T* bp = up_b + (size_t)n * GROUPS_R;
+    float xv[CH];
+    for (int r = 0; r < S; ++r) {
+        const device T* a = act + (size_t)r * R;
+        float acc = 0.0f;
+        for (int gq = 0; gq < GROUPS_R; ++gq) {
+            const float sc = float(sp[gq]);
+            const float bi = float(bp[gq]);
+            for (int c = 0; c < CPG; ++c) {
+                const int e = gq * 64 + c * CH;
+                float sum = hc_load_vector<T, CH, BITS_U>(a + e, xv);
+                acc += hc_qdot<CH, BITS_U>(w + e * BP / PF, xv, sc, bi, sum);
+            }
+        }
+        float gate = 1.0f / (1.0f + metal::exp(-acc));
+        float v = gate * float(xn[(size_t)r * K + n]);
+        v += simd_shuffle_down(v, 1);
+        v += simd_shuffle_down(v, 2);
+        if (s == 0) mixed[(size_t)r * H + h] = T(v / float(HC));
+    }
+"""
+
+
+def _kernel(name: str, input_names: list[str], output_names: list[str], source: str, header: str = ""):
+    kernel = _KERNELS.get(name)
+    if kernel is None:
+        kernel = mx.fast.metal_kernel(
+            name=name,
+            input_names=input_names,
+            output_names=output_names,
+            header=header,
+            source=source,
+            ensure_row_contiguous=True,
+        )
+        _KERNELS[name] = kernel
+    return kernel
+
+
+def enabled() -> bool:
+    return not _DISABLED and not _RUNTIME_FAILED
+
+
+def _quantized_ok(projection) -> bool:
+    return (
+        type(projection) is nn.QuantizedLinear
+        and getattr(projection, "group_size", None) == _GROUP_SIZE
+        and getattr(projection, "bits", None) in _SUPPORTED_BITS
+        and getattr(projection, "mode", "affine") == "affine"
+        and "bias" not in projection
+        and isinstance(getattr(projection, "weight", None), mx.array)
+        and projection.weight.dtype == mx.uint32
+        and isinstance(getattr(projection, "scales", None), mx.array)
+        and isinstance(getattr(projection, "biases", None), mx.array)
+        and projection.scales.dtype == mx.bfloat16
+        and projection.biases.dtype == mx.bfloat16
+    )
+
+
+def compatible(module, hyper_input) -> bool:
+    """Whether ``module`` (a Qwen4ExpGatedResidual) can take the fused path for ``hyper_input``."""
+    if not enabled():
+        return False
+    if not (
+        isinstance(hyper_input, mx.array)
+        and hyper_input.ndim == 3
+        and hyper_input.dtype == mx.bfloat16
+        and 1 <= hyper_input.shape[0] * hyper_input.shape[1] <= MAX_ROWS
+    ):
+        return False
+    if hasattr(module, "input_inject_weight") or getattr(
+        module, "_omlx_exact_hybrid_projection", False
+    ):
+        return False
+    hc_count = getattr(module, "hc_count", None)
+    hidden = getattr(module, "hidden_size", None)
+    lowrank = getattr(module, "hc_lowrank", None)
+    if not (
+        isinstance(hc_count, int)
+        and isinstance(hidden, int)
+        and isinstance(lowrank, int)
+        and hc_count == 4
+        and hidden % 256 == 0
+        and lowrank % 64 == 0
+        and lowrank % 8 == 0
+        and (hc_count * hidden) % 512 == 0
+        and hyper_input.shape[2] == hc_count * hidden
+    ):
+        return False
+    norm = getattr(module, "hc_norm", None)
+    if not (
+        norm is not None
+        and getattr(norm, "group_size", None) == hidden
+        and isinstance(getattr(norm, "weight", None), mx.array)
+        and norm.weight.dtype == mx.bfloat16
+        and norm.weight.shape == (hc_count * hidden,)
+    ):
+        return False
+    if not (
+        _quantized_ok(getattr(module, "input_mix_weight_down", None))
+        and _quantized_ok(getattr(module, "input_mix_weight_up", None))
+    ):
+        return False
+    if "block_inject_weight" in module and not _quantized_ok(module.block_inject_weight):
+        return False
+    return mx.default_device() == mx.gpu and mx.metal.is_available()
+
+
+def _eps_array(module) -> mx.array:
+    eps = getattr(module, "_omlx_hc_fused_eps", None)
+    if eps is None:
+        eps = mx.array([float(module.hc_norm.eps)], dtype=mx.float32)
+        mx.eval(eps)
+        module._omlx_hc_fused_eps = eps
+    return eps
+
+
+def fused_forward(module, hyper_input):
+    """Fused equivalent of ``Qwen4ExpGatedResidual._forward``; ``None`` on runtime failure."""
+    global _RUNTIME_FAILED, _FAILURE_LOGGED
+    try:
+        hc, hidden, lowrank = module.hc_count, module.hidden_size, module.hc_lowrank
+        width = hc * hidden
+        batch, seq, _ = hyper_input.shape
+        rows = batch * seq
+        down, up = module.input_mix_weight_down, module.input_mix_weight_up
+        inject = module.block_inject_weight if "block_inject_weight" in module else None
+        flat = hyper_input.reshape(rows, width)
+        dtype = hyper_input.dtype
+        normed = _kernel(
+            "omlx_qwen4_hc_fused_norm", ["x", "w", "eps"], ["xn"], _N_SOURCE
+        )(
+            inputs=[flat, module.hc_norm.weight, _eps_array(module)],
+            template=[("T", dtype), ("K", width), ("H", hidden)],
+            grid=(256, hc, rows),
+            threadgroup=(256, 1, 1),
+            output_shapes=[(rows, width)],
+            output_dtypes=[dtype],
+        )[0]
+        if inject is not None:
+            inject_tensors = (inject.weight, inject.scales, inject.biases)
+        else:
+            inject_tensors = (down.weight, down.scales, down.biases)
+        act, injection = _kernel(
+            "omlx_qwen4_hc_fused_down",
+            ["xn", "down_w", "down_s", "down_b", "inject_w", "inject_s", "inject_b"],
+            ["act", "inj"],
+            _D_SOURCE,
+            header=_HEADER,
+        )(
+            inputs=[normed, down.weight, down.scales, down.biases, *inject_tensors],
+            template=[
+                ("T", dtype),
+                ("BITS_D", down.bits),
+                ("BITS_I", inject.bits if inject is not None else down.bits),
+                ("K", width),
+                ("R", lowrank),
+                ("HC", hc),
+                ("INJ", 1 if inject is not None else 0),
+            ],
+            grid=(32, 8 * (lowrank // 8 + 1), rows),
+            threadgroup=(32, 8, 1),
+            output_shapes=[(rows, lowrank), (rows, hc)],
+            output_dtypes=[dtype, dtype],
+        )
+        mixed = _kernel(
+            "omlx_qwen4_hc_fused_up",
+            ["xn", "act", "up_w", "up_s", "up_b"],
+            ["mixed"],
+            _U_SOURCE,
+            header=_HEADER,
+        )(
+            inputs=[normed, act, up.weight, up.scales, up.biases],
+            template=[
+                ("T", dtype),
+                ("BITS_U", up.bits),
+                ("K", width),
+                ("R", lowrank),
+                ("HC", hc),
+                ("H", hidden),
+                ("S", rows),
+            ],
+            grid=(256, hidden // 64, 1),
+            threadgroup=(256, 1, 1),
+            output_shapes=[(rows, hidden)],
+            output_dtypes=[dtype],
+        )[0]
+        mixed = mixed.reshape(batch, seq, hidden)
+        if inject is None:
+            return mixed
+        return mixed, hyper_input, injection.reshape(batch, seq, hc)
+    except Exception as exc:  # noqa: BLE001 - optional native path
+        _RUNTIME_FAILED = True
+        if not _FAILURE_LOGGED:
+            _FAILURE_LOGGED = True
+            logger.warning(
+                "Qwen4 fused hyper-connection kernels failed closed; using the "
+                "canonical path: %s",
+                exc,
+            )
+        return None
+
+
+__all__ = ["MAX_ROWS", "compatible", "enabled", "fused_forward"]

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/hc_fused.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/hc_fused.py
@@ -17,9 +17,12 @@ row-batched Metal kernels replace it for small row counts:
   normed stream, mean over streams via simd shuffles.
 
 Rows live in the grid (``batch * seq <= 16``). The affine unpack helpers come
-from :mod:`hc_projection`. Results match the canonical path to a few bf16 ULP
-(fp32 is kept through the epilogues); the path fails closed to ``_forward`` on
-any runtime error. Disable with ``OMLX_QWEN4_HC_FUSED=0``.
+from :mod:`hc_projection`. Any ``hidden_size`` that is a multiple of 64 is
+supported: the norm, down and inject loops guard their partial final blocks
+(compiled out for the shipped 2560). Results match the canonical path to a few
+bf16 ULP (fp32 is kept through the epilogues); the path fails closed to
+``_forward`` on any runtime error and logs once when a model's layout keeps it
+on the canonical path. Disable with ``OMLX_QWEN4_HC_FUSED=0``.
 """
 
 from __future__ import annotations
@@ -46,6 +49,7 @@ _DISABLED = os.environ.get("OMLX_QWEN4_HC_FUSED", "1").strip().lower() in {
 _KERNELS: dict[str, object] = {}
 _RUNTIME_FAILED = False
 _FAILURE_LOGGED = False
+_INELIGIBLE_LOGGED = False
 
 _N_SOURCE = r"""
     const uint row = threadgroup_position_in_grid.z;
@@ -54,14 +58,15 @@ _N_SOURCE = r"""
     const uint sg = simdgroup_index_in_threadgroup;
     const uint lane = thread_index_in_simdgroup;
     threadgroup float part[8];
-    constexpr int PER = H / 256;
+    constexpr int PER = (H + 255) / 256;
     const device T* xp = x + (size_t)row * K + (size_t)s * H;
     const device T* wp = w + (size_t)s * H;
     device T* op = xn + (size_t)row * K + (size_t)s * H;
     float v[PER];
     float ss = 0.0f;
     for (int i = 0; i < PER; ++i) {
-        v[i] = float(xp[t + i * 256]);
+        const int k = t + i * 256;
+        v[i] = (k < H) ? float(xp[k]) : 0.0f;
         ss += v[i] * v[i];
     }
     ss = simd_sum(ss);
@@ -72,7 +77,7 @@ _N_SOURCE = r"""
     const float inv = metal::rsqrt(tot / float(H) + eps[0]);
     for (int i = 0; i < PER; ++i) {
         const int k = t + i * 256;
-        op[k] = T(v[i] * inv * (1.0f + float(wp[k])));
+        if (k < H) op[k] = T(v[i] * inv * (1.0f + float(wp[k])));
     }
 """
 
@@ -106,7 +111,8 @@ _D_SOURCE = r"""
         const device T* xp = x + ks * SLICE + int(lane) * VPT;
         float result[4] = {0.0f};
         float xv[VPT];
-        for (int k = 0; k < SLICE; k += BLOCK) {
+        constexpr int TAIL = SLICE % BLOCK;
+        for (int k = 0; k < SLICE - TAIL; k += BLOCK) {
             float sum = hc_load_vector<T, VPT, BITS_D>(xp, xv);
             for (int r = 0; r < 4; ++r) {
                 result[r] += hc_qdot<VPT, BITS_D>(
@@ -117,6 +123,17 @@ _D_SOURCE = r"""
             sp += BLOCK / 64;
             bp += BLOCK / 64;
             xp += BLOCK;
+        }
+        // Partial final block: only lanes whose VPT elements lie inside the slice take part.
+        // The helpers read exactly VPT values and VPT * BITS / 8 weight bytes, so nothing is
+        // touched past the slice; every lane still joins the simd_sum below.
+        if (TAIL > 0 && int(lane) * VPT < TAIL) {
+            float sum = hc_load_vector<T, VPT, BITS_D>(xp, xv);
+            for (int r = 0; r < 4; ++r) {
+                result[r] += hc_qdot<VPT, BITS_D>(
+                    wp + r * ROW_BYTES, xv,
+                    float(sp[r * GROUPS]), float(bp[r * GROUPS]), sum);
+            }
         }
         for (int r = 0; r < 4; ++r) {
             float v = simd_sum(result[r]);
@@ -149,9 +166,8 @@ _D_SOURCE = r"""
         const device T* xp = x + ks * SLICE + int(lane) * VPT;
         float result[HC] = {0.0f};
         float xv[VPT];
-        int k = 0;
-        const int last = (ks == KS - 1) ? (SLICE - BLOCK) : SLICE;
-        for (; k < last; k += BLOCK) {
+        constexpr int TAIL = SLICE % BLOCK;
+        for (int k = 0; k < SLICE - TAIL; k += BLOCK) {
             float sum = hc_load_vector<T, VPT, BITS_I>(xp, xv);
             for (int r = 0; r < HC; ++r) {
                 result[r] += hc_qdot<VPT, BITS_I>(
@@ -163,10 +179,10 @@ _D_SOURCE = r"""
             bp += BLOCK / 64;
             xp += BLOCK;
         }
-        if (ks == KS - 1) {
+        if (TAIL > 0 && int(lane) * VPT < TAIL) {
             float sum = hc_load_vector<T, VPT, BITS_I>(xp, xv);
             for (int r = 0; r < HC; ++r) {
-                result[r] += hc_qdot_safe<VPT, BITS_I>(
+                result[r] += hc_qdot<VPT, BITS_I>(
                     wp + r * ROW_BYTES, xv,
                     float(sp[r * GROUPS]), float(bp[r * GROUPS]), sum);
             }
@@ -257,6 +273,20 @@ def _quantized_ok(projection) -> bool:
     )
 
 
+def _ineligible(reason: str) -> bool:
+    """Record (once per process) why a model stays on the canonical path, so a future
+    checkpoint that misses the fused kernels shows up in the log instead of just running slower."""
+    global _INELIGIBLE_LOGGED
+    if not _INELIGIBLE_LOGGED:
+        _INELIGIBLE_LOGGED = True
+        logger.info(
+            "Qwen4 fused hyper-connection kernels not used for this model (%s); "
+            "the canonical path stays in effect",
+            reason,
+        )
+    return False
+
+
 def compatible(module, hyper_input) -> bool:
     """Whether ``module`` (a Qwen4ExpGatedResidual) can take the fused path for ``hyper_input``."""
     if not enabled():
@@ -271,7 +301,7 @@ def compatible(module, hyper_input) -> bool:
     if hasattr(module, "input_inject_weight") or getattr(
         module, "_omlx_exact_hybrid_projection", False
     ):
-        return False
+        return _ineligible("combined input projection layout")
     hc_count = getattr(module, "hc_count", None)
     hidden = getattr(module, "hidden_size", None)
     lowrank = getattr(module, "hc_lowrank", None)
@@ -280,15 +310,17 @@ def compatible(module, hyper_input) -> bool:
         and isinstance(hidden, int)
         and isinstance(lowrank, int)
         and hc_count == 4
-        # The down projection walks each K-slice (= hidden) in blocks of 32 lanes x 2 packs
-        # x 8 values = 512 elements for 4/5-bit weights with no tail handling; the norm
-        # kernel needs a multiple of 256. Require 512 for every bit width.
-        and hidden % 512 == 0
+        # Every kernel walks the hidden axis in 64-element quantisation groups (the up
+        # kernel's grid is hidden // 64); the norm, down and inject loops guard their
+        # partial final blocks, so any multiple of 64 is fine.
+        and hidden % 64 == 0
         and lowrank % 64 == 0
         and lowrank % 8 == 0
         and hyper_input.shape[2] == hc_count * hidden
     ):
-        return False
+        return _ineligible(
+            f"geometry hidden_size={hidden} hc_lowrank={lowrank} hc_count={hc_count}"
+        )
     norm = getattr(module, "hc_norm", None)
     if not (
         norm is not None
@@ -297,14 +329,16 @@ def compatible(module, hyper_input) -> bool:
         and norm.weight.dtype == mx.bfloat16
         and norm.weight.shape == (hc_count * hidden,)
     ):
-        return False
+        return _ineligible("hc_norm layout")
     if not (
         _quantized_ok(getattr(module, "input_mix_weight_down", None))
         and _quantized_ok(getattr(module, "input_mix_weight_up", None))
     ):
-        return False
+        return _ineligible(
+            "projection quantisation (need affine group-size-64 4/5/6/8-bit with bf16 scales)"
+        )
     if "block_inject_weight" in module and not _quantized_ok(module.block_inject_weight):
-        return False
+        return _ineligible("block_inject_weight quantisation")
     return mx.default_device() == mx.gpu and mx.metal.is_available()
 
 

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/hc_fused.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/hc_fused.py
@@ -280,10 +280,12 @@ def compatible(module, hyper_input) -> bool:
         and isinstance(hidden, int)
         and isinstance(lowrank, int)
         and hc_count == 4
-        and hidden % 256 == 0
+        # The down projection walks each K-slice (= hidden) in blocks of 32 lanes x 2 packs
+        # x 8 values = 512 elements for 4/5-bit weights with no tail handling; the norm
+        # kernel needs a multiple of 256. Require 512 for every bit width.
+        and hidden % 512 == 0
         and lowrank % 64 == 0
         and lowrank % 8 == 0
-        and (hc_count * hidden) % 512 == 0
         and hyper_input.shape[2] == hc_count * hidden
     ):
         return False

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/hc_fused.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/hc_fused.py
@@ -16,8 +16,10 @@ row-batched Metal kernels replace it for small row counts:
 * ``U`` -- ``input_mix_weight_up`` per output element, sigmoid, times the
   normed stream, mean over streams via simd shuffles.
 
-Rows live in the grid (``batch * seq <= 16``). The affine unpack helpers come
-from :mod:`hc_projection`. Any ``hidden_size`` that is a multiple of 64 is
+Rows live in the grid (``batch * seq <= 16``); within that limit the fused path
+runs ahead of upstream's exact hybrid projection and compiled single-token path
+(serial decode) as well as the canonical path (MTP verify). The affine unpack
+helpers come from :mod:`hc_projection`. Any ``hidden_size`` that is a multiple of 64 is
 supported: the norm, down and inject loops guard their partial final blocks
 (compiled out for the shipped 2560). Results match the canonical path to a few
 bf16 ULP (fp32 is kept through the epilogues); the path fails closed to
@@ -298,11 +300,12 @@ def compatible(module, hyper_input) -> bool:
         and 1 <= hyper_input.shape[0] * hyper_input.shape[1] <= MAX_ROWS
     ):
         return False
-    if getattr(module, "_omlx_exact_hybrid_projection", False):
-        # Upstream's exact hybrid projection (installed at load time for serial decode)
-        # keeps its own compiled single-token path; that is a runtime choice, not a
-        # checkpoint layout, so it is not logged.
-        return False
+    # With Lightning MTP off, load_weights installs upstream's exact hybrid projection
+    # (``_omlx_exact_hybrid_projection``) and compiles ``_forward`` for single-token
+    # decode. The fused path deliberately takes precedence over both: three kernels
+    # per module against a compiled call plus its own kernels measured +12..14%
+    # serial tok/s on the M5 Max. ``_forward`` keeps the hybrid for the rows this
+    # path does not take.
     if hasattr(module, "input_inject_weight"):
         return _ineligible("combined input projection layout")
     hc_count = getattr(module, "hc_count", None)

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -926,14 +926,14 @@ class Qwen4ExpRMSNorm(nn.Module):
 
     def __call__(self, x: mx.array) -> mx.array:
         dtype = x.dtype
-        y = x.astype(mx.float32)
-        if self.group_size is not None:
-            y = y.reshape(*y.shape[:-1], -1, self.group_size)
-            weight = self.weight.reshape(-1, self.group_size)
-        else:
-            weight = self.weight
-        y = y * mx.rsqrt(mx.mean(mx.square(y), axis=-1, keepdims=True) + self.eps)
-        y = y * (1.0 + weight.astype(mx.float32))
+        scale = 1.0 + self.weight.astype(mx.float32)
+        if self.group_size is None:
+            return mx.fast.rms_norm(x, scale, self.eps).astype(dtype)
+        # rms_norm takes a 1-D weight, so a grouped norm cannot hand it the
+        # per-group scale; normalise over the group axis and scale afterwards.
+        # The scale stays fp32 -- rounding (1 + w) to bf16 costs half a ULP.
+        y = x.astype(mx.float32).reshape(*x.shape[:-1], -1, self.group_size)
+        y = mx.fast.rms_norm(y, None, self.eps) * scale.reshape(-1, self.group_size)
         return y.reshape(x.shape).astype(dtype)
 
 

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -32,6 +32,7 @@ from .qsa_fast import (
     contiguous_causal_gathered_qsa_decode,
     pool_completed_index_keys,
 )
+from . import hc_fused
 
 _PLE_RUNTIME_MODEL_PATH: Path | None = None
 _PLE_RUNTIME_MODE = "resident"
@@ -1492,6 +1493,10 @@ class Qwen4ExpGatedResidual(nn.Module):
             )
 
     def __call__(self, hyper_input: mx.array, target_verify: bool = False):
+        if hc_fused.compatible(self, hyper_input):
+            fused = hc_fused.fused_forward(self, hyper_input)
+            if fused is not None:
+                return fused
         compiled_forward = getattr(self, "_compiled_forward", None)
         if (
             compiled_forward is not None

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -913,6 +913,18 @@ class QSAQuantizedKVCache(_QSAIndexerCache, QuantizedKVCache):
         return size + self.indexer_nbytes
 
 
+# Dispatch each decoder layer's graph to the GPU as soon as it is built (decode and
+# verify rows only) so the GPU executes layer i while the host builds layer i+1.
+# Scheduling only: outputs are bit-identical. Disable with OMLX_QWEN4_EAGER_DISPATCH=0.
+_EAGER_DISPATCH = os.environ.get("OMLX_QWEN4_EAGER_DISPATCH", "1").strip().lower() not in {
+    "0",
+    "false",
+    "no",
+    "off",
+}
+_EAGER_DISPATCH_MAX_ROWS = 64
+
+
 class Qwen4ExpRMSNorm(nn.Module):
     """Qwen4 RMSNorm, whose checkpoint weights are centered at zero."""
 
@@ -2494,6 +2506,12 @@ class Qwen4ExpModel(nn.Module):
                 gdn_sink=gdn_sink,
                 target_verify=gdn_sink is not None,
             )
+            if (
+                _EAGER_DISPATCH
+                and hidden_states.shape[0] * hidden_states.shape[1]
+                <= _EAGER_DISPATCH_MAX_ROWS
+            ):
+                mx.async_eval(hidden_states)
             if hidden_sink is not None and index in capture:
                 hidden_sink.append(
                     self.hyper_connection_mixer(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,9 @@
+import os
+
+# MLX 0.32.2 runs fp32 GPU matmuls at TF32 precision on M5-class tensor units;
+# the fp32 parity tests assert 2e-5, which TF32 cannot hold. Test session only.
+os.environ.setdefault("MLX_ENABLE_TF32", "0")
+
 # SPDX-License-Identifier: Apache-2.0
 """
 Pytest configuration and fixtures for oMLX tests.

--- a/tests/test_qwen4_eager_dispatch.py
+++ b/tests/test_qwen4_eager_dispatch.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-layer eager dispatch in Qwen4ExpModel: fires for decode/verify rows only and never changes outputs."""
+from __future__ import annotations
+
+import sys
+
+import mlx.core as mx
+import pytest
+
+from omlx.patches import mlx_vlm_qwen4_exp_compat as compat
+
+
+@pytest.fixture(autouse=True)
+def _vendored_qwen4():
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+from tests.test_mlx_vlm_qwen4_exp_compat import _tiny_config
+
+
+def _model():
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models.qwen4_exp.language import LanguageModel
+
+    config = _tiny_config()
+    mx.random.seed(1)
+    model = LanguageModel(config.text_config, config)
+    mx.eval(model.parameters())
+    return model, config
+
+
+def _count_dispatches(monkeypatch, language, rows: int):
+    calls = []
+    real = mx.async_eval
+
+    def spy(*a, **k):
+        # Count only the decoder-layer loop's dispatches; mlx-lm's gated-delta kernel also async_evals.
+        if sys._getframe(1).f_code.co_filename == language.__file__:
+            calls.append(len(a))
+        return real(*a, **k)
+
+    monkeypatch.setattr(language.mx, "async_eval", spy)
+    model, config = _model()
+    inputs = mx.random.randint(0, config.text_config.vocab_size, (1, rows))
+    out = model(inputs)
+    out = getattr(out, "logits", out)
+    mx.eval(out)
+    return len(calls), out
+
+
+@pytest.mark.parametrize("rows,expected", [(1, True), (4, True), (64, True), (65, False), (200, False)])
+def test_dispatches_once_per_layer_for_small_row_counts(monkeypatch, rows, expected):
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models.qwen4_exp import language
+
+    monkeypatch.setattr(language, "_EAGER_DISPATCH", True)
+    count, _ = _count_dispatches(monkeypatch, language, rows)
+    layers = _tiny_config().text_config.num_hidden_layers
+    assert count == (layers if expected else 0)
+
+
+def test_kill_switch_and_bitwise_equality(monkeypatch):
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models.qwen4_exp import language
+
+    monkeypatch.setattr(language, "_EAGER_DISPATCH", False)
+    off_count, off = _count_dispatches(monkeypatch, language, 4)
+    monkeypatch.setattr(language, "_EAGER_DISPATCH", True)
+    on_count, on = _count_dispatches(monkeypatch, language, 4)
+    assert off_count == 0 and on_count > 0
+    assert mx.array_equal(on.view(mx.uint32) if on.dtype == mx.float32 else on.view(mx.uint16),
+                          off.view(mx.uint32) if off.dtype == mx.float32 else off.view(mx.uint16)).item()

--- a/tests/test_qwen4_hc_fused.py
+++ b/tests/test_qwen4_hc_fused.py
@@ -75,10 +75,15 @@ def test_fused_matches_canonical_path(bits, rows, use_combine):
     _assert_fused_matches_canonical(_module(bits, use_combine), rows, use_combine)
 
 
+# Sizes the checkpoint never has, chosen so every kernel sees a partial final block:
+#   768  -> down tail 256 for 4/5-bit;                          norm and inject loops exact
+#   1152 -> down tail 128 (all bits), inject tail 128 (4/5-bit), norm tail 128
+#   1344 -> down tail 320 (4/5) / 64 (6/8), inject tail 64,       norm tail 64
+#   512, 1536 -> odd multiples of 512, no tails anywhere
 @pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")
-@pytest.mark.parametrize("hidden,bits", [(512, 4), (1536, 5), (1536, 6)])
+@pytest.mark.parametrize("bits", [4, 5, 6, 8])
+@pytest.mark.parametrize("hidden", [512, 768, 1152, 1344, 1536])
 def test_fused_matches_canonical_path_at_other_hidden_sizes(hidden, bits):
-    # Odd multiples of 512 exercise the down kernel's block loop at a size the checkpoint never has.
     mx.random.seed(20260906 + hidden + bits)
     _assert_fused_matches_canonical(_module(bits, True, hidden=hidden), 16, True)
 
@@ -117,22 +122,24 @@ def _assert_fused_matches_canonical(module, rows, use_combine):
 
 
 @pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")
-def test_fused_norm_is_bit_identical_to_rms_norm():
+@pytest.mark.parametrize("hidden", [HIDDEN, 768, 1152, 1344])
+def test_fused_norm_is_bit_identical_to_rms_norm(hidden):
     from mlx_vlm.models.qwen4_exp import hc_fused
 
     mx.random.seed(7)
-    module = _module(4)
-    x = (mx.random.normal((1, 4, WIDTH)) * 3).astype(mx.bfloat16)
-    flat = x.reshape(4, WIDTH)
+    module = _module(4, hidden=hidden)
+    width = HC * hidden
+    x = (mx.random.normal((1, 4, width)) * 3).astype(mx.bfloat16)
+    flat = x.reshape(4, width)
     normed = hc_fused._kernel("omlx_qwen4_hc_fused_norm", ["x", "w", "eps"], ["xn"], hc_fused._N_SOURCE)(
         inputs=[flat, module.hc_norm.weight, hc_fused._eps_array(module)],
-        template=[("T", mx.bfloat16), ("K", WIDTH), ("H", HIDDEN)],
+        template=[("T", mx.bfloat16), ("K", width), ("H", hidden)],
         grid=(256, HC, 4),
         threadgroup=(256, 1, 1),
-        output_shapes=[(4, WIDTH)],
+        output_shapes=[(4, width)],
         output_dtypes=[mx.bfloat16],
     )[0]
-    expected = module.hc_norm(x).reshape(4, WIDTH)
+    expected = module.hc_norm(x).reshape(4, width)
     mx.eval(normed, expected)
     assert mx.array_equal(normed.view(mx.uint16), expected.view(mx.uint16)).item()
 
@@ -151,16 +158,31 @@ def test_gated_residual_call_routes_through_fused_path(monkeypatch):
     assert calls == [(1, 2, WIDTH)]
 
 
-@pytest.mark.parametrize("hidden,bits", [(768, 4), (1280, 5), (768, 6), (1280, 8)])
-def test_compatible_rejects_hidden_not_multiple_of_512(hidden, bits):
-    # The fused down projection walks each K-slice (= hidden) in 512-element blocks for 4/5-bit
-    # weights with no tail handling; hidden=768/4-bit and 1280/5-bit pass the norm kernel's
-    # multiple-of-256 rule yet read past the slice (PR #3469 review).
+@pytest.mark.parametrize("hidden,bits", [(800, 4), (1056, 5)])
+def test_compatible_rejects_hidden_not_multiple_of_64(hidden, bits):
+    # 64 is the quantisation group and the up kernel's grid unit; nothing below it is handled.
     from mlx_vlm.models.qwen4_exp import hc_fused
 
     module = _module(bits, True, hidden=hidden)
     x = mx.random.normal((1, 4, HC * hidden)).astype(mx.bfloat16)
     assert not hc_fused.compatible(module, x)
+
+
+def test_ineligible_model_is_logged_once(monkeypatch, caplog):
+    from mlx_vlm.models.qwen4_exp import hc_fused
+
+    monkeypatch.setattr(hc_fused, "_INELIGIBLE_LOGGED", False)
+    module = _module(4, True, hidden=800)
+    x = mx.random.normal((1, 4, HC * 800)).astype(mx.bfloat16)
+    with caplog.at_level("INFO", logger=hc_fused.logger.name):
+        assert not hc_fused.compatible(module, x)
+        assert not hc_fused.compatible(module, x)
+        # Prefill-sized inputs are expected to skip the fused path and must not log.
+        monkeypatch.setattr(hc_fused, "_INELIGIBLE_LOGGED", False)
+        assert not hc_fused.compatible(_module(4), mx.random.normal((1, 64, WIDTH)).astype(mx.bfloat16))
+    messages = [r.getMessage() for r in caplog.records if "fused hyper-connection kernels not used" in r.getMessage()]
+    assert len(messages) == 1
+    assert "hidden_size=800" in messages[0]
 
 
 def test_compatible_fails_closed():

--- a/tests/test_qwen4_hc_fused.py
+++ b/tests/test_qwen4_hc_fused.py
@@ -180,14 +180,28 @@ def test_ineligible_model_is_logged_once(monkeypatch, caplog):
         # Prefill-sized inputs are expected to skip the fused path and must not log.
         monkeypatch.setattr(hc_fused, "_INELIGIBLE_LOGGED", False)
         assert not hc_fused.compatible(_module(4), mx.random.normal((1, 64, WIDTH)).astype(mx.bfloat16))
-        # Upstream's exact hybrid projection is a deliberate runtime choice, not a layout gap.
-        monkeypatch.setattr(hc_fused, "_INELIGIBLE_LOGGED", False)
-        hybrid = _module(4)
-        hybrid._omlx_exact_hybrid_projection = True
-        assert not hc_fused.compatible(hybrid, mx.random.normal((1, 1, WIDTH)).astype(mx.bfloat16))
     messages = [r.getMessage() for r in caplog.records if "fused hyper-connection kernels not used" in r.getMessage()]
     assert len(messages) == 1
     assert "hidden_size=800" in messages[0]
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")
+def test_fused_path_takes_precedence_over_exact_hybrid_projection(monkeypatch):
+    # With MTP off, load_weights flags modules with upstream's exact hybrid projection and compiles
+    # their single-token _forward. The fused path must still win for decode rows (+12..14% serial).
+    from mlx_vlm.models.qwen4_exp import hc_fused
+
+    module = _module(4)
+    module._omlx_exact_hybrid_projection = True
+    module._compiled_forward = lambda h: pytest.fail("compiled single-token path must not run")
+    x = mx.random.normal((1, 1, WIDTH)).astype(mx.bfloat16)
+    assert hc_fused.compatible(module, x)
+    calls = []
+    original = hc_fused.fused_forward
+    monkeypatch.setattr(hc_fused, "fused_forward", lambda m, h: calls.append(h.shape) or original(m, h))
+    out = module(x)
+    mx.eval(out)
+    assert calls == [(1, 1, WIDTH)]
 
 
 def test_compatible_fails_closed():

--- a/tests/test_qwen4_hc_fused.py
+++ b/tests/test_qwen4_hc_fused.py
@@ -19,19 +19,20 @@ HC, HIDDEN, LOWRANK = 4, 2560, 320
 WIDTH = HC * HIDDEN
 
 
-def _module(bits: int, use_combine: bool = True):
+def _module(bits: int, use_combine: bool = True, hidden: int = HIDDEN):
     compat.apply_mlx_vlm_qwen4_exp_compat_patch()
     from mlx_vlm.models.qwen4_exp.language import Qwen4ExpGatedResidual, Qwen4ExpRMSNorm
 
+    width = HC * hidden
     module = Qwen4ExpGatedResidual.__new__(Qwen4ExpGatedResidual)
     nn.Module.__init__(module)
-    module.hc_count, module.hidden_size, module.hc_lowrank = HC, HIDDEN, LOWRANK
-    module.hc_norm = Qwen4ExpRMSNorm(WIDTH, group_size=HIDDEN, eps=1e-6)
-    module.hc_norm.weight = (mx.random.normal((WIDTH,)) * 0.05).astype(mx.bfloat16)
-    module.input_mix_weight_down = nn.QuantizedLinear(WIDTH, LOWRANK, bias=False, group_size=64, bits=bits)
-    module.input_mix_weight_up = nn.QuantizedLinear(LOWRANK, WIDTH, bias=False, group_size=64, bits=bits)
+    module.hc_count, module.hidden_size, module.hc_lowrank = HC, hidden, LOWRANK
+    module.hc_norm = Qwen4ExpRMSNorm(width, group_size=hidden, eps=1e-6)
+    module.hc_norm.weight = (mx.random.normal((width,)) * 0.05).astype(mx.bfloat16)
+    module.input_mix_weight_down = nn.QuantizedLinear(width, LOWRANK, bias=False, group_size=64, bits=bits)
+    module.input_mix_weight_up = nn.QuantizedLinear(LOWRANK, width, bias=False, group_size=64, bits=bits)
     if use_combine:
-        module.block_inject_weight = nn.QuantizedLinear(WIDTH, HC, bias=False, group_size=64, bits=bits)
+        module.block_inject_weight = nn.QuantizedLinear(width, HC, bias=False, group_size=64, bits=bits)
     for name in ("input_mix_weight_down", "input_mix_weight_up", "block_inject_weight"):
         projection = getattr(module, name, None)
         if projection is not None:
@@ -50,7 +51,8 @@ def _reference_fp32(module, x):
     normed = module.hc_norm(x).astype(mx.float32)
     mix = nn.silu((normed @ dequant(module.input_mix_weight_down).T) / HC)
     gate = mx.sigmoid(mix @ dequant(module.input_mix_weight_up).T)
-    mixed = mx.mean(gate.reshape(*gate.shape[:-1], HC, HIDDEN) * normed.reshape(*normed.shape[:-1], HC, HIDDEN), axis=-2)
+    hidden = module.hidden_size
+    mixed = mx.mean(gate.reshape(*gate.shape[:-1], HC, hidden) * normed.reshape(*normed.shape[:-1], HC, hidden), axis=-2)
     if "block_inject_weight" not in module:
         return mixed, None
     return mixed, 2 * mx.sigmoid((normed @ dequant(module.block_inject_weight).T) / HC)
@@ -69,11 +71,23 @@ def _ulps(a, b):
 @pytest.mark.parametrize("rows", [1, 4, 16])
 @pytest.mark.parametrize("use_combine", [True, False])
 def test_fused_matches_canonical_path(bits, rows, use_combine):
+    mx.random.seed(20260905 + bits * 100 + rows)
+    _assert_fused_matches_canonical(_module(bits, use_combine), rows, use_combine)
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")
+@pytest.mark.parametrize("hidden,bits", [(512, 4), (1536, 5), (1536, 6)])
+def test_fused_matches_canonical_path_at_other_hidden_sizes(hidden, bits):
+    # Odd multiples of 512 exercise the down kernel's block loop at a size the checkpoint never has.
+    mx.random.seed(20260906 + hidden + bits)
+    _assert_fused_matches_canonical(_module(bits, True, hidden=hidden), 16, True)
+
+
+def _assert_fused_matches_canonical(module, rows, use_combine):
     from mlx_vlm.models.qwen4_exp import hc_fused
 
-    mx.random.seed(20260905 + bits * 100 + rows)
-    module = _module(bits, use_combine)
-    x = mx.random.normal((1, rows, WIDTH)).astype(mx.bfloat16)
+    hidden = module.hidden_size
+    x = mx.random.normal((1, rows, HC * hidden)).astype(mx.bfloat16)
     mx.eval(x)
     assert hc_fused.compatible(module, x)
     fused = hc_fused.fused_forward(module, x)
@@ -90,7 +104,7 @@ def test_fused_matches_canonical_path(bits, rows, use_combine):
         assert _ulps(fused_inject, ref_inject)[0] <= 4
     else:
         fused_mixed, canon_mixed = fused, canonical
-    assert fused_mixed.shape == canon_mixed.shape == (1, rows, HIDDEN)
+    assert fused_mixed.shape == canon_mixed.shape == (1, rows, hidden)
     assert fused_mixed.dtype == mx.bfloat16
     max_vs_canon, mean_vs_canon = _ulps(fused_mixed, canon_mixed)
     assert max_vs_canon <= 16 and mean_vs_canon <= 0.5
@@ -135,6 +149,18 @@ def test_gated_residual_call_routes_through_fused_path(monkeypatch):
     out = module(x)
     mx.eval(out)
     assert calls == [(1, 2, WIDTH)]
+
+
+@pytest.mark.parametrize("hidden,bits", [(768, 4), (1280, 5), (768, 6), (1280, 8)])
+def test_compatible_rejects_hidden_not_multiple_of_512(hidden, bits):
+    # The fused down projection walks each K-slice (= hidden) in 512-element blocks for 4/5-bit
+    # weights with no tail handling; hidden=768/4-bit and 1280/5-bit pass the norm kernel's
+    # multiple-of-256 rule yet read past the slice (PR #3469 review).
+    from mlx_vlm.models.qwen4_exp import hc_fused
+
+    module = _module(bits, True, hidden=hidden)
+    x = mx.random.normal((1, 4, HC * hidden)).astype(mx.bfloat16)
+    assert not hc_fused.compatible(module, x)
 
 
 def test_compatible_fails_closed():

--- a/tests/test_qwen4_hc_fused.py
+++ b/tests/test_qwen4_hc_fused.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fused hyper-connection kernels: parity with the canonical path, eligibility, kill switch."""
+from __future__ import annotations
+
+import importlib
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+
+from omlx.patches import mlx_vlm_qwen4_exp_compat as compat
+
+
+@pytest.fixture(autouse=True)
+def _vendored_qwen4():
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+
+HC, HIDDEN, LOWRANK = 4, 2560, 320
+WIDTH = HC * HIDDEN
+
+
+def _module(bits: int, use_combine: bool = True):
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models.qwen4_exp.language import Qwen4ExpGatedResidual, Qwen4ExpRMSNorm
+
+    module = Qwen4ExpGatedResidual.__new__(Qwen4ExpGatedResidual)
+    nn.Module.__init__(module)
+    module.hc_count, module.hidden_size, module.hc_lowrank = HC, HIDDEN, LOWRANK
+    module.hc_norm = Qwen4ExpRMSNorm(WIDTH, group_size=HIDDEN, eps=1e-6)
+    module.hc_norm.weight = (mx.random.normal((WIDTH,)) * 0.05).astype(mx.bfloat16)
+    module.input_mix_weight_down = nn.QuantizedLinear(WIDTH, LOWRANK, bias=False, group_size=64, bits=bits)
+    module.input_mix_weight_up = nn.QuantizedLinear(LOWRANK, WIDTH, bias=False, group_size=64, bits=bits)
+    if use_combine:
+        module.block_inject_weight = nn.QuantizedLinear(WIDTH, HC, bias=False, group_size=64, bits=bits)
+    for name in ("input_mix_weight_down", "input_mix_weight_up", "block_inject_weight"):
+        projection = getattr(module, name, None)
+        if projection is not None:
+            # Checkpoint-like statistics: positive scales, small biases. Random-sign scales drive the
+            # up-projection gate into saturation where any rounding difference flips whole elements.
+            projection.scales = (mx.abs(mx.random.normal(projection.scales.shape)) * 0.01 + 0.002).astype(mx.bfloat16)
+            projection.biases = (mx.random.normal(projection.biases.shape) * 0.005).astype(mx.bfloat16)
+    mx.eval(module.parameters())
+    return module
+
+
+def _reference_fp32(module, x):
+    def dequant(q):
+        return mx.dequantize(q.weight, q.scales, q.biases, group_size=q.group_size, bits=q.bits).astype(mx.float32)
+
+    normed = module.hc_norm(x).astype(mx.float32)
+    mix = nn.silu((normed @ dequant(module.input_mix_weight_down).T) / HC)
+    gate = mx.sigmoid(mix @ dequant(module.input_mix_weight_up).T)
+    mixed = mx.mean(gate.reshape(*gate.shape[:-1], HC, HIDDEN) * normed.reshape(*normed.shape[:-1], HC, HIDDEN), axis=-2)
+    if "block_inject_weight" not in module:
+        return mixed, None
+    return mixed, 2 * mx.sigmoid((normed @ dequant(module.block_inject_weight).T) / HC)
+
+
+def _ulps(a, b):
+    a = a.astype(mx.float32)
+    b = b.astype(mx.float32)
+    ulp = float(mx.abs(b).max().item()) * 2.0**-7
+    diff = mx.abs(a - b) / ulp
+    return float(diff.max().item()), float(diff.mean().item())
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")
+@pytest.mark.parametrize("bits", [4, 5, 6, 8])
+@pytest.mark.parametrize("rows", [1, 4, 16])
+@pytest.mark.parametrize("use_combine", [True, False])
+def test_fused_matches_canonical_path(bits, rows, use_combine):
+    from mlx_vlm.models.qwen4_exp import hc_fused
+
+    mx.random.seed(20260905 + bits * 100 + rows)
+    module = _module(bits, use_combine)
+    x = mx.random.normal((1, rows, WIDTH)).astype(mx.bfloat16)
+    mx.eval(x)
+    assert hc_fused.compatible(module, x)
+    fused = hc_fused.fused_forward(module, x)
+    assert fused is not None
+    canonical = module._forward(x)
+    mx.eval(fused, canonical)
+    ref_mixed, ref_inject = _reference_fp32(module, x)
+    if use_combine:
+        fused_mixed, passthrough, fused_inject = fused
+        canon_mixed, _, canon_inject = canonical
+        assert passthrough is x
+        assert fused_inject.shape == canon_inject.shape == (1, rows, HC)
+        assert _ulps(fused_inject, canon_inject)[0] <= 4
+        assert _ulps(fused_inject, ref_inject)[0] <= 4
+    else:
+        fused_mixed, canon_mixed = fused, canonical
+    assert fused_mixed.shape == canon_mixed.shape == (1, rows, HIDDEN)
+    assert fused_mixed.dtype == mx.bfloat16
+    max_vs_canon, mean_vs_canon = _ulps(fused_mixed, canon_mixed)
+    assert max_vs_canon <= 16 and mean_vs_canon <= 0.5
+    # Both paths round differently; judge each against fp32. The fused path keeps fp32 through
+    # the epilogues, so it must stay at least as close to fp32 as the canonical path (with slack).
+    max_fused, mean_fused = _ulps(fused_mixed, ref_mixed)
+    max_canon, mean_canon = _ulps(canon_mixed, ref_mixed)
+    assert max_fused <= max(2 * max_canon, 6)
+    assert mean_fused <= mean_canon * 1.5 + 0.05
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")
+def test_fused_norm_is_bit_identical_to_rms_norm():
+    from mlx_vlm.models.qwen4_exp import hc_fused
+
+    mx.random.seed(7)
+    module = _module(4)
+    x = (mx.random.normal((1, 4, WIDTH)) * 3).astype(mx.bfloat16)
+    flat = x.reshape(4, WIDTH)
+    normed = hc_fused._kernel("omlx_qwen4_hc_fused_norm", ["x", "w", "eps"], ["xn"], hc_fused._N_SOURCE)(
+        inputs=[flat, module.hc_norm.weight, hc_fused._eps_array(module)],
+        template=[("T", mx.bfloat16), ("K", WIDTH), ("H", HIDDEN)],
+        grid=(256, HC, 4),
+        threadgroup=(256, 1, 1),
+        output_shapes=[(4, WIDTH)],
+        output_dtypes=[mx.bfloat16],
+    )[0]
+    expected = module.hc_norm(x).reshape(4, WIDTH)
+    mx.eval(normed, expected)
+    assert mx.array_equal(normed.view(mx.uint16), expected.view(mx.uint16)).item()
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")
+def test_gated_residual_call_routes_through_fused_path(monkeypatch):
+    from mlx_vlm.models.qwen4_exp import hc_fused
+
+    module = _module(4)
+    x = mx.random.normal((1, 2, WIDTH)).astype(mx.bfloat16)
+    calls = []
+    original = hc_fused.fused_forward
+    monkeypatch.setattr(hc_fused, "fused_forward", lambda m, h: calls.append(h.shape) or original(m, h))
+    out = module(x)
+    mx.eval(out)
+    assert calls == [(1, 2, WIDTH)]
+
+
+def test_compatible_fails_closed():
+    from mlx_vlm.models.qwen4_exp import hc_fused
+
+    module = _module(4)
+    ok = mx.random.normal((1, 4, WIDTH)).astype(mx.bfloat16)
+    if mx.metal.is_available():
+        assert hc_fused.compatible(module, ok)
+    assert not hc_fused.compatible(module, mx.random.normal((1, 17, WIDTH)).astype(mx.bfloat16))
+    assert not hc_fused.compatible(module, mx.random.normal((2, 9, WIDTH)).astype(mx.bfloat16))
+    assert not hc_fused.compatible(module, mx.random.normal((1, 4, WIDTH)).astype(mx.float16))
+    assert not hc_fused.compatible(module, mx.random.normal((4, WIDTH)).astype(mx.bfloat16))
+    module.input_inject_weight = nn.Linear(WIDTH, LOWRANK + HC, bias=False)
+    assert not hc_fused.compatible(module, ok)
+    del module.input_inject_weight
+    module.input_mix_weight_down = nn.Linear(WIDTH, LOWRANK, bias=False)
+    assert not hc_fused.compatible(module, ok)
+
+
+def test_kill_switch_disables_fused_path(monkeypatch):
+    monkeypatch.setenv("OMLX_QWEN4_HC_FUSED", "0")
+    from mlx_vlm.models.qwen4_exp import hc_fused
+
+    reloaded = importlib.reload(hc_fused)
+    try:
+        assert not reloaded.enabled()
+        assert not reloaded.compatible(_module(4), mx.random.normal((1, 4, WIDTH)).astype(mx.bfloat16))
+    finally:
+        monkeypatch.delenv("OMLX_QWEN4_HC_FUSED")
+        importlib.reload(hc_fused)

--- a/tests/test_qwen4_hc_fused.py
+++ b/tests/test_qwen4_hc_fused.py
@@ -180,6 +180,11 @@ def test_ineligible_model_is_logged_once(monkeypatch, caplog):
         # Prefill-sized inputs are expected to skip the fused path and must not log.
         monkeypatch.setattr(hc_fused, "_INELIGIBLE_LOGGED", False)
         assert not hc_fused.compatible(_module(4), mx.random.normal((1, 64, WIDTH)).astype(mx.bfloat16))
+        # Upstream's exact hybrid projection is a deliberate runtime choice, not a layout gap.
+        monkeypatch.setattr(hc_fused, "_INELIGIBLE_LOGGED", False)
+        hybrid = _module(4)
+        hybrid._omlx_exact_hybrid_projection = True
+        assert not hc_fused.compatible(hybrid, mx.random.normal((1, 1, WIDTH)).astype(mx.bfloat16))
     messages = [r.getMessage() for r in caplog.records if "fused hyper-connection kernels not used" in r.getMessage()]
     assert len(messages) == 1
     assert "hidden_size=800" in messages[0]

--- a/tests/test_qwen4_rms_norm.py
+++ b/tests/test_qwen4_rms_norm.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``Qwen4ExpRMSNorm`` against the hand-rolled formulation it replaced.
+
+The module used to spell RMS norm out in MLX ops (fp32 upcast, optional
+grouping, ``y * rsqrt(mean(y^2) + eps) * (1 + w)``) where ``mx.fast.rms_norm``
+exists.  Routing it through the fast path is a refactor, so these are
+characterization tests: ``_reference`` is the old body verbatim, and the module
+must keep matching it.
+
+``rms_norm`` takes a 1-D weight only, so the grouped case cannot hand its
+``(groups, group_size)`` weight to the kernel and applies the scale separately.
+That scale must stay fp32 -- rounding ``(1 + w)`` to bf16 costs 3.9e-3 relative,
+which is half a bf16 ULP of pure avoidable error.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import mlx.core as mx
+import pytest
+
+from omlx.patches import mlx_vlm_qwen4_exp_compat as compat
+
+compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+language = importlib.import_module("mlx_vlm.models.qwen4_exp.language")
+
+BF16_ULP = 2.0**-7
+FP32_ULP = 2.0**-23
+
+
+def _reference(x: mx.array, weight: mx.array, eps: float, group_size: int | None):
+    """The pre-fast-path body, kept verbatim as the thing we must not change."""
+    dtype = x.dtype
+    y = x.astype(mx.float32)
+    if group_size is not None:
+        y = y.reshape(*y.shape[:-1], -1, group_size)
+        weight = weight.reshape(-1, group_size)
+    y = y * mx.rsqrt(mx.mean(mx.square(y), axis=-1, keepdims=True) + eps)
+    y = y * (1.0 + weight.astype(mx.float32))
+    return y.reshape(x.shape).astype(dtype)
+
+
+def _module(dim: int, group_size: int | None, weight: mx.array):
+    module = language.Qwen4ExpRMSNorm(dim, group_size=group_size, eps=1e-6)
+    module.weight = weight
+    return module
+
+
+# (name, input shape, dim, group_size) -- every geometry the model builds.
+_SEEDS = {
+    (name, scale): 1000 * i + int(scale * 100)
+    for i, name in enumerate(
+        [
+            "hc_norm_verify",
+            "hc_norm_decode",
+            "hc_norm_6rows",
+            "qk_layernorm",
+            "qk_layernorm_decode",
+            "indexer",
+            "ple_pre_fc",
+            "gdn_norm_conv",
+        ]
+    )
+    for scale in (0.0, 0.02, 0.5)
+}
+
+SHAPES = [
+    ("hc_norm_verify", (1, 4, 10240), 10240, 2560),
+    ("hc_norm_decode", (1, 1, 10240), 10240, 2560),
+    ("hc_norm_6rows", (1, 6, 10240), 10240, 2560),
+    ("qk_layernorm", (1, 4, 24, 256), 256, None),
+    ("qk_layernorm_decode", (1, 1, 24, 256), 256, None),
+    ("indexer", (1, 4, 4, 128), 128, None),
+    ("ple_pre_fc", (1, 4, 2560), 2560, None),
+    ("gdn_norm_conv", (1, 4, 2048), 2048, None),
+]
+
+
+@pytest.mark.parametrize("name,shape,dim,group_size", SHAPES, ids=[s[0] for s in SHAPES])
+@pytest.mark.parametrize("weight_scale", [0.0, 0.02, 0.5])
+def test_stays_within_one_bf16_ulp_of_the_hand_rolled_formulation(
+    name, shape, dim, group_size, weight_scale
+):
+    """bf16 is the production dtype; the fast path may move at most one ULP.
+
+    The kernel sums the squares in a different order than ``mx.mean``, so a
+    handful of values land on the far side of a bf16 rounding boundary.  Over
+    3.1M elements that is ~2 ppm at any weight magnitude, never above one ULP.
+    weight_scale 0.02 is the checkpoint's actual magnitude; 0.0 is the
+    zero-centered init, which makes ``(1 + w)`` a no-op and would hide a
+    dropped scale, so it is covered but never on its own.
+    """
+    mx.random.seed(_SEEDS[(name, weight_scale)])
+    x = (mx.random.normal(shape) * 1.5).astype(mx.bfloat16)
+    weight = (mx.random.normal((dim,)) * weight_scale).astype(mx.bfloat16)
+
+    got = _module(dim, group_size, weight)(x)
+    want = _reference(x, weight, 1e-6, group_size)
+
+    assert got.dtype == mx.bfloat16
+    assert got.shape == x.shape
+    delta = mx.abs(got.astype(mx.float32) - want.astype(mx.float32))
+    rel = delta / mx.maximum(mx.abs(want.astype(mx.float32)), 1e-30)
+    assert mx.max(rel).item() <= BF16_ULP, f"{name} moved more than one ULP"
+    # the rate is an aggregate property -- one element of a 6144-wide decode
+    # tensor is 163 ppm by construction, so it is asserted in bulk below
+    assert (delta > 0).sum().item() <= 2, f"{name} moved more than two elements"
+
+
+def test_deviation_is_smaller_than_the_models_own_batching_spread():
+    """The bar: MLX already moves this norm's input more than we do.
+
+    Running the same row through a 1-row and a 4-row forward gives different
+    results from MLX's own matmul path selection.  A refactor that stays below
+    that spread cannot be what makes a generation differ.
+    """
+    mx.random.seed(4242)
+    x = (mx.random.normal((1, 4, 10240)) * 1.5).astype(mx.bfloat16)
+    weight = (mx.random.normal((10240,)) * 0.02).astype(mx.bfloat16)
+    module = _module(10240, 2560, weight)
+
+    ours = mx.abs(
+        module(x).astype(mx.float32) - _reference(x, weight, 1e-6, 2560).astype(mx.float32)
+    )
+    # the same reference formulation, one row at a time vs all four at once
+    batched = _reference(x, weight, 1e-6, 2560)
+    per_row = mx.concatenate(
+        [_reference(x[:, i : i + 1], weight, 1e-6, 2560) for i in range(x.shape[1])], axis=1
+    )
+    theirs = mx.abs(batched.astype(mx.float32) - per_row.astype(mx.float32))
+
+    assert mx.max(ours).item() <= mx.max(theirs).item(), (
+        f"our max {mx.max(ours).item():.3e} exceeds the batching spread "
+        f"{mx.max(theirs).item():.3e}"
+    )
+
+
+@pytest.mark.parametrize("name,shape,dim,group_size", SHAPES, ids=[s[0] for s in SHAPES])
+def test_fp32_inputs_stay_within_a_few_ulp(name, shape, dim, group_size):
+    """fp32 has no bf16 rounding to mask the kernel's different summation order."""
+    mx.random.seed(11)
+    x = (mx.random.normal(shape) * 1.5).astype(mx.float32)
+    weight = (mx.random.normal((dim,)) * 0.02).astype(mx.float32)
+
+    got = _module(dim, group_size, weight)(x)
+    want = _reference(x, weight, 1e-6, group_size)
+
+    assert got.dtype == mx.float32
+    rel = mx.abs(got - want) / mx.maximum(mx.abs(want), 1e-30)
+    assert mx.max(rel).item() <= 4 * FP32_ULP
+
+
+def test_the_grouped_scale_is_not_rounded_to_bf16():
+    """A bf16 (1 + w) costs ~3.9e-3 relative -- the full half-ULP rounding bound.
+
+    Guards the one shortcut that looks harmless and is not: precomputing the
+    scale in the weight's own dtype instead of fp32.  Round-to-nearest cannot
+    exceed half a ULP, so this asserts the error saturates that bound rather
+    than passing it -- which is already ~16000x the fp32 path's ~2 fp32 ULP.
+    """
+    mx.random.seed(5)
+    weight = (mx.random.normal((10240,)) * 0.02).astype(mx.bfloat16)
+    exact = 1.0 + weight.astype(mx.float32)
+    rounded = exact.astype(mx.bfloat16).astype(mx.float32)
+    worst = mx.max(mx.abs(rounded - exact) / mx.abs(exact)).item()
+    assert 0.4 * BF16_ULP < worst <= 0.5 * BF16_ULP
+
+    x = (mx.random.normal((1, 4, 10240)) * 1.5).astype(mx.bfloat16)
+    got = _module(10240, 2560, weight)(x)
+    naive = (
+        mx.fast.rms_norm(x.reshape(1, 4, 4, 2560), None, 1e-6).astype(mx.float32)
+        * rounded.reshape(-1, 2560)
+    ).reshape(x.shape).astype(mx.bfloat16)
+    assert not mx.array_equal(got, naive).item()
+
+
+def test_grouping_is_per_group_not_whole_vector():
+    """Four groups of 2560 must each get their own scale; one flat norm differs."""
+    mx.random.seed(2)
+    x = (mx.random.normal((1, 4, 10240)) * 1.5).astype(mx.bfloat16)
+    # groups with deliberately unequal magnitude, so a whole-vector norm cannot
+    # coincide with the grouped one
+    x = mx.concatenate([x[..., :2560] * 8.0, x[..., 2560:]], axis=-1)
+    weight = (mx.random.normal((10240,)) * 0.02).astype(mx.bfloat16)
+
+    grouped = _module(10240, 2560, weight)(x)
+    flat = _module(10240, None, weight)(x)
+    assert not mx.array_equal(grouped, flat).item()
+    assert mx.array_equal(grouped, _reference(x, weight, 1e-6, 2560)).item()
+
+
+def test_rejects_a_dim_not_divisible_by_group_size():
+    with pytest.raises(ValueError, match="divisible"):
+        language.Qwen4ExpRMSNorm(10240, group_size=3000)
+
+
+def test_weight_stays_a_parameter_and_nothing_else_is_registered():
+    """A cached scale filed into the module dict would break checkpoint I/O."""
+    module = language.Qwen4ExpRMSNorm(10240, group_size=2560, eps=1e-6)
+    mx.eval(module(mx.zeros((1, 4, 10240), mx.bfloat16)))
+    assert list(module.parameters()) == ["weight"]
+
+
+def test_deviation_rate_across_the_whole_geometry_is_a_few_ppm():
+    """The rate bound the per-shape tests are too small to carry.
+
+    ~3.1M elements per weight scale.  Measured 1-8 ppm and independent of
+    weight magnitude; 50 ppm leaves an order of magnitude of headroom.
+    """
+    total = moved = 0
+    worst = 0.0
+    for scale in (0.0, 0.02, 0.5):
+        for seed in range(12):
+            for name, shape, dim, group_size in SHAPES:
+                mx.random.seed(seed * 97 + len(name))
+                x = (mx.random.normal(shape) * 1.5).astype(mx.bfloat16)
+                weight = (mx.random.normal((dim,)) * scale).astype(mx.bfloat16)
+                got = _module(dim, group_size, weight)(x)
+                want = _reference(x, weight, 1e-6, group_size)
+                delta = mx.abs(got.astype(mx.float32) - want.astype(mx.float32))
+                total += got.size
+                moved += (delta > 0).sum().item()
+                rel = delta / mx.maximum(mx.abs(want.astype(mx.float32)), 1e-30)
+                worst = max(worst, mx.max(rel).item())
+
+    assert worst <= BF16_ULP, f"{worst / BF16_ULP:.2f} ULP exceeds one"
+    assert moved / total <= 50e-6, f"{moved / total * 1e6:.2f} ppm over {total} elements"


### PR DESCRIPTION
### Summary

Qwen4-Exp decode was host-bound, not GPU-bound. On an M5 Max serving `Qwen3.8-Flash-Next-oQ4e-mtp`, a serial decode step spent ~22 ms on the host (5.4 ms of Python graph build plus 16.9 ms of MLX kernel encoding for an ~8.5k-node graph) while the GPU needed ~11.5 ms and sat idle for half of every step. This branch attacks the host side in three steps. Measured as a whole against the original `main` (e467261e), interleaved ABBA on the same box, same checkpoint, same prompts:

| Mode | main (e467261e) | this branch |
|---|---|---|
| Serial decode (MTP off), code 5k | 43.2 tok/s | 63.4 tok/s (+47%) |
| Serial decode, code 41k | 40.2 tok/s | 57.2 tok/s (+42%) |
| Serial decode, prose 5.8k / 34k | 43.2 / 41.0 tok/s | 62.7 / 57.9 tok/s (+45% / +41%) |
| Lightning MTP depth 3, mean of 4 prompts | 46.4 ms/cycle, 57.9 tok/s | 35.9 ms/cycle (−23%), 76.8 tok/s (+33%) |
| Lightning MTP depth 3, code 5k | 43.6 ms/cycle | 32.1 ms/cycle (−26%) |
| Lightning MTP depth 3, code 41k | 49.6 ms/cycle | 39.2 ms/cycle (−21%) |

MTP acceptance is unchanged within noise (77.4 vs 77.0%, 71.7 vs 69.8%, 70.1 vs 68.6%, 81.1 vs 78.9% on the four prompts).

Every path has an environment kill switch and fails closed to the existing code.

### What changed, and what each part is worth

**1. `Qwen4ExpRMSNorm` through `mx.fast.rms_norm` (c472afa5)** — the norm was hand-written in MLX ops (cast, square, mean, rsqrt, scale). It now calls the fused fast op, with the grouped hyper-connection norm normalising per stream and scaling afterwards. Numerics: the `1 + weight` scale stays fp32, so results differ from the old path by at most 1 bf16 ULP (2 ppm aggregate). Gain: **−4.0% ms/cycle** under MTP in an in-server A/B.

**2. Eager per-layer dispatch (dc6197dd)** — the decoder loop called one `async_eval` after building the whole forward, so the GPU waited through the entire Python build and most of the encoding. The loop now dispatches each decoder layer's output as soon as it is built (decode and verify rows only, ≤ 64 rows), so the GPU runs layer *i* while the host builds layer *i+1*. This is scheduling only: outputs are bit-identical, and the A/B shows identical cycle counts and acceptance in every arm. Gain: **serial +18..22% tok/s; MTP −11.5% ms/cycle** (44.1 → 39.1; code 5k 65.8 → 75.9 tok/s).

**3. Fused hyper-connection kernels (1650644a, 504b44e9, def1b1fd)** — `Qwen4ExpGatedResidual._forward` built ~30 MLX nodes per call and runs 97 times per forward; per-module encode attribution put it at 5.2 ms of host time per step, the largest single item. Three row-batched Metal kernels replace it for ≤ 16 rows: a per-stream RMS norm (bit-identical to `mx.fast.rms_norm`), the down and inject projections split over four K-slices with the `silu(mix/hc)` and `2·sigmoid(inject/hc)` epilogues folded in, and the up projection with the sigmoid gate, stream mix and mean over streams via simd shuffles. The affine unpack helpers are shared with `hc_projection`; 4/5/6/8-bit gs64 weights are supported, with independent bit widths for the down and inject projections. Numerics: fp32 is kept through the epilogues, so results are within a few bf16 ULP of the canonical path and at least as close to an fp32 reference as the canonical path is. Gain: **MTP −6.5% ms/cycle** on top of eager dispatch (39.2 → 36.6). Serial was unchanged at this point — not because serial decode is GPU-bound, as the first version of this description said, but because the fused path was being bypassed on 91 of the 97 modules (part 4).

Review follow-up (@mvdbos): the 4/5-bit down loop walks each K-slice in 512-element blocks with no tail, while the eligibility check only asked for a multiple of 256, so a hidden size such as 768/4-bit or 1280/5-bit passed the check and read past its slice (77 and 88 ULP off canonical in a repro; the shipped hidden 2560 was never affected). 504b44e9 adds the guard; def1b1fd then adds lane-guarded partial-block handling to the norm, down and inject loops and relaxes the gate to any multiple of 64. For hidden 2560 every tail is zero and the guards fold away — old and new kernels are bit-identical for every bit width at 1/4/16 rows, and an interleaved A/B is null (serial within ±0.5%, MTP 36.2/36.9 vs 36.0/36.3 ms/cycle). `compatible()` also logs once, at INFO, when a model's layout keeps it on the canonical path, so a future checkpoint that misses the fused kernels shows up in the log instead of just running slower (ec982bed keeps that line quiet for the deliberate hybrid-projection case below).

**4. Fused kernels ahead of the exact hybrid projection (b954693b)** — found through the new log line. With Lightning MTP off, `qwen4_exp.load_weights` flags 91 of the 97 hyper-connections with upstream's exact hybrid projection and compiles their single-token `_forward`; the fused path stepped aside for those modules, so in serial decode it only ever ran on the other 6 (with MTP on the hybrid is never installed, which is why the MTP numbers were fine). The fused path now takes precedence for the rows it covers; `_forward` is untouched and keeps the hybrid for everything else. Gain: **serial +12..16% tok/s** on top of the above — interleaved checkout-switching A/B, MTP off: code 5k 55.2 → 62.5, code 41k 50.8 → 57.0, prose 5.8k 54.2 → 62.6, prose 34k 51.4 → 58.1. MTP verify is unchanged. Serial outputs now match the canonical path to a few bf16 ULP, as the MTP path already did, instead of bit-exactly.

Stacked, parts 1–3 take an MTP verify cycle from 46.4 to 35.9 ms on this box (the combined run above), and parts 1–4 take serial decode from 43 to 63 tok/s; the per-part figures come from the individual A/Bs during development.

### Measurement

All numbers are decode-only tokens per second (or milliseconds per MTP cycle) from interleaved ABBA runs on one M5 Max, four prompts (code and prose at ~5k and ~35–41k tokens), 512 generated tokens, two passes each. MTP runs pin the draft depth so the adaptive controller cannot confound the comparison. Where a change is not bitwise, `ms/cycle` is the fair metric, and acceptance rates are reported alongside.

### Safety and tests

- Kill switches: `OMLX_QWEN4_EAGER_DISPATCH=0`, `OMLX_QWEN4_HC_FUSED=0`. The fused kernels fail closed to `_forward` on any runtime error with a one-time warning.
- The fused path is gated on batch·seq ≤ 16, bf16 input, `hc_count == 4`, quantised gs64 projections in 4/5/6/8 bits, no combined `input_inject_weight`, and Metal being available. Prefill and batched decode take the existing path.
- New tests: `tests/test_qwen4_eager_dispatch.py` (fires once per layer for ≤ 64 rows, never for prefill, outputs bit-identical on/off), `tests/test_qwen4_hc_fused.py` (parity against the canonical path and an fp32 reference for 4/5/6/8 bits × 1/4/16 rows × with/without inject, norm kernel bit-identity, eligibility fail-closed, kill switch), `tests/test_qwen4_rms_norm.py` (ULP and ppm bounds, grouping, fp32 scale).
- `tests/conftest.py` pins `MLX_ENABLE_TF32=0` so the fp32 parity tests hold on M5-class GPUs where TF32 is the default.