### PR TITLE
fix(scheduler): a throttled prefill chunk must never grow past the tokens left

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -3623,6 +3623,12 @@ class Scheduler:
                 request_id=request.request_id,
                 gathered_core=gathered_core,
             )
+            # A chunk may never exceed the tokens actually left: the token
+            # row and the VLM inputs_embeds (one row wider — the +1 final
+            # token deferred to insert()) are sliced with the same size and
+            # MLX clamps silently, so an oversized chunk desynchronizes them
+            # and Qwen4Exp's PLE dies on an off-by-one reshape (#3240).
+            n_to_process = min(n_to_process, remaining)
             if getattr(request, "benchmark_trace", False):
                 request.benchmark_prefill_chunks.append(int(n_to_process))
                 request.benchmark_requested_steps.append(int(prefill_step_size))
@@ -4431,6 +4437,18 @@ class Scheduler:
             else:
                 bucket = self._PREFILL_STEP_TIERS[1]  # 512
             n = max(min_chunk, min(n, bucket))
+
+        # The floor is an admission bound, not a padding requirement: when a
+        # prefill tail is shorter than min_chunk, both floor above must never
+        # grow the chunk past what the caller had to work with. Returning
+        # more than requested breaks the documented ">= 1, <= requested"
+        # contract, and the external-prefill loop slices the token row and
+        # the VLM inputs_embeds (which spans the +1 final token the token
+        # stream defers) with the same chunk size — MLX clamps silently, so
+        # an oversized chunk desynchronizes the two by exactly the rows left
+        # on each side and Qwen4Exp's PLE dies on an off-by-one reshape
+        # (#3240).
+        n = min(requested, n)
 
         n = self._snap_chunk_size(n, requested)
 
@@ -5257,6 +5275,11 @@ class Scheduler:
             request_id=state.request.request_id,
             gathered_core=gathered_core,
         )
+        # Same invariant as the external loop (#3240): the throttle may
+        # shrink but never grow a chunk past the tokens actually left —
+        # otherwise tokens_processed drifts past the rows actually cached
+        # (skewed progress and boundary-snapshot totals).
+        n = min(n, remaining)
         if getattr(state.request, "benchmark_trace", False):
             state.request.benchmark_prefill_chunks.append(int(n))
             state.request.benchmark_requested_steps.append(int(prefill_step_size))

--- a/tests/test_prefill_oom_graceful.py
+++ b/tests/test_prefill_oom_graceful.py
@@ -1273,3 +1273,29 @@ def test_speed_priority_guard_passes_full_chunk_that_fits():
     ns._fake_current = 10 * _GB
     ns._prefill_speed_priority = True
     assert _guard_call(ns, 2048, kv_len=5000) == 2048
+
+
+def test_adaptive_throttle_tail_below_floor_never_grows_chunk():
+    """Regression (#3240): the min-chunk floor must never INFLATE a chunk
+    beyond what the caller asked for. A prefill tail shorter than
+    prefill_min_chunk_tokens used to be raised back up to the floor
+    (max(min_chunk, min(requested, n_fit))), and the external-prefill loop
+    has no clamp after the throttle — so the chunk sized the token slice and
+    the VLM inputs_embeds slice differently (embeds always covers the +1
+    final token the token stream defers for the first decode step). MLX
+    slices silently clamp, so the model received e.g. 152 input_ids columns
+    against 153 embeds rows, and Qwen4Exp's PLE died with the reported
+    off-by-one:
+    "[reshape] Cannot reshape array of size 1556480 into shape (1,153,4,2560)".
+    The throttle's documented contract is ">= 1, <= requested"; the floor is
+    an admission bound, not a padding requirement.
+    """
+    hard = 40 * _GB
+    ns = _throttle_ctx(
+        current=39.5 * _GB, hard=hard, samples_bpt=2 * 1024**2, min_chunk=256
+    )
+    ns._fake_current = 39.5 * _GB
+    # Pressure over the target: the shrink path runs and the floor (256) is
+    # above the tail (152).
+    n = _call(ns, 152, kv_len=122_000)
+    assert n <= 152

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -6138,6 +6138,57 @@ class TestVLMPositionStateClearing:
         model.clear_vlm_position_state.assert_called_once()
         seed_mrope.assert_called_once_with(model, request)
 
+    def test_vlm_external_prefill_never_slices_embeds_longer_than_tokens(
+        self, mock_tokenizer
+    ):
+        """Regression (#3240): an external-prefill chunk must never exceed the
+        tokens actually left in the input array.
+
+        VLM ``inputs_embeds`` always spans one row wider than the token side
+        (the final token is deferred to ``insert()`` for the first decode
+        step), and MLX slices silently clamp at the array edge. So a chunk
+        inflated past the remaining tail — e.g. the prefill throttle raising
+        a short tail back to the ``prefill_min_chunk_tokens`` floor — fed the
+        model 152 input_ids columns against 153 embeds rows and Qwen4Exp's
+        PLE died with the reported off-by-one:
+        "[reshape] Cannot reshape array of size 1556480 into shape (1,153,4,2560)".
+        The floor stub reproduces that inflation and the assertion pins the
+        invariant at the model boundary.
+        """
+        model = self._make_vlm_model()
+        scheduler = Scheduler(
+            model=model,
+            tokenizer=mock_tokenizer,
+            config=SchedulerConfig(prefill_step_size=4),
+            stream=mx.new_stream(mx.cpu),
+        )
+        # Floor-always throttle stubs: mimics the throttle state that
+        # inflates every chunk to the min-chunk floor.
+        scheduler._adaptive_chunk_size = lambda requested, **kw: 256
+        scheduler._guard_prefill_chunk = lambda n_tokens, **kw: n_tokens
+
+        request = Request(
+            request_id="vlm-tail-chunk",
+            prompt="image prompt",
+            sampling_params=SamplingParams(max_tokens=1),
+        )
+        request.prompt_token_ids = list(range(10))
+        request.num_prompt_tokens = 10
+        embeds = mx.zeros((1, 10, 4), dtype=mx.float32)
+
+        scheduler._do_external_prefill(
+            request,
+            tokens=request.prompt_token_ids,
+            existing_cache=[],
+            vlm_embeds=(embeds, {}, 0),
+        )
+
+        assert model.call_count > 0
+        for model_call in model.call_args_list:
+            input_ids = model_call.args[0]
+            inputs_embeds = model_call.kwargs["inputs_embeds"]
+            assert inputs_embeds.shape[1] == input_ids.shape[1]
+
 
 class TestBuildStateMachineStopStrings:
     """Tests for _build_state_machine stop-string tokenization.


### PR DESCRIPTION
## Symptom

Intermittent server-side crash on image-bearing requests to a Qwen4Exp VLM engine, matching the signature in #3240:

```
ValueError: [reshape] Cannot reshape array of size 1556480 into shape (1,153,4,2560).
  ...
  File "omlx/scheduler.py", line 3674, in _do_external_prefill
    self.model(input_arr[:, :n_to_process], cache=prompt_cache, **model_kwargs)
  ...
  File ".../qwen4_exp/language.py", line 2389, in Qwen4ExpPLELayer.__call__
    keys = self.norm_key(...)
```

`1556480 = 152 × (hc_count·hidden_size)` vs `153 × 10240`: the PLE layer's `input_ids` spans exactly one token less than `hidden_states` (which comes from `inputs_embeds`).

## Root cause

`Scheduler._adaptive_chunk_size` documents "`>= 1`, `<= requested`", but its floor — `n = max(min_chunk, min(requested, n_fit))` and the band-tier clamp below it — returns **more than `requested`** whenever a prefill tail is shorter than `prefill_min_chunk_tokens` and memory pressure takes the shrink path. The log is silent on exactly this case: the throttle INFO line is gated on `n < requested`.

`_do_external_prefill` then never re-clamps the chunk to the tokens actually left, and its two same-sized slices are not same-length:

- `input_arr` covers `tokens[:-1]` (the final token is deferred to `insert()` for the first decode step);
- VLM `inputs_embeds` spans the **full prompt** — always exactly one row wider.

MLX slices silently clamp at the array edge, so a chunk inflated past the tail desynchronizes the two: `input_arr[:, :n]` → 152 columns, `embeds_array[:, :n]` → 153 rows → the model gets mismatched lengths and Qwen4Exp's PLE dies on the reshape. This also explains the probabilistic nature: it needs an embeds-bearing (VLM) request **and** a tail shorter than the floor **and** throttle shrink pressure landing exactly on that chunk (e.g. `prefill_min_chunk_tokens: 256` near the memory ceiling).

## Fix

- `_adaptive_chunk_size` now honors its documented contract (`n = min(requested, n)` after the floor clamps).
- Both prefill loops (external + text-chunked) clamp the chunk to the tokens actually remaining before slicing. The chunked loop is text-only, but the same inflation silently drifted its `tokens_processed` past the rows actually cached (skewed progress and boundary-snapshot totals).

The floor remains an admission bound — the guard still rejects/raises based on the min-chunk transient — it just no longer *pads* a short tail.

## Tests (red → green)

- `tests/test_prefill_oom_graceful.py::test_adaptive_throttle_tail_below_floor_never_grows_chunk` — helper contract: requested 152, floor 256 under pressure; red: returned 256.
- `tests/test_scheduler.py::TestVLMPositionStateClearing::test_vlm_external_prefill_never_slices_embeds_longer_than_tokens` — drives `_do_external_prefill` with floor stubs and asserts `inputs_embeds` and `input_ids` lengths at the model boundary; red: 10 vs 9.

## Notes on #3240

This eliminates a mechanism that reproduces the exact numeric signature of the issue (N vs N+1 in the PLE reshape, embeds wider by the deferred final token). The reporter's deterministic small-prompt boundary may involve an additional path (their stack went through the legacy pending-embeds route on 0.6.3); I can extend the repro there if the symptom persists after this lands.
