### PR TITLE
fix(qwen4): align prefill pricing with execution route

### DIFF
--- a/omlx/admin/context_benchmark.py
+++ b/omlx/admin/context_benchmark.py
@@ -244,7 +244,7 @@ def _guard_ready(scheduler: Any) -> bool:
 def _make_fits(scheduler: Any) -> Callable[[int], bool]:
     def fits(n: int) -> bool:
         try:
-            scheduler.preflight_or_raise(num_prompt_tokens=n, text_only=True)
+            scheduler.preflight_or_raise(num_prompt_tokens=n)
         except PrefillMemoryExceededError:
             return False
         return True

--- a/omlx/engine/base.py
+++ b/omlx/engine/base.py
@@ -71,7 +71,6 @@ async def _run_scheduler_preflight_with_cleanup_retry(
     request_id: str | None,
     eviction_callback: Any | None,
     executor: Any | None = None,
-    text_only: bool = False,
 ) -> None:
     """Run route preflight after transient post-request cleanup settles.
 
@@ -92,13 +91,11 @@ async def _run_scheduler_preflight_with_cleanup_retry(
         eviction_request = scheduler.preflight_eviction_request(
             num_prompt_tokens=num_prompt_tokens,
             request_id=request_id,
-            text_only=text_only,
         )
         if eviction_request is None:
             scheduler.preflight_or_raise(
                 num_prompt_tokens=num_prompt_tokens,
                 request_id=request_id,
-                text_only=text_only,
             )
             return
 
@@ -153,7 +150,6 @@ async def _run_scheduler_preflight_with_cleanup_retry(
         scheduler.preflight_or_raise(
             num_prompt_tokens=num_prompt_tokens,
             request_id=request_id,
-            text_only=text_only,
         )
         return
 

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -102,7 +102,6 @@ class BatchedEngine(BaseEngine):
                 "_mlx_executor",
                 None,
             ),
-            text_only=True,
         )
 
     @property

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1583,7 +1583,6 @@ class VLMBatchedEngine(BaseEngine):
         *,
         num_prompt_tokens: int,
         request_id: str | None,
-        text_only: bool = False,
     ) -> None:
         await _run_scheduler_preflight_with_cleanup_retry(
             scheduler,
@@ -1595,7 +1594,6 @@ class VLMBatchedEngine(BaseEngine):
                 "_mlx_executor",
                 None,
             ),
-            text_only=text_only,
         )
 
     @property
@@ -4058,7 +4056,6 @@ class VLMBatchedEngine(BaseEngine):
             scheduler,
             num_prompt_tokens=num_tokens,
             request_id=request_id,
-            text_only=image_tokens == 0,
         )
 
     async def preflight_completion(
@@ -4094,7 +4091,6 @@ class VLMBatchedEngine(BaseEngine):
             scheduler,
             num_prompt_tokens=num_tokens,
             request_id=request_id,
-            text_only=True,
         )
 
     async def stream_chat(

--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -13,6 +13,7 @@ Key features:
 from __future__ import annotations
 
 import logging
+import os
 import threading
 import time
 from collections import Counter
@@ -43,6 +44,28 @@ except ImportError:
 # different head dimensions; unsupported cases fall back to an unfused
 # score-matrix allocation.
 _SDPA_VECTOR_QUERY_TOKEN_THRESHOLD = 8
+
+
+def qwen4_gathered_min_query_tokens() -> int:
+    """Keep narrow Lightning MTP windows on masked SDPA (M5 crossover)."""
+    try:
+        return max(
+            2, int(os.environ.get("OMLX_QWEN4_GATHERED_MIN_QUERY", "16"))
+        )
+    except ValueError:
+        return 16
+
+
+def qwen4_gathered_prefill_route(
+    query_tokens: int, cache_tokens: int, indexer_budget: int
+) -> bool:
+    """Whether Qwen4 text prefill uses sparse gathered QSA."""
+    return (
+        query_tokens >= qwen4_gathered_min_query_tokens()
+        and cache_tokens + query_tokens > indexer_budget
+    )
+
+
 _SDPA_FULL_SUPPORTED_HEAD_DIMS = frozenset({64, 72, 80, 96, 128})
 _SDPA_VECTOR_SUPPORTED_HEAD_DIMS = frozenset({64, 96, 128, 256})
 # Default bytes/elem for the materialized unfused score matrix when the model's
@@ -862,6 +885,16 @@ class MemoryMonitor:
         """True when this monitor prices Qwen4 QSA gathered-core prefill."""
         return isinstance(
             self._prefill_memory_profile, _Qwen4ExpPrefillMemoryProfile
+        )
+
+    def qwen4_gathered_prefill_route(
+        self, query_tokens: int, cache_tokens: int
+    ) -> bool:
+        profile = self._prefill_memory_profile
+        return isinstance(
+            profile, _Qwen4ExpPrefillMemoryProfile
+        ) and qwen4_gathered_prefill_route(
+            query_tokens, cache_tokens, profile.indexer_budget
         )
 
     def estimate_chunk_transient_bytes(

--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -66,6 +66,39 @@ def qwen4_gathered_prefill_route(
     )
 
 
+_TEXT_MROPE_EQUAL_PLANES: list[tuple[Any, int, bool]] = []
+
+
+def qwen4_text_mrope_broadcast(position_ids: Any, length: int) -> bool:
+    """True for missing/2-D text ids, or 3-D mRoPE that is a text broadcast.
+
+    The parent LanguageModel tiles identical ``(1, L)`` positions to
+    ``(3, 1, L)`` for text-only mRoPE. Real image grids differ across the
+    three planes and must stay on the official mask+SDPA path. Shared by the
+    Qwen4 runtime eligibility gate and the scheduler's route pricing so both
+    sides decide identically for image-region chunks.
+    """
+    if position_ids is None:
+        return True
+    if mx is None or not isinstance(position_ids, mx.array):
+        return False
+    if position_ids.ndim == 2:
+        return tuple(position_ids.shape) == (1, length)
+    if position_ids.ndim != 3 or tuple(position_ids.shape) != (3, 1, length):
+        return False
+    for cached_ids, cached_len, cached_same in _TEXT_MROPE_EQUAL_PLANES:
+        if cached_ids is position_ids and cached_len == length:
+            return cached_same
+    same = bool(
+        mx.array_equal(position_ids[0], position_ids[1]).item()
+        and mx.array_equal(position_ids[1], position_ids[2]).item()
+    )
+    _TEXT_MROPE_EQUAL_PLANES.append((position_ids, length, same))
+    if len(_TEXT_MROPE_EQUAL_PLANES) > 8:
+        del _TEXT_MROPE_EQUAL_PLANES[:-8]
+    return same
+
+
 _SDPA_FULL_SUPPORTED_HEAD_DIMS = frozenset({64, 72, 80, 96, 128})
 _SDPA_VECTOR_SUPPORTED_HEAD_DIMS = frozenset({64, 96, 128, 256})
 # Default bytes/elem for the materialized unfused score matrix when the model's

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -23,6 +23,9 @@ from omlx.memory_monitor import (
     qwen4_gathered_min_query_tokens as _gathered_min_query_tokens,
 )
 from omlx.memory_monitor import qwen4_gathered_prefill_route
+from omlx.memory_monitor import (
+    qwen4_text_mrope_broadcast as _broadcast_text_mrope_position_ids,
+)
 
 from .cache import ArraysCache, BatchKVCache, KVCache, QuantizedKVCache, dynamic_roll
 from ..qwen3_5.language import LanguageModel as Qwen3_5LanguageModel
@@ -48,39 +51,6 @@ logger = logging.getLogger(__name__)
 _PLE_RUNTIME_MODEL_PATH: Path | None = None
 _PLE_RUNTIME_MODE = "resident"
 _HYPER_SPLIT_INDICES: dict[tuple[int, int], tuple[mx.array, mx.array]] = {}
-# Identity cache: keep the array alive so CPython cannot recycle id().
-_TEXT_MROPE_EQUAL_PLANES: list[tuple[Any, int, bool]] = []
-
-
-def _broadcast_text_mrope_position_ids(
-    position_ids: Optional[mx.array],
-    length: int,
-) -> bool:
-    """True for missing/2-D text ids, or 3-D MRoPE that is a text broadcast.
-
-    Parent LanguageModel tiles identical ``(1, L)`` positions to ``(3, 1, L)``
-    for text-only mRoPE. Real image grids differ across the three planes and
-    must stay on the official mask+SDPA path.
-    """
-    if position_ids is None:
-        return True
-    if not isinstance(position_ids, mx.array):
-        return False
-    if position_ids.ndim == 2:
-        return tuple(position_ids.shape) == (1, length)
-    if position_ids.ndim != 3 or tuple(position_ids.shape) != (3, 1, length):
-        return False
-    for cached_ids, cached_len, cached_same in _TEXT_MROPE_EQUAL_PLANES:
-        if cached_ids is position_ids and cached_len == length:
-            return cached_same
-    same = bool(
-        mx.array_equal(position_ids[0], position_ids[1]).item()
-        and mx.array_equal(position_ids[1], position_ids[2]).item()
-    )
-    _TEXT_MROPE_EQUAL_PLANES.append((position_ids, length, same))
-    if len(_TEXT_MROPE_EQUAL_PLANES) > 8:
-        del _TEXT_MROPE_EQUAL_PLANES[:-8]
-    return same
 
 
 def _rank_two_text_position_ids(

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -19,6 +19,11 @@ import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 
+from omlx.memory_monitor import (
+    qwen4_gathered_min_query_tokens as _gathered_min_query_tokens,
+)
+from omlx.memory_monitor import qwen4_gathered_prefill_route
+
 from .cache import ArraysCache, BatchKVCache, KVCache, QuantizedKVCache, dynamic_roll
 from ..qwen3_5.language import LanguageModel as Qwen3_5LanguageModel
 from ..qwen3_5.language import (
@@ -90,17 +95,6 @@ def _rank_two_text_position_ids(
         and position_ids.ndim == 2
         and tuple(position_ids.shape) == (1, length)
     )
-
-
-def _gathered_min_query_tokens() -> int:
-    """Keep narrow Lightning MTP windows on masked SDPA (M5 crossover)."""
-    raw = os.environ.get("OMLX_QWEN4_GATHERED_MIN_QUERY", "").strip()
-    if raw:
-        try:
-            return max(2, int(raw))
-        except ValueError:
-            pass
-    return 16
 
 
 def _split_text_mrope_positions(
@@ -1284,10 +1278,6 @@ class Qwen4ExpAttention(Qwen3_5Attention):
         if not (
             x.ndim == 3
             and x.shape[0] == 1
-            # Narrow multi-row windows (Lightning MTP history/verify passes)
-            # are cheaper on the official masked path; see
-            # _gathered_min_query_tokens.
-            and x.shape[1] >= _gathered_min_query_tokens()
             and causal_mask
             and type(cache) is QSAKVCache
             and isinstance(cache.offset, int)
@@ -1296,11 +1286,8 @@ class Qwen4ExpAttention(Qwen3_5Attention):
             and self._batch_one_text_position_ids(position_ids, x.shape[1])
         ):
             return False
-        return bool(
-            # Below the QSA budget the official path attends the complete
-            # prefix directly and is faster than building gathered blocks.
-            # Switch only after sparse selection can reduce actual work.
-            cache.offset + x.shape[1] > self.indexer.token_budget
+        return qwen4_gathered_prefill_route(
+            x.shape[1], cache.offset, self.indexer.token_budget
         )
 
     def _gathered_text_decode_eligible(

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -3481,14 +3481,15 @@ class Scheduler:
         checker = getattr(monitor, "is_qwen4_gathered_prefill_profile", None)
         return callable(checker) and checker() is True
 
-    def _qwen4_text_gathered_pricing(self, text_only: bool) -> bool:
-        """True when this engine can price Qwen4 text prefill as gathered QSA.
-
-        Callers that do not know whether the request is text-only must pass
-        False. Preflight and prefill then share an argument instead of a
-        mutable flag on the shared monitor.
-        """
-        return text_only is True and Scheduler._qwen4_prefill_accounting_enabled(self)
+    def _qwen4_text_gathered_pricing(
+        self, text_only: bool, *, query_tokens: int, cache_tokens: int
+    ) -> bool:
+        """Predict the Qwen4 text-prefill route for one concrete chunk."""
+        if text_only is not True:
+            return False
+        monitor = getattr(self, "memory_monitor", None)
+        checker = getattr(monitor, "qwen4_gathered_prefill_route", None)
+        return callable(checker) and checker(query_tokens, cache_tokens) is True
 
     @staticmethod
     def _qwen4_actual_gathered_pricing(
@@ -3533,7 +3534,6 @@ class Scheduler:
             RuntimeError: If memory limit exceeded during prefill.
         """
         n_tokens = len(tokens)
-        gathered_core = self._qwen4_text_gathered_pricing(vlm_embeds is None)
         if n_tokens <= 1:
             # Nothing to prefill, return cache + tokens as-is.
             cache = existing_cache or make_prompt_cache(self.model)
@@ -3577,7 +3577,9 @@ class Scheduler:
         if getattr(request, "benchmark_trace", False):
             request.benchmark_boundary_enabled = boundary_enabled
             request.benchmark_cache_block_size = block_size if boundary_enabled else 0
-        base_size = _cache_base_sizes(prompt_cache) if boundary_enabled else 0
+        base_size = max(int(getattr(request, "cached_tokens", 0)), 0)
+        if boundary_enabled:
+            base_size = _cache_base_sizes(prompt_cache)
         # Sanity check: base_size from cache offsets should match the number
         # of tokens actually cached. A mismatch indicates stale meta_state
         # in a restored RotatingKVCache (e.g. shared layer_meta_states from
@@ -3676,23 +3678,49 @@ class Scheduler:
                     block_size=block_size,
                 )
 
+            cache_tokens = base_size + processed_tokens
+            gathered_core = self._qwen4_text_gathered_pricing(
+                vlm_embeds is None,
+                query_tokens=n_to_process,
+                cache_tokens=cache_tokens,
+            )
             try:
                 n_to_process = self._adaptive_chunk_size(
                     n_to_process,
                     request_id=request.request_id,
                     loop_label="external",
-                    kv_len=base_size + processed_tokens,
+                    kv_len=cache_tokens,
                     gathered_core=gathered_core,
+                )
+                gathered_core = self._qwen4_text_gathered_pricing(
+                    vlm_embeds is None,
+                    query_tokens=n_to_process,
+                    cache_tokens=cache_tokens,
                 )
                 # Check the predicted peak before submitting work to Metal.
                 n_to_process = self._guard_prefill_chunk(
                     n_to_process,
-                    kv_len=base_size + processed_tokens,
+                    kv_len=cache_tokens,
                     progress=processed_tokens,
                     loop_label="external",
                     request_id=request.request_id,
                     gathered_core=gathered_core,
                 )
+                final_route = self._qwen4_text_gathered_pricing(
+                    vlm_embeds is None,
+                    query_tokens=n_to_process,
+                    cache_tokens=cache_tokens,
+                )
+                if final_route != gathered_core:
+                    gathered_core = final_route
+                    n_to_process = self._guard_prefill_chunk(
+                        n_to_process,
+                        kv_len=cache_tokens,
+                        progress=processed_tokens,
+                        loop_label="external",
+                        request_id=request.request_id,
+                        gathered_core=gathered_core,
+                    )
             except _PrefillEvictionNeeded:
                 # Keep token progress aligned with the advanced KV on retry.
                 # Cold requests must also retain their locally created cache.
@@ -5496,27 +5524,44 @@ class Scheduler:
         # convert that into a finish_reason="error" output for the client.
         # Chunked prefill is text-only (VLM never builds _PrefillState).
         qwen4_accounting = Scheduler._qwen4_prefill_accounting_enabled(self)
-        if qwen4_accounting and state.qwen4_gathered_core is None:
-            state.qwen4_gathered_core = self._qwen4_text_gathered_pricing(True)
-        gathered_core = state.qwen4_gathered_core or False
+        cache_tokens = state.base_size + state.tokens_processed
+
+        def qwen4_route(query_tokens: int) -> bool:
+            return qwen4_accounting and self._qwen4_text_gathered_pricing(
+                True, query_tokens=query_tokens, cache_tokens=cache_tokens
+            )
+
+        gathered_core = qwen4_route(n)
         n = self._adaptive_chunk_size(
             n,
             request_id=state.request.request_id,
             loop_label="chunked_step",
-            kv_len=state.base_size + state.tokens_processed,
+            kv_len=cache_tokens,
             gathered_core=gathered_core,
         )
+        gathered_core = qwen4_route(n)
 
         # Pre-chunk safety guard (mirrors the external loop): never submit a
         # chunk whose predicted peak would trip the uncatchable async Metal OOM.
         n = self._guard_prefill_chunk(
             n,
-            kv_len=state.base_size + state.tokens_processed,
+            kv_len=cache_tokens,
             progress=state.tokens_processed,
             loop_label="chunked_step",
             request_id=state.request.request_id,
             gathered_core=gathered_core,
         )
+        final_route = qwen4_route(n)
+        if final_route != gathered_core:
+            gathered_core = final_route
+            n = self._guard_prefill_chunk(
+                n,
+                kv_len=cache_tokens,
+                progress=state.tokens_processed,
+                loop_label="chunked_step",
+                request_id=state.request.request_id,
+                gathered_core=gathered_core,
+            )
         # Count only tokens actually passed to the model.
         n = min(n, remaining)
         if getattr(state.request, "benchmark_trace", False):
@@ -10259,7 +10304,9 @@ class Scheduler:
         kv_exact = int(
             monitor.estimate_resident_kv_bytes(new_tokens, chunk_tokens=floor_chunk)
         )
-        gathered_core = self._qwen4_text_gathered_pricing(text_only)
+        gathered_core = self._qwen4_text_gathered_pricing(
+            text_only, query_tokens=floor_chunk, cache_tokens=kv_len
+        )
         transient = int(
             self._admission_transient_bound(
                 floor_chunk, kv_len, gathered_core=gathered_core

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -3489,6 +3489,7 @@ class Scheduler:
         query_tokens: int,
         cache_tokens: int,
         position_ids: Any = None,
+        prompt_cache: list[Any] | None = None,
     ) -> bool:
         """Predict the Qwen4 prefill route for one concrete chunk.
 
@@ -3501,6 +3502,18 @@ class Scheduler:
         its actual position_ids, so an image-bearing tail is still caught
         before Metal sees it.
         """
+        if prompt_cache is not None:
+            try:
+                from mlx_vlm.models.qwen4_exp.language import QSAKVCache
+            except ImportError:
+                return False
+            qsa_caches = [
+                cache
+                for cache in prompt_cache
+                if callable(getattr(cache, "reserve_index_capacity", None))
+            ]
+            if not qsa_caches or any(type(cache) is not QSAKVCache for cache in qsa_caches):
+                return False
         monitor = getattr(self, "memory_monitor", None)
         checker = getattr(monitor, "qwen4_gathered_prefill_route", None)
         if not (callable(checker) and checker(query_tokens, cache_tokens) is True):
@@ -3688,6 +3701,7 @@ class Scheduler:
                 query_tokens=n_tokens,
                 cache_tokens=cache_tokens,
                 position_ids=sliced.get("position_ids"),
+                prompt_cache=prompt_cache,
             )
 
         while input_arr.shape[1] > 0:
@@ -5548,7 +5562,9 @@ class Scheduler:
 
         def qwen4_route(query_tokens: int) -> bool:
             return qwen4_accounting and self._qwen4_text_gathered_pricing(
-                query_tokens=query_tokens, cache_tokens=cache_tokens
+                query_tokens=query_tokens,
+                cache_tokens=cache_tokens,
+                prompt_cache=state.cache,
             )
 
         gathered_core = qwen4_route(n)

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -365,6 +365,7 @@ try:
         estimate_mla_kv_bytes_per_token,
         estimate_qwen4_exp_kv_bytes_per_token,
         make_prefill_memory_profile,
+        qwen4_text_mrope_broadcast,
     )
 
     HAS_TIERED_CACHE = True
@@ -376,6 +377,7 @@ except ImportError:
     estimate_mla_kv_bytes_per_token = None
     estimate_qwen4_exp_kv_bytes_per_token = None
     make_prefill_memory_profile = None
+    qwen4_text_mrope_broadcast = None
     HAS_TIERED_CACHE = False
 
 # Import cache type handlers for hybrid cache support
@@ -3482,14 +3484,30 @@ class Scheduler:
         return callable(checker) and checker() is True
 
     def _qwen4_text_gathered_pricing(
-        self, text_only: bool, *, query_tokens: int, cache_tokens: int
+        self,
+        *,
+        query_tokens: int,
+        cache_tokens: int,
+        position_ids: Any = None,
     ) -> bool:
-        """Predict the Qwen4 text-prefill route for one concrete chunk."""
-        if text_only is not True:
-            return False
+        """Predict the Qwen4 prefill route for one concrete chunk.
+
+        Mirrors the runtime gate ``_gathered_text_prefill_eligible``: the
+        shared query/cache budget predicate plus the mRoPE plane test.
+        Callers that know the chunk's position_ids (the external VLM prefill
+        loop slices them from ``vlm_extra_kwargs``) pass them so image-region
+        chunks stay dense-priced; callers without them (admission) assume a
+        text chunk. The mid-prefill guard re-prices every real chunk with
+        its actual position_ids, so an image-bearing tail is still caught
+        before Metal sees it.
+        """
         monitor = getattr(self, "memory_monitor", None)
         checker = getattr(monitor, "qwen4_gathered_prefill_route", None)
-        return callable(checker) and checker(query_tokens, cache_tokens) is True
+        if not (callable(checker) and checker(query_tokens, cache_tokens) is True):
+            return False
+        if position_ids is None or qwen4_text_mrope_broadcast is None:
+            return True
+        return qwen4_text_mrope_broadcast(position_ids, query_tokens) is True
 
     @staticmethod
     def _qwen4_actual_gathered_pricing(
@@ -3658,6 +3676,20 @@ class Scheduler:
         )
 
         Scheduler._announce_first_prefill_chunk(self, input_arr, base_size, boundary_enabled, block_size, embeds_array)
+
+        def _chunk_route(n_tokens: int, cache_tokens: int) -> bool:
+            # Price the exact chunk execution will run: the shared
+            # query/cache predicate plus the chunk's mRoPE plane test when
+            # the VLM pipeline supplies position_ids. Image-region chunks
+            # have differing planes and stay dense-priced; text chunks
+            # gather, with or without images elsewhere in the prompt.
+            sliced = _slice_vlm_extra(extra_kwargs, n_tokens) if extra_kwargs else {}
+            return self._qwen4_text_gathered_pricing(
+                query_tokens=n_tokens,
+                cache_tokens=cache_tokens,
+                position_ids=sliced.get("position_ids"),
+            )
+
         while input_arr.shape[1] > 0:
             _trace_chunk_start = time.perf_counter()
             _trace_processed_before = processed_tokens
@@ -3679,11 +3711,7 @@ class Scheduler:
                 )
 
             cache_tokens = base_size + processed_tokens
-            gathered_core = self._qwen4_text_gathered_pricing(
-                vlm_embeds is None,
-                query_tokens=n_to_process,
-                cache_tokens=cache_tokens,
-            )
+            gathered_core = _chunk_route(n_to_process, cache_tokens)
             try:
                 n_to_process = self._adaptive_chunk_size(
                     n_to_process,
@@ -3692,11 +3720,7 @@ class Scheduler:
                     kv_len=cache_tokens,
                     gathered_core=gathered_core,
                 )
-                gathered_core = self._qwen4_text_gathered_pricing(
-                    vlm_embeds is None,
-                    query_tokens=n_to_process,
-                    cache_tokens=cache_tokens,
-                )
+                gathered_core = _chunk_route(n_to_process, cache_tokens)
                 # Check the predicted peak before submitting work to Metal.
                 n_to_process = self._guard_prefill_chunk(
                     n_to_process,
@@ -3706,11 +3730,7 @@ class Scheduler:
                     request_id=request.request_id,
                     gathered_core=gathered_core,
                 )
-                final_route = self._qwen4_text_gathered_pricing(
-                    vlm_embeds is None,
-                    query_tokens=n_to_process,
-                    cache_tokens=cache_tokens,
-                )
+                final_route = _chunk_route(n_to_process, cache_tokens)
                 if final_route != gathered_core:
                     gathered_core = final_route
                     n_to_process = self._guard_prefill_chunk(
@@ -5528,7 +5548,7 @@ class Scheduler:
 
         def qwen4_route(query_tokens: int) -> bool:
             return qwen4_accounting and self._qwen4_text_gathered_pricing(
-                True, query_tokens=query_tokens, cache_tokens=cache_tokens
+                query_tokens=query_tokens, cache_tokens=cache_tokens
             )
 
         gathered_core = qwen4_route(n)
@@ -8931,7 +8951,6 @@ class Scheduler:
                     num_prompt_tokens=request.num_prompt_tokens,
                     cached_tokens=request.cached_tokens or 0,
                     request_id=request.request_id,
-                    text_only=getattr(request, "vlm_inputs_embeds", None) is None,
                 )
             except Exception:
                 self._release_paged_cache_for_request(request.request_id)
@@ -10192,7 +10211,6 @@ class Scheduler:
             num_prompt_tokens=prompt_tokens,
             cached_tokens=cached_tokens,
             current=current,
-            text_only=getattr(request, "vlm_inputs_embeds", None) is None,
         )
         if est is None:
             return None  # can't estimate, skip
@@ -10251,7 +10269,6 @@ class Scheduler:
         num_prompt_tokens: int,
         cached_tokens: int,
         current: int,
-        text_only: bool = False,
     ) -> _AdmissionEstimate | None:
         """Deterministic admission estimate shared by every preflight path.
 
@@ -10305,7 +10322,7 @@ class Scheduler:
             monitor.estimate_resident_kv_bytes(new_tokens, chunk_tokens=floor_chunk)
         )
         gathered_core = self._qwen4_text_gathered_pricing(
-            text_only, query_tokens=floor_chunk, cache_tokens=kv_len
+            query_tokens=floor_chunk, cache_tokens=kv_len
         )
         transient = int(
             self._admission_transient_bound(
@@ -10370,7 +10387,6 @@ class Scheduler:
         num_prompt_tokens: int,
         cached_tokens: int = 0,
         request_id: str | None = None,
-        text_only: bool = False,
     ) -> None:
         """Pre-StreamingResponse prefill memory check.
 
@@ -10396,7 +10412,6 @@ class Scheduler:
             num_prompt_tokens=num_prompt_tokens,
             cached_tokens=cached_tokens,
             current=current,
-            text_only=text_only,
         )
         if est is None:
             return
@@ -10457,7 +10472,6 @@ class Scheduler:
         num_prompt_tokens: int,
         cached_tokens: int = 0,
         request_id: str | None = None,
-        text_only: bool = False,
     ) -> PrefillEvictionRequest | None:
         """Return an idle-model eviction request for route-level preflight.
 
@@ -10481,7 +10495,6 @@ class Scheduler:
             num_prompt_tokens=num_prompt_tokens,
             cached_tokens=cached_tokens,
             current=current,
-            text_only=text_only,
         )
         if est is None:
             return None

--- a/tests/test_context_benchmark.py
+++ b/tests/test_context_benchmark.py
@@ -167,7 +167,6 @@ class _FakeScheduler:
         num_prompt_tokens,
         cached_tokens=0,
         request_id=None,
-        text_only=False,
     ):
         if num_prompt_tokens > self.boundary:
             raise PrefillMemoryExceededError(

--- a/tests/test_engine_preflight.py
+++ b/tests/test_engine_preflight.py
@@ -181,12 +181,10 @@ async def test_batched_engine_preflight_runs_eviction_before_final_check():
     scheduler.preflight_eviction_request.assert_called_once_with(
         num_prompt_tokens=123,
         request_id="req-evict",
-        text_only=True,
     )
     scheduler.preflight_or_raise.assert_called_once_with(
         num_prompt_tokens=123,
         request_id="req-evict",
-        text_only=True,
     )
     assert order == [("evict", "req-evict"), ("final", "checked")]
 
@@ -231,7 +229,6 @@ async def test_batched_engine_retries_transient_rejection_after_cleanup(monkeypa
     scheduler.preflight_or_raise.assert_called_once_with(
         num_prompt_tokens=60_000,
         request_id="req-next",
-        text_only=True,
     )
     evict.assert_not_awaited()
 

--- a/tests/test_prefill_oom_graceful.py
+++ b/tests/test_prefill_oom_graceful.py
@@ -1546,7 +1546,7 @@ def test_prefill_loop_records_pool_release_before_next_chunk(chunked, monkeypatc
     original_adaptive = ns._adaptive_chunk_size
 
     def adaptive(n, **kwargs):
-        charges.append(ns._prefill_transient_tracker.flat_overhead_charge_for(True))
+        charges.append(ns._prefill_transient_tracker.flat_overhead_charge_for(False))
         return original_adaptive(n, **kwargs)
 
     ns._adaptive_chunk_size = adaptive

--- a/tests/test_scheduler_prefill_memory_guard.py
+++ b/tests/test_scheduler_prefill_memory_guard.py
@@ -1044,8 +1044,19 @@ def test_qwen4_text_admission_uses_gathered_transient():
     assert dense is not None and gathered is not None
     assert gathered.kv_exact == dense.kv_exact
     assert gathered.transient * 4 < dense.transient
-    assert scheduler._qwen4_text_gathered_pricing(True) is True
-    assert scheduler._qwen4_text_gathered_pricing(False) is False
+
+
+def test_qwen4_pricing_tracks_execution_route(monkeypatch):
+    monkeypatch.delenv("OMLX_QWEN4_GATHERED_MIN_QUERY", raising=False)
+    scheduler = _make_scheduler()
+    _attach_qwen4_profile(scheduler)
+    route = scheduler._qwen4_text_gathered_pricing
+
+    assert route(True, query_tokens=2048, cache_tokens=0) is False
+    assert route(True, query_tokens=2048, cache_tokens=2048) is True
+    assert route(True, query_tokens=15, cache_tokens=2048) is False
+    assert route(True, query_tokens=16, cache_tokens=2048) is True
+    assert route(False, query_tokens=2048, cache_tokens=2048) is False
 
 
 def test_qwen4_preflight_doors_use_gathered_for_text_only():

--- a/tests/test_scheduler_prefill_memory_guard.py
+++ b/tests/test_scheduler_prefill_memory_guard.py
@@ -1025,25 +1025,29 @@ def _attach_qwen4_profile(scheduler: Scheduler) -> None:
     )
 
 
-def test_qwen4_text_admission_uses_gathered_transient():
+def test_qwen4_admission_prices_the_gathered_route():
+    """Admission prices the floor chunk by the shared execution predicate.
+
+    Execution gathers every text chunk, with or without images elsewhere in
+    the prompt, so the request's media type must not change the admission
+    price. Image-region chunks are re-priced exactly by the per-chunk guard,
+    which sees each real chunk's mRoPE position_ids.
+    """
     scheduler = _make_scheduler()
     _attach_qwen4_profile(scheduler)
     current = 147 * 1024**3
-    dense = scheduler._admission_estimate(
+    est = scheduler._admission_estimate(
         num_prompt_tokens=233_472,
         cached_tokens=0,
         current=current,
-        text_only=False,
     )
-    gathered = scheduler._admission_estimate(
-        num_prompt_tokens=233_472,
-        cached_tokens=0,
-        current=current,
-        text_only=True,
+    assert est is not None
+    assert est.kv_exact > 0
+    assert est.transient == int(
+        scheduler._admission_transient_bound(
+            est.floor_chunk, est.kv_len, gathered_core=True
+        )
     )
-    assert dense is not None and gathered is not None
-    assert gathered.kv_exact == dense.kv_exact
-    assert gathered.transient * 4 < dense.transient
 
 
 def test_qwen4_pricing_tracks_execution_route(monkeypatch):
@@ -1052,76 +1056,66 @@ def test_qwen4_pricing_tracks_execution_route(monkeypatch):
     _attach_qwen4_profile(scheduler)
     route = scheduler._qwen4_text_gathered_pricing
 
-    assert route(True, query_tokens=2048, cache_tokens=0) is False
-    assert route(True, query_tokens=2048, cache_tokens=2048) is True
-    assert route(True, query_tokens=15, cache_tokens=2048) is False
-    assert route(True, query_tokens=16, cache_tokens=2048) is True
-    assert route(False, query_tokens=2048, cache_tokens=2048) is False
+    assert route(query_tokens=2048, cache_tokens=0) is False
+    assert route(query_tokens=2048, cache_tokens=2048) is True
+    assert route(query_tokens=15, cache_tokens=2048) is False
+    assert route(query_tokens=16, cache_tokens=2048) is True
+
+    # Without position info the chunk is assumed text: execution gathers it.
+    assert route(query_tokens=2048, cache_tokens=2048) is True
+
+    # VLM text chunks (broadcast-identical mRoPE planes) gather exactly like
+    # execution; image-region chunks (differing planes) stay dense-priced.
+    n = 32
+    equal = mx.zeros((3, 1, n), dtype=mx.int64)
+    differing = mx.zeros((3, 1, n), dtype=mx.int64)
+    differing[2] = differing[2] + 1
+    assert route(query_tokens=n, cache_tokens=2048, position_ids=equal) is True
+    assert route(query_tokens=n, cache_tokens=2048, position_ids=differing) is False
 
 
-def test_qwen4_preflight_doors_use_gathered_for_text_only():
+def test_qwen4_preflight_doors_admit_at_the_gathered_price():
     scheduler = _make_scheduler()
     _attach_qwen4_profile(scheduler)
     scheduler._prefill_memory_guard = True
     current = 147 * 1024**3
-    dense = scheduler._admission_estimate(
+    est = scheduler._admission_estimate(
         num_prompt_tokens=233_472,
         cached_tokens=0,
         current=current,
-        text_only=False,
     )
-    gathered = scheduler._admission_estimate(
-        num_prompt_tokens=233_472,
-        cached_tokens=0,
-        current=current,
-        text_only=True,
-    )
-    assert dense is not None and gathered is not None
-    cap = (dense.estimated + gathered.estimated) // 2
-    scheduler._memory_hard_limit_bytes = cap
+    assert est is not None
+    scheduler._memory_hard_limit_bytes = current + est.estimated
     scheduler._memory_abort_limit_bytes = 10**18
     with (
         patch("omlx.scheduler.mx.get_active_memory", return_value=current),
         patch("omlx.scheduler.get_phys_footprint", return_value=current),
     ):
-        with pytest.raises(PrefillMemoryExceededError):
-            scheduler.preflight_or_raise(
-                num_prompt_tokens=233_472, text_only=False
-            )
-        scheduler.preflight_or_raise(num_prompt_tokens=233_472, text_only=True)
+        scheduler.preflight_or_raise(num_prompt_tokens=233_472)
         assert (
-            scheduler.preflight_eviction_request(
-                num_prompt_tokens=233_472, text_only=True
-            )
+            scheduler.preflight_eviction_request(num_prompt_tokens=233_472)
             is None
         )
-        assert (
-            scheduler.preflight_eviction_request(
-                num_prompt_tokens=233_472, text_only=False
-            )
-            is not None
-        )
 
 
-def test_qwen4_image_request_preflight_stays_dense():
+def test_qwen4_image_request_preflight_admits_at_gathered_price():
+    """Image-bearing requests admit at the gathered price.
+
+    Their text chunks execute gathered; the mid-prefill guard prices the
+    actual image-region chunks dense via their mRoPE position_ids (covered
+    by test_qwen4_pricing_tracks_execution_route).
+    """
     scheduler = _make_scheduler()
     _attach_qwen4_profile(scheduler)
     scheduler._prefill_memory_guard = True
     current = 147 * 1024**3
-    dense = scheduler._admission_estimate(
+    est = scheduler._admission_estimate(
         num_prompt_tokens=233_472,
         cached_tokens=0,
         current=current,
-        text_only=False,
     )
-    gathered = scheduler._admission_estimate(
-        num_prompt_tokens=233_472,
-        cached_tokens=0,
-        current=current,
-        text_only=True,
-    )
-    assert dense is not None and gathered is not None
-    scheduler._memory_hard_limit_bytes = (dense.estimated + gathered.estimated) // 2
+    assert est is not None
+    scheduler._memory_hard_limit_bytes = current + est.estimated
     scheduler._memory_abort_limit_bytes = 10**18
     request = _make_request(233_472)
     request.vlm_inputs_embeds = object()
@@ -1130,4 +1124,4 @@ def test_qwen4_image_request_preflight_stays_dense():
         patch("omlx.scheduler.get_phys_footprint", return_value=current),
     ):
         rejection = scheduler._preflight_memory_check(request)
-    assert rejection is not None
+    assert rejection is None

--- a/tests/test_scheduler_prefill_memory_guard.py
+++ b/tests/test_scheduler_prefill_memory_guard.py
@@ -1051,6 +1051,14 @@ def test_qwen4_admission_prices_the_gathered_route():
 
 
 def test_qwen4_pricing_tracks_execution_route(monkeypatch):
+    from omlx.patches import mlx_vlm_qwen4_exp_compat as compat
+
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models.qwen4_exp.language import (
+        QSAKVCache,
+        QSAQuantizedKVCache,
+    )
+
     monkeypatch.delenv("OMLX_QWEN4_GATHERED_MIN_QUERY", raising=False)
     scheduler = _make_scheduler()
     _attach_qwen4_profile(scheduler)
@@ -1072,6 +1080,21 @@ def test_qwen4_pricing_tracks_execution_route(monkeypatch):
     differing[2] = differing[2] + 1
     assert route(query_tokens=n, cache_tokens=2048, position_ids=equal) is True
     assert route(query_tokens=n, cache_tokens=2048, position_ids=differing) is False
+
+    # Runtime requires the exact floating-point QSA cache type. Quantized QSA
+    # caches use the official dense path and must be priced that way before it runs.
+    assert route(
+        query_tokens=n,
+        cache_tokens=2048,
+        position_ids=equal,
+        prompt_cache=[QSAKVCache()],
+    ) is True
+    assert route(
+        query_tokens=n,
+        cache_tokens=2048,
+        position_ids=equal,
+        prompt_cache=[QSAQuantizedKVCache()],
+    ) is False
 
 
 def test_qwen4_preflight_doors_admit_at_the_gathered_price():


### PR DESCRIPTION
## Summary

Qwen4-exp prefill execution chooses between mask-dense and gathered QSA from the concrete chunk shape:

- gathered QSA requires `query_tokens >= OMLX_QWEN4_GATHERED_MIN_QUERY` (16 by default);
- sparse selection must reduce work: `cache_tokens + query_tokens > indexer_budget`;
- image-region chunks stay mask-dense: their mRoPE position planes differ, text chunks have broadcast-identical planes.

The scheduler instead priced every text-only Qwen4 request as gathered and every image-bearing request as mask-dense — regardless of what execution does per chunk. A long agent session with images in history was rejected by the preflight guard because of it: its text chunks executed gathered, but admission charged the dense route's flat-overhead ledger (~31 GB from one real dense chunk) and predicted ~109.8 GB against a 109.4 GB cap.

This PR shares the route predicate between execution and memory pricing, reevaluates it after chunk resizing, mirrors the mRoPE plane test so VLM text chunks price gathered while image-region chunks stay dense, and preserves the existing runtime marker correction as a safety net.

## Commit scope

- `53db88e8` adds the deterministic route-accounting regression.
- `c792e03f` shares the query/cache route predicate and recomputes pricing through admission, adaptive sizing, the safety guard, chunked prefill, and restored-prefix handling.
- `a683e02c` mirrors the runtime mRoPE plane test for concrete VLM chunks and removes the obsolete request-level `text_only` preflight signal from scheduler, engine, and context-benchmark call paths.
- `d6b122f3` mirrors runtime's exact `QSAKVCache` type gate so quantized QSA caches are dense-priced before execution, adds regression coverage, and finishes stale test/benchmark signature cleanup.

## Before

For the default 2,048-token indexer budget, the first cold 2,048-token chunk was priced as gathered even though execution used mask-dense:

```text
query=2048, cache=0     scheduler=gathered, execution=mask_dense
query=2048, cache=2048  scheduler=gathered, execution=gathered
```

Adaptive or guard-driven reductions below the 16-token gathered-query floor created the same mismatch at high context. The scheduler also retained the previous chunk's route in chunked prefill rather than predicting each new chunk, and restored prefixes could be omitted from route prediction when boundary snapshots were disabled.

In the other direction, any image-bearing conversation was priced mask-dense everywhere — admission, the throttle, and the guard — even though execution gathers its text chunks (`predicted=mask_dense actual=gathered` on every logged chunk of a 215k-token session). The post-execution marker corrected attribution only after the model call, so admission kept charging the dense ledger.

## After

- `qwen4_gathered_prefill_route()` is the shared execution/pricing predicate for query width, cache length, configured minimum width, and indexer budget.
- Admission prices its actual floor chunk and pre-chunk KV length by the shared predicate alone; the request's media type no longer changes the price.
- External prefill prices each concrete chunk with its sliced mRoPE `position_ids` and concrete cache types: broadcast-identical planes (text) gather only with exact `QSAKVCache` instances, while image-region chunks and `QSAQuantizedKVCache` stay dense-priced — mirroring `_gathered_text_prefill_eligible`.
- Chunked prefill predicts the route for every concrete chunk (text-only by construction).
- Route pricing is recomputed after adaptive sizing and again after the safety guard. If the guard crosses a route boundary, it runs once more using the corrected memory regime.
- Restored-prefix token counts participate even when boundary snapshots are disabled.
- Existing `_omlx_last_prefill_gathered` markers still verify the executed route and correct attribution if another structural eligibility condition differs.

The mid-prefill guard re-prices every real chunk with its actual `position_ids` and cache types, so image-bearing tails and quantized QSA caches are caught before Metal sees them even though admission assumes a text tail.

No HTTP API or setting changes. The removed `text_only` argument was internal preflight plumbing superseded by concrete per-chunk route prediction. `OMLX_QWEN4_GATHERED_MIN_QUERY` keeps its existing behavior.

## Runtime validation

The real-model A/B below was run on `origin/main` (`aa8db734`) and the then-current PR head `c792e03f`. Both used the same donor environment, model, server settings, fresh temporary cache/base directories, and prompt sequence. Both ad-hoc signatures verified successfully; the PR bundle's embedded source contained the shared predicate. The later VLM/cache-type follow-ups are covered by the current-head unit suite and targeted rebuilt-bundle check under **Tests**.

### Identical cold-prefill comparison

The workload starts with a prefix-cache miss and a **13,309-token** Qwen4-exp prompt. Its first two 2,048-token chunks cross the sparse-budget boundary exactly.

On `origin/main`, the same request produced both correction directions on consecutive chunks:

```text
predicted=gathered actual=mask_dense query=2048 kv_len=0
predicted=mask_dense actual=gathered query=2048 kv_len=2048
```

On PR head, the request produced **zero** `Qwen4 prefill pricing route corrected after execution` messages. Correction count for this identical workload fell from **2 to 0 (100%)**: the first chunk was predicted mask-dense, and the next chunk was predicted gathered, matching execution as cache state evolved. Later adaptively reduced chunks also produced no corrections.

Cold-prefill completion time was **17.19 seconds on main** and **18.29 seconds on PR head**, excluding model load. This single run shows no material throughput change; it is not used to claim a latency improvement.

### Identical cached-prefix continuation

Both follow-up requests contained **13,351 prompt tokens** and reused **12,288 tokens** from six 2,048-token blocks:

```text
paged cache hit, 12288 tokens in 6 blocks, 1063 tokens remaining, cache reconstructed
... served cached_tokens=12288, prompt=13351
```

Continuation time was **2.13 seconds on main** and **2.06 seconds on PR head**. PR head again produced zero route corrections, verifying that restored-prefix length participates in route prediction in the built application.

No OOM occurred in either run; that is a secondary safety observation, not the purpose of this fix. **Concurrent-prefill behavior was not validated**, so this PR makes no concurrency or queue-throughput claim.

## Reproduce

The first commit contains only the deterministic regression:

```bash
git checkout 53db88e8
MLX_ENABLE_TF32=0 python -m pytest -q \
  tests/test_scheduler_prefill_memory_guard.py::test_qwen4_pricing_tracks_execution_route
```

Before the implementation, it fails because `_qwen4_text_gathered_pricing()` accepts only `text_only` and cannot represent the query/cache threshold that execution uses:

```text
TypeError: Scheduler._qwen4_text_gathered_pricing() got an unexpected keyword argument 'query_tokens'
```

At PR head:

```bash
git checkout d6b122f3
MLX_ENABLE_TF32=0 python -m pytest -q \
  tests/test_scheduler_prefill_memory_guard.py::test_qwen4_pricing_tracks_execution_route
```

The test passes and explicitly covers:

- dense at `query=2048, cache=0, budget=2048`;
- gathered at `query=2048, cache=2048`;
- dense below the default 16-token query floor;
- gathered at the 16-token floor;
- gathered for broadcast-identical mRoPE planes (VLM text chunks);
- dense for differing mRoPE planes (image-region chunks);
- gathered for exact `QSAKVCache` and dense for `QSAQuantizedKVCache`.

## Tests

Key coverage:

```bash
MLX_ENABLE_TF32=0 python -m pytest -q \
  tests/test_scheduler_prefill_memory_guard.py \
  tests/test_qwen4_qsa_decode_gather.py \
  tests/test_qwen4_qsa_prefill_memory.py \
  tests/test_prefill_oom_graceful.py \
  tests/test_server_prefill_memory_handler.py \
  tests/test_mlx_vlm_qwen4_exp_compat.py \
  tests/test_qwen4_qsa_reserved_capacity.py \
  tests/test_qwen4_qsa_reservation_integration.py \
  tests/test_scheduler_chunked_prefill.py
```

Coverage includes admission estimates, external and chunked prefill, adaptive/guard sizing, route-local transient/reclaim accounting, QSA execution compatibility, cache markers, mRoPE plane pricing, and restored-prefix reservation.

Validation:

- Unit suite at PR head `d6b122f3`: **10,717 passed, 150 skipped, 19 deselected** with `MLX_ENABLE_TF32=0` (integration tests excluded).
- Focused scheduler/prefill/engine coverage: **233 passed**.
- Freshly rebuilt and ad-hoc-signed PR app bundle directly imported its embedded `omlx` package and confirmed exact `QSAKVCache` prices gathered while `QSAQuantizedKVCache` prices dense.
- Identical real-model built-app workload at `c792e03f`: route corrections fell from **2 on main to 0 on the tested PR head**; cached continuation behavior was unchanged.
- Concurrent-prefill behavior was not validated.
- `codesign --verify --deep --strict` passed for the rebuilt bundle.
- `git diff --check` clean.



