### PR TITLE
fix(eval): stop a comma from swallowing the GSM8K answer

### DIFF
--- a/omlx/eval/gsm8k.py
+++ b/omlx/eval/gsm8k.py
@@ -43,16 +43,23 @@ FEW_SHOT_EXAMPLES = [
 ]
 
 
+# A number, with optional thousands separators. The digit anchors at both
+# ends matter: ``[\d,]+`` alone also matches a bare comma, so punctuation
+# after the final digit ("the answer is 18, which is the total") became the
+# last "number" in the text and extraction returned an empty string.
+_NUMBER_PATTERN = r"-?\d(?:[\d,]*\d)?(?:\.\d+)?"
+
+
 def _extract_numeric_answer(text: str) -> str:
     """Extract the final numeric answer from a GSM8K-style response.
 
     Looks for #### pattern first, then falls back to the last number.
     """
-    match = re.search(r"####\s*(-?[\d,]+(?:\.\d+)?)", text)
+    match = re.search(rf"####\s*({_NUMBER_PATTERN})", text)
     if match:
         return match.group(1).replace(",", "")
 
-    numbers = re.findall(r"-?[\d,]+(?:\.\d+)?", text)
+    numbers = re.findall(_NUMBER_PATTERN, text)
     if numbers:
         return numbers[-1].replace(",", "")
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -156,6 +156,23 @@ class TestGSM8K:
         assert _extract_numeric_answer("The answer is 42.") == "42"
         assert _extract_numeric_answer("She has 15 apples and 20 oranges, so 35 total.") == "35"
 
+    def test_extract_numeric_answer_trailing_comma_after_last_number(self):
+        # A bare "," is not a number: punctuation after the final digit must
+        # not become the extracted answer.
+        assert _extract_numeric_answer("The total is 72 clips, altogether.") == "72"
+        assert (
+            _extract_numeric_answer("Thus, the answer is 18, which is the total.")
+            == "18"
+        )
+        assert _extract_numeric_answer("He gave away 8 lollipops,") == "8"
+
+    def test_extract_numeric_answer_keeps_thousands_separator(self):
+        assert _extract_numeric_answer("The final total is 1,234 dollars.") == "1234"
+        assert _extract_numeric_answer("That comes to 1,234.50, in the end.") == "1234.50"
+
+    def test_extract_numeric_answer_commas_only(self):
+        assert _extract_numeric_answer("Well, hmm, no idea,") == ""
+
     def test_extract_numeric_answer_empty(self):
         assert _extract_numeric_answer("I don't know") == ""
         assert _extract_numeric_answer("") == ""


### PR DESCRIPTION
## Summary

GSM8K scores a correct answer as wrong whenever the model's last sentence puts a comma after the final number. `_extract_numeric_answer` returns an empty string instead of the number, `check_answer` short-circuits on the empty prediction, and the question is counted wrong (the external-API path reports it as `parse_error`).

```
>>> from omlx.eval.gsm8k import _extract_numeric_answer
>>> _extract_numeric_answer("The total is 72 clips, altogether.")
''
```

## Root cause

`omlx/eval/gsm8k.py:55`. When the response has no `#### N` marker, extraction falls back to the last number in the text:

```python
numbers = re.findall(r"-?[\d,]+(?:\.\d+)?", text)
if numbers:
    return numbers[-1].replace(",", "")
```

`[\d,]+` needs only one character from the class, so a bare `,` is a match. On `"The total is 72 clips, altogether."` findall returns `['72', ',']`; the last element is the comma, and `.replace(",", "")` turns it into `""`. The number is right there in the text, and the function reports that it found nothing.

The `####` branch at line 51 uses the same class and has the same hole (`#### ,` captures a comma).

## Fix

Anchor the pattern on a digit at both ends and share it between the two branches:

```python
_NUMBER_PATTERN = r"-?\d(?:[\d,]*\d)?(?:\.\d+)?"
```

Thousands separators still match, because they sit between digits: `1,234` and `1,234.50` are unchanged. `72,` now matches just `72`. A lone comma matches nothing, so it can no longer become the "last number".

## Verification

`tests/test_eval.py::TestGSM8K` gains three cases. Red on `main` at aa8db73, green with the change:

```
$ python -m pytest tests/test_eval.py -k TestGSM8K -q      # on main + the new tests
FAILED tests/test_eval.py::TestGSM8K::test_extract_numeric_answer_trailing_comma_after_last_number
  assert '' == '72'
FAILED tests/test_eval.py::TestGSM8K::test_extract_numeric_answer_keeps_thousands_separator
  assert '' == '1234.50'
2 failed, 9 passed

$ python -m pytest tests/test_eval.py -q                   # with the change
84 passed in 5.72s
```

Scoring keys are untouched: I ran both the old and the new extractor over all 1,319 gold answers in `omlx/eval/data/gsm8k_test.jsonl` and every one of them extracts the same value (they all carry `#### N`, so they never reached the fallback).

Adjacent suites: `pytest tests/test_eval.py tests/test_mbpp_extract_code.py tests/test_accuracy_benchmark.py tests/test_accuracy_upload.py tests/test_admin_external_accuracy_diagnostics.py` gives 155 passed.

Full suite with the CI filter, `pytest tests/ -m "not slow and not integration" -n 2` on an M-series Mac with Python 3.11.15: 10807 passed, 176 skipped, 0 failed in 5m30s.

`ruff check` and `black --check` report the same findings on this file before and after the change (one pre-existing `UP045` in `get_category`, and black wants to reformat an untouched dict literal in `load_dataset`), so nothing new was introduced.
