### PR TITLE
fix(scheduler): yield between contended prefill chunks

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -3842,6 +3842,8 @@ class Scheduler:
 
             # Reclaim Metal intermediates between prefill chunks.
             Scheduler._clear_cache(self)
+            if vlm_embeds is None:
+                self._accrue_decode_debt(time.perf_counter() - _trace_chunk_start)
             if getattr(request, "benchmark_trace", False):
                 _trace_total_ms = (
                     time.perf_counter() - _trace_chunk_start
@@ -5743,12 +5745,12 @@ class Scheduler:
         scheduled: "list[Request]",
         rejected: "list[RequestOutput]",
     ) -> None:
-        """Process one prefill chunk per in-flight chunked-prefill request.
+        """Advance in-flight prefills until decode fairness requires a yield.
 
         Called at the start of each step() before _schedule_waiting(). Each
-        call advances every request in self.prefilling by one prefill_step_size
-        chunk. When a request's prefill completes it is inserted into
-        BatchGenerator and moved to self.running.
+        request advances by at most one chunk. Deferred requests precede
+        already-advanced requests in the next round. Completed prefills are
+        inserted into BatchGenerator and moved to self.running.
 
         Args:
             scheduled: The step's running list of newly-scheduled requests;
@@ -5771,6 +5773,10 @@ class Scheduler:
             # _do_abort_request() between steps — just skip it.
             if state is None:
                 continue
+
+            if not self._prefill_gate_open():
+                still_prefilling.extendleft(reversed(pending_prefills[index:]))
+                break
 
             try:
                 done = self._step_prefill_chunk(state)
@@ -10414,10 +10420,7 @@ class Scheduler:
             # admissions. This is also the per-step admission budget —
             # prefills can no longer chain back-to-back inside one step
             # while decodes wait.
-            if self._decode_fairness and (
-                (self.running and self._decode_time_owed_s > 0.0)
-                or time.perf_counter() < self._prefill_hold_deadline()
-            ):
+            if not self._prefill_gate_open():
                 break
 
             # Store-cache backpressure: when the post-completion pipeline is

--- a/tests/test_prefill_fairness_budget.py
+++ b/tests/test_prefill_fairness_budget.py
@@ -1,0 +1,292 @@
+"""Regressions for sharing decode time between consecutive prefill forwards."""
+
+from itertools import count
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import mlx.core as mx
+import pytest
+
+from omlx.decode_activity import get_decode_activity
+from omlx.prefill_progress import get_prefill_tracker
+from omlx.request import Request, SamplingParams
+from omlx.scheduler import (
+    Scheduler,
+    SchedulerConfig,
+    _PrefillAbortedError,
+    _PrefillState,
+)
+
+
+@pytest.fixture(autouse=True)
+def isolated_activity():
+    get_decode_activity().clear()
+    get_prefill_tracker().clear()
+    with patch("omlx.scheduler._sync_and_clear_cache"):
+        yield
+    get_decode_activity().clear()
+    get_prefill_tracker().clear()
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    current = SimpleNamespace(now=100.0)
+    monkeypatch.setattr("omlx.scheduler.time.perf_counter", lambda: current.now)
+    return current
+
+
+def make_scheduler(**settings) -> Scheduler:
+    model = MagicMock()
+    model.layers = []
+    tokenizer = MagicMock()
+    tokenizer.eos_token_id = 2
+    config = SchedulerConfig(
+        **{
+            "max_num_seqs": 8,
+            "prefill_step_size": 4,
+            "chunked_prefill": True,
+            "paged_cache_block_size": 0,
+            **settings,
+        }
+    )
+    scheduler = Scheduler(model=model, tokenizer=tokenizer, config=config)
+    batch_generator = MagicMock()
+    next_uid = count(42)
+    batch_generator.insert.side_effect = lambda *args, **kwargs: [next(next_uid)]
+    batch_generator.next_generated.return_value = iter([])
+    scheduler.batch_generator = batch_generator
+    scheduler._current_sampler_params = ()
+    return scheduler
+
+
+def make_request(request_id: str, token_count: int = 20) -> Request:
+    tokens = list(range(token_count))
+    request = Request(
+        request_id=request_id,
+        prompt=tokens,
+        sampling_params=SamplingParams(max_tokens=32),
+    )
+    request.prompt_token_ids = tokens
+    request.num_prompt_tokens = len(tokens)
+    request.remaining_tokens = tokens
+    return request
+
+
+def add_prefill(scheduler: Scheduler, request_id: str) -> Request:
+    request = make_request(request_id)
+    scheduler.requests[request_id] = request
+    scheduler.prefilling.append(request)
+    scheduler._prefill_states[request_id] = _PrefillState(
+        request=request,
+        cache=[],
+        tokens_remaining=mx.zeros((1, request.num_prompt_tokens - 1), dtype=mx.int32),
+        last_token=request.prompt_token_ids[-1:],
+        tokens_processed=0,
+        base_size=0,
+        emitted_boundaries={},
+        boundary_enabled=False,
+        block_size=0,
+        total_length=request.num_prompt_tokens,
+        sampler=MagicMock(),
+        sm=MagicMock(),
+        per_row_lps=[],
+    )
+    return request
+
+
+def prefill_ids(scheduler: Scheduler) -> list[str]:
+    return [request.request_id for request in scheduler.prefilling]
+
+
+def test_each_forward_rechecks_debt_and_rotates_without_starvation():
+    scheduler = make_scheduler()
+    scheduler.running["decoder"] = make_request("decoder")
+    request_ids = ["prefill-a", "prefill-b", "prefill-c"]
+    for request_id in request_ids:
+        add_prefill(scheduler, request_id)
+    advanced = []
+
+    def advance(state):
+        advanced.append(state.request.request_id)
+        scheduler._accrue_decode_debt(0.5)
+        return False
+
+    with patch.object(scheduler, "_step_prefill_chunk", side_effect=advance):
+        for turn, request_id in enumerate(request_ids * 2):
+            scheduler._advance_chunked_prefills([], [])
+            assert advanced == (request_ids * 2)[: turn + 1]
+            assert prefill_ids(scheduler)[-1] == request_id
+            assert scheduler._decode_time_owed_s > 0
+            scheduler._advance_chunked_prefills([], [])
+            assert len(advanced) == turn + 1
+            scheduler._repay_decode_debt(scheduler._decode_time_owed_s)
+
+    assert prefill_ids(scheduler) == request_ids
+
+
+def test_shared_hold_from_another_prefiller_interrupts_current_loop(clock):
+    scheduler = make_scheduler()
+    other_prefiller = make_scheduler()
+    get_decode_activity().publish("decoding-engine", 1)
+    for request_id in ("prefill-a", "prefill-b", "prefill-c"):
+        add_prefill(scheduler, request_id)
+    advanced = []
+
+    def advance(state):
+        advanced.append(state.request.request_id)
+        other_prefiller._accrue_decode_debt(0.5)
+        return False
+
+    with patch.object(scheduler, "_step_prefill_chunk", side_effect=advance):
+        scheduler._advance_chunked_prefills([], [])
+        assert advanced == ["prefill-a"]
+        assert scheduler._prefill_hold_until == 0
+        assert prefill_ids(scheduler) == ["prefill-b", "prefill-c", "prefill-a"]
+        scheduler._advance_chunked_prefills([], [])
+        assert advanced == ["prefill-a"]
+        clock.now = get_decode_activity().hold_until()
+        scheduler._advance_chunked_prefills([], [])
+
+    assert advanced == ["prefill-a", "prefill-b"]
+    assert prefill_ids(scheduler) == ["prefill-c", "prefill-a", "prefill-b"]
+
+
+@pytest.mark.parametrize(
+    ("decode_fairness", "has_decoder"), [(True, False), (False, True)]
+)
+def test_uncontended_or_disabled_fairness_keeps_advancing_all_requests(
+    decode_fairness, has_decoder
+):
+    scheduler = make_scheduler(decode_fairness=decode_fairness)
+    if has_decoder:
+        scheduler.running["decoder"] = make_request("decoder")
+    request_ids = ["prefill-a", "prefill-b", "prefill-c"]
+    for request_id in request_ids:
+        add_prefill(scheduler, request_id)
+    advanced = []
+
+    def advance(state):
+        advanced.append(state.request.request_id)
+        scheduler._accrue_decode_debt(0.5)
+        return False
+
+    with patch.object(scheduler, "_step_prefill_chunk", side_effect=advance):
+        scheduler._advance_chunked_prefills([], [])
+
+    assert advanced == request_ids
+    assert prefill_ids(scheduler) == request_ids
+    assert scheduler._decode_time_owed_s == 0
+
+
+def test_completed_request_creates_contention_for_remaining_prefills():
+    scheduler = make_scheduler()
+    completed = add_prefill(scheduler, "completed")
+    add_prefill(scheduler, "prefill-a")
+    add_prefill(scheduler, "prefill-b")
+    scheduled = []
+    rejected = []
+    advanced = []
+
+    def advance(state):
+        advanced.append(state.request.request_id)
+        scheduler._accrue_decode_debt(0.5)
+        return state.request is completed
+
+    with patch.object(scheduler, "_step_prefill_chunk", side_effect=advance):
+        scheduler._advance_chunked_prefills(scheduled, rejected)
+
+    assert advanced == ["completed", "prefill-a"]
+    assert scheduled == [completed]
+    assert rejected == []
+    assert scheduler.running == {"completed": completed}
+    assert "completed" not in scheduler._prefill_states
+    assert prefill_ids(scheduler) == ["prefill-b", "prefill-a"]
+
+
+def test_missing_and_aborted_rows_do_not_discard_waiting_prefills():
+    scheduler = make_scheduler()
+    scheduler.running["decoder"] = make_request("decoder")
+    scheduler.prefilling.append(make_request("missing"))
+    add_prefill(scheduler, "aborted")
+    add_prefill(scheduler, "prefill-a")
+    add_prefill(scheduler, "prefill-b")
+    advanced = []
+
+    def advance(state):
+        advanced.append(state.request.request_id)
+        scheduler._accrue_decode_debt(0.5)
+        if state.request.request_id == "aborted":
+            raise _PrefillAbortedError([], 4)
+        return False
+
+    with patch.object(scheduler, "_step_prefill_chunk", side_effect=advance):
+        scheduler._advance_chunked_prefills([], [])
+        assert advanced == ["aborted"]
+        assert prefill_ids(scheduler) == ["prefill-a", "prefill-b"]
+        assert "aborted" not in scheduler._prefill_states
+        scheduler._repay_decode_debt(scheduler._decode_time_owed_s)
+        scheduler._advance_chunked_prefills([], [])
+
+    assert advanced == ["aborted", "prefill-a"]
+    assert prefill_ids(scheduler) == ["prefill-b", "prefill-a"]
+
+
+def test_inflight_chunk_debt_defers_new_admission_until_decode_runs():
+    scheduler = make_scheduler()
+    scheduler.running["decoder"] = make_request("decoder")
+    add_prefill(scheduler, "inflight-a")
+    add_prefill(scheduler, "inflight-b")
+    waiting = make_request("waiting")
+    scheduler.add_request(waiting)
+    events = []
+
+    def advance(state):
+        events.append(state.request.request_id)
+        scheduler._accrue_decode_debt(0.5)
+        return False
+
+    def decode():
+        events.append("decode")
+        return iter([])
+
+    scheduler.batch_generator.next_generated.side_effect = decode
+    with (
+        patch.object(scheduler, "_step_prefill_chunk", side_effect=advance),
+        patch.object(scheduler, "_begin_prefill") as begin,
+        patch.object(scheduler, "_do_external_prefill") as external,
+    ):
+        output = scheduler.step()
+
+    assert events == ["inflight-a", "decode"]
+    assert list(scheduler.waiting) == [waiting]
+    assert output.has_work
+    begin.assert_not_called()
+    external.assert_not_called()
+
+
+def test_short_external_prefills_share_admission_debt(clock):
+    scheduler = make_scheduler()
+    scheduler.running["decoder"] = make_request("decoder")
+    requests = [make_request(request_id, 3) for request_id in ("short-a", "short-b")]
+    for request in requests:
+        scheduler.add_request(request)
+    forwarded = []
+
+    def forward(tokens, **kwargs):
+        forwarded.append(tokens.shape[1])
+        clock.now += 0.5
+
+    scheduler.model.side_effect = forward
+    with patch("omlx.scheduler.make_prompt_cache", return_value=[]):
+        scheduled, rejected = scheduler._schedule_waiting()
+        assert scheduled == [requests[0]]
+        assert rejected == []
+        assert list(scheduler.waiting) == [requests[1]]
+        assert forwarded == [2]
+        scheduler._repay_decode_debt(scheduler._decode_time_owed_s)
+        scheduled, rejected = scheduler._schedule_waiting()
+
+    assert scheduled == [requests[1]]
+    assert rejected == []
+    assert not scheduler.waiting
+    assert forwarded == [2, 2]


### PR DESCRIPTION
## Summary

Close two enforcement gaps in the existing decode-fairness policy:

1. In-flight prefills could continue executing back-to-back after an earlier chunk had accrued decode debt.
2. Non-embedding external prefills did not accrue corresponding debt, allowing consecutive short requests to bypass the intended admission pacing.

This PR reuses the existing fairness mechanism introduced in #2633. It does not introduce a new scheduling policy, implement batched prefill, or change the fairness configuration.

## Background

The decode-starvation discussion in https://github.com/jundot/omlx/issues/2031#issuecomment-5161710821 identified that `_advance_chunked_prefills()` advances one chunk for each in-flight request before returning to decode. As concurrency increases, multiple prefill chunks can therefore accumulate ahead of the next decode step.

PR #2633 introduced time-based decode debt, shared hold deadlines, and contended chunk sizing to address this class of problem.

The remaining issue addressed here is enforcement: the existing policy was not consistently observed between consecutive prefill operations.

## Problem

### The in-flight loop only had an outer fairness check

`step()` checks `_prefill_gate_open()` before calling `_advance_chunked_prefills()`. However, the latter previously continued through every in-flight prefill request without checking the gate again.

A chunk could accrue decode debt, or another engine could extend the shared hold deadline, while the current loop continued submitting more prefill work.

With a local decoder already running, the effective ordering could be:

```text
Check gate
→ prefill A
→ prefill B
→ prefill C
→ decode
```

Limiting each individual chunk does not bound the uninterrupted interval formed by several consecutive chunks.

### Short external prefills were not included in debt accounting

Short prompts can take `_do_external_prefill()` instead of the resumable chunked-prefill path.

That path did not accrue decode debt for its non-embedding prefill work. Consequently, `_schedule_waiting()` could prefill several short requests consecutively while an existing request was decoding.

## Changes

### Recheck fairness before advancing each in-flight request

Call `_prefill_gate_open()` immediately before `_step_prefill_chunk()`.

The loop now stops when newly accrued local debt or an updated shared hold requires yielding. The existing scheduler then continues to decode or observes the cross-engine hold, as appropriate.

This does not impose a fixed one-prefill/one-decode alternation. Further prefill proceeds when the existing fairness policy permits it.

### Preserve fair progress when yielding

Place the unprocessed suffix of the prefill queue ahead of requests that already advanced.

For example:

```text
Current queue: A, B, C
A advances and closes the gate
Next queue: B, C, A
```

This avoids repeatedly restarting with the same already-advanced request after each yield. Relative order is preserved within both the deferred and already-advanced portions of the queue.

The helper's docstring is updated to describe this behavior.

### Account for non-embedding external prefill

When `vlm_embeds is None`, call `_accrue_decode_debt()` after each external-prefill chunk's existing synchronization and cache cleanup, using the measured elapsed chunk time.

The next admission check can then observe the work just performed.

This does not make `_do_external_prefill()` resumable, and does not extend the new accounting to the VLM embeddings path.

### Reuse the same gate for new-request admission

Replace the duplicated debt/hold condition in `_schedule_waiting()` with `_prefill_gate_open()`.

In-flight prefill advancement and new-request admission now consult the same existing predicate instead of maintaining separate versions of the fairness check.

## Scope and compatibility

- No new configuration fields or changes to existing defaults.
- No changes to the fairness ratio or contended chunk-sizing constants.
- No batched prefill, mixed prefill/decode, or new per-step token budget.
- No changes to model kernels, sampling, KV-cache formats, memory-estimation formulas, or public APIs.
- No redesign of VLM or speculative prefill scheduling.
- With fairness disabled, all eligible in-flight requests continue advancing as before.
- Without decode contention or an applicable hold, no artificial prefill wait is introduced.

The production change is limited to the scheduler: 11 added lines and 8 removed lines, including the docstring update. The remainder of the diff adds regression tests.

## Validation

Tests were run against an isolated snapshot of the committed patch, without the separate, uncommitted batched-prefill work.

### Red/green regression check

| Revision | Test set | Result |
| --- | --- | --- |
| Parent commit `e467261e`, with the new regression tests added | 8 new cases | 6 failed, 2 passed |
| This commit `9d4b011f` | New cases and existing related suites | 112 passed |

The new cases cover:

- Rechecking local debt between chunks and rotating requests across repeated yields.
- Observing a shared hold established by another prefilling engine.
- Preserving behavior without contention and with fairness disabled.
- A completed prefill introducing decode contention during the loop.
- Missing or aborted prefill state without discarding remaining requests.
- Deferring new admission after an in-flight chunk accrues debt.
- Debt accounting across consecutive short external prefills.

## Trade-offs and limitations

This is a fairness correctness fix, not a throughput optimization claim.

Under contention, prefill completion or new-request admission may take longer because existing decode requests receive execution opportunities before additional prefill work. That is the intended trade-off.

Yielding remains cooperative: the scheduler cannot preempt an executing Metal operation. This PR does not establish a hard latency deadline or a strict GPU-time guarantee.

## Related work

- Follow-up to #2633.
- Related to the decode-starvation discussion in #2031, especially https://github.com/jundot/omlx/issues/2031#issuecomment-5161710821. Batched and mixed prefill remain outside this PR's scope.
- Related to #3209, which reports continued decode degradation during concurrent long prefill. This patch has not been validated against that issue's full workload and does not claim to resolve it completely.

> ps: I'm trying to introduce Batched prefill, and this is some preliminary work.