### PR TITLE
fix(distributed): track all-rank readiness and prevent empty stream responses

### DIFF
--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -1508,7 +1508,7 @@ raise SystemExit(2)
 
         if (
             not full_text
-            and not tool_calls
+            and not backend_tool_calls
             and finish_reason is None
             and completion_tokens == 0
         ):

--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -459,6 +459,13 @@ raise SystemExit(2)
         if endpoint is None:
             await asyncio.to_thread(self._supervisor.stop)
             raise DistributedLaunchError("distributed endpoint was not created")
+        try:
+            await asyncio.to_thread(self._require_cluster_ready)
+        except Exception:
+            await asyncio.to_thread(self._supervisor.stop)
+            self._tokenizer = None
+            self._model_type = None
+            raise
         self._client = self._new_client(endpoint)
         self._loaded = True
         logger.info(
@@ -468,6 +475,42 @@ raise SystemExit(2)
             self.deployment.backend,
             self.deployment.plan_hash[:16],
         )
+
+    def _require_cluster_ready(self) -> None:
+        """Fail fast when rank-zero or any cluster rank is not ready.
+
+        A rank can stay alive (``returncode is None``) while its HTTP listener
+        is gone or another rank lost its connection. Checking /health and
+        verifying that the supervisor observed all ranks reporting ready prevents
+        returning an empty 200 stream on dead deployments.
+        """
+        endpoint = self._supervisor.endpoint
+        if not endpoint:
+            return
+        try:
+            response = httpx.get(f"{endpoint}/health", timeout=5.0)
+            if response.status_code == 404:
+                response = httpx.get(f"{endpoint}/v1/models", timeout=5.0)
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise DistributedInferenceError(
+                "distributed rank-zero is not reachable "
+                f"({endpoint}): {type(exc).__name__}"
+            ) from exc
+
+        status = self._supervisor.status()
+        if status.returncode is not None:
+            detail = status.failure_reason or f"exit code {status.returncode}"
+            raise DistributedInferenceError(f"distributed job exited: {detail}")
+        if status.failure_reason:
+            raise DistributedInferenceError(
+                f"distributed cluster failure: {status.failure_reason}"
+            )
+        if len(status.ranks) < self.deployment.world_size:
+            raise DistributedInferenceError(
+                f"distributed cluster incomplete: {len(status.ranks)} of "
+                f"{self.deployment.world_size} ranks reported ready"
+            )
 
     def _validate_model_settings(self) -> None:
         settings = self._model_settings
@@ -1463,6 +1506,22 @@ raise SystemExit(2)
             self._mark_backend_finished(request_id)
             await self._leave_request(request_id)
 
+        if (
+            not full_text
+            and not tool_calls
+            and finish_reason is None
+            and completion_tokens == 0
+        ):
+            status = self._supervisor.status()
+            detail = status.failure_reason
+            if not detail and status.returncode is not None:
+                detail = f"distributed job exited with code {status.returncode}"
+            if not detail:
+                detail = "distributed backend closed stream without generating tokens"
+            raise DistributedInferenceError(
+                f"rank-zero inference stream failed: {detail}"
+            )
+
         pending_final_text = ""
         if reasoning_open:
             pending_final_text = "</think>"
@@ -1741,6 +1800,17 @@ raise SystemExit(2)
         finally:
             self._mark_backend_finished(request_id)
             await self._leave_request(request_id)
+
+        if not full_text and finish_reason is None and completion_tokens == 0:
+            status = self._supervisor.status()
+            detail = status.failure_reason
+            if not detail and status.returncode is not None:
+                detail = f"distributed job exited with code {status.returncode}"
+            if not detail:
+                detail = "distributed backend closed stream without generating tokens"
+            raise DistributedInferenceError(
+                f"rank-zero inference stream failed: {detail}"
+            )
 
         finished_at = time.monotonic()
         await self._record_strategy_benchmark(

--- a/tests/test_distributed_engine.py
+++ b/tests/test_distributed_engine.py
@@ -1498,3 +1498,82 @@ async def test_stream_generate_rejects_empty_stream_on_rank_drop():
                 pass
     finally:
         await engine._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_distributed_stream_chat_toolcall_only_text_is_not_an_empty_stream():
+    """A tool-call-only stream (no prose) must finalize, not UnboundLocalError.
+
+    Regression: the empty-stream guard read ``tool_calls`` before assignment,
+    so any response with empty ``full_text`` crashed even when the backend
+    had accumulated tool calls (typical non-thinking coder output).
+    """
+    events = [
+        {
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_read",
+                                "type": "function",
+                                "function": {
+                                    "name": "read",
+                                    "arguments": '{"path":"/tmp/x"}',
+                                },
+                            }
+                        ]
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ]
+        },
+        {
+            "choices": [],
+            "usage": {
+                "prompt_tokens": 20,
+                "completion_tokens": 3,
+                "total_tokens": 23,
+                "prompt_tokens_details": {"cached_tokens": 0},
+            },
+        },
+    ]
+    content = "".join(f"data: {json.dumps(event)}\n\n" for event in events)
+    content += "data: [DONE]\n\n"
+
+    def handler(request):
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            text=content,
+        )
+
+    engine = _ready_engine(handler)
+    try:
+        outputs = [
+            output
+            async for output in engine.stream_chat(
+                [{"role": "user", "content": "Read it."}],
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "read",
+                            "parameters": {"type": "object"},
+                        },
+                    }
+                ],
+            )
+        ]
+    finally:
+        await engine._client.aclose()
+
+    assert outputs[-1].finish_reason == "tool_calls"
+    assert outputs[-1].tool_calls == [
+        {
+            "id": "call_read",
+            "name": "read",
+            "arguments": '{"path":"/tmp/x"}',
+        }
+    ]

--- a/tests/test_distributed_engine.py
+++ b/tests/test_distributed_engine.py
@@ -1243,8 +1243,8 @@ async def test_start_stops_supervisor_and_clears_state_on_dead_rank_zero(monkeyp
         def load_tokenizer(*args, **kwargs):
             return _Tokenizer()
 
-    import types
     import sys
+    import types
 
     monkeypatch.setitem(
         sys.modules,

--- a/tests/test_distributed_engine.py
+++ b/tests/test_distributed_engine.py
@@ -1162,6 +1162,187 @@ async def test_distributed_stream_generate_bounds_retries_and_gives_up():
     assert len(calls) == 4
 
 
+class _UnreachableHttpx:
+    """Stand-in for httpx in _require_cluster_ready: the GET fails."""
+
+    HTTPError = httpx.HTTPError
+
+    class Response:
+        status_code = 500
+
+        def raise_for_status(self):
+            raise httpx.ConnectError("refused", request=None)
+
+    @staticmethod
+    def get(*args, **kwargs):
+        return _UnreachableHttpx.Response()
+
+
+@pytest.mark.asyncio
+async def test_distributed_rejects_unreachable_rank_zero(monkeypatch):
+    engine = DistributedBatchedEngine(_deployment())
+    engine._tokenizer = _Tokenizer()
+
+    class _Unreachable:
+        endpoint = "http://127.0.0.1:1"
+        failure_reason = None
+        stderr_tail = ()
+
+        def status(self):
+            return SimpleNamespace(
+                returncode=None,
+                failure_reason=None,
+                phase="ready",
+                ranks=({"rank": 0}, {"rank": 1}),
+            )
+
+        def start(self):
+            return None
+
+        def stop(self):
+            return None
+
+    engine._supervisor = _Unreachable()
+    monkeypatch.setattr(distributed, "httpx", _UnreachableHttpx)
+
+    with pytest.raises(
+        DistributedInferenceError, match="rank-zero is not reachable"
+    ):
+        engine._require_cluster_ready()
+
+
+@pytest.mark.asyncio
+async def test_start_stops_supervisor_and_clears_state_on_dead_rank_zero(monkeypatch):
+    engine = DistributedBatchedEngine(_deployment())
+
+    stopped = []
+
+    class _LiveThenDead:
+        endpoint = "http://127.0.0.1:1"
+
+        def start(self):
+            return None
+
+        def stop(self):
+            stopped.append(True)
+            return None
+
+    engine._supervisor = _LiveThenDead()
+    monkeypatch.setattr(distributed, "httpx", _UnreachableHttpx)
+
+    class _Utils:
+        @staticmethod
+        def _download(*args, **kwargs):
+            return "/tmp/model"
+
+        @staticmethod
+        def load_config(*args, **kwargs):
+            return {"model_type": "qwen3_5"}
+
+        @staticmethod
+        def load_tokenizer(*args, **kwargs):
+            return _Tokenizer()
+
+    import types
+    import sys
+
+    monkeypatch.setitem(
+        sys.modules,
+        "mlx_lm.utils",
+        types.ModuleType("mlx_lm.utils"),
+    )
+    for name in ("_download", "load_config", "load_tokenizer"):
+        setattr(
+            sys.modules["mlx_lm.utils"],
+            name,
+            getattr(_Utils, name),
+        )
+
+    with pytest.raises(
+        DistributedInferenceError, match="rank-zero is not reachable"
+    ):
+        await engine.start()
+
+    assert stopped == [True], "start() must stop the supervisor on probe failure"
+    assert engine._tokenizer is None, "tokenizer must be cleared after failed start"
+    assert engine._model_type is None, "model type must be cleared after failed start"
+    assert engine._loaded is False
+
+
+@pytest.mark.asyncio
+async def test_start_rejects_incomplete_ranks(monkeypatch):
+    engine = DistributedBatchedEngine(_deployment())
+
+    class _IncompleteSupervisor:
+        endpoint = "http://127.0.0.1:1"
+
+        def status(self):
+            return SimpleNamespace(
+                returncode=None,
+                failure_reason=None,
+                phase="ready",
+                ranks=({"rank": 0},),  # Only 1 of 2 ranks reported ready
+            )
+
+        def start(self):
+            return None
+
+        def stop(self):
+            return None
+
+    class _HealthyHttpx:
+        HTTPError = httpx.HTTPError
+
+        class Response:
+            status_code = 200
+
+            def raise_for_status(self):
+                return None
+
+        @staticmethod
+        def get(*args, **kwargs):
+            return _HealthyHttpx.Response()
+
+    engine._supervisor = _IncompleteSupervisor()
+    monkeypatch.setattr(distributed, "httpx", _HealthyHttpx)
+
+    with pytest.raises(
+        DistributedInferenceError, match="distributed cluster incomplete: 1 of 2 ranks"
+    ):
+        engine._require_cluster_ready()
+
+
+@pytest.mark.asyncio
+async def test_stream_chat_rejects_empty_stream_on_rank_drop():
+    """Empty SSE stream on dropped rank raises error instead of empty 200 response."""
+    def handler(request):
+        # Rank zero returns 200 but immediately closes stream (data: [DONE] only)
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            text="data: [DONE]\n\n",
+        )
+
+    engine = _ready_engine(handler)
+    engine._supervisor.status = lambda: SimpleNamespace(
+        returncode=None,
+        failure_reason="rank 1 connection closed by remote host",
+        stderr_tail=(),
+        phase="failed",
+        ranks=(),
+    )
+
+    try:
+        with pytest.raises(
+            DistributedInferenceError,
+            match="rank 1 connection closed by remote host",
+        ):
+            async for _ in engine.stream_chat([{"role": "user", "content": "hi"}]):
+                pass
+    finally:
+        await engine._client.aclose()
+
+
 @pytest.mark.asyncio
 async def test_distributed_chat_does_not_retry_unrelated_404():
     calls = []
@@ -1285,5 +1466,35 @@ async def test_preflight_fails_open_when_the_probe_itself_breaks(monkeypatch):
     monkeypatch.setattr(distributed, "check_peers", broken_check_peers)
     try:
         await engine.preflight_chat([{"role": "user", "content": "hi"}])
+    finally:
+        await engine._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_stream_generate_rejects_empty_stream_on_rank_drop():
+    """stream_generate raises error instead of empty output on dropped rank."""
+    def handler(request):
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            text="data: [DONE]\n\n",
+        )
+
+    engine = _ready_engine(handler)
+    engine._supervisor.status = lambda: SimpleNamespace(
+        returncode=1,
+        failure_reason="worker exited with code 1",
+        stderr_tail=(),
+        phase="failed",
+        ranks=(),
+    )
+
+    try:
+        with pytest.raises(
+            DistributedInferenceError,
+            match="distributed job exited with code 1",
+        ):
+            async for _ in engine.stream_generate("hi"):
+                pass
     finally:
         await engine._client.aclose()


### PR DESCRIPTION
Require health and readiness from every planned rank before a distributed engine becomes available. If rank zero closes an inference stream without output, return a distributed inference error; tool-call-only responses remain valid.

Validation: `pytest tests/test_distributed_engine.py -q` — 51 passed.
