### PR TITLE
perf(qwen4_exp): fused RMSNorm kernel for hyper-connection prefill

### DIFF
--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/hc_prefill.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/hc_prefill.py
@@ -1,0 +1,242 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fused RMSNorm for Qwen4-Exp's hyper-connection module during prefill
+(S in the hundreds-to-thousands range, not the single-token decode step).
+
+``Qwen4ExpGatedResidual._forward`` computes its RMSNorm (``self.hc_norm``)
+as a plain MLX composition -- reshape, square, mean, rsqrt, multiply,
+multiply -- dispatched once per layer per token. Layer-level profiling on a
+real ``Qwen3.8-Flash-Next-oQ4e-mtp`` checkpoint found this norm to be the
+dominant cost inside the module, ahead of its two read projections and its
+up-projection, which all run through MLX's own (already reasonably fast)
+``qmm``. This module replaces just the norm with one fused Metal dispatch;
+the read/up projections are left exactly as they are -- ``nn.Linear`` or
+``nn.QuantizedLinear``, quantized or not, whatever the checkpoint has.
+
+A tiled-matmul kernel for the projections was also built and measured (see
+the PR this shipped in). It did produce a further improvement on top of this
+norm fusion, but a smaller and less consistent one -- roughly +7-11% over
+this norm-only path at S in {2048, 4096}, and a small *regression* at
+S=1024 -- for two entire additional hand-written Metal kernels' worth of
+review surface and quantization-format coupling. That tradeoff did not seem
+worth it, so this PR ships only the norm fusion, which is simpler, has no
+quantization-scheme dependency at all, and captures most of the available
+win on its own:
+
+============  ============  ==========  ==========
+S             canonical     this path   speedup
+============  ============  ==========  ==========
+1024          266.61 ms     179.34 ms   1.49x
+2048          514.97 ms     374.39 ms   1.38x
+4096          1062.68 ms    799.52 ms   1.33x
+============  ============  ==========  ==========
+
+(Forced-accumulation timing, every one of 96 simulated hyper-connection
+calls actually executed per measurement, interleaved rounds, GPU confirmed
+exclusive -- see the PR description for the full methodology.)
+
+Set ``OMLX_QWEN4_HC_PREFILL=1`` to enable; it is opt-in (default off) since
+this is new, independently designed Metal exercised so far only on one Mac
+generation (M4 Max). Fails closed to the canonical path on any shape/dtype
+mismatch, or any runtime exception the first time the kernel actually runs
+-- turning it on cannot make a checkpoint this was not tuned against
+produce wrong output, only leave it on the unmodified path.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+
+import mlx.core as mx
+import mlx.nn as nn
+
+logger = logging.getLogger(__name__)
+
+_HC_COUNT = 4
+_HIDDEN_SIZE = 2560
+_STREAM_WIDTH = _HC_COUNT * _HIDDEN_SIZE  # 10240
+
+_RUNTIME_FAILED = False
+_FAILURE_LOGGED = False
+
+
+def _enabled() -> bool:
+    return os.environ.get("OMLX_QWEN4_HC_PREFILL", "").strip().lower() in (
+        "1",
+        "true",
+        "on",
+        "yes",
+    )
+
+
+@dataclass
+class _Prepared:
+    """Per-module state needed to run the fused norm and the rest of the
+    canonical forward pass with the module's own (untouched) projections."""
+
+    gain: mx.array
+    eps: float
+    has_inject: bool
+
+
+def _prepare(module) -> "_Prepared | None":
+    """Validate one hyper-connection module. Fails closed: anything that
+    does not match the exact shape this kernel was tuned for returns
+    ``None`` and the caller falls back to ``module._forward``.
+
+    Unlike a projection-shaped kernel, this only constrains the norm's own
+    shape -- the projections underneath (``input_mix_weight_down``,
+    ``input_mix_weight_up``, ``block_inject_weight``) are used exactly as
+    the module already has them, quantized or not, at whatever bit width.
+    """
+    if getattr(module, "hidden_size", None) != _HIDDEN_SIZE:
+        return None
+    if getattr(module, "hc_count", None) != _HC_COUNT:
+        return None
+
+    norm = getattr(module, "hc_norm", None)
+    gain = getattr(norm, "weight", None)
+    if not isinstance(gain, mx.array) or gain.shape != (_STREAM_WIDTH,):
+        return None
+    if getattr(norm, "group_size", None) != _HIDDEN_SIZE:
+        return None
+    eps = getattr(norm, "eps", None)
+    if not isinstance(eps, float):
+        return None
+
+    for name in ("input_mix_weight_down", "input_mix_weight_up"):
+        if not callable(getattr(module, name, None)):
+            return None
+
+    return _Prepared(gain=gain, eps=float(eps), has_inject="block_inject_weight" in module)
+
+
+_R1_HEADER = "#include <metal_stdlib>\nusing namespace metal;\n"
+
+# One threadgroup per (token, lane): grid.x = 32 * S * HC_COUNT. A thread's
+# own HIDDEN/32 values live in registers for the whole call -- nothing but
+# this thread ever reads them again, so there is nothing to stage in
+# threadgroup memory.
+_R1_SOURCE = """
+    constexpr int HID = {hidden}, PER = {hidden} / 32;
+    uint tid = thread_position_in_threadgroup.x;
+    uint grp = threadgroup_position_in_grid.x;      // 0 .. S*{lanes}-1
+    uint base = grp * HID + tid * PER;
+
+    float xv[PER];
+    float sq = 0.0f;
+    for (int i = 0; i < PER; ++i) {{
+        xv[i] = float(x[base + i]);
+        sq += xv[i] * xv[i];
+    }}
+    sq = simd_sum(sq);                              // broadcasts to all 32 lanes, no barrier
+    float scale = rsqrt(sq / float(HID) + eps[0]);
+
+    uint gbase = (grp % {lanes}) * HID + tid * PER;  // gain is [{lanes},HID], independent of token
+    for (int i = 0; i < PER; ++i) {{
+        float g = float(gain[gbase + i]);
+        n[base + i] = bfloat16_t(xv[i] * scale * (1.0f + g));
+    }}
+"""
+
+
+@lru_cache(maxsize=None)
+def _r1_kernel():
+    return mx.fast.metal_kernel(
+        name="omlx_qwen4_hc_prefill_r1_rmsnorm",
+        input_names=["x", "gain", "eps"],
+        output_names=["n"],
+        source=_R1_SOURCE.format(hidden=_HIDDEN_SIZE, lanes=_HC_COUNT),
+        header=_R1_HEADER,
+    )
+
+
+def _r1_rmsnorm(x: mx.array, gain: mx.array, eps: float) -> mx.array:
+    """Grouped RMSNorm, one dispatch, ``x`` never leaves registers.
+
+    ``x``    [S, 10240] bf16
+    ``gain`` [10240] bf16 (zero-centered; applied as ``1 + gain``)
+    returns  [S, 10240] bf16
+    """
+    lead = x.shape[:-1]
+    s = 1
+    for d in lead:
+        s *= d
+    x2 = x.reshape(s, _STREAM_WIDTH)
+    eps_arr = mx.array([eps], dtype=mx.float32)
+
+    (n,) = _r1_kernel()(
+        inputs=[x2, gain, eps_arr],
+        grid=(32 * s * _HC_COUNT, 1, 1),
+        threadgroup=(32, 1, 1),
+        output_shapes=[(s, _STREAM_WIDTH)],
+        output_dtypes=[mx.bfloat16],
+    )
+    return n.reshape(*lead, _STREAM_WIDTH)
+
+
+def prefill_read(module, hyper_input: mx.array):
+    """Entry point called from ``Qwen4ExpGatedResidual.__call__``.
+
+    Runs the fused norm above, then the rest of ``_forward``'s logic
+    verbatim (silu, sigmoid, the 4-lane mean, the injection sigmoid),
+    through the module's own, unmodified projection layers -- only the
+    norm dispatch is replaced.
+
+    Returns ``None`` (canonical path) whenever ``OMLX_QWEN4_HC_PREFILL`` is
+    not set, the module's shape does not match what this kernel was tuned
+    for, or the kernel raises the first time it actually runs -- in the
+    last case it disables itself for the rest of the process rather than
+    retrying every call.
+    """
+    global _RUNTIME_FAILED, _FAILURE_LOGGED
+    if _RUNTIME_FAILED or not _enabled():
+        return None
+    if not (
+        isinstance(hyper_input, mx.array)
+        and hyper_input.dtype == mx.bfloat16
+        and hyper_input.ndim >= 2
+        and hyper_input.shape[-1] == _STREAM_WIDTH
+        and mx.default_device() == mx.gpu
+    ):
+        return None
+
+    prepared = getattr(module, "_omlx_hc_prefill", False)
+    if prepared is False:
+        prepared = _prepare(module)
+        module._omlx_hc_prefill = prepared
+    if prepared is None:
+        return None
+
+    try:
+        normed = _r1_rmsnorm(hyper_input, prepared.gain, prepared.eps)
+        mix = module.input_mix_weight_down(normed)
+        block_injection = (
+            module.block_inject_weight(normed) if prepared.has_inject else None
+        )
+        mix = nn.silu(mix / module.hc_count)
+        mix = mx.sigmoid(module.input_mix_weight_up(mix))
+        mix = mix.reshape(*mix.shape[:-1], module.hc_count, module.hidden_size)
+        streams = normed.reshape(*normed.shape[:-1], module.hc_count, module.hidden_size)
+        mixed_input = mx.mean(mix * streams, axis=-2)
+    except Exception as exc:  # noqa: BLE001 - optional native path, fail closed
+        _RUNTIME_FAILED = True
+        if not _FAILURE_LOGGED:
+            _FAILURE_LOGGED = True
+            logger.warning(
+                "Qwen4 prefill hyper-connection norm kernel failed closed; "
+                "using canonical path for the rest of this process: %s",
+                exc,
+            )
+        return None
+
+    if block_injection is None:
+        return mixed_input
+    injection_weights = 2 * mx.sigmoid(block_injection / module.hc_count)
+    return mixed_input, hyper_input, injection_weights
+
+
+__all__ = ["prefill_read"]

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/hc_prefill.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/hc_prefill.py
@@ -41,6 +41,15 @@ generation (M4 Max). Fails closed to the canonical path on any shape/dtype
 mismatch, or any runtime exception the first time the kernel actually runs
 -- turning it on cannot make a checkpoint this was not tuned against
 produce wrong output, only leave it on the unmodified path.
+
+The kernel itself is not tied to Qwen4-Exp's specific ``hc_count=4,
+hidden_size=2560`` -- the Metal source takes both as compile-time template
+parameters, and the only real constraint is ``hidden_size % 32 == 0`` (each
+of the 32 lanes in a simdgroup owns ``hidden_size/32`` elements; a
+non-multiple would need boundary handling this kernel doesn't have). Each
+distinct ``(hidden_size, hc_count)`` pair gets its own compiled kernel,
+cached after first use, so this costs nothing at the validated shape --
+confirmed by benchmark, see the PR description.
 """
 
 from __future__ import annotations
@@ -54,10 +63,6 @@ import mlx.core as mx
 import mlx.nn as nn
 
 logger = logging.getLogger(__name__)
-
-_HC_COUNT = 4
-_HIDDEN_SIZE = 2560
-_STREAM_WIDTH = _HC_COUNT * _HIDDEN_SIZE  # 10240
 
 _RUNTIME_FAILED = False
 _FAILURE_LOGGED = False
@@ -80,28 +85,37 @@ class _Prepared:
     gain: mx.array
     eps: float
     has_inject: bool
+    hidden: int
+    lanes: int
+    stream: int
 
 
 def _prepare(module) -> "_Prepared | None":
     """Validate one hyper-connection module. Fails closed: anything that
-    does not match the exact shape this kernel was tuned for returns
-    ``None`` and the caller falls back to ``module._forward``.
+    does not match a shape this kernel can run returns ``None`` and the
+    caller falls back to ``module._forward``.
 
     Unlike a projection-shaped kernel, this only constrains the norm's own
     shape -- the projections underneath (``input_mix_weight_down``,
     ``input_mix_weight_up``, ``block_inject_weight``) are used exactly as
     the module already has them, quantized or not, at whatever bit width.
+    ``hidden_size`` and ``hc_count`` are read from the module, not fixed to
+    Qwen4-Exp's specific values (see the module docstring) -- the only
+    hard requirement is ``hidden_size`` being a multiple of 32.
     """
-    if getattr(module, "hidden_size", None) != _HIDDEN_SIZE:
+    hidden = getattr(module, "hidden_size", None)
+    if not isinstance(hidden, int) or hidden <= 0 or hidden % 32 != 0:
         return None
-    if getattr(module, "hc_count", None) != _HC_COUNT:
+    lanes = getattr(module, "hc_count", None)
+    if not isinstance(lanes, int) or lanes <= 0:
         return None
+    stream = lanes * hidden
 
     norm = getattr(module, "hc_norm", None)
     gain = getattr(norm, "weight", None)
-    if not isinstance(gain, mx.array) or gain.shape != (_STREAM_WIDTH,):
+    if not isinstance(gain, mx.array) or gain.shape != (stream,):
         return None
-    if getattr(norm, "group_size", None) != _HIDDEN_SIZE:
+    if getattr(norm, "group_size", None) != hidden:
         return None
     eps = getattr(norm, "eps", None)
     if not isinstance(eps, float):
@@ -111,7 +125,10 @@ def _prepare(module) -> "_Prepared | None":
         if not callable(getattr(module, name, None)):
             return None
 
-    return _Prepared(gain=gain, eps=float(eps), has_inject="block_inject_weight" in module)
+    return _Prepared(
+        gain=gain, eps=float(eps), has_inject="block_inject_weight" in module,
+        hidden=hidden, lanes=lanes, stream=stream,
+    )
 
 
 _R1_HEADER = "#include <metal_stdlib>\nusing namespace metal;\n"
@@ -144,38 +161,44 @@ _R1_SOURCE = """
 
 
 @lru_cache(maxsize=None)
-def _r1_kernel():
+def _r1_kernel(hidden: int, lanes: int):
     return mx.fast.metal_kernel(
-        name="omlx_qwen4_hc_prefill_r1_rmsnorm",
+        name=f"omlx_qwen4_hc_prefill_r1_rmsnorm_h{hidden}_l{lanes}",
         input_names=["x", "gain", "eps"],
         output_names=["n"],
-        source=_R1_SOURCE.format(hidden=_HIDDEN_SIZE, lanes=_HC_COUNT),
+        source=_R1_SOURCE.format(hidden=hidden, lanes=lanes),
         header=_R1_HEADER,
     )
 
 
-def _r1_rmsnorm(x: mx.array, gain: mx.array, eps: float) -> mx.array:
+def _r1_rmsnorm(x: mx.array, gain: mx.array, eps: float, hidden: int, lanes: int, stream: int) -> mx.array:
     """Grouped RMSNorm, one dispatch, ``x`` never leaves registers.
 
-    ``x``    [S, 10240] bf16
-    ``gain`` [10240] bf16 (zero-centered; applied as ``1 + gain``)
-    returns  [S, 10240] bf16
+    ``x``    [S, stream] bf16, ``stream == lanes * hidden``
+    ``gain`` [stream] bf16 (zero-centered; applied as ``1 + gain``)
+    returns  [S, stream] bf16
+
+    ``(hidden, lanes)`` select (and, on first use, compile) the kernel
+    variant for that shape -- see ``_r1_kernel``'s cache. The validated
+    Qwen4-Exp shape (2560, 4) pays the same cost as before generalization:
+    one dict lookup keyed by a pair of ints, not a runtime branch inside
+    the kernel itself.
     """
     lead = x.shape[:-1]
     s = 1
     for d in lead:
         s *= d
-    x2 = x.reshape(s, _STREAM_WIDTH)
+    x2 = x.reshape(s, stream)
     eps_arr = mx.array([eps], dtype=mx.float32)
 
-    (n,) = _r1_kernel()(
+    (n,) = _r1_kernel(hidden, lanes)(
         inputs=[x2, gain, eps_arr],
-        grid=(32 * s * _HC_COUNT, 1, 1),
+        grid=(32 * s * lanes, 1, 1),
         threadgroup=(32, 1, 1),
-        output_shapes=[(s, _STREAM_WIDTH)],
+        output_shapes=[(s, stream)],
         output_dtypes=[mx.bfloat16],
     )
-    return n.reshape(*lead, _STREAM_WIDTH)
+    return n.reshape(*lead, stream)
 
 
 def prefill_read(module, hyper_input: mx.array):
@@ -187,10 +210,10 @@ def prefill_read(module, hyper_input: mx.array):
     norm dispatch is replaced.
 
     Returns ``None`` (canonical path) whenever ``OMLX_QWEN4_HC_PREFILL`` is
-    not set, the module's shape does not match what this kernel was tuned
-    for, or the kernel raises the first time it actually runs -- in the
-    last case it disables itself for the rest of the process rather than
-    retrying every call.
+    not set, the module's shape does not match what this kernel can run
+    (see ``_prepare``), or the kernel raises the first time it actually
+    runs -- in the last case it disables itself for the rest of the
+    process rather than retrying every call.
     """
     global _RUNTIME_FAILED, _FAILURE_LOGGED
     if _RUNTIME_FAILED or not _enabled():
@@ -199,7 +222,6 @@ def prefill_read(module, hyper_input: mx.array):
         isinstance(hyper_input, mx.array)
         and hyper_input.dtype == mx.bfloat16
         and hyper_input.ndim >= 2
-        and hyper_input.shape[-1] == _STREAM_WIDTH
         and mx.default_device() == mx.gpu
     ):
         return None
@@ -210,9 +232,14 @@ def prefill_read(module, hyper_input: mx.array):
         module._omlx_hc_prefill = prepared
     if prepared is None:
         return None
+    if hyper_input.shape[-1] != prepared.stream:
+        return None
 
     try:
-        normed = _r1_rmsnorm(hyper_input, prepared.gain, prepared.eps)
+        normed = _r1_rmsnorm(
+            hyper_input, prepared.gain, prepared.eps,
+            prepared.hidden, prepared.lanes, prepared.stream,
+        )
         mix = module.input_mix_weight_down(normed)
         block_injection = (
             module.block_inject_weight(normed) if prepared.has_inject else None

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -1581,6 +1581,12 @@ class Qwen4ExpGatedResidual(nn.Module):
             and not get_mtp_runtime().enabled
         ):
             return compiled_forward(hyper_input)
+        if not target_verify:
+            from .hc_prefill import prefill_read
+
+            prefilled = prefill_read(self, hyper_input)
+            if prefilled is not None:
+                return prefilled
         return self._forward(hyper_input, target_verify=target_verify)
 
     def _forward(self, hyper_input: mx.array, target_verify: bool = False):

--- a/tests/test_mlx_vlm_qwen4_exp_compat.py
+++ b/tests/test_mlx_vlm_qwen4_exp_compat.py
@@ -1532,3 +1532,114 @@ def test_qwen4_lightning_mtp_isolated_from_dense_qwen35_runtime_patch():
 
     assert resident_owner.mtp is not None
     assert later_owner.mtp is not None
+
+
+def _real_size_hc_config():
+    return SimpleNamespace(
+        hc_count=4,
+        hidden_size=2560,
+        hc_lowrank=320,
+        rms_norm_eps=1e-6,
+    )
+
+
+def _quantize_hc_module(module, bits):
+    # Cast to bf16 before quantizing so scales/biases come out bf16, matching
+    # real checkpoints (a float32 Linear -- MLX's default init dtype --
+    # quantizes to float32 scales, which the prefill kernel's compatibility
+    # check correctly rejects; this is a test-fixture detail, not something
+    # production checkpoints hit).
+    module.input_mix_weight_down.weight = module.input_mix_weight_down.weight.astype(
+        mx.bfloat16
+    )
+    module.input_mix_weight_down = module.input_mix_weight_down.to_quantized(64, bits)
+    module.input_mix_weight_up.weight = module.input_mix_weight_up.weight.astype(
+        mx.bfloat16
+    )
+    module.input_mix_weight_up = module.input_mix_weight_up.to_quantized(64, bits)
+    if "block_inject_weight" in module:
+        module.block_inject_weight.weight = module.block_inject_weight.weight.astype(
+            mx.bfloat16
+        )
+        module.block_inject_weight = module.block_inject_weight.to_quantized(64, bits)
+    return module
+
+
+@pytest.mark.parametrize("use_combine", [True, False])
+@pytest.mark.parametrize("bits", [4, 8])
+@pytest.mark.parametrize("tokens", [1, 7, 37, 128])
+def test_qwen4_hc_prefill_matches_canonical_forward(
+    monkeypatch, use_combine, bits, tokens
+):
+    """The fused-norm path must agree with the canonical path at the real
+    production shape (hc_count=4, hidden_size=2560), across quantization
+    bit widths (the projections underneath are untouched, so this is really
+    testing that the norm swap alone is transparent to them) and with/
+    without the top-level combine-less mixer. Only bf16-level agreement is
+    expected -- the fused norm reduces with a simdgroup sum, a different
+    summation order than MLX's own reduction -- so this uses a loose
+    tolerance; the tighter float64-referenced cross-check lives in the
+    originating PR's benchmark harness, not this fast unit test.
+    """
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    monkeypatch.setenv("OMLX_QWEN4_HC_PREFILL", "1")
+    from mlx_vlm.models.qwen4_exp.language import Qwen4ExpGatedResidual
+
+    mx.random.seed(1234 + tokens * 7 + bits)
+    config = _real_size_hc_config()
+    module = Qwen4ExpGatedResidual(config, use_combine=use_combine)
+    _quantize_hc_module(module, bits)
+
+    inputs = mx.random.normal((1, tokens, 4 * 2560)).astype(mx.bfloat16)
+    canonical = module._forward(inputs)
+    fused = module(inputs)
+    mx.eval(canonical, fused) if not isinstance(canonical, tuple) else mx.eval(
+        *canonical, *fused
+    )
+
+    assert getattr(module, "_omlx_hc_prefill", None) is not None
+
+    if not use_combine:
+        assert mx.allclose(canonical, fused, rtol=3e-2, atol=3e-2).item()
+        return
+    for expected, actual in zip(canonical, fused):
+        assert mx.allclose(expected, actual, rtol=3e-2, atol=3e-2).item()
+
+
+def test_qwen4_hc_prefill_disabled_by_default(monkeypatch):
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    monkeypatch.delenv("OMLX_QWEN4_HC_PREFILL", raising=False)
+    from mlx_vlm.models.qwen4_exp.hc_prefill import prefill_read
+    from mlx_vlm.models.qwen4_exp.language import Qwen4ExpGatedResidual
+
+    mx.random.seed(99)
+    module = Qwen4ExpGatedResidual(_real_size_hc_config())
+    _quantize_hc_module(module, 4)
+    inputs = mx.random.normal((1, 5, 4 * 2560)).astype(mx.bfloat16)
+
+    assert prefill_read(module, inputs) is None
+    assert getattr(module, "_omlx_hc_prefill", False) is False
+
+
+def test_qwen4_hc_prefill_fails_closed_on_shape_mismatch(monkeypatch):
+    """A module whose shape this kernel was not tuned for (here, the tiny
+    test config used elsewhere in this file) must fall back cleanly even
+    with the kernel enabled, never raise."""
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    monkeypatch.setenv("OMLX_QWEN4_HC_PREFILL", "1")
+    from mlx_vlm.models.qwen4_exp.hc_prefill import prefill_read
+    from mlx_vlm.models.qwen4_exp.language import Qwen4ExpGatedResidual
+
+    config = SimpleNamespace(
+        hc_count=2, hidden_size=32, hc_lowrank=32, rms_norm_eps=1e-6
+    )
+    module = Qwen4ExpGatedResidual(config)
+    inputs = mx.random.normal((1, 5, 64)).astype(mx.bfloat16)
+
+    assert prefill_read(module, inputs) is None
+    assert getattr(module, "_omlx_hc_prefill", False) is None
+
+    canonical = module._forward(inputs)
+    routed = module(inputs)
+    mx.eval(canonical, routed)
+    assert mx.array_equal(canonical, routed).item()

--- a/tests/test_mlx_vlm_qwen4_exp_compat.py
+++ b/tests/test_mlx_vlm_qwen4_exp_compat.py
@@ -1622,24 +1622,53 @@ def test_qwen4_hc_prefill_disabled_by_default(monkeypatch):
 
 
 def test_qwen4_hc_prefill_fails_closed_on_shape_mismatch(monkeypatch):
-    """A module whose shape this kernel was not tuned for (here, the tiny
-    test config used elsewhere in this file) must fall back cleanly even
-    with the kernel enabled, never raise."""
+    """A module whose ``hidden_size`` is not a multiple of 32 -- the one
+    real constraint this kernel has (see ``hc_prefill.py``'s module
+    docstring) -- must fall back cleanly even with the kernel enabled,
+    never raise. 100 is deliberately not a multiple of 32."""
     compat.apply_mlx_vlm_qwen4_exp_compat_patch()
     monkeypatch.setenv("OMLX_QWEN4_HC_PREFILL", "1")
     from mlx_vlm.models.qwen4_exp.hc_prefill import prefill_read
     from mlx_vlm.models.qwen4_exp.language import Qwen4ExpGatedResidual
 
     config = SimpleNamespace(
-        hc_count=2, hidden_size=32, hc_lowrank=32, rms_norm_eps=1e-6
+        hc_count=4, hidden_size=100, hc_lowrank=32, rms_norm_eps=1e-6
     )
     module = Qwen4ExpGatedResidual(config)
-    inputs = mx.random.normal((1, 5, 64)).astype(mx.bfloat16)
+    inputs = mx.random.normal((1, 5, 400)).astype(mx.bfloat16)
 
     assert prefill_read(module, inputs) is None
     assert getattr(module, "_omlx_hc_prefill", False) is None
 
     canonical = module._forward(inputs)
     routed = module(inputs)
-    mx.eval(canonical, routed)
-    assert mx.array_equal(canonical, routed).item()
+    mx.eval(*canonical, *routed)
+    assert all(mx.array_equal(e, a).item() for e, a in zip(canonical, routed))
+
+
+@pytest.mark.parametrize("hc_count,hidden_size", [(4, 2560), (8, 2560), (4, 1536), (6, 3200), (2, 32)])
+def test_qwen4_hc_prefill_generalizes_beyond_production_shape(monkeypatch, hc_count, hidden_size):
+    """The kernel is not hardcoded to Qwen4-Exp's specific (hc_count=4,
+    hidden_size=2560) -- both are compile-time template parameters, and
+    the only real requirement is ``hidden_size % 32 == 0``. This checks a
+    handful of other shapes, including a tiny one (2, 32), all engage and
+    agree with canonical.
+    """
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    monkeypatch.setenv("OMLX_QWEN4_HC_PREFILL", "1")
+    from mlx_vlm.models.qwen4_exp.language import Qwen4ExpGatedResidual
+
+    mx.random.seed(hc_count * 1000 + hidden_size)
+    config = SimpleNamespace(
+        hc_count=hc_count, hidden_size=hidden_size, hc_lowrank=32, rms_norm_eps=1e-6
+    )
+    module = Qwen4ExpGatedResidual(config)
+    inputs = mx.random.normal((1, 37, hc_count * hidden_size)).astype(mx.bfloat16)
+
+    canonical = module._forward(inputs)
+    fused = module(inputs)
+    mx.eval(*canonical, *fused)
+
+    assert getattr(module, "_omlx_hc_prefill", None) is not None
+    for expected, actual in zip(canonical, fused):
+        assert mx.allclose(expected, actual, rtol=3e-2, atol=3e-2).item()


### PR DESCRIPTION
## Summary

**RMSNorm optimization for Qwen4-Exp's hyper-connection module (`Qwen4ExpGatedResidual`), prefill only** (not the single-token decode step). One fused Metal kernel replaces the module's norm; its three projections (`input_mix_weight_down`, `input_mix_weight_up`, `block_inject_weight`) are untouched. Opt-in via `OMLX_QWEN4_HC_PREFILL=1` (default off). Fails closed to the canonical path on any shape mismatch or runtime exception.

### Table 1 -- the norm's speedup, holds across scale

| S | canonical norm | fused norm | speedup |
|--:|--:|--:|--:|
| 1024 | 111.01 ms | 32.24 ms | 3.44x |
| 2048 | 216.51 ms | 61.75 ms | 3.51x |
| 4096 | 433.72 ms | 124.14 ms | 3.49x |
| 100,000* | 337.56 ms | 88.91 ms | 3.80x |

*single dispatch, not the real chunked serving path (server chunks at ~4096) -- included only to confirm the kernel doesn't weaken at large S.

### Table 2 -- where the module sits in the full pipeline

| Component | S=4K (ms/forward) | S=100K (×27, projected) |
|---|--:|--:|
| MoE | 3359.8 | 90.71 s |
| GDN (`linear_attn`) | 2297.6 | 62.04 s |
| QSA (`self_attn_qsa`) | 1679.2 | 45.34 s |
| **Hyper-connection** | **1225.9** | **33.10 s** |
| &nbsp;&nbsp;&nbsp;&nbsp;└ of which RMSNorm, before → after this PR | 500.7 → 143.3 ms | 13.52 s → 3.87 s |
| PLE | 286.7 | 7.74 s |
| **Total, before → after (PROJECTED, not confirmed)** | 8849.2 → 8491.8 ms (+4.21%) | 238.93 → 229.28 s (+4.21%) |
| **Total, before → after (ACTUALLY MEASURED, see below)** | -- | 255.06 → 254.56 s (**+0.2%, not significant**) |

## Experimental conditions

**Table 1**: forced-accumulation over 96 simulated hyper-connection calls per measurement (a loop that reassigns its own output each iteration would let MLX's lazy graph skip every iteration but the last and silently inflate any measured speedup), 5 interleaved rounds, single Mac (M4 Max, 40 GPU cores), GPU confirmed exclusive (`pgrep` check for no competing processes).

**Table 2**: layer-level profiling on a real `Qwen3.8-Flash-Next-oQ4e-mtp` checkpoint, single request immediately after a server restart, unique-salted 100,024-token prompt, `cached_tokens: 0` confirmed (nothing prefix-cached). S=100K column is the S=4K column × 27 (the real observed chunk count for this prompt length, cross-checked against the profiler's own total). The RMSNorm sub-row and the "Total, before → after" row are not independently measured lines of that same real-server run -- they apply Table 1's S=4096 share (40.8%) and speedup (3.49x) to the real 1225.9 ms/forward hyper-connection figure (1225.9 × 40.8% = 500.7 ms before; 500.7 / 3.49x = 143.3 ms after; that 357.4 ms saving is then just subtracted from the real 8849.2 ms/forward total), so treat both as a projection built from two real measurements, not a third independent one -- and see "Real end-to-end validation" just below, which is the actual measurement of whether this projection holds.

**Real end-to-end validation**: restart-per-sample A/B (10 samples/arm, mode order rotated each round, unique-salted prompt per sample, cache-hit auto-retry at >2000 tok/s, both `OMLX_HC2K` and `OMLX_HC2K_PREFILL` -- unrelated mechanisms from a separate local project -- disabled in both arms to isolate this PR's diff against clean upstream). Result: median TTFT 255.06s (canonical) vs 254.56s (this PR), a 0.2% difference, Welch's t = -1.35 (not significant; a first pass at 5 samples/arm gave the same qualitative result). **The isolated speedup above does not currently show up end-to-end**, most likely because the module is only ~13.85% of total forward time, so even its full improvement projects to only a ~3% whole-request saving -- smaller than the pipeline's own run-to-run noise (canonical arm's stdev alone is 12s on a ~255s baseline).

I was not able to pin down *why* the end-to-end number falls short of the ~4% projection -- "run-to-run noise swamps a small real effect" and "the kernel achieves less than its isolated speedup once embedded in the real pipeline" both remain live possibilities, and I couldn't design an experiment in the time I had that cleanly separated them. I'd rather say that plainly than paper over it. That said: if the component-level RMSNorm improvement (Table 1) is judged meaningful on its own -- correct (see "Correctness" below), robust across scale, and harmless when disabled by default -- I think this PR is reasonable to merge on that basis alone, even without a confirmed end-to-end number.

Given that: the correctness case is solid (below) and the change is harmless when disabled (default off), but I can only back the performance claim at the component level, not end-to-end. Your call on whether that's worth merging as a foundation for further work in this area.

## Change

New file: `omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/hc_prefill.py`.

- One Metal dispatch per call: one threadgroup per (token, lane) pair (grid = `32 * S * hc_count`), each thread keeps its `hidden_size/32` slice in registers and reduces with `simd_sum` across the one simdgroup -- no barrier, no shared memory. `hidden_size`/`hc_count` are compile-time template parameters, not hardcoded to Qwen4-Exp's specific values -- any `hidden_size` that's a multiple of 32 and any `hc_count` works, each shape compiling and caching its own kernel variant on first use, with no cost at the validated shape (see "Known gaps").
- `prefill_read` runs the fused norm, then the rest of `_forward`'s logic verbatim through the module's own, unmodified projection layers.

`language.py`: `Qwen4ExpGatedResidual.__call__` tries `hc_prefill.prefill_read(self, hyper_input)` before falling through to `self._forward`, mirroring the existing compiled-decode branch above it. Skipped when `target_verify` is set, matching that branch.

## What this is not

A tiled-`simdgroup_matrix` matmul kernel for the three projections was also built and measured. It added a further +7-11% over the norm-only version at S in {2048, 4096} but *regressed* at S=1024, for two additional hand-written Metal kernels' worth of review surface and a hard dependency on the checkpoint's quantization layout. Given the end-to-end result above, that tradeoff looks even less worth it than originally thought, so this PR ships only the norm fusion.

## Correctness

`tests/test_mlx_vlm_qwen4_exp_compat.py`:
- `test_qwen4_hc_prefill_matches_canonical_forward` -- real production shape, bits in {4, 8}, with/without the combine-less mixer, S in {1, 7, 37, 128} -- agrees with `module._forward` within bf16-level tolerance.
- `test_qwen4_hc_prefill_disabled_by_default` -- confirms the flag is opt-in.
- `test_qwen4_hc_prefill_fails_closed_on_shape_mismatch` -- a `hidden_size` not divisible by 32 falls back to canonical cleanly with the flag on.
- `test_qwen4_hc_prefill_generalizes_beyond_production_shape` -- 5 other `(hc_count, hidden_size)` shapes, including a tiny one, all engage and agree with canonical.

## Switches

`OMLX_QWEN4_HC_PREFILL=1` enables; unset/`0`/`false`/`off`/`no` (default) leaves canonical untouched. Opt-in, since this is new Metal exercised so far only on an M4 Max, unlike `hc_projection.py`'s decode kernel (default-on), which reproduces MLX's own `qmv` traversal instruction-for-instruction. Fails closed on any shape mismatch (checked once per module, cached) or runtime exception (disables itself process-wide, logged once).

## Known gaps

The kernel generalizes beyond `hc_count=4, hidden_size=2560` -- the only real requirement is `hidden_size % 32 == 0` (each of the 32 simdgroup lanes owns a whole number of elements), verified against 5 other shapes including a tiny `hc_count=2, hidden_size=32` one, with no regression at the validated production shape (interleaved, forced-accumulation, S=1024 and S=4096: within 0.13-0.03% of the pre-generalization code). Speed itself was only measured at S in {1024, 2048, 4096, 100000-single-dispatch} and only at the production shape; not measured below S=1024, and not re-benchmarked at the other shapes (only correctness was checked there).

## When this engages

This only takes over when every condition below holds; outside them, `prefill_read` returns `None` and `Qwen4ExpGatedResidual.__call__` falls straight through to the existing, unmodified implementation.

| | Condition |
|---|---|
| Switch | `OMLX_QWEN4_HC_PREFILL` is `1`/`true`/`on`/`yes` |
| Switch | the kernel hasn't already failed once in this process |
| Input | `hyper_input` is `bfloat16`, `ndim >= 2`, on GPU |
| Input | its last dimension equals `hc_count × hidden_size` |
| Module shape | `hidden_size` is a positive multiple of 32 |
| Module shape | `hc_count` is a positive integer |
| Module norm | `hc_norm.group_size == hidden_size`, its `weight` shape matches, `eps` is a `float` |
| Module projections | `input_mix_weight_down` / `input_mix_weight_up` are callable |
| Call site | not already served by the single-token compiled-decode path |
| Call site | `target_verify` is `False` |

Not required, by design: any particular quantization bit width or format on the projections, whether `block_inject_weight` exists, or any particular token count `S`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
