### PR TITLE
qwen3_5: support MTP S=2, group-32 weight in prefill

### DIFF
--- a/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_prefill.cpp
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_prefill.cpp
@@ -537,7 +537,8 @@ class Qwen35QAffineQmmTPrimitive : public Primitive {
       msg << "Unsupported Qwen affine qmm bits " << bits_ << ".";
       throw std::invalid_argument(msg.str());
     }
-    if (group_size_ != 64 && group_size_ != 128) {
+    if (group_size_ != 64 && group_size_ != 128 &&
+        !(group_size_ == 32 && bits_ == 4 && variant_ == 8)) {
       std::ostringstream msg;
       msg << "Unsupported Qwen affine qmm group_size " << group_size_ << ".";
       throw std::invalid_argument(msg.str());
@@ -563,7 +564,8 @@ class Qwen35QAffineQmmTPrimitive : public Primitive {
     if (!qwen_q_affine_bits_supported(bits)) {
       return true;
     }
-    if (group_size != 64 && group_size != 128) {
+    if (group_size != 64 && group_size != 128 &&
+        !(group_size == 32 && bits == 4 && variant == 8)) {
       return true;
     }
     if (x.dtype() != float16 && x.dtype() != bfloat16) {
@@ -682,7 +684,8 @@ class Qwen35QAffineQmmTPrimitive : public Primitive {
         kname,
         "qwen35_q",
         bits_,
-        group_size_ == 128 ? "_affine_qmm128_t_" : "_affine_qmm_t_",
+        group_size_ == 32 ? "_affine_qmm32_t_"
+            : (group_size_ == 128 ? "_affine_qmm128_t_" : "_affine_qmm_t_"),
         qwen_type_name(x.dtype()),
         "_bm_",
         cfg.bm,
@@ -937,7 +940,8 @@ array qwen35_q_affine_qmm_t(
         << "_affine_qmm_t] unsupported bits.";
     throw std::invalid_argument(msg.str());
   }
-  if (group_size != 64 && group_size != 128) {
+  if (group_size != 64 && group_size != 128 &&
+      !(group_size == 32 && bits == 4 && variant == 8)) {
     std::ostringstream msg;
     msg << "[omlx_qwen35_prefill.qwen35_q" << bits
         << "_affine_qmm_t] unsupported group_size " << group_size << ".";
@@ -994,7 +998,7 @@ array qwen35_q_affine_qmm_t(
 
   // Demote rather than throwing when the NAX tile does not fit or the runtime
   // lacks tensor units / the separately built NAX metallib.
-  bool nax = use_nax && is_nax_available() && nax_qmm_kernels_built() &&
+  bool nax = group_size != 32 && use_nax && is_nax_available() && nax_qmm_kernels_built() &&
       nax_qmm_runtime_ok.load(std::memory_order_relaxed);
   if (nax) {
     const auto nax_cfg = qwen_q_affine_nax_variant(nax_variant);

--- a/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_qmm.metal
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_qmm.metal
@@ -2,6 +2,41 @@
 #include "mlx/backend/metal/kernels/steel/gemm/gemm.h"
 #include "kernels/quantized_moe.h"
 
+#define define_qwen35_q_affine_qmm32_t(bits)                                  \
+  template <typename T, const int BM, const int BK, const int BN>              \
+  [[kernel]] void qwen35_q##bits##_affine_qmm32_t(                            \
+      const device uint32_t* w [[buffer(0)]],                                  \
+      const device T* scales [[buffer(1)]],                                    \
+      const device T* biases [[buffer(2)]],                                    \
+      const device T* x [[buffer(3)]],                                         \
+      device T* y [[buffer(4)]],                                               \
+      const constant int& K [[buffer(5)]],                                     \
+      const constant int& N [[buffer(6)]],                                     \
+      const constant int& M [[buffer(7)]],                                     \
+      uint3 tid [[threadgroup_position_in_grid]],                              \
+      uint lid [[thread_index_in_threadgroup]],                                \
+      uint simd_gid [[simdgroup_index_in_threadgroup]],                        \
+      uint simd_lid [[thread_index_in_simdgroup]]) {                           \
+    constexpr int BK_padded = (BK + 16 / sizeof(T));                           \
+                                                                               \
+    threadgroup T Xs[BM * BK_padded];                                          \
+    threadgroup T Ws[BN * BK_padded];                                          \
+                                                                               \
+    qmm_t_impl<T, 32, bits, true, BM, BK, BN>(                                 \
+        w, scales, biases, x, y, Xs, Ws, K, N, M, K,                          \
+        tid, lid, simd_gid, simd_lid);                                         \
+  }
+
+#define instantiate_qwen35_q_affine_qmm32_t(bits, type, bm, bk, bn)           \
+  instantiate_kernel(                                                         \
+      "qwen35_q" #bits "_affine_qmm32_t_" #type "_bm_" #bm "_bk_" #bk       \
+      "_bn_" #bn,                                                            \
+      qwen35_q##bits##_affine_qmm32_t,                                        \
+      type,                                                                   \
+      bm,                                                                     \
+      bk,                                                                     \
+      bn)
+
 #define define_qwen35_q_affine_qmm_t(bits)                                    \
   template <typename T, const int BM, const int BK, const int BN>              \
   [[kernel]] void qwen35_q##bits##_affine_qmm_t(                              \
@@ -153,6 +188,10 @@
       score_type,                                                              \
       topk,                                                                    \
       threads)
+
+define_qwen35_q_affine_qmm32_t(4)
+instantiate_qwen35_q_affine_qmm32_t(4, float16_t, 64, 32, 64);
+instantiate_qwen35_q_affine_qmm32_t(4, bfloat16_t, 64, 32, 64);
 
 define_qwen35_q_affine_qmm_t(2)
 define_qwen35_q_affine_qmm_t(4)

--- a/omlx/custom_kernels/qwen35_prefill/fast.py
+++ b/omlx/custom_kernels/qwen35_prefill/fast.py
@@ -810,11 +810,13 @@ def _qmm_group_size_kwargs(group_size: int) -> dict:
 def qmm_supports_group_size(group_size: int) -> bool:
     """True if the compiled extension can run qmm at this group size.
 
-    gs=64 always works (the pre-group_size builds are gs=64-only).  Other
-    group sizes require the rebuilt binding; routing a gs=128 layer through
+    gs=32 is provided by the current q4/variant-8 build, while gs=64 works in
+    every build. Group 128 requires the rebuilt binding; routing it through
     an old build would silently run the gs=64 kernel on gs=128 data.
     """
-    return group_size == 64 or _EXT_HAS_QMM_GROUP_SIZE
+    return group_size in (32, 64) or (
+        group_size == 128 and _EXT_HAS_QMM_GROUP_SIZE
+    )
 
 
 _NAX_ARCH_RE = re.compile(r"applegpu_g(\d+)([a-z])")

--- a/omlx/patches/qwen35_gdn_prework.py
+++ b/omlx/patches/qwen35_gdn_prework.py
@@ -2,7 +2,7 @@
 #
 # Kernel adapted from mlx-serve (src/transformer.zig, GDN_PREWORK_SOURCE),
 # itself a port of the mlxfast-challenge qwen35_packed_gdn_prework kernel.
-"""Fused GDN prework for Qwen3.5/3.6 MTP verify widths (S in 3..9).
+"""Fused GDN prework for Qwen3.5/3.6 MTP verify widths (S in 2..9).
 
 The composed target-verify prework in mlx-vlm's ``Qwen3_5GatedDeltaNet`` —
 conv-state concat + depthwise conv1d + SiLU + q/k/v split + reshapes + two
@@ -17,8 +17,8 @@ donor kernel: the in-kernel sigmoid uses MLX's own unary formula
 inputs; the RMS applies the ones-weight rounding then the separate scalar
 multiply's rounding — the composed chain's two casts.
 
-S >= 3 is a HARD gate: the next conv state is copied from qkv rows only,
-which is wrong when a state row would still come from the OLD conv state.
+At S=2 the next conv state retains the final row of the old conv state
+before the two new qkv rows. Wider verifies retain only new qkv rows.
 Only the target-verify arm routes here; decode (S=1) and prefill keep the
 stock path.
 """
@@ -92,12 +92,14 @@ _SOURCE = """
             v_out[out_base + i] = activated[i];
         }
     }
-    if (row + uint(NKEEP) >= uint(S)) {
-        uint state_row = row + uint(NKEEP) - uint(S);
-        uint raw_base = row * uint(C) + channel_base + lane * 4;
+    for (uint state_row = row; state_row < uint(NKEEP); state_row += uint(S)) {
+        uint source_row = uint(S) + state_row;
         uint state_base = state_row * uint(C) + channel_base + lane * 4;
         for (uint i = 0; i < 4; ++i) {
-            conv_out[state_base + i] = qkv[raw_base + i];
+            uint channel = channel_base + lane * 4 + i;
+            conv_out[state_base + i] = source_row < uint(NKEEP)
+                ? conv_state[source_row * uint(C) + channel]
+                : qkv[(source_row - uint(NKEEP)) * uint(C) + channel];
         }
     }
 """
@@ -581,7 +583,7 @@ def apply_qwen35_gdn_prework_patch() -> bool:
     def _eligible(self, inputs, mask, cache, gdn_sink, s_len):
         if gdn_sink is None or cache is None:
             return False
-        if inputs.shape[0] != 1 or not (3 <= s_len <= 9):
+        if inputs.shape[0] != 1 or not (2 <= s_len <= 9):
             return False
         if mask is not None:
             return False

--- a/omlx/patches/qwen35_q4_mlp.py
+++ b/omlx/patches/qwen35_q4_mlp.py
@@ -93,8 +93,12 @@ def _is_supported_affine_linear_shape(
         return False
     if ndim < 2 or seq_len <= 1:
         return False
+    bits = getattr(linear, "bits", None)
     group_size = getattr(linear, "group_size", None)
-    if group_size not in (64, 128):
+    if group_size == 32:
+        if dtype != mx.bfloat16 or bits != 4:
+            return False
+    elif group_size not in (64, 128):
         return False
     if not _qmm_supports_group_size(int(group_size)):
         return False
@@ -105,7 +109,6 @@ def _is_supported_affine_linear_shape(
     ):
         # The custom gs128 tile cannot use NAX; stock MLX can on M5 hardware.
         return False
-    bits = getattr(linear, "bits", None)
     if bits not in _SUPPORTED_QMM_BITS or getattr(linear, "mode", None) != "affine":
         return False
     if _native_qmm_for_bits(int(bits)) is None:
@@ -197,6 +200,8 @@ def _linear_qmm(linear: nn.QuantizedLinear, x: mx.array, variant: int) -> mx.arr
     if not _is_supported_affine_linear(linear, x):
         return linear(x)
     gs = int(getattr(linear, "group_size", 64))
+    if gs == 32 and (variant != 8 or is_nax_available()):
+        return linear(x)
     return qmm(x, linear.weight, linear.scales, linear.biases, variant, gs)
 
 
@@ -235,6 +240,11 @@ def _make_patched_mlp(
         gate_proj = getattr(self, "gate_proj", None)
         up_proj = getattr(self, "up_proj", None)
         down_proj = getattr(self, "down_proj", None)
+        projections = (gate_proj, up_proj, down_proj)
+        if any(getattr(proj, "group_size", None) == 32 for proj in projections) and (
+            variant != 8 or is_nax_available()
+        ):
+            return orig_call(self, x, *args, **kwargs)
         gate_dim = _quantized_linear_output_dim(gate_proj)
         if not (
             _can_route_affine_linear(gate_proj, x, min_tokens, q8_min_tokens)

--- a/tests/test_qwen35_q4_mlp.py
+++ b/tests/test_qwen35_q4_mlp.py
@@ -33,27 +33,45 @@ def _quantized_bf16(linear, bits=4):
     return qlinear
 
 
-@pytest.mark.parametrize("bits", [4, 5, 6, 8])
-def test_qwen35_q_affine_qmm_matches_mlx_quantized_matmul(bits):
+@pytest.mark.parametrize(
+    "bits,group_size,tokens,dtype,variant",
+    [(bits, 64, 32, mx.bfloat16, 8) for bits in (4, 5, 6, 8)]
+    + [
+        (4, 32, tokens, dtype, 8)
+        for dtype in (mx.float16, mx.bfloat16)
+        for tokens in (31, 128, 129)
+    ]
+    + [(4, 32, 32, mx.bfloat16, variant) for variant in (0, 9)]
+    + [(8, 32, 32, mx.bfloat16, 8)],
+)
+def test_qwen35_q_affine_qmm_matches_mlx_quantized_matmul(
+    bits, group_size, tokens, dtype, variant
+):
     fast = _require_qmm_kernels((bits,))
-    x = mx.random.normal((1, 32, 256)).astype(mx.bfloat16)
+    x = mx.random.normal((1, tokens, 256)).astype(dtype)
     w_full = mx.random.normal((128, 256)).astype(mx.float32)
     weight, scales, biases = mx.quantize(
-        w_full, group_size=64, bits=bits, mode="affine"
+        w_full, group_size=group_size, bits=bits, mode="affine"
     )
     scales = scales.astype(x.dtype)
     biases = biases.astype(x.dtype)
+    qmm = getattr(fast, f"qwen35_q{bits}_affine_qmm_t")
+    if group_size == 32 and (bits != 4 or variant != 8):
+        with pytest.raises(ValueError, match="unsupported group_size"):
+            qmm(x, weight, scales, biases, variant, group_size)
+        return
+
     ref = mx.quantized_matmul(
         x,
         weight,
         scales=scales,
         biases=biases,
         transpose=True,
-        group_size=64,
+        group_size=group_size,
         bits=bits,
         mode="affine",
     )
-    got = getattr(fast, f"qwen35_q{bits}_affine_qmm_t")(x, weight, scales, biases, 8)
+    got = qmm(x, weight, scales, biases, variant, group_size)
     mx.eval(ref, got)
 
     diff = mx.abs(got.astype(mx.float32) - ref.astype(mx.float32))
@@ -309,6 +327,7 @@ def test_qwen35_q8_gdn_backend_has_first_refusal_before_gpu_threshold(
         "expected",
     ),
     [
+        (32, False, False, False, True),
         (64, True, True, False, True),
         (128, False, False, False, True),
         (128, False, True, False, True),
@@ -362,6 +381,38 @@ def test_qwen35_qmm_routing_uses_stock_nax_availability(
         )
         is expected
     )
+
+    if group_size == 32:
+        assert fast.qmm_supports_group_size(32)
+        assert not q4patch._is_supported_affine_linear_shape(
+            linear, mx.float16, ndim=3, seq_len=2048, input_dim=256
+        )
+        linear.bits = 8
+        assert not q4patch._is_supported_affine_linear_shape(
+            linear, mx.bfloat16, ndim=3, seq_len=2048, input_dim=256
+        )
+        linear.bits = 4
+
+        calls = []
+        native_result = object()
+
+        def qmm(*args):
+            calls.append(args)
+            return native_result
+
+        monkeypatch.setattr(q4patch, "_native_qmm_for_bits", lambda _bits: qmm)
+        x = mx.zeros((1, 2048, 256), dtype=mx.bfloat16)
+        assert q4patch._linear_qmm(linear, x, 8) is native_result
+        assert len(calls) == 1
+
+        calls.clear()
+        monkeypatch.setattr(q4patch, "is_nax_available", lambda: True)
+        q4patch._linear_qmm(linear, x, 8)
+        assert calls == []
+
+        monkeypatch.setattr(q4patch, "is_nax_available", lambda: False)
+        q4patch._linear_qmm(linear, x, 9)
+        assert calls == []
 
 
 def test_qwen35_q4_mlp_patch_prechecks_down_proj_before_gate_up(monkeypatch):


### PR DESCRIPTION
### Benchmark

Model: `Qwen3.8-27B-MTPLX-Optimized-Speed`  
Prompt: 4,096 tokens  
Generation: 1 token  
Warm-up: 2 runs  
Memory: 28.8 GB

| Implementation | TTFT | Prefill throughput |
|---|---:|---:|
| Baseline | 21,062 ms | 194 tok/s |
| Custom Group-32 kernel | 18,480 ms | 222 tok/s |
| Improvement | **12.3% lower** | **14.4% higher** |

Command:

```bash
python -P scripts/bench.py downloads/Qwen3.8-27B-MTPLX-Optimized-Speed --pp 4096 --gen 1 --warmup 2
```

For prefill, I got this perf boost. About 10%. Extended existing tests to cover these.

I used env variables for A/B testing, but not included that one in this PR.