### PR TITLE
feat(grammar): constrained decoding under native and vlm_mtp speculative walks (#2918)

### DIFF
--- a/omlx/api/grammar.py
+++ b/omlx/api/grammar.py
@@ -13,19 +13,34 @@ bitmask is permissive during reasoning and constrained during output.
 This keeps the processor simple and enables uniform batched bitmask
 computation (parallel model forward || bitmask fill).
 
-The processor supports two usage modes:
+The processor has two ways of learning which token was sampled from its
+bitmask:
 
-1. **Per-request** (original): call ``processor(tokens, logits)`` directly.
-   Handles accept + bitmask fill + mask application in one call.
+1. **Deferred** (default, the BatchGenerator path): ``__call__`` only fills
+   and applies the bitmask and marks the row :attr:`pending`; the scheduler's
+   monkey-patched ``GenerationBatch._step`` calls :meth:`accept_token` with
+   the sampled id at the top of the following step, where the id has to be
+   evaluated anyway.  Advancing the matcher from ``tokens`` here would force a
+   host sync per step, which is what constrained decoding's throughput was
+   lost to before the accept moved (#2561).
 
-2. **Batched**: call ``processor.advance(tokens)`` to accept the previous
-   token, then use ``BatchGrammarMatcher.batch_fill_next_token_bitmask``
-   with the exposed ``matcher`` property to fill bitmasks in parallel
-   across the batch, and apply the combined bitmask externally.
+2. **Speculative** (the MTP verify walks, entered via
+   :meth:`begin_speculative`): the caller hands ``__call__`` the concrete
+   history the logits are conditioned on (the committed prefix plus the draft
+   tokens before this position) and the processor advances the matcher to
+   that history itself, accepting new tokens and rolling back when the
+   history is shorter than the last one it saw.  :meth:`snapshot_state` /
+   :meth:`restore_state` checkpoint the matcher position so a rejected draft
+   suffix can be undone with ``GrammarMatcher.rollback``.  The row is never
+   marked pending in this mode; :meth:`end_speculative` hands the request
+   back to the deferred protocol with a consistent matcher.
+
+A third, unused batched mode (``advance`` + ``BatchGrammarMatcher``) is kept
+for compatibility.
 """
 
 import logging
-from typing import List, Optional
+from typing import Any
 
 import mlx.core as mx
 import numpy as np
@@ -39,6 +54,7 @@ def create_grammar_compiler(tokenizer, model):
     Returns None if vocab_size cannot be determined.
     """
     from .._torch_stub import install as _install_torch_stub
+
     _install_torch_stub()
     import xgrammar as xgr
 
@@ -66,11 +82,15 @@ class GrammarConstraintProcessor:
 
     def __init__(self, compiled_grammar, vocab_size: int):
         from .._torch_stub import install as _install_torch_stub
+
         _install_torch_stub()
         import xgrammar as xgr
         from xgrammar.kernels.apply_token_bitmask_mlx import apply_token_bitmask_mlx
 
-        self._matcher = xgr.GrammarMatcher(compiled_grammar)
+        # ``max_rollback_tokens`` is unlimited by default on xgrammar >= 0.2.3
+        # (the argument is deprecated); passing -1 keeps older matchers able
+        # to rewind a full speculative window too.
+        self._matcher = xgr.GrammarMatcher(compiled_grammar, max_rollback_tokens=-1)
         self._vocab_size = vocab_size
         self._apply_mask = apply_token_bitmask_mlx
 
@@ -80,6 +100,19 @@ class GrammarConstraintProcessor:
         self._first_call = True
         self._pending = False
 
+        # Speculative-mode bookkeeping (see begin_speculative). History
+        # lengths count prompt + generated tokens, the way the callers'
+        # token buffers do.
+        self._speculative = False
+        self._base = 0  # history length when speculative mode began
+        self._seen = 0  # history length the matcher currently reflects
+        self._matcher_rel = 0  # tokens accepted into the matcher since _base
+        # History index past which the matcher stopped advancing: one past
+        # the terminating token, or the index of a token the grammar
+        # rejected (``_dead``). None while the matcher is live.
+        self._stop: int | None = None
+        self._dead = False
+
     # ------------------------------------------------------------------
     # Per-request mode (original interface)
     # ------------------------------------------------------------------
@@ -87,16 +120,20 @@ class GrammarConstraintProcessor:
     def __call__(self, tokens, logits: mx.array) -> mx.array:
         """Fill bitmask and apply to logits.
 
-        Accept is handled by the monkey-patched GenerationBatch._step(),
-        which is the only place that can see which token was sampled from
-        the result.  This method only fills the bitmask, applies it, and
-        records that a token is now in flight for this row (see
-        :attr:`pending`).
+        In deferred mode accept is handled by the monkey-patched
+        ``GenerationBatch._step()``, which is the only place that can see
+        which token was sampled from the result; this method only fills the
+        bitmask, applies it, and records that a token is now in flight for
+        this row (see :attr:`pending`).  In speculative mode the matcher is
+        first advanced (or rolled back) to ``tokens``.
         """
-        if self._terminated:
+        if self._speculative:
+            self._sync_to_history(tokens)
+        if self._terminated or self._dead:
             return logits
 
-        self._pending = True
+        if not self._speculative:
+            self._pending = True
         self._bitmask.fill(-1)
         self._matcher.fill_next_token_bitmask(self._bitmask)
 
@@ -104,7 +141,7 @@ class GrammarConstraintProcessor:
         return self._apply_mask(mx_bitmask, logits, self._vocab_size)
 
     def accept_token(self, token_id: int) -> None:
-        """Accept a generated token to advance matcher state."""
+        """Accept a generated token to advance matcher state (deferred mode)."""
         self._pending = False
         if self._terminated:
             return
@@ -121,8 +158,138 @@ class GrammarConstraintProcessor:
         because ``GenerationBatch.extend()`` merges rows primed by a
         *different* batch instance, each with its own token already sampled;
         only per-row state survives that merge and the matching ``filter()``.
+        Speculative mode never sets it: the walk advances the matcher itself.
         """
         return self._pending
+
+    # ------------------------------------------------------------------
+    # Speculative mode (MTP verify walks)
+    # ------------------------------------------------------------------
+
+    @property
+    def speculative(self) -> bool:
+        """True while the processor advances the matcher from its ``tokens``."""
+        return self._speculative
+
+    def begin_speculative(self, history_len: int) -> None:
+        """Switch to self-advancing mode.
+
+        ``history_len`` is the length of the history (prompt + generated) the
+        matcher currently reflects, i.e. every token accepted so far and no
+        token in flight.  The deferred protocol guarantees exactly that
+        between two steps: the accept of ``_next_tokens`` runs at the top of
+        the step that pushes it into the token buffer, so the buffer length
+        is the right value and any pending token is about to be pushed and
+        will be accepted by the first speculative ``__call__``.
+        """
+        self._speculative = True
+        self._base = int(history_len)
+        self._seen = self._base
+        self._matcher_rel = 0
+        self._dead = False
+        self._stop = self._base if self._terminated else None
+        self._pending = False
+
+    def end_speculative(self, history, pending: bool) -> None:
+        """Return to the deferred protocol.
+
+        ``history`` is the committed token history (a host list or an array;
+        None to skip the final sync); the matcher is moved to it, accepting
+        or rolling back as needed.  ``pending`` says whether the caller has a
+        sampled-but-unaccepted token in flight (``_next_tokens`` set) that the
+        scheduler's deferred accept must feed to :meth:`accept_token`.
+        """
+        if not self._speculative:
+            return
+        if history is not None:
+            self._sync_to_history(history)
+        self._speculative = False
+        self._pending = bool(pending) and not self._terminated
+
+    def snapshot_state(self) -> dict:
+        """Checkpoint the matcher position for position-keyed rewind."""
+        return {
+            "seen": self._seen,
+            "matcher_rel": self._matcher_rel,
+            "stop": self._stop,
+            "terminated": self._terminated,
+            "dead": self._dead,
+        }
+
+    def restore_state(self, state: dict) -> None:
+        """Rewind to a checkpoint produced by :meth:`snapshot_state`.
+
+        Only backwards moves are possible: a checkpoint is always taken
+        before the positions it undoes were accepted.
+        """
+        target = int(state["matcher_rel"])
+        if target > self._matcher_rel:
+            raise RuntimeError(
+                "GrammarConstraintProcessor.restore_state cannot move the matcher "
+                f"forward (at {self._matcher_rel}, checkpoint {target})"
+            )
+        self._rollback_matcher_to(target)
+        self._seen = int(state["seen"])
+        self._stop = state["stop"]
+        self._terminated = bool(state["terminated"])
+        self._dead = bool(state["dead"])
+
+    # -- speculative-mode internals ---------------------------------------
+
+    def _sync_to_history(self, tokens) -> None:
+        n = len(tokens)
+        if n > self._seen:
+            new = tokens[self._seen : n]
+            ids = new.tolist() if hasattr(new, "tolist") else list(new)
+            for offset, token_id in enumerate(ids):
+                self._accept_speculative(int(token_id), self._seen + offset)
+            self._seen = n
+        elif n < self._seen:
+            self._rewind_history(n)
+
+    def _accept_speculative(self, token_id: int, index: int) -> None:
+        if self._stop is not None:
+            # Terminated or dead: the matcher does not move; the history
+            # still grows so a later rewind knows where it stands.
+            return
+        if self._matcher.accept_token(token_id):
+            self._matcher_rel += 1
+            if self._matcher.is_terminated():
+                self._terminated = True
+                self._stop = index + 1
+            return
+        # A speculative prefix left the grammar (a draft that was not
+        # masked against this state). Rows conditioned on it are never
+        # committed: the target's sample at the same position is masked and
+        # therefore differs from the offending draft.
+        self._dead = True
+        self._stop = index
+        logger.debug(
+            "GrammarMatcher rejected speculative token %d at history index %d",
+            token_id,
+            index,
+        )
+
+    def _matcher_rel_at(self, history_len: int) -> int:
+        effective = history_len if self._stop is None else min(history_len, self._stop)
+        return max(0, effective - self._base)
+
+    def _rewind_history(self, history_len: int) -> None:
+        self._rollback_matcher_to(self._matcher_rel_at(history_len))
+        if self._stop is not None:
+            if self._terminated and history_len < self._stop:
+                self._terminated = False
+                self._stop = None
+            elif self._dead and history_len <= self._stop:
+                self._dead = False
+                self._stop = None
+        self._seen = history_len
+
+    def _rollback_matcher_to(self, target_rel: int) -> None:
+        steps = self._matcher_rel - target_rel
+        if steps > 0:
+            self._matcher.rollback(steps)
+            self._matcher_rel = target_rel
 
     # ------------------------------------------------------------------
     # Batched mode helpers
@@ -159,3 +326,8 @@ class GrammarConstraintProcessor:
                 return False
 
         return True
+
+
+def grammar_processors(processors) -> list[Any]:
+    """Return the :class:`GrammarConstraintProcessor` instances in a row's list."""
+    return [p for p in (processors or []) if isinstance(p, GrammarConstraintProcessor)]

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -44,11 +44,11 @@ def vlm_mtp_processor_conflicts(data: dict) -> list:
     Neutral values (repetition 1.0, presence 0.0) build no processor and do
     not conflict.
 
-    ``thinking_budget_enabled`` is intentionally absent: the vlm_mtp path
-    applies ``ThinkingBudgetProcessor`` at verify time via
+    ``thinking_budget_enabled`` and ``guided_grammar_enabled`` are
+    intentionally absent: the vlm_mtp path applies ``ThinkingBudgetProcessor``
+    and ``GrammarConstraintProcessor`` at verify time via
     ``MTPProcessingSampler`` (see omlx/speculative/processing_sampler.py),
-    so a thinking-budget default no longer forces the BatchGenerator
-    fallback.
+    so neither default forces the BatchGenerator fallback any more.
     """
     conflicts = []
     rep = data.get("repetition_penalty")
@@ -57,8 +57,6 @@ def vlm_mtp_processor_conflicts(data: dict) -> list:
     pres = data.get("presence_penalty")
     if pres is not None and pres != 0.0:
         conflicts.append("presence_penalty")
-    if data.get("guided_grammar_enabled"):
-        conflicts.append("guided_grammar_enabled")
     return conflicts
 
 

--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -421,8 +421,6 @@ def _mtp_common_eligible(gen_batch: Any) -> bool:
     uids = getattr(gen_batch, "uids", None)
     if uids is None or len(uids) == 0:
         return False
-    if _has_grammar_processors(gen_batch):
-        return False
     return True
 
 
@@ -592,6 +590,11 @@ def _is_mtp_batch_eligible(gen_batch: Any) -> bool:
     uids = getattr(gen_batch, "uids", None)
     if uids is None or len(uids) <= 1:
         return False
+    if _has_grammar_processors(gen_batch):
+        # Row-wise MTP extracts and re-merges per-row caches around each
+        # cycle; the grammar processor's speculative mode is wired for the
+        # singleton cycle only (see _grammar_enter_speculative).
+        return False
     if not _allows_new_mtp_activation(gen_batch, "_omlx_mtp_batch_state"):
         return False
     if getattr(
@@ -631,6 +634,8 @@ def _ineligibility_reason(gen_batch: Any) -> str:
     if uids is None:
         return "GenerationBatch has no uids"
     if len(uids) != 1:
+        if _has_grammar_processors(gen_batch):
+            return "row-wise batch MTP keeps grammar-constrained rows on the standard step"
         if not _allows_new_mtp_activation(gen_batch, "_omlx_mtp_batch_state"):
             return "pending prompt work may still merge into this batch"
         if getattr(
@@ -643,8 +648,6 @@ def _ineligibility_reason(gen_batch: Any) -> str:
         return ""
     if not _allows_new_mtp_activation(gen_batch, "_omlx_mtp_state"):
         return "pending prompt work may still merge into this singleton batch"
-    if _has_grammar_processors(gen_batch):
-        return "grammar-constrained decoding uses GenerationBatch._step hooks"
     return ""
 
 
@@ -880,7 +883,7 @@ def _proc_list(gen_batch: Any) -> Optional[List[Any]]:
 
 
 def _has_grammar_processors(gen_batch: Any) -> bool:
-    """True when MTP would bypass grammar state advanced by scheduler._step."""
+    """True when any row of the batch carries a grammar constraint."""
     processors_by_seq = getattr(gen_batch, "logits_processors", None)
     if not processors_by_seq:
         return False
@@ -893,6 +896,57 @@ def _has_grammar_processors(gen_batch: Any) -> bool:
         for processors in processors_by_seq
         for proc in (processors or [])
     )
+
+
+def _grammar_enter_speculative(gen_batch: Any) -> None:
+    """Switch the singleton row's grammar processors to self-advancing mode.
+
+    Called at MTP activation, before the first speculative processor call.
+    The scheduler's deferred accept has by then advanced the matcher through
+    every token in ``_token_context[0]`` and left the sampled ``_next_tokens``
+    in flight; the buffer length is therefore the history the matcher
+    reflects, and the in-flight token is accepted by the first speculative
+    ``__call__`` when ``_post_init_mtp`` pushes it into the buffer.
+    """
+    procs = _proc_list(gen_batch)
+    if procs is None:
+        return
+    try:
+        from omlx.api.grammar import grammar_processors
+    except Exception:
+        return
+    grammar = grammar_processors(procs)
+    if not grammar:
+        return
+    buf = gen_batch._token_context[0]
+    history_len = int(getattr(buf, "_size", None) or len(buf.tokens))
+    for proc in grammar:
+        proc.begin_speculative(history_len)
+
+
+def _grammar_leave_speculative(gen_batch: Any) -> None:
+    """Hand grammar processors back to the scheduler's deferred accept.
+
+    Runs on every MTP exit (reconcile, park, late-join handoff, plain drop).
+    ``gen_batch.tokens[row]`` is the streamed history; the matcher is moved
+    to it, and the row is marked pending exactly when a sampled
+    ``_next_tokens`` is waiting for the standard step to feed it.
+    """
+    processors_by_seq = getattr(gen_batch, "logits_processors", None)
+    if not processors_by_seq:
+        return
+    try:
+        from omlx.api.grammar import grammar_processors
+    except Exception:
+        return
+    tokens_rows = getattr(gen_batch, "tokens", None) or []
+    pending = getattr(gen_batch, "_next_tokens", None) is not None
+    for row, procs in enumerate(processors_by_seq):
+        for proc in grammar_processors(procs):
+            if not proc.speculative:
+                continue
+            history = tokens_rows[row] if row < len(tokens_rows) else None
+            proc.end_speculative(history, pending=pending)
 
 
 def _mtp_state_valid_for_batch(gen_batch: Any, state: Optional[_MtpState]) -> bool:
@@ -918,6 +972,7 @@ def _drop_mtp_state(
     released at activation (``take_primed``), on real multi-row merges
     (``patched_extend``), or with the cache itself at request end.
     """
+    _grammar_leave_speculative(gen_batch)
     state = getattr(gen_batch, "_omlx_mtp_state", None)
     if state is None:
         return None
@@ -2467,6 +2522,10 @@ def _post_init_mtp(gen_batch: Any) -> None:
     main_lp = gen_batch._next_logprobs[0]  # (vocab,)
 
     if procs is not None:
+        # Grammar rows advance their matcher from the prefixes this path
+        # hands them from here on; main_tok is the in-flight token the
+        # buffer push below makes them accept.
+        _grammar_enter_speculative(gen_batch)
         prev_buf = gen_batch._token_context[0].update_and_fetch(main_tok)
     else:
         prev_buf = None

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -704,6 +704,10 @@ def _omlx_advance_grammar_rows(self) -> None:
     """
     from .api.grammar import GrammarConstraintProcessor
 
+    # Rows the MTP verify walk drives are never pending: in speculative mode
+    # the processor advances its own matcher from the prefixes the walk
+    # hands it, and it re-enters this protocol (pending set) when the walk
+    # hands the row back (see GrammarConstraintProcessor.end_speculative).
     rows = [
         (e, proc)
         for e, procs in enumerate(self.logits_processors)
@@ -8886,16 +8890,16 @@ class Scheduler:
             return None
 
         # Per-request logits processors that implement the snapshot/restore
-        # protocol (today: ThinkingBudgetProcessor) ARE applied on this
-        # path: MTPProcessingSampler threads them into mlx-vlm's verify
-        # walk through the positioned ``sample_target`` hook, with
-        # position-keyed state checkpoints so draft rejections rewind them
-        # correctly (see omlx/speculative/processing_sampler.py). Model
-        # level suppress tokens are reproduced via _make_suppressing_sampler.
-        # Everything else (grammar constraints, repetition/presence/
-        # frequency penalties) still has no application point here — same
-        # convention as Lightning MTP: fall back to BatchGenerator so every
-        # processor stays enforced (#2399).
+        # protocol (today: ThinkingBudgetProcessor and
+        # GrammarConstraintProcessor) ARE applied on this path:
+        # MTPProcessingSampler threads them into mlx-vlm's verify walk
+        # through the positioned ``sample_target`` hook, with position-keyed
+        # state checkpoints so draft rejections rewind them correctly (see
+        # omlx/speculative/processing_sampler.py). Model level suppress
+        # tokens are reproduced via _make_suppressing_sampler. Everything
+        # else (repetition/presence/frequency penalties) still has no
+        # application point here — same convention as Lightning MTP: fall
+        # back to BatchGenerator so every processor stays enforced (#2399).
         mtp_processors: list[Any] = []
         unsupported_processors: list[Any] = []
         for proc in logits_processors or []:

--- a/omlx/speculative/processing_sampler.py
+++ b/omlx/speculative/processing_sampler.py
@@ -44,10 +44,15 @@ argmax and never calls the sampler for drafts; any plain ``sampler(...)``
 call falls through to the base sampler.
 
 Scope: processors must expose ``snapshot_state()`` / ``restore_state()``
-(today: ``ThinkingBudgetProcessor``). Grammar constraints stay on the
-BatchGenerator fallback — beyond statefulness, a grammar mask makes the
-unconstrained drafter's proposals systematically rejectable, so the
-speculative path would buy nothing there anyway.
+(today: ``ThinkingBudgetProcessor`` and ``GrammarConstraintProcessor``).
+Processors that also expose ``begin_speculative(history_len)`` /
+``end_speculative(history, pending)`` are switched into self-advancing mode
+for the lifetime of the wrapper: the grammar processor normally learns the
+sampled token from the scheduler's deferred accept, which this path never
+runs, so here it advances its matcher from the history each call hands it.
+Output stays grammar-valid because every emitted token is a target-side
+sample from masked logits; the drafter's greedy proposals are unmasked on
+this path, so acceptance under a grammar is a measurement, not a given.
 """
 
 from __future__ import annotations
@@ -96,6 +101,10 @@ class MTPProcessingSampler:
         self._history: list[int] = [int(t) for t in prompt_token_ids]
         self._prompt_len = len(self._history)
         self._snapshots: dict[int, list[dict]] = {}
+        for proc in self._processors:
+            begin = getattr(proc, "begin_speculative", None)
+            if callable(begin):
+                begin(self._prompt_len)
         self._initial_snapshot = self._snap()
         self._degraded = False
 
@@ -127,6 +136,12 @@ class MTPProcessingSampler:
         self._restore(self._initial_snapshot)
         del self._history[self._prompt_len :]
         self._snapshots.clear()
+        for proc in self._processors:
+            end = getattr(proc, "end_speculative", None)
+            if callable(end):
+                # The BatchGenerator fallback samples from scratch: nothing
+                # is in flight for the deferred accept to pick up.
+                end(self._history, pending=False)
 
     # -- mlx-vlm positioned verify hook -------------------------------------
 

--- a/tests/test_grammar_speculative.py
+++ b/tests/test_grammar_speculative.py
@@ -1,0 +1,614 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Grammar constraints under speculative (MTP) decoding.
+
+Covers the speculative mode of ``GrammarConstraintProcessor`` and its wiring:
+
+1. The processor, driven the way the native verify walk drives it (per-position
+   prefixes, per-row checkpoints, restore on partial accept), produces at every
+   committed position the same bitmask a fresh matcher produces when advanced
+   linearly along the emitted tokens. A mutation control (a processor that does
+   not advance) fails the same property.
+2. Dead and terminated prefixes: masks pass through, and a rewind revives them.
+3. The hand-back to the deferred protocol (``end_speculative``) leaves the
+   matcher on the streamed history with the row pending.
+4. ``MTPProcessingSampler`` admits the grammar processor and every token it
+   samples is grammar-legal, including across draft-rejection rewinds.
+5. The native path: eligibility, activation hook order, the real
+   ``_run_verify_cycle_chain`` with a grammar row, and the exit hook.
+
+Everything runs on the real xgrammar matcher with a 256-entry mock vocabulary
+(one token per printable ASCII character) and no model weights.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+from types import SimpleNamespace
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+xgr = pytest.importorskip("xgrammar")
+
+from omlx.api.grammar import GrammarConstraintProcessor  # noqa: E402
+from omlx.speculative.processing_sampler import (  # noqa: E402
+    MTPProcessingSampler,
+    supports_vlm_mtp_processing,
+)
+
+VOCAB_SIZE = 256
+EOS = 2
+PROMPT = [200, 201, 202, 203, 204]  # arbitrary ids; never part of the grammar
+SCHEMA = {
+    "type": "object",
+    "properties": {
+        "k": {"type": "string", "maxLength": 4},
+        "n": {"type": "integer"},
+    },
+    "required": ["k", "n"],
+    "additionalProperties": False,
+}
+TARGET_TEXT = '{"k": "ab", "n": 12}'
+
+
+def _vocab() -> list[str]:
+    vocab = [f"<tok_{i}>" for i in range(VOCAB_SIZE)]
+    vocab[0] = "<unk>"
+    vocab[1] = "<s>"
+    vocab[EOS] = "</s>"
+    for code in range(32, 127):
+        vocab[code] = chr(code)
+    return vocab
+
+
+@pytest.fixture(scope="module")
+def compiled():
+    info = xgr.TokenizerInfo(_vocab(), stop_token_ids=[EOS])
+    compiler = xgr.GrammarCompiler(info)
+    cg = compiler.compile_json_schema(
+        json.dumps(SCHEMA), any_whitespace=False, indent=None
+    )
+    ref = xgr.GrammarMatcher(cg)
+    assert ref.accept_string(TARGET_TEXT), "fixture text must be grammar-legal"
+    assert ref.accept_token(EOS) and ref.is_terminated()
+    return cg
+
+
+def _target_ids() -> list[int]:
+    return [ord(c) for c in TARGET_TEXT] + [EOS]
+
+
+def _allowed_from_matcher(matcher) -> set[int]:
+    width = (VOCAB_SIZE + 31) // 32
+    bitmask = np.full((1, width), -1, dtype=np.int32)
+    matcher.fill_next_token_bitmask(bitmask)
+    words = bitmask[0].astype(np.uint32)
+    return {t for t in range(VOCAB_SIZE) if (int(words[t // 32]) >> (t % 32)) & 1}
+
+
+def _allowed_from_logits(logits) -> set[int]:
+    row = np.array(logits, dtype=np.float32).reshape(-1)[:VOCAB_SIZE]
+    return {t for t in range(VOCAB_SIZE) if np.isfinite(row[t])}
+
+
+def _reference_allowed(cg, generated: list[int]) -> set[int]:
+    """Allowed set of a fresh matcher advanced linearly along ``generated``."""
+    matcher = xgr.GrammarMatcher(cg)
+    for token in generated:
+        assert matcher.accept_token(token), f"reference rejected {token}"
+    if matcher.is_terminated():
+        return set(range(VOCAB_SIZE))  # processor passes logits through
+    return _allowed_from_matcher(matcher)
+
+
+def _zeros():
+    return mx.zeros((1, VOCAB_SIZE))
+
+
+def _first_illegal(cg, generated: list[int]) -> int:
+    matcher = xgr.GrammarMatcher(cg)
+    for token in generated:
+        matcher.accept_token(token)
+    allowed = _allowed_from_matcher(matcher)
+    for candidate in (ord("#"), ord("!"), ord("Z"), ord("\\"), 3, 0):
+        if candidate not in allowed:
+            return candidate
+    raise AssertionError("no illegal token found")
+
+
+# ---------------------------------------------------------------------------
+# 1. Verify-walk emulation against the linear reference
+# ---------------------------------------------------------------------------
+
+
+def _run_emulated_walk(cg, proc, *, k: int, seed: int) -> None:
+    """Drive ``proc`` the way ``_run_verify_cycle_chain`` does and check masks.
+
+    Mirrors the native path: ``begin_speculative`` at activation with the
+    prompt-length history and the first token in flight; the seed's
+    processor call on ``prompt + [t0]``; the draft chain (snapshot, one call
+    per draft with the hypothetical prefix, restore); then cycles of k+1 rows
+    with per-row checkpoints, restore to the last emitted row's checkpoint and
+    a buffer trimmed to the committed prefix.
+    """
+    rng = random.Random(seed)
+    target = _target_ids()
+    prompt = list(PROMPT)
+
+    proc.begin_speculative(len(prompt))
+    committed = [target[0]]  # main_tok, sampled under the deferred mask
+    # Seed: the distribution after main_tok is masked with prefix prompt+[t0].
+    allowed = _allowed_from_logits(proc(mx.array(prompt + committed), _zeros()))
+    assert allowed == _reference_allowed(cg, committed), "seed row mask"
+    committed.append(target[1])  # next_main_tok
+    assert not proc.pending
+
+    def draft_chain(buffer: list[int], chain_prefix: int, n_committed: int):
+        """One draft chain: masked drafts along the hypothetical prefix."""
+        snap = proc.snapshot_state()
+        drafts: list[int] = []
+        for j in range(k):
+            prefix = buffer + [chain_prefix] + drafts
+            out = proc(mx.array(prefix), _zeros())
+            legal = _allowed_from_logits(out)
+            want = target[n_committed + j] if n_committed + j < len(target) else EOS
+            if want not in legal or rng.random() < 0.35:
+                # The drafter samples under the mask of its own hypothetical
+                # prefix: after a wrong draft the target's next token may be
+                # illegal there, and sometimes it just guesses another legal one.
+                options = sorted(legal - {want}) or sorted(legal)
+                tok = rng.choice(options)
+            else:
+                tok = want
+            assert tok in legal, "the drafter samples under the mask"
+            drafts.append(tok)
+        proc.restore_state(snap)
+        return drafts
+
+    buffer = prompt + committed[:-1]
+    drafts = draft_chain(buffer, committed[-1], len(committed))
+
+    while True:
+        # --- verify cycle ---
+        next_main = committed[-1]
+        n_before = len(committed)
+        prev_rows = []
+        row_allowed = []
+        row_snaps = []
+        inputs = [next_main] + drafts
+        for j in range(k + 1):
+            prev_rows.append(buffer + inputs[: j + 1])
+            out = proc(mx.array(prev_rows[j]), _zeros())
+            row_allowed.append(_allowed_from_logits(out))
+            row_snaps.append(proc.snapshot_state())
+        assert not proc.pending
+        # Greedy acceptance against the target sequence.
+        m = 0
+        while (
+            m < k and n_before + m < len(target) and drafts[m] == target[n_before + m]
+        ):
+            m += 1
+        if m < k:
+            proc.restore_state(row_snaps[m])
+        pos_last = n_before + m
+        emit_last = target[pos_last] if pos_last < len(target) else EOS
+        emitted = drafts[:m] + [emit_last]
+        if EOS in emitted:
+            # The request finishes at EOS; the scheduler discards the rest.
+            emitted = emitted[: emitted.index(EOS) + 1]
+        # Every committed row's mask equals the linear reference at its position.
+        for j in range(len(emitted)):
+            assert row_allowed[j] == _reference_allowed(cg, committed + drafts[:j]), (
+                f"seed={seed} cycle at {n_before} row {j}"
+            )
+            assert emitted[j] in row_allowed[j]
+        committed.extend(emitted)
+        if emitted[-1] == EOS:
+            break
+        buffer = prompt + committed[:-1]
+        assert proc._seen == len(buffer), "buffer trimmed to the committed prefix"
+        drafts = draft_chain(buffer, committed[-1], len(committed))
+
+    assert committed == target
+    # The final EOS is next_main of a cycle that never runs; accept it as the
+    # standard epilogue would and the matcher terminates exactly there.
+    proc(mx.array(prompt + committed), _zeros())
+    assert proc.is_terminated
+
+
+class TestSpeculativeModeMatchesLinearMatcher:
+    @pytest.mark.parametrize("k", [1, 2, 3, 4])
+    @pytest.mark.parametrize("seed", range(6))
+    def test_masks_match_reference_along_emitted_tokens(self, compiled, k, seed):
+        proc = GrammarConstraintProcessor(compiled, VOCAB_SIZE)
+        _run_emulated_walk(compiled, proc, k=k, seed=seed)
+
+    def test_mutation_control_non_advancing_processor_fails(
+        self, compiled, monkeypatch
+    ):
+        """The old processor (mask from a frozen state) fails the same property."""
+        proc = GrammarConstraintProcessor(compiled, VOCAB_SIZE)
+        monkeypatch.setattr(proc, "_sync_to_history", lambda tokens: None)
+        with pytest.raises(AssertionError):
+            _run_emulated_walk(compiled, proc, k=3, seed=0)
+
+    def test_speculative_mode_never_sets_pending(self, compiled):
+        proc = GrammarConstraintProcessor(compiled, VOCAB_SIZE)
+        proc.begin_speculative(len(PROMPT))
+        proc(mx.array(PROMPT + [ord("{")]), _zeros())
+        assert proc.pending is False
+        assert proc.speculative is True
+
+
+# ---------------------------------------------------------------------------
+# 2. Dead and terminated prefixes
+# ---------------------------------------------------------------------------
+
+
+class TestDeadAndTerminated:
+    def test_illegal_speculative_prefix_passes_through_until_restored(self, compiled):
+        proc = GrammarConstraintProcessor(compiled, VOCAB_SIZE)
+        proc.begin_speculative(len(PROMPT))
+        good = [ord("{"), ord('"')]
+        proc(mx.array(PROMPT + good), _zeros())
+        snap = proc.snapshot_state()
+        bad = _first_illegal(compiled, good)
+        out = proc(mx.array(PROMPT + good + [bad]), _zeros())
+        # Dead: nothing masked (the row can never be committed).
+        assert _allowed_from_logits(out) == set(range(VOCAB_SIZE))
+        out = proc(mx.array(PROMPT + good + [bad, ord("k")]), _zeros())
+        assert _allowed_from_logits(out) == set(range(VOCAB_SIZE))
+        # Restore to the checkpoint before the illegal token revives the matcher.
+        proc.restore_state(snap)
+        out = proc(mx.array(PROMPT + good), _zeros())
+        assert _allowed_from_logits(out) == _reference_allowed(compiled, good)
+
+    def test_rewind_by_shorter_history_revives_dead_prefix(self, compiled):
+        proc = GrammarConstraintProcessor(compiled, VOCAB_SIZE)
+        proc.begin_speculative(len(PROMPT))
+        good = [ord("{"), ord('"'), ord("k")]
+        bad = _first_illegal(compiled, good)
+        proc(mx.array(PROMPT + good + [bad]), _zeros())
+        # A shorter history (as after a buffer trim) rewinds past the dead token.
+        out = proc(mx.array(PROMPT + good[:2]), _zeros())
+        assert _allowed_from_logits(out) == _reference_allowed(compiled, good[:2])
+
+    def test_terminated_then_rollback_revives(self, compiled):
+        proc = GrammarConstraintProcessor(compiled, VOCAB_SIZE)
+        proc.begin_speculative(len(PROMPT))
+        target = _target_ids()
+        proc(mx.array(PROMPT + target[:-1]), _zeros())
+        snap = proc.snapshot_state()
+        out = proc(mx.array(PROMPT + target), _zeros())  # accepts EOS
+        assert proc.is_terminated
+        assert _allowed_from_logits(out) == set(range(VOCAB_SIZE))
+        proc.restore_state(snap)
+        assert not proc.is_terminated
+        out = proc(mx.array(PROMPT + target[:-1]), _zeros())
+        assert _allowed_from_logits(out) == _reference_allowed(compiled, target[:-1])
+        assert EOS in _allowed_from_logits(out)
+
+    def test_restore_cannot_move_forward(self, compiled):
+        proc = GrammarConstraintProcessor(compiled, VOCAB_SIZE)
+        proc.begin_speculative(len(PROMPT))
+        proc(mx.array(PROMPT + [ord("{"), ord('"')]), _zeros())
+        later = proc.snapshot_state()
+        proc(mx.array(PROMPT + [ord("{")]), _zeros())
+        with pytest.raises(RuntimeError):
+            proc.restore_state(later)
+
+
+# ---------------------------------------------------------------------------
+# 3. Hand-back to the deferred protocol
+# ---------------------------------------------------------------------------
+
+
+class TestEndSpeculative:
+    def test_end_syncs_to_streamed_history_and_marks_pending(self, compiled):
+        proc = GrammarConstraintProcessor(compiled, VOCAB_SIZE)
+        # Deferred prelude: the __init__ step masks position 0.
+        proc(mx.array(PROMPT), _zeros())
+        assert proc.pending
+        proc.begin_speculative(len(PROMPT))
+        assert not proc.pending
+        target = _target_ids()
+        # The walk got ahead of what was streamed (three speculative tokens).
+        proc(mx.array(PROMPT + target[:6]), _zeros())
+        streamed = PROMPT + target[:3]
+        proc.end_speculative(streamed, pending=True)
+        assert proc.speculative is False
+        assert proc.pending is True
+        # Deferred accept of the in-flight token, then the mask is the reference's.
+        proc.accept_token(target[3])
+        assert not proc.pending
+        out = proc(mx.array(streamed + [target[3]]), _zeros())
+        assert proc.pending
+        assert _allowed_from_logits(out) == _reference_allowed(compiled, target[:4])
+
+    def test_end_accepts_streamed_tokens_the_walk_had_not_seen(self, compiled):
+        proc = GrammarConstraintProcessor(compiled, VOCAB_SIZE)
+        proc.begin_speculative(len(PROMPT))
+        target = _target_ids()
+        proc(mx.array(PROMPT + target[:2]), _zeros())
+        # The queue drained one token further than the matcher (emit_last).
+        proc.end_speculative(PROMPT + target[:3], pending=True)
+        out = proc(mx.array(PROMPT + target[:3]), _zeros())
+        assert _allowed_from_logits(out) == _reference_allowed(compiled, target[:3])
+
+    def test_end_without_history_only_switches_mode(self, compiled):
+        proc = GrammarConstraintProcessor(compiled, VOCAB_SIZE)
+        proc.begin_speculative(len(PROMPT))
+        proc(mx.array(PROMPT + [ord("{")]), _zeros())
+        proc.end_speculative(None, pending=False)
+        assert proc.speculative is False
+        assert proc.pending is False
+
+    def test_end_is_noop_in_deferred_mode(self, compiled):
+        proc = GrammarConstraintProcessor(compiled, VOCAB_SIZE)
+        proc(mx.array(PROMPT), _zeros())
+        proc.end_speculative(PROMPT, pending=False)
+        assert proc.pending is True  # untouched
+
+
+# ---------------------------------------------------------------------------
+# 4. vlm_mtp: MTPProcessingSampler with a grammar processor
+# ---------------------------------------------------------------------------
+
+
+def _argmax_sampler(logits):
+    return mx.argmax(logits, axis=-1)
+
+
+def _favor(token_ids: list[int]) -> mx.array:
+    rows = np.zeros((len(token_ids), VOCAB_SIZE), dtype=np.float32)
+    for r, t in enumerate(token_ids):
+        rows[r, t] = 10.0
+    return mx.array(rows)
+
+
+class TestProcessingSampler:
+    def test_grammar_processor_passes_the_gate(self, compiled):
+        proc = GrammarConstraintProcessor(compiled, VOCAB_SIZE)
+        assert supports_vlm_mtp_processing(proc)
+
+    def test_sampled_tokens_are_legal_across_rewinds(self, compiled):
+        proc = GrammarConstraintProcessor(compiled, VOCAB_SIZE)
+        sampler = MTPProcessingSampler(_argmax_sampler, [proc], PROMPT)
+        assert proc.speculative and not proc.pending
+        target = _target_ids()
+
+        first = sampler.process_first_logits(_favor([_first_illegal(compiled, [])]))
+        bonus = int(_argmax_sampler(first).item())
+        assert bonus in _reference_allowed(compiled, [])
+        assert bonus == target[0]  # the only legal opener is "{"
+        sampler.note_first_bonus(bonus, position=1)
+
+        # Verify walk 1 at positions 1..3: slot 2 favours an illegal token.
+        favored = [target[1], _first_illegal(compiled, target[:2]), target[3]]
+        out = sampler.sample_target(_favor(favored), positions=[1, 2, 3])
+        sampled = [int(t) for t in out.tolist()]
+        history = [target[0]]
+        for tok in sampled:
+            assert tok in _reference_allowed(compiled, history)
+            history.append(tok)
+
+        # Draft rejection: mlx-vlm re-samples the suffix from position 2.
+        out = sampler.sample_target(_favor([target[2], target[3]]), positions=[2, 3])
+        sampled = [int(t) for t in out.tolist()]
+        assert sampled == [target[2], target[3]]
+        assert _allowed_from_logits(proc(sampler._history, _zeros())) == (
+            _reference_allowed(compiled, target[:4])
+        )
+
+    def test_reset_hands_back_a_pristine_deferred_processor(self, compiled):
+        proc = GrammarConstraintProcessor(compiled, VOCAB_SIZE)
+        sampler = MTPProcessingSampler(_argmax_sampler, [proc], PROMPT)
+        sampler.process_first_logits(_zeros())
+        sampler.note_first_bonus(ord("{"), position=1)
+        sampler.sample_target(_favor([ord('"')]), positions=[1])
+        sampler.reset_processors()
+        assert proc.speculative is False
+        assert proc.pending is False
+        out = proc(mx.array(PROMPT), _zeros())
+        assert _allowed_from_logits(out) == _reference_allowed(compiled, [])
+
+
+# ---------------------------------------------------------------------------
+# 5. Native path wiring
+# ---------------------------------------------------------------------------
+
+
+class _MtpModel:
+    def __init__(self):
+        self.mtp = object()
+        self._omlx_mtp_decode_enabled = True
+
+    def mtp_forward(self, *_):
+        pass
+
+
+class TestNativePathWiring:
+    def test_grammar_rows_are_eligible_for_singleton_mtp(self, compiled):
+        from omlx.patches.mlx_lm_mtp import batch_generator as bg
+
+        proc = GrammarConstraintProcessor(compiled, VOCAB_SIZE)
+        batch = SimpleNamespace(model=_MtpModel(), uids=[1], logits_processors=[[proc]])
+        assert bg._has_grammar_processors(batch) is True
+        assert bg._is_mtp_eligible(batch) is True
+        assert bg._ineligibility_reason(batch) == ""
+
+    def test_grammar_rows_stay_off_rowwise_batch_mtp(self, compiled, monkeypatch):
+        from omlx.patches.mlx_lm_mtp import batch_generator as bg
+
+        monkeypatch.setenv(bg._ROWWISE_BATCH_MTP_ENV, "1")
+        proc = GrammarConstraintProcessor(compiled, VOCAB_SIZE)
+        batch = SimpleNamespace(
+            model=_MtpModel(), uids=[1, 2], logits_processors=[[proc], []]
+        )
+        assert bg._is_mtp_batch_eligible(batch) is False
+        assert "grammar" in bg._ineligibility_reason(batch)
+        batch.logits_processors = [[], []]
+        assert bg._is_mtp_batch_eligible(batch) is True
+
+    def test_enter_hook_baselines_on_the_token_buffer(self, compiled):
+        from mlx_lm.models.cache import TokenBuffer
+
+        from omlx.patches.mlx_lm_mtp import batch_generator as bg
+
+        proc = GrammarConstraintProcessor(compiled, VOCAB_SIZE)
+        proc(mx.array(PROMPT), _zeros())  # deferred prelude, main_tok in flight
+        batch = SimpleNamespace(
+            logits_processors=[[proc]], _token_context=[TokenBuffer(list(PROMPT))]
+        )
+        bg._grammar_enter_speculative(batch)
+        assert proc.speculative and not proc.pending
+        assert proc._base == len(PROMPT)
+
+    def test_post_init_enters_speculative_before_any_forward(
+        self, compiled, monkeypatch
+    ):
+        from omlx.patches.mlx_lm_mtp import batch_generator as bg
+
+        class MarkerError(Exception):
+            pass
+
+        def enter(_batch):
+            raise MarkerError()
+
+        monkeypatch.setattr(bg, "_grammar_enter_speculative", enter)
+        monkeypatch.setattr(
+            bg, "_call_backbone", lambda *a, **k: pytest.fail("forward before enter")
+        )
+        proc = GrammarConstraintProcessor(compiled, VOCAB_SIZE)
+        batch = SimpleNamespace(
+            uids=[1],
+            model=_MtpModel(),
+            _next_tokens=mx.array([ord("{")], dtype=mx.uint32),
+            _next_logprobs=[mx.zeros((VOCAB_SIZE,))],
+            samplers=[None],
+            fallback_sampler=_argmax_sampler,
+            logits_processors=[[proc]],
+            _token_context=[SimpleNamespace(update_and_fetch=lambda t: t)],
+        )
+        with pytest.raises(MarkerError):
+            bg._post_init_mtp(batch)
+
+    def test_verify_cycle_emits_legal_tokens_and_keeps_matcher_in_step(
+        self, compiled, monkeypatch
+    ):
+        from mlx_lm.models.cache import TokenBuffer
+
+        from omlx.patches.mlx_lm_mtp import batch_generator as bg
+
+        target = _target_ids()
+        k = 3
+        # Cycle boundary inside the string value: committed = target[:7]
+        # ('{"k": "'), buffer holds target[:6] (accepted), next_main = target[6]
+        # is the opening quote not yet pushed. Rows 0..3 predict positions 7..10.
+        base = 7
+        proc = GrammarConstraintProcessor(compiled, VOCAB_SIZE)
+        proc.begin_speculative(len(PROMPT))
+        proc(mx.array(PROMPT + target[: base - 1]), _zeros())
+        buffer = TokenBuffer(PROMPT + target[: base - 1])
+        # Drafts: the first is right ('a'), the second is legal but wrong
+        # ('x' for 'b'), the third is illegal after it (a backslash: the
+        # bounded string production has no escape branch). Greedy acceptance
+        # must stop at m = 1 and the dead third row must never be committed.
+        wrong_legal = sorted(
+            _reference_allowed(compiled, target[: base + 1]) - {target[base + 1]}
+        )[0]
+        illegal = ord("\\")
+        assert illegal not in _reference_allowed(compiled, target[:base] + [wrong_legal])
+        drafts = [target[base], wrong_legal, illegal]
+
+        def fake_backbone(_model, inputs, _cache, **_kwargs):
+            width = int(inputs.shape[1])
+            # Row j predicts the target token after input j; the dead row
+            # favours the illegal token, which is fine: it is never emitted.
+            rows = []
+            for j in range(width):
+                pos = base + j
+                favored = target[pos] if pos < len(target) else EOS
+                if j == 3:
+                    favored = illegal
+                row = [-100.0] * VOCAB_SIZE
+                row[favored] = 0.0
+                rows.append(row)
+            return (
+                mx.array([rows], dtype=mx.float32),
+                mx.zeros((1, width, 8), dtype=mx.float32),
+                None,
+            )
+
+        rollbacks = []
+        monkeypatch.setattr(bg, "_call_backbone", fake_backbone)
+        monkeypatch.setattr(
+            bg,
+            "_chain_rollback",
+            lambda _m, _c, accepted, num_drafts, _g: (
+                rollbacks.append((accepted, num_drafts)) or True
+            ),
+        )
+        monkeypatch.setattr(bg, "_chain_next_drafts", lambda *a, **k: None)
+        monkeypatch.setattr(bg, "_clear_rollback", lambda _c: None)
+
+        state = bg._MtpState(
+            uid=1,
+            chain=True,
+            depth=k,
+            mtp_cache=[],
+            next_main=mx.array([target[base - 1]], dtype=mx.uint32),
+            drafts=mx.array(drafts, dtype=mx.uint32),
+            draft_lps=[mx.zeros((VOCAB_SIZE,)) for _ in drafts],
+        )
+        batch = SimpleNamespace(
+            model=SimpleNamespace(),
+            prompt_cache=[SimpleNamespace(offset=len(PROMPT) + base - 1)],
+            tokens=[PROMPT + target[:base]],
+            samplers=[None],
+            fallback_sampler=_argmax_sampler,
+            logits_processors=[[proc]],
+            _token_context=[buffer],
+        )
+
+        bg._run_verify_cycle_chain(batch, state)
+
+        emitted = [tok for tok, _lp, _src in state.queue]
+        # m = 1: the right draft plus the target's correction for the wrong one.
+        assert emitted == [target[base], target[base + 1]], emitted
+        assert rollbacks == [(1, k)]
+        assert not proc.pending
+        # Buffer and matcher both sit on prompt + committed + next_main + d1.
+        assert buffer._size == len(PROMPT) + base + 1
+        assert proc._seen == len(PROMPT) + base + 1
+        out = proc(mx.array(PROMPT + target[: base + 1]), _zeros())
+        assert _allowed_from_logits(out) == _reference_allowed(
+            compiled, target[: base + 1]
+        )
+
+        # Exit: everything streamed, a fresh token in flight for the standard step.
+        batch.tokens[0].extend(emitted)
+        batch._next_tokens = mx.array([target[base + 2]], dtype=mx.uint32)
+        batch._omlx_mtp_state = state
+        bg._drop_mtp_state(batch, "test-exit")
+        assert proc.speculative is False
+        assert proc.pending is True
+        proc.accept_token(target[base + 2])
+        out = proc(mx.array(PROMPT + target[: base + 3]), _zeros())
+        assert _allowed_from_logits(out) == _reference_allowed(
+            compiled, target[: base + 3]
+        )
+
+    def test_leave_hook_is_a_noop_for_deferred_rows(self, compiled):
+        from omlx.patches.mlx_lm_mtp import batch_generator as bg
+
+        proc = GrammarConstraintProcessor(compiled, VOCAB_SIZE)
+        proc(mx.array(PROMPT), _zeros())
+        batch = SimpleNamespace(
+            logits_processors=[[proc]], tokens=[list(PROMPT)], _next_tokens=None
+        )
+        bg._grammar_leave_speculative(batch)
+        assert proc.pending is True
+        assert proc.speculative is False

--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -722,8 +722,13 @@ class TestBatchGeneratorDispatch:
         assert GenerationBatch.next(batch) == []
         assert calls[:3] == ["realign", "batch_eligible", "single_eligible"]
 
-    def test_realign_can_make_grammar_rows_disable_mtp(self, monkeypatch):
-        """If realignment reveals processors, MTP must not activate first."""
+    def test_realign_runs_before_mtp_activation_sees_grammar_rows(self, monkeypatch):
+        """Realignment runs first, and the grammar row it reveals activates MTP.
+
+        Grammar-constrained singletons ride the MTP path (the processor is
+        switched to its speculative mode at activation), so the row state the
+        activation reads must be the realigned one.
+        """
         from mlx_lm.generate import GenerationBatch
 
         from omlx.patches.mlx_lm_mtp import batch_generator
@@ -740,6 +745,7 @@ class TestBatchGeneratorDispatch:
             logits_processors=[],
             _omlx_mtp_activation_safe=True,
         )
+        seen_at_activation = []
 
         def realign_rows():
             batch.logits_processors = [[processor]]
@@ -751,11 +757,12 @@ class TestBatchGeneratorDispatch:
             "_has_grammar_processors",
             lambda b: bool(b.logits_processors and b.logits_processors[0]),
         )
-        monkeypatch.setattr(
-            batch_generator,
-            "_prepare_mtp_state_for_next",
-            lambda _: pytest.fail("MTP activated before row realignment"),
-        )
+
+        def prepare(b):
+            seen_at_activation.append(list(b.logits_processors))
+            return None
+
+        monkeypatch.setattr(batch_generator, "_prepare_mtp_state_for_next", prepare)
         monkeypatch.setattr(batch_generator, "_drop_mtp_state", lambda *_, **__: None)
         monkeypatch.setattr(
             batch_generator,
@@ -764,7 +771,7 @@ class TestBatchGeneratorDispatch:
         )
 
         assert GenerationBatch.next(batch) == []
-        assert batch.logits_processors == [[processor]]
+        assert seen_at_activation == [[[processor]]]
 
     def test_decode_eligibility_reads_model_instance_flag_not_global(self):
         from omlx.patches.mlx_lm_mtp import (
@@ -881,11 +888,11 @@ class TestBatchGeneratorDispatch:
             assert _is_mtp_eligible(_GenBatch(_MtpModel(), uids=[1, 2])) is False
             # Empty batch never triggers.
             assert _is_mtp_eligible(_GenBatch(_MtpModel(), uids=[])) is False
-            # Grammar-constrained decoding relies on GenerationBatch._step hooks,
-            # so MTP must stay off until it mirrors accept_token explicitly.
+            # Grammar-constrained singletons ride the MTP path: the processor
+            # advances its own matcher from the verify walk's prefixes.
             with pytest.MonkeyPatch.context() as mp:
                 mp.setattr(batch_generator, "_has_grammar_processors", lambda _: True)
-                assert _is_mtp_eligible(_GenBatch(_MtpModel(), uids=[1])) is False
+                assert _is_mtp_eligible(_GenBatch(_MtpModel(), uids=[1])) is True
         finally:
             set_mtp_active(prior_active)
 

--- a/tests/test_model_settings.py
+++ b/tests/test_model_settings.py
@@ -683,12 +683,24 @@ class TestVlmMtpProcessorExclusivity:
         [
             ("repetition_penalty", 1.2),
             ("presence_penalty", 0.5),
-            ("guided_grammar_enabled", True),
         ],
     )
     def test_conflicting_setting_raises(self, field, value):
         with pytest.raises(ValueError, match="vlm_mtp_enabled cannot be combined"):
             ModelSettings(vlm_mtp_enabled=True, **{field: value})
+
+    def test_guided_grammar_no_longer_conflicts(self):
+        """The grammar processor rides the vlm_mtp verify walk through
+        MTPProcessingSampler (snapshot/restore plus self-advancing mode), so
+        a default grammar no longer forces the BatchGenerator fallback."""
+        settings = ModelSettings(vlm_mtp_enabled=True, guided_grammar_enabled=True)
+        assert settings.vlm_mtp_enabled is True
+        assert settings.guided_grammar_enabled is True
+        data, conflicts = resolve_vlm_mtp_conflicts(
+            {"vlm_mtp_enabled": True, "guided_grammar_enabled": True}
+        )
+        assert conflicts == []
+        assert data["vlm_mtp_enabled"] is True
 
     def test_thinking_budget_no_longer_conflicts(self):
         """Thinking budget is applied on the vlm_mtp path at verify time
@@ -710,10 +722,10 @@ class TestVlmMtpProcessorExclusivity:
 
     def test_resolve_helper_clears_vlm_mtp(self):
         data, conflicts = resolve_vlm_mtp_conflicts(
-            {"vlm_mtp_enabled": True, "guided_grammar_enabled": True}
+            {"vlm_mtp_enabled": True, "repetition_penalty": 1.2}
         )
         assert data["vlm_mtp_enabled"] is False
-        assert conflicts == ["guided_grammar_enabled"]
+        assert conflicts == ["repetition_penalty"]
 
     def test_resolve_helper_no_conflict_passthrough(self):
         original = {"vlm_mtp_enabled": True, "repetition_penalty": 1.0}


### PR DESCRIPTION
## Problem

Grammar-constrained requests never get MTP. Three gates keep them apart on `main`:

1. Native Lightning MTP: `_mtp_common_eligible()` returns False when any row of the batch carries a `GrammarConstraintProcessor`, so one constrained request switches the whole batch to the standard step (`omlx/patches/mlx_lm_mtp/batch_generator.py`, `_has_grammar_processors`).
2. `vlm_mtp`: only processors exposing `snapshot_state()` / `restore_state()` ride `MTPProcessingSampler`; the grammar processor does not, so the request falls back to BatchGenerator (`omlx/speculative/processing_sampler.py`, `supports_vlm_mtp_processing`).
3. Config: `vlm_mtp_enabled` next to a default `guided_grammar_enabled` is rejected in `ModelSettings.__post_init__`, and a persisted file with the pair has `vlm_mtp_enabled` switched off at load.

The reason is where the grammar learns which token was sampled. `GrammarConstraintProcessor.__call__(tokens, logits)` does not read `tokens`; it fills the bitmask for the matcher's current state and marks the row pending, and the scheduler's patched `GenerationBatch._step` feeds the sampled id to `accept_token` at the top of the following step, where the id has to be evaluated anyway (`scheduler.py`, `_omlx_advance_grammar_rows`). The speculative walks never run that step during a cycle and never maintain `_next_tokens`, so under MTP the matcher would stay frozen while its bitmask was applied to every verify position. Excluding grammar was the right call for that processor. #2918 asks for the pair to work.

## Change

The verify walks already apply processors once per position with the prefix each row is conditioned on, checkpoint snapshot-capable processors after every row and restore the checkpoint of the last emitted row on a partial accept (the native walk since #2617, `MTPProcessingSampler` since #2456). This makes the grammar processor a member of that protocol without touching the plain path.

- `omlx/api/grammar.py`: a speculative mode. `begin_speculative(history_len)` switches it on; from then `__call__` advances the matcher to the history it is handed (accepting the new suffix, or rolling back with `GrammarMatcher.rollback` when the history is shorter than the last one seen), and never marks the row pending. `snapshot_state` / `restore_state` carry the matcher position. A prefix the grammar rejects marks the processor dead until a rewind; rows conditioned on it are never committed, because the target's distribution at that position is masked and the offending draft has zero probability under it, so it fails the greedy match and the acceptance ratio alike. `end_speculative(history, pending)` moves the matcher to the streamed history and hands the row back to the deferred accept. The deferred protocol itself is unchanged, so the standard path pays no new host sync.
- `omlx/patches/mlx_lm_mtp/batch_generator.py`: the singleton path enters the mode at activation (`_post_init_mtp`, before the first processor call) and leaves it on every exit through `_drop_mtp_state` (reconcile, park, late-join handoff, plain drop), with `pending` set iff a sampled `_next_tokens` is waiting for the standard step. `_mtp_common_eligible` no longer excludes grammar rows; the opt-in row-wise batch path still does (its per-row cache extract/merge is not wired for the mode), and `_ineligibility_reason` says so.
- `omlx/speculative/processing_sampler.py`: the wrapper calls `begin_speculative(len(prompt))` on processors that expose it and `end_speculative` in `reset_processors`, so `vlm_mtp` admits grammar. mlx-vlm's drafts stay greedy and unmasked on that path; output is grammar-valid because every emitted token is a target-side sample from masked logits, and acceptance under a grammar there is a number to measure, not a given.
- `omlx/model_settings.py`: `guided_grammar_enabled` leaves `vlm_mtp_processor_conflicts`.
- `omlx/scheduler.py`: comments only; `_omlx_advance_grammar_rows` skips speculative rows by construction (they are never pending).

## Tests

`tests/test_grammar_speculative.py` runs on the real xgrammar matcher with a 256-token mock vocabulary (one token per printable ASCII character, `</s>` as the stop token), no model weights:

- an emulation of the native walk (activation with the prompt-length history and the first token in flight, the seed call, the draft chain with snapshot/restore, then cycles of k+1 rows with per-row checkpoints, restore to the last emitted row and a buffer trimmed to the committed prefix) over random drafts that are right, legal-but-wrong or illegal, for k = 1..4 and six seeds: at every committed position the processor's bitmask equals a fresh matcher's advanced linearly along the emitted tokens, and the emitted sequence completes the grammar. A mutation control (a processor that does not advance) fails the same property;
- dead and terminated prefixes pass logits through and are revived by a restore or a shorter history; `restore_state` refuses to move forward;
- the hand-back leaves the matcher on the streamed history with the row pending, and the deferred `accept_token` continues from there;
- `MTPProcessingSampler` with a grammar processor samples only legal tokens across a draft-rejection rewind, and `reset_processors` returns a pristine deferred processor;
- eligibility (singleton on, row-wise off), the activation hook running before any forward, the real `_run_verify_cycle_chain` with a grammar row (drafts right / legal-but-wrong / illegal, m = 1) through to `_drop_mtp_state`.

`tests/test_mlx_lm_mtp_patch.py` and `tests/test_model_settings.py` are updated for the new contract. `ruff check` reports no new findings in the touched files.

## What this does not claim

No speed number. The gain depends on how often the head's drafts survive the mask, and on the draft side the per-position mask costs one small host sync per draft (the same cost `ThinkingBudgetProcessor` already pays in the chain). The measurement I will run when the box is free: a 611-request structured-output corpus (classification and extraction schemas with `maxLength` strings, temperature 0.1) at C = 1 on Qwen3.8-27B-oQ6e-mtp, `mtp_enabled` on versus off, with the gates: grammar armed on every request, every output accepted by a fresh `GrammarMatcher` on its schema, parse and truncation rates not worse than the baseline, acceptance from the `MTP[uid]` line, and decode tok/s from the response timings. Results go here before the draft flag comes off.

Refs #2918.
