### PR TITLE
feat(thinking): add opt-in EOS guard

### DIFF
--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -389,29 +389,31 @@ class ThinkingParser:
 
 
 class ThinkingBudgetProcessor:
-    """Logits processor that enforces a thinking token budget.
+    """Logits processor for an optional budget and opt-in EOS guard.
 
-    Counts tokens generated while in thinking mode.  When the budget is
-    exceeded, forces the close-think token(s) one at a time, then becomes
-    a no-op for the rest of generation.
+    When a budget is configured, counts tokens generated while in thinking
+    mode and forces the close-think sequence at the limit.  An explicitly
+    configured stop-token set is masked only while thinking remains open.
 
     Handles both single-token and multi-token close-think sequences, and
     supports alternative think markers (e.g. ``<longcat_think>``).
 
     Args:
         think_end_token_ids: Token ID(s) for the close-think tag.
-        budget: Maximum number of thinking tokens before forcing close.
+        budget: Optional maximum number of thinking tokens before forcing close.
         think_start_token_id: Token ID for the open-think tag (re-entry detection).
+        stop_token_ids: Explicitly enabled terminal IDs to mask until close.
     """
 
     def __init__(
         self,
         think_end_token_ids: List[int],
-        budget: int,
+        budget: Optional[int],
         think_start_token_id: Optional[int] = None,
         leading_token_ids: Optional[List[int]] = None,
         trailing_token_ids: Optional[List[int]] = None,
         token_to_piece: Optional[Callable[[int], str | bytes | None]] = None,
+        stop_token_ids: Optional[Sequence[int]] = None,
     ):
         self._think_end_ids = think_end_token_ids
         # Full force sequence: \n + </think> + \n\n (matches training pattern)
@@ -420,9 +422,12 @@ class ThinkingBudgetProcessor:
             + list(think_end_token_ids)
             + (trailing_token_ids or [])
         )
-        self._budget = budget
+        self._budget = None if budget is None else max(1, int(budget))
         self._think_start_id = think_start_token_id
         self._token_to_piece = token_to_piece
+        self._stop_token_ids = tuple(
+            sorted({int(token_id) for token_id in (stop_token_ids or ())})
+        )
 
         # State
         self._thinking_tokens: int = 0
@@ -458,10 +463,15 @@ class ThinkingBudgetProcessor:
         if self._forcing:
             return self._force_next_token(logits, mx)
 
+        if self._in_thinking and self._stop_token_ids:
+            logits[..., list(self._stop_token_ids)] = mx.array(float("-inf"))
+
         if self._waiting_utf8:
             return logits
 
         if self._in_thinking:
+            if self._budget is None:
+                return logits
             self._thinking_tokens += 1
             if self._thinking_tokens >= self._budget:
                 if self._last_token_utf8_complete:

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -6091,15 +6091,24 @@ class Scheduler:
         if suppress_processor is not None:
             logits_processors.append(suppress_processor)
 
-        # Add thinking budget processor for reasoning models
-        if (
+        # Suppressing target-selected EOS changes sampling behavior, so it is
+        # deliberately operator-controlled and off by default.  The guard
+        # masks model terminal IDs only while a prompt-opened thinking region
+        # remains active; request-specific stop IDs stay authoritative.
+        thinking_eos_guard = os.environ.get(
+            "OMLX_THINKING_EOS_GUARD", "0"
+        ).strip().lower() in {"1", "true", "on", "yes"}
+        needs_think_protocol = bool(
+            thinking_eos_guard
+            and request is not None
+            and getattr(request, "needs_think_prefix", False)
+        )
+        parser_budget_protocol = bool(
             sampling_params.thinking_budget is not None
             and request is not None
-            and (
-                getattr(request, "needs_think_prefix", False)
-                or self._get_output_parser_thinking_end_text() is not None
-            )
-        ):
+            and self._get_output_parser_thinking_end_text() is not None
+        )
+        if needs_think_protocol or parser_budget_protocol:
             think_end_ids = self._resolve_think_end_token_ids()
             if think_end_ids:
                 from .api.thinking import ThinkingBudgetProcessor
@@ -6120,6 +6129,11 @@ class Scheduler:
                     leading_token_ids=leading_ids,
                     trailing_token_ids=trailing_ids,
                     token_to_piece=self._thinking_budget_token_to_piece,
+                    stop_token_ids=(
+                        sorted(self._get_stop_tokens() - set(think_end_ids))
+                        if needs_think_protocol
+                        else None
+                    ),
                 )
                 logits_processors.append(processor)
 

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -49,12 +49,19 @@ class TestThinkingBudgetProcessor:
 
     NEWLINE_ID = 99  # Dummy \n token ID
 
-    def _make_processor(self, budget: int = 5, end_ids=None, trailing_ids=None):
+    def _make_processor(
+        self,
+        budget: int | None = 5,
+        end_ids=None,
+        trailing_ids=None,
+        stop_ids=None,
+    ):
         return ThinkingBudgetProcessor(
             think_end_token_ids=end_ids or [self.THINK_END_ID],
             budget=budget,
             think_start_token_id=self.THINK_START_ID,
             trailing_token_ids=trailing_ids,
+            stop_token_ids=stop_ids,
         )
 
     # --- Budget enforcement ---
@@ -131,6 +138,40 @@ class TestThinkingBudgetProcessor:
         original = _make_logits()
         result = proc(_make_tokens(10, self.THINK_END_ID, 50), original)
         assert mx.array_equal(result, original)
+
+    def test_masks_eos_until_natural_thinking_close_without_budget(self):
+        """Prompt-opened thinking cannot terminate before ``</think>``."""
+        eos_id = 2
+        proc = self._make_processor(budget=None, stop_ids=[eos_id])
+
+        masked = proc(_make_tokens(10), _make_logits())
+        assert masked[0, eos_id].item() == float("-inf")
+        assert masked[0, 0].item() == 0.0
+        assert not proc._forcing
+
+        # Once the target naturally emits the close marker, ordinary EOS is
+        # immediately available for the answer phase.
+        unmasked = proc(
+            _make_tokens(10, self.THINK_END_ID),
+            _make_logits(),
+        )
+        assert proc._done
+        assert unmasked[0, eos_id].item() == 0.0
+
+    def test_eos_mask_survives_snapshot_restore(self):
+        """Speculative rollback preserves the open-thinking EOS guard."""
+        eos_id = 2
+        proc = self._make_processor(budget=None, stop_ids=[eos_id])
+        proc(_make_tokens(10), _make_logits())
+        snapshot = proc.snapshot_state()
+
+        proc(_make_tokens(10, self.THINK_END_ID), _make_logits())
+        assert proc._done
+        proc.restore_state(snapshot)
+
+        masked = proc(_make_tokens(10), _make_logits())
+        assert not proc._done
+        assert masked[0, eos_id].item() == float("-inf")
 
     def test_first_call_skips_state_update(self):
         """First call should not check tokens[-1] for state transitions."""
@@ -338,6 +379,51 @@ class TestParserBackedThinkingBudgetWiring:
         ]
         assert len(budget_processors) == 1
         assert budget_processors[0]._think_end_ids == [101]
+
+    def test_prompt_opened_thinking_gets_opt_in_eos_guard_without_budget(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("OMLX_THINKING_EOS_GUARD", "1")
+        scheduler = self._make_scheduler(None, {})
+        scheduler._resolve_think_end_token_ids = MagicMock(return_value=[42])
+        # A close marker can also appear in a model's terminal-token set. It
+        # must remain sampleable or the protocol could never close.
+        scheduler._get_stop_tokens = MagicMock(return_value={2, 3, 42})
+        request = self._make_request()
+        request.sampling_params.thinking_budget = None
+        # Caller-owned stops remain authoritative and are not folded into the
+        # protocol guard. Only scheduler/model terminal EOS IDs are masked.
+        request.sampling_params.stop_token_ids = [77]
+        request.needs_think_prefix = True
+
+        _, processors = scheduler._build_sampler_and_processors(
+            request.sampling_params,
+            request,
+        )
+
+        protocol_processors = [
+            p for p in processors if isinstance(p, ThinkingBudgetProcessor)
+        ]
+        assert len(protocol_processors) == 1
+        assert protocol_processors[0]._budget is None
+        assert protocol_processors[0]._stop_token_ids == (2, 3)
+
+    def test_eos_guard_is_disabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("OMLX_THINKING_EOS_GUARD", raising=False)
+        scheduler = self._make_scheduler(None, {})
+        request = self._make_request()
+        request.sampling_params.thinking_budget = None
+        request.needs_think_prefix = True
+
+        _, processors = scheduler._build_sampler_and_processors(
+            request.sampling_params,
+            request,
+        )
+
+        assert not any(
+            isinstance(processor, ThinkingBudgetProcessor)
+            for processor in processors
+        )
 
     def test_parser_marker_ignores_none_tokenizer_think_end(self):
         factory = OutputParserFactory(


### PR DESCRIPTION
## Summary

This is the EOS-masking behavior split requested in #3327, now explicitly opt-in instead of applying whenever a prompt opens reasoning.

Set `OMLX_THINKING_EOS_GUARD=1` to mask model terminal IDs only while a prompt-opened `<think>` region remains active. The natural close marker immediately removes the mask. The default is off.

## Behavioral boundaries

- Default behavior and ordinary model-selected EOS remain unchanged.
- Request-specific stop IDs remain authoritative and are never added to the mask.
- A close marker that is also present in the model terminal set remains sampleable.
- The guard works without a thinking-token budget; existing budget-forced close behavior is preserved.
- Snapshot/restore retains the open/closed state for speculative rollback.
- No output reclassification or MTP contract-error behavior is included.

## Cost

M3 Ultra microbenchmark, 129,280-token float32 vocabulary, 300 interleaved evaluated samples:

- control median: 178.187 µs/token
- guarded median: 221.667 µs/token
- incremental median: **43.480 µs/token**
- approximately 0.35% of a 12.5 ms token at 80 tok/s

## Validation

Python 3.13 focused validation: **137 passed, 253 deselected** across thinking-budget, scheduler processor, VLM-MTP processor/fallback, and stop handling tests.

Opened as a draft specifically for the sampling/latency tradeoff discussion requested by the maintainer.