### PR TITLE
fix(mtp): fail closed on processor contract violations

### DIFF
--- a/omlx/speculative/processing_sampler.py
+++ b/omlx/speculative/processing_sampler.py
@@ -61,6 +61,10 @@ import mlx.core as mx
 logger = logging.getLogger(__name__)
 
 
+class MTPProcessorContractError(RuntimeError):
+    """Positioned MTP sampling cannot safely enforce request processors."""
+
+
 def supports_vlm_mtp_processing(processor: Any) -> bool:
     """True when a logits processor can be applied on the vlm_mtp path."""
     return callable(getattr(processor, "snapshot_state", None)) and callable(
@@ -145,13 +149,16 @@ class MTPProcessingSampler:
         after every slot so a later call can rewind to any re-sampled
         position.
         """
-        if self._degraded or not self._processors:
+        if self._degraded:
+            raise MTPProcessorContractError(
+                "positioned sampling previously violated its processor contract"
+            )
+        if not self._processors:
             return self._base(logprobs)
         if not positions:
-            # Positioned contract violated — never sample unprocessed
-            # silently (#2399); degrade loudly.
+            # Positioned contract violated — abort rather than sampling an
+            # unprocessed token that could bypass a privacy/safety processor.
             self._degrade("sample_target called without positions")
-            return self._base(logprobs)
 
         if logprobs.ndim == 1:
             logprobs = logprobs[None, :]
@@ -161,13 +168,11 @@ class MTPProcessingSampler:
                 f"row/position mismatch (rows={n_slots}, "
                 f"positions={len(positions)})"
             )
-            return self._base(logprobs)
 
         base_pos = int(positions[0])
         snapshot = self._snapshots.get(base_pos)
         if snapshot is None:
             self._degrade(f"no checkpoint for base position {base_pos}")
-            return self._base(logprobs)
 
         # Rewind: restore state at base_pos and drop the re-sampled suffix.
         self._restore(snapshot)
@@ -181,10 +186,6 @@ class MTPProcessingSampler:
             pos = int(positions[i])
             if pos != base_pos + i:
                 self._degrade(f"non-contiguous positions ({positions!r})")
-                # Finish this call unprocessed for the remaining slots.
-                rest = self._base(logprobs[i:])
-                rest_list = [int(t) for t in mx.reshape(rest, (-1,)).tolist()]
-                return mx.array(sampled + rest_list, dtype=mx.int32)
             processed = logprobs[i][None, :]
             for proc in self._processors:
                 processed = proc(self._history, processed)
@@ -206,10 +207,10 @@ class MTPProcessingSampler:
 
     def _degrade(self, reason: str) -> None:
         self._degraded = True
-        logger.warning(
-            "MTPProcessingSampler degraded to plain sampling (%s) — "
-            "per-request logits processors are NOT enforced for the rest "
-            "of this request. This indicates an mlx-vlm contract change; "
-            "please report it.",
+        logger.error(
+            "MTPProcessingSampler aborted (%s): continuing would bypass "
+            "per-request logits processors. This indicates an mlx-vlm "
+            "contract change; please report it.",
             reason,
         )
+        raise MTPProcessorContractError(reason)

--- a/tests/test_vlm_mtp_thinking_budget.py
+++ b/tests/test_vlm_mtp_thinking_budget.py
@@ -27,6 +27,7 @@ import omlx.scheduler as scheduler_mod
 from omlx.api.thinking import ThinkingBudgetProcessor
 from omlx.scheduler import Scheduler
 from omlx.speculative.processing_sampler import (
+    MTPProcessorContractError,
     MTPProcessingSampler,
     supports_vlm_mtp_processing,
 )
@@ -179,15 +180,22 @@ class TestMTPProcessingSampler:
         assert not hasattr(proc, "_accepted_up_to")
         assert sampler._history == PROMPT
 
-    def test_missing_positions_degrades_loudly(self, caplog):
+    def test_missing_positions_fails_closed(self, caplog):
         _, sampler, _ = self._fresh(budget=4)
         with caplog.at_level(
-            logging.WARNING, logger="omlx.speculative.processing_sampler"
+            logging.ERROR, logger="omlx.speculative.processing_sampler"
         ):
-            out = sampler.sample_target(_positioned_logprobs(2))
+            with pytest.raises(MTPProcessorContractError):
+                sampler.sample_target(_positioned_logprobs(2))
         assert sampler._degraded
-        assert "NOT enforced" in caplog.text
-        assert [int(t) for t in out.tolist()] == [THINK, THINK]
+        assert "continuing would bypass" in caplog.text
+
+        # A caller cannot catch the first error and silently reuse the
+        # degraded sampler without its processors.
+        with pytest.raises(MTPProcessorContractError):
+            sampler.sample_target(
+                _positioned_logprobs(1), row_ids=[0], positions=[1]
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This is the positioned-MTP processor-contract split requested in #3327.

`MTPProcessingSampler` previously logged a warning and silently fell back to the base sampler when positions, row counts, checkpoints, or contiguity violated the positioned-processing contract. That fallback bypassed request logits processors for the affected token and the remainder of the request.

The sampler now raises a dedicated `MTPProcessorContractError` immediately and remains failed closed on subsequent calls. Requests with no processors retain the existing direct base-sampler path.

## Scope

- No EOS masking.
- No thinking-output reclassification.
- No changes to valid positioned MTP sampling, snapshots, rewind, or accepted-token accounting.
- Only malformed/incompatible processor contracts change from unprocessed sampling to an explicit error.

## Validation

Python 3.13: **78 passed** across positioned MTP processing, VLM MTP, proxy routing, rollback, and fallback coverage.