### PR TITLE
fix(vlm): do not concatenate per-image vision cache entries with mismatched shapes

### DIFF
--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -3198,15 +3198,30 @@ class VLMBatchedEngine(BaseEngine):
                     self._vision_cache.get(h, self._model_name) for h in per_hashes
                 ]
 
+                # Per-image entries are keyed by the image alone, but the
+                # number of soft tokens an image encodes to depends on the
+                # resize regime, which depends on the *other* images in the
+                # request (Gemma 4 per-image resize: 1024x1024 -> 256 tokens,
+                # 1536x640 -> 250). Entries cached from separate single-image
+                # requests can therefore disagree, and mx.concatenate raises
+                # before _vision_features_match_image_tokens below ever gets to
+                # reject them. Check the shapes agree first and fall through to
+                # the whole-request entry (and then a recompute) when they do
+                # not.
+                per_image_usable = (
+                    all(f is not None for f in cached_per_image)
+                    and len({f.shape[1:] for f in cached_per_image}) == 1
+                )
+
                 cached_whole = None
-                if not all(f is not None for f in cached_per_image):
+                if not per_image_usable:
                     # Fallback: whole-request entry (stored when per-image split
                     # is unsupported, e.g. Gemma 4 multi-image with per-image
                     # resize). Mirrors the store-side branch below.
                     cached_whole = self._vision_cache.get(image_hash, self._model_name)
 
                 used_cached_features = False
-                if all(f is not None for f in cached_per_image):
+                if per_image_usable:
                     # All images cached individually — combine and use
                     combined = mx.concatenate(cached_per_image, axis=0)
                     if self._vision_features_match_image_tokens(

--- a/tests/test_vlm_engine.py
+++ b/tests/test_vlm_engine.py
@@ -1469,6 +1469,102 @@ class TestPrepareVisionInputs:
         assert call_kwargs.get("audio") is None
 
 
+    # --- per-image vision feature cache -------------------------------
+
+    def _vision_cache_engine(self, images, entries_by_index):
+        """Engine whose vision cache already holds the given per-image
+        features, keyed by each image's real per-image hash."""
+        from omlx.utils.image import compute_per_image_hashes
+
+        engine = self._setup_engine_for_vision(model_type="gemma4")
+        hashes = compute_per_image_hashes(images)
+        entries = {hashes[i]: f for i, f in entries_by_index.items()}
+
+        cache = MagicMock()
+        cache.get.side_effect = lambda h, _model: entries.get(h)
+        engine._vision_cache = cache
+        engine._vision_cache_enabled = True
+
+        # Keep the embedding step inert but mx.eval-able.
+        embed = MagicMock()
+        embed.inputs_embeds = mx.zeros((1, 3, 8))
+        embed.to_dict.return_value = {"inputs_embeds": embed.inputs_embeds}
+        engine._vlm_model.get_input_embeddings.return_value = embed
+
+        # The token-count cross-check is a separate guard; neutralise it so
+        # these tests isolate the shape agreement.
+        engine._image_token_count = MagicMock(return_value=None)
+        return engine, cache
+
+    @staticmethod
+    def _two_images():
+        from PIL import Image
+
+        return [Image.new("RGB", (8, 8), "red"), Image.new("RGB", (12, 5), "blue")]
+
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    @patch("mlx_vlm.utils.prepare_inputs")
+    @patch("mlx_vlm.prompt_utils.apply_chat_template")
+    def test_per_image_cache_used_when_shapes_agree(self, mock_act, mock_prepare):
+        """Two entries of equal shape still combine and serve from cache."""
+        images = self._two_images()
+        engine, _ = self._vision_cache_engine(
+            images, {0: mx.zeros((1, 4, 8)), 1: mx.ones((1, 4, 8))}
+        )
+        mock_act.return_value = [{"role": "user", "content": "formatted"}]
+        mock_prepare.return_value = {
+            "input_ids": mx.array([[1, 2, 3]]),
+            "pixel_values": mx.zeros((2, 3, 8, 8)),
+        }
+        engine._compute_vision_features = MagicMock(return_value=None)
+
+        engine._prepare_vision_inputs([{"role": "user", "content": "Describe"}], images)
+
+        used = engine._vlm_model.get_input_embeddings.call_args[1][
+            "cached_image_features"
+        ]
+        assert used.shape == (2, 4, 8)
+        engine._compute_vision_features.assert_not_called()
+
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    @patch("mlx_vlm.utils.prepare_inputs")
+    @patch("mlx_vlm.prompt_utils.apply_chat_template")
+    def test_mismatched_per_image_shapes_fall_through(self, mock_act, mock_prepare):
+        """Entries cached under different resize regimes must not be
+        concatenated. Gemma 4 encodes an image to a token count that depends
+        on the other images in the request, so two entries cached from
+        separate single-image requests can disagree; mx.concatenate raised a
+        500 before this fell through."""
+        images = self._two_images()
+        recomputed = mx.zeros((2, 6, 8))
+        engine, cache = self._vision_cache_engine(
+            images, {0: mx.zeros((1, 4, 8)), 1: mx.ones((1, 6, 8))}
+        )
+        mock_act.return_value = [{"role": "user", "content": "formatted"}]
+        mock_prepare.return_value = {
+            "input_ids": mx.array([[1, 2, 3]]),
+            "pixel_values": mx.zeros((2, 3, 8, 8)),
+        }
+        engine._compute_vision_features = MagicMock(return_value=recomputed)
+
+        engine._prepare_vision_inputs([{"role": "user", "content": "Describe"}], images)
+
+        # Fell through to a recompute rather than raising...
+        engine._compute_vision_features.assert_called_once()
+        used = engine._vlm_model.get_input_embeddings.call_args[1][
+            "cached_image_features"
+        ]
+        assert used is recomputed
+        # ...and consulted the whole-request entry on the way, which is only
+        # fetched when the per-image path is unusable.
+        from omlx.utils.image import compute_image_hash
+
+        assert any(
+            call.args and call.args[0] == compute_image_hash(images)
+            for call in cache.get.call_args_list
+        )
+
+
 class TestFormatMessagesForVLMTemplate:
     """Tests for VLMBatchedEngine._format_messages_for_vlm_template()."""
 


### PR DESCRIPTION
## Summary

Closes #3508.

`_prepare_vision_inputs` combines cached per-image vision features with
`mx.concatenate(cached_per_image, axis=0)`. If two entries were cached under
different resize regimes, their shapes disagree and the request 500s.

This checks the shapes before combining and falls through to the existing
`cached_whole` path when they differ.

## Root cause

Entries are keyed by the image alone. But the soft-token count depends on the
image's aspect ratio. Measured on gemma-4-26B-A4B, each cached from its own
single-image request:

| image | tokens |
|---|---|
| 1024x1024 | 256 |
| 1536x640 | 250 |

So two images cached from separate single-image requests can never be
concatenated. `mx.concatenate` raises before
`_vision_features_match_image_tokens` can reject them.

```
POST /v1/chat/completions -> 500 (unhandled): [concatenate] All the input array
dimensions must match exactly except for the concatenation axis. However, the
provided shapes are (1,256,2816), (1,250,2816), and the concatenation axis is 0.
```

Repro (3/3, fresh image bytes each run): image A alone, image B alone, then A+B.
Order matters. `A+B` first stores a whole-request entry and does not reproduce.
Script in #3508.

Recovery today needs both cache tiers. Deleting
`~/.omlx/cache/vision_features` alone leaves the in-memory LRU holding the
entries; unloading the model alone lets the SSD tier repopulate them.

## The change

`per_image_usable` now gates both the combine and the `cached_whole` fetch.

Both, because the fetch sits behind `if not all(f is not None ...)`. Gating only
the combine would reach `elif cached_whole is not None` with `cached_whole`
still `None`, forcing a recompute and skipping an entry that may exist.

## Test plan

- [x] mismatched shapes fall through to the recompute, and fetch the
      whole-request entry on the way
- [x] matching shapes still combine and serve from cache, so the fix cannot
      degrade into "never use the per-image cache"
- [x] mutation check: reverting the source change fails the first test with the
      production `ValueError`, second still passes
- [x] `tests/test_vlm_engine.py` + `tests/test_vision_feature_cache.py`: 147 passed

## Scope and trade-off

You may prefer to fix the key rather than the consumer. A per-image entry
describes an image *in a request context*, but `compute_per_image_hashes`
hashes only `WxH` and the raw RGB bytes. Adding the resize regime
(`num_soft_tokens_per_image` is already in `extra_model_inputs` at lookup time)
would let both variants coexist and actually hit cache for mixed-aspect sets.

I did not send that because it invalidates every existing SSD entry. Measured
cost on an M4 Max, gemma-4-26B-A4B, 1024x1024: a cold miss is ~930 ms against
~485 ms warm. About 445 ms per image, once.

That is a call about your invalidation story, not mine. This guard is worth
having underneath it either way, since shapes can disagree for reasons the key
does not model. Happy to follow up with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
