### PR TITLE
perf(qwen): retain wide prefill with fine-grained prefix caching

### DIFF
--- a/benchmarks/bench_qwen35_cache.py
+++ b/benchmarks/bench_qwen35_cache.py
@@ -1,0 +1,680 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Deterministic, single-request-at-a-time Qwen3.8-27B cache benchmark.
+
+This intentionally uses only the Python standard library.  It is designed to
+be run against an explicitly supplied, isolated oMLX server (usually port
+8845).  It refuses the production port unless ``--allow-8843`` is supplied.
+The harness does not change prompts between repetitions: prefix identity is a
+measurement property, especially for the multi-turn and cache-boundary cases.
+
+The generated JSONL is an append-only cache-boundary record. It contains
+synthetic prompts only; no caller supplied logs or private prompts are
+accepted by this tool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import random
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+MODEL = "Qwen--Qwen3.8-27B-oQ4e-mtp"
+DEFAULT_OUTPUT = "results/qwen-cache-bench.jsonl"
+FACT = "PLANTED_FACT_3070: the cache boundary marker is amber-otter-4821."
+SHORT_PROMPTS = {
+    "count": "Count from 1 to 200, one number per line. Output only the numbers.",
+    "code": (
+        "Write a Python function parse_log_line(line) using a compiled regex to "
+        "parse an nginx access log into ip, ts, method, path, status, bytes, "
+        "referer, and user_agent. Include type conversions and five doctest "
+        "examples. Output only code."
+    ),
+}
+WORD_BANK = (
+    "alpha",
+    "bravo",
+    "charlie",
+    "delta",
+    "echo",
+    "foxtrot",
+    "golf",
+    "hotel",
+    "india",
+    "juliet",
+    "kilo",
+    "lima",
+    "maple",
+    "north",
+    "orbit",
+    "paper",
+    "quartz",
+    "river",
+    "sable",
+    "tango",
+    "umber",
+    "violet",
+    "willow",
+    "xenon",
+    "yellow",
+    "zulu",
+)
+# Measured from the local Qwen tokenizer.json's ByteLevel-BPE vocabulary for
+# this deterministic ASCII fixture (raw user content, before chat-template
+# wrappers). Keep the estimator dependency-free; the tokenizer audit remains a
+# CPU-only preflight check rather than a runtime requirement.
+QWEN_APPROX_CHARS_PER_TOKEN = 3.68
+
+
+def sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def approx_tokens(text: str) -> int:
+    """Return a tokenizer-free estimate calibrated to the local Qwen BPE."""
+
+    return max(1, round(len(text.encode("utf-8")) / QWEN_APPROX_CHARS_PER_TOKEN))
+
+
+def build_long_prompt(target_tokens: int, seed: int, regime: str = "retrieval") -> str:
+    """Build a repeatable synthetic prompt near ``target_tokens``.
+
+    The planted fact is deliberately placed at one-third of the context for a
+    separate retrieval case. Count/code cases use the same filler construction
+    and exercise long-context decode without asking the model to retrieve the
+    answer.
+    """
+
+    rng = random.Random(seed)
+    header = (
+        "Synthetic benchmark context. This is generated filler, not a user log.\n"
+        "Read the complete context before answering.\n"
+    )
+    if regime == "retrieval":
+        trailer = (
+            "\nQuestion: What is the exact value after PLANTED_FACT_3070? Output "
+            "only that value. /no_think"
+        )
+    elif regime == "count":
+        trailer = "\nCount from 1 to 200, one number per line. Output only the numbers. /no_think"
+    elif regime == "code":
+        trailer = (
+            "\nWrite a Python class implementing an LRU cache with get, put, and "
+            "eviction callbacks, with docstrings. Output only code. /no_think"
+        )
+    else:
+        raise ValueError(f"unknown long-context regime: {regime}")
+    target_chars = max(
+        len(header) + len(trailer) + 32,
+        round(target_tokens * QWEN_APPROX_CHARS_PER_TOKEN),
+    )
+    # Keep a fixed prefix and place the fact at a stable interior location.  A
+    # fresh RNG is used for every construction, so every arm sees byte-identical
+    # text when given the same seed and target.
+    filler_target = max(0, target_chars - len(header) - len(trailer))
+    pieces: list[str] = []
+    length = 0
+    i = 0
+    while length < filler_target:
+        line = (
+            f"record-{i:06d} "
+            + " ".join(rng.choice(WORD_BANK) for _ in range(16))
+            + "\n"
+        )
+        pieces.append(line)
+        length += len(line)
+        i += 1
+    filler = "".join(pieces)[:filler_target]
+    if regime == "retrieval":
+        # Keep the marker in the context body, rather than in the question,
+        # so retrieval and cache-boundary behaviour are both exercised.
+        split = len(filler) // 3
+        return header + filler[:split] + "\n" + FACT + "\n" + filler[split:] + trailer
+    return header + filler + trailer
+
+
+def fake_tool_result(turn: int, words: int = 730) -> str:
+    """Produce a deterministic, private-data-free ~750-token tool result."""
+
+    rng = random.Random(0x3070 + turn * 7919)
+    lines = [f"Synthetic tool result turn={turn}; source=generated fixture."]
+    while approx_tokens("\n".join(lines)) < words:
+        n = len(lines)
+        lines.append(
+            f"item-{n:04d}: "
+            + " ".join(rng.choice(WORD_BANK) for _ in range(14))
+        )
+    return "\n".join(lines)
+
+
+def validate_base_url(base_url: str, allow_8843: bool) -> str:
+    parsed = urllib.parse.urlparse(base_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ValueError("--base-url must be an http(s) URL with a hostname")
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    if port == 8843 and not allow_8843:
+        raise ValueError(
+            "refusing production port 8843; use an isolated port (normally 8845) "
+            "or pass --allow-8843 deliberately"
+        )
+    return base_url.rstrip("/")
+
+
+def read_log_end(path: Path | None) -> int | None:
+    if path is None:
+        return None
+    try:
+        return path.stat().st_size
+    except FileNotFoundError:
+        return 0
+
+
+MTP_RE = re.compile(
+    r"MTP\[(?P<id>[^\]]+)\].*?tokens=(?P<tokens>\d+)\s+"
+    r"cycles=(?P<cycles>\d+)\s+tok/cycle=(?P<tok_cycle>[\d.]+)\s+"
+    r"accept=(?P<accepted>\d+)/(?P<attempted>\d+)\s+\((?P<accept_pct>[\d.]+)%\)"
+    r".*?timing\[backbone=(?P<backbone_ms>[\d.]+)ms\s+"
+    r"mtp=(?P<mtp_ms>[\d.]+)ms\s+sample=(?P<sample_ms>[\d.]+)ms\s+"
+    r"cache=(?P<cache_ms>[\d.]+)ms\]"
+)
+DEPTH_RE = re.compile(r"depth\[(?P<depth>[^\]]+)\]")
+DEPTH_ENTRY_RE = re.compile(r"(?P<name>d\d+)=(?P<num>\d+)/(?:\d+)")
+BOUNDARY_RE = re.compile(
+    r"boundary_snapshot_(?P<event>\w+)\s+tokens=(?P<tokens>\d+)\s+"
+    r"block_size=(?P<block_size>\d+)\s+"
+    r"available_boundaries=(?P<available>\d+)"
+)
+BOUNDARY_STORE_RE = re.compile(
+    r"Using boundary cache snapshot for [^:]+:\s+storing\s+"
+    r"(?P<stored>\d+)/(?P<total>\d+) tokens\s+"
+    r"\(skipping trailing partial block,\s+(?P<intermediate>\d+)\s+"
+    r"intermediate snapshots\)"
+)
+CACHE_PHASE_RE = re.compile(r"Cache phase timings:\s*(?P<phases>.*)$")
+CACHE_PHASE_ENTRY_RE = re.compile(
+    r"(?P<name>[A-Za-z0-9_]+)=(?P<ms>[\d.]+)ms/(?P<count>\d+)"
+)
+
+
+def parse_log_slice(path: Path | None, start: int | None, end: int | None = None) -> dict[str, Any]:
+    if path is None or start is None:
+        return {"start": start, "end": end, "mtp": [], "cache_boundary": [], "cache_phase_timings": []}
+    try:
+        file_end = path.stat().st_size
+        start = max(0, int(start))
+        if start >= file_end:
+            return {"start": start, "end": file_end, "mtp": [], "cache_boundary": [], "cache_phase_timings": []}
+        actual_end = file_end if end is None else max(start, min(int(end), file_end))
+        with path.open("rb") as handle:
+            handle.seek(start)
+            text = handle.read(actual_end - start).decode("utf-8", "replace")
+    except FileNotFoundError:
+        return {"start": start, "end": end, "mtp": [], "cache_boundary": [], "cache_phase_timings": []}
+
+    mtp: list[dict[str, Any]] = []
+    boundary: list[dict[str, Any]] = []
+    phase_timings: list[dict[str, Any]] = []
+    for line in text.splitlines():
+        match = MTP_RE.search(line)
+        if match:
+            row = {key: value for key, value in match.groupdict().items()}
+            for key in ("tokens", "cycles", "accepted", "attempted"):
+                row[key] = int(row[key])
+            for key in ("tok_cycle", "accept_pct", "backbone_ms", "mtp_ms", "sample_ms", "cache_ms"):
+                row[key] = float(row[key])
+            row["decode_ms"] = sum(row[key] for key in ("backbone_ms", "mtp_ms", "sample_ms", "cache_ms"))
+            row["decode_tps"] = row["tokens"] / (row["decode_ms"] / 1000.0) if row["decode_ms"] else None
+            depth_match = DEPTH_RE.search(line)
+            row["depth_buckets"] = (
+                {entry.group("name"): int(entry.group("num")) for entry in DEPTH_ENTRY_RE.finditer(depth_match.group("depth"))}
+                if depth_match else {}
+            )
+            mtp.append(row)
+        match = BOUNDARY_RE.search(line)
+        if match:
+            row = match.groupdict()
+            row.update(
+                event="boundary_snapshot_" + row.pop("event"),
+                tokens=int(row["tokens"]),
+                block_size=int(row["block_size"]),
+                available_boundaries=int(row["available"]),
+            )
+            row.pop("available", None)
+            boundary.append(row)
+        store_match = BOUNDARY_STORE_RE.search(line)
+        if store_match:
+            boundary.append(
+                {
+                    "event": "boundary_cache_snapshot",
+                    "stored_tokens": int(store_match.group("stored")),
+                    "total_tokens": int(store_match.group("total")),
+                    "intermediate_snapshots": int(store_match.group("intermediate")),
+                }
+            )
+        phase_match = CACHE_PHASE_RE.search(line)
+        if phase_match:
+            phases: dict[str, dict[str, Any]] = {}
+            for phase in CACHE_PHASE_ENTRY_RE.finditer(phase_match.group("phases")):
+                phases[phase.group("name")] = {
+                    "ms": float(phase.group("ms")),
+                    "count": int(phase.group("count")),
+                }
+            if phases:
+                phase_timings.append(phases)
+        lower = line.lower()
+        if "cache" in lower and any(word in lower for word in ("phase", "restore", "prefix", "boundary")) and not (phase_match or store_match or BOUNDARY_RE.search(line)):
+            # Do not store raw log lines: an unrelated request must never leak
+            # into the campaign artifact.  The digest is enough to correlate a
+            # phase line while keeping the content private.
+            boundary.append({"event": "cache_phase_line", "line_sha256": sha256_text(line)})
+    return {"start": start, "end": actual_end, "mtp": mtp, "cache_boundary": boundary, "cache_phase_timings": phase_timings}
+
+
+def _int_or_none(value: Any) -> int | None:
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def usage_metrics(usage: dict[str, Any]) -> dict[str, Any]:
+    prompt_details = usage.get("prompt_tokens_details") or {}
+    completion_details = usage.get("completion_tokens_details") or {}
+    cache = next(
+        (
+            usage.get(key)
+            for key in ("cache_tokens", "cached_tokens", "cache_read_input_tokens")
+            if usage.get(key) is not None
+        ),
+        prompt_details.get("cached_tokens"),
+    )
+    reasoning = next(
+        (
+            usage.get(key)
+            for key in ("reasoning_tokens", "reasoning_output_tokens")
+            if usage.get(key) is not None
+        ),
+        completion_details.get("reasoning_tokens"),
+    )
+    return {
+        "prompt_tokens": _int_or_none(usage.get("prompt_tokens")),
+        "cache_tokens": _int_or_none(cache),
+        "completion_tokens": _int_or_none(usage.get("completion_tokens")),
+        "reasoning_tokens": _int_or_none(reasoning),
+        "usage_raw": usage,
+    }
+
+
+def request_stream(
+    base_url: str,
+    model: str,
+    messages: list[dict[str, Any]],
+    max_tokens: int,
+    seed: int,
+    timeout: float,
+    log_path: Path | None,
+) -> dict[str, Any]:
+    payload = {
+        "model": model,
+        "messages": messages,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "max_tokens": max_tokens,
+        "temperature": 0.0,
+        "seed": seed,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    body = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    request = urllib.request.Request(
+        base_url + "/v1/chat/completions",
+        data=body,
+        method="POST",
+        headers={"Content-Type": "application/json", "Accept": "text/event-stream"},
+    )
+    log_start = read_log_end(log_path)
+    sent = time.monotonic()
+    content_parts: list[str] = []
+    reasoning_parts: list[str] = []
+    usage: dict[str, Any] = {}
+    first: float | None = None
+    last: float | None = None
+    error: str | None = None
+    finish_reason: str | None = None
+    done_seen = False
+    malformed_sse_events = 0
+    stream_error: Any = None
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            for raw in response:
+                line = raw.decode("utf-8", "replace").strip()
+                if not line.startswith("data:"):
+                    continue
+                data = line[5:].strip()
+                if data == "[DONE]":
+                    done_seen = True
+                    break
+                try:
+                    event = json.loads(data)
+                except json.JSONDecodeError:
+                    malformed_sse_events += 1
+                    continue
+                if event.get("error") is not None:
+                    stream_error = event.get("error")
+                event_usage = event.get("usage")
+                if isinstance(event_usage, dict):
+                    usage.update(event_usage)
+                choices = event.get("choices") or []
+                if choices and isinstance(choices[0], dict):
+                    reason = choices[0].get("finish_reason")
+                    if reason is not None:
+                        finish_reason = str(reason)
+                delta = choices[0].get("delta") if choices else {}
+                if not isinstance(delta, dict):
+                    continue
+                text = delta.get("content") or ""
+                reasoning = delta.get("reasoning_content") or ""
+                if text:
+                    content_parts.append(str(text))
+                if reasoning:
+                    reasoning_parts.append(str(reasoning))
+                if text or reasoning:
+                    now = time.monotonic()
+                    first = now if first is None else first
+                    last = now
+    except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError, OSError) as exc:
+        error = f"{type(exc).__name__}: {exc}"
+    received = time.monotonic()
+    content = "".join(content_parts)
+    reasoning = "".join(reasoning_parts)
+    output = content + reasoning
+    gen_window = (last - first) if first is not None and last is not None else None
+    metrics = usage_metrics(usage)
+    completion_tokens = metrics["completion_tokens"]
+    invalid_reasons: list[str] = []
+    if stream_error is not None:
+        invalid_reasons.append(
+            "event_error=" + json.dumps(stream_error, ensure_ascii=False, sort_keys=True)
+        )
+    if malformed_sse_events:
+        invalid_reasons.append(f"malformed_sse_events={malformed_sse_events}")
+    if not done_seen:
+        invalid_reasons.append("missing_done")
+    if not usage:
+        invalid_reasons.append("missing_usage")
+    if metrics["prompt_tokens"] is None:
+        invalid_reasons.append("missing_prompt_tokens")
+    if completion_tokens is None:
+        invalid_reasons.append("missing_completion_tokens")
+    elif completion_tokens <= 0:
+        invalid_reasons.append("no_completion_tokens")
+    if first is None:
+        invalid_reasons.append("no_output_delta")
+    if not output and completion_tokens and completion_tokens > 0:
+        invalid_reasons.append("empty_output")
+    if error is None and invalid_reasons:
+        error = "invalid_stream: " + "; ".join(invalid_reasons)
+    metrics.update(
+        {
+            "ttft_s": (first - sent) if first is not None else None,
+            "end_to_end_s": received - sent,
+            "generation_window_s": gen_window,
+            "output_tokens_per_s": (
+                max(metrics["completion_tokens"] - 1, 0) / gen_window
+                if metrics["completion_tokens"] is not None and gen_window and gen_window > 0
+                else None
+            ),
+            "output_sha256": sha256_text(output),
+            "output": output,
+            "content": content,
+            "reasoning_content": reasoning,
+            "finish_reason": finish_reason,
+            "stream_done": done_seen,
+            "malformed_sse_events": malformed_sse_events,
+            "stream_error": stream_error,
+            "stream_valid": not invalid_reasons and error is None,
+            "invalid_reasons": invalid_reasons,
+            "error": error,
+            "log": parse_log_slice(log_path, log_start),
+        }
+    )
+    return metrics
+
+
+def case_messages(case: str, seed: int, context_override: int | None) -> tuple[list[dict[str, Any]], int, dict[str, Any]]:
+    short_kind = case[:-3] if case.endswith("128") else case
+    if short_kind in SHORT_PROMPTS:
+        prompt = SHORT_PROMPTS[short_kind] + " /no_think"
+        return [{"role": "user", "content": prompt}], 128 if case.endswith("128") else 400, {
+            "kind": case,
+            "regime": short_kind,
+        }
+    if case.startswith("context16k") or case.startswith("context57k"):
+        context_name = "context16k" if case.startswith("context16k") else "context57k"
+        suffix = case[len(context_name):].lstrip("-_") or "retrieval"
+        if suffix.startswith("continuation-"):
+            regime = suffix[len("continuation-"):]
+            if regime not in {"count", "code"}:
+                raise ValueError(f"unknown continuation regime: {regime}")
+            target = context_override or (16_000 if context_name == "context16k" else 57_000)
+            prime = build_long_prompt(target, seed, "retrieval")
+            return [
+                {"role": "user", "content": prime},
+                {"role": "assistant", "content": "amber-otter-4821"},
+                {"role": "user", "content": SHORT_PROMPTS[regime] + " /no_think"},
+            ], 400, {
+                "kind": case,
+                "regime": regime,
+                "target_context_tokens": target,
+                "approx_prompt_tokens": approx_tokens(prime),
+                "planted_fact": FACT,
+                "continuation": True,
+            }
+        regime = suffix if suffix in {"count", "code", "retrieval"} else "retrieval"
+        target = context_override or (16_000 if context_name == "context16k" else 57_000)
+        prompt = build_long_prompt(target, seed, regime)
+        max_tokens = 32 if regime == "retrieval" else 400
+        return [{"role": "user", "content": prompt}], max_tokens, {
+            "kind": case,
+            "regime": regime,
+            "target_context_tokens": target,
+            "approx_prompt_tokens": approx_tokens(prompt),
+            "planted_fact": FACT if regime == "retrieval" else None,
+        }
+    if case == "tool128":
+        prompt = (
+            "Return one compact JSON tool call with keys tool and args. Use tool "
+            "name inspect_fixture and argument path synthetic/module_3.py. "
+            "Output only JSON. /no_think"
+        )
+        return [{"role": "user", "content": prompt}], 128, {"kind": case}
+    raise ValueError(f"case_messages does not build {case}")
+
+
+def prompt_metadata(messages: list[dict[str, Any]], meta: dict[str, Any]) -> dict[str, Any]:
+    serialized = json.dumps(messages, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    prompt_text = "\n".join(str(message.get("content", "")) for message in messages)
+    return {
+        **meta,
+        "prompt_sha256": sha256_text(serialized),
+        "prompt_prefix_sha256": sha256_text(serialized[:2048]),
+        "prompt_chars": len(prompt_text),
+        "approx_prompt_tokens": approx_tokens(prompt_text),
+        "approx_chars_per_token": QWEN_APPROX_CHARS_PER_TOKEN,
+        "approx_token_estimator": "local Qwen tokenizer.json ByteLevel-BPE audit; chat wrappers excluded",
+    }
+
+
+def run_multiturn(args: argparse.Namespace, output_handle: Any) -> None:
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "system",
+            "content": "You are a concise synthetic coding agent. Thinking is disabled.",
+        },
+        {
+            "role": "user",
+            "content": "Inspect the generated repository fixture and report the next safe action. /no_think",
+        },
+    ]
+    for turn in range(1, args.turns + 1):
+        meta = prompt_metadata(messages, {"kind": "multiturn", "turn": turn, "growth_target_tokens": 750})
+        start = time.time()
+        metrics = request_stream(
+            args.base_url, args.model, messages, 8, args.seed + turn, args.timeout, args.log_path
+        )
+        row = {
+            "schema": 1,
+            "campaign": "qwen27b-m5-campaign",
+            "arm": args.arm,
+            "case": "multiturn",
+            "warmup": False,
+            "run": turn,
+            "seed": args.seed + turn,
+            "request_started_unix": start,
+            "model": args.model,
+            "max_tokens": 8,
+            "temperature": 0.0,
+            "stream": True,
+            "chat_template_kwargs": {"enable_thinking": False},
+            "thinking_enabled": False,
+            **meta,
+            **metrics,
+        }
+        output_handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+        output_handle.flush()
+        print(f"multiturn turn={turn} prompt~{meta['approx_prompt_tokens']} tok", flush=True)
+        assistant = metrics.get("output") or ""
+        messages.append({"role": "assistant", "content": assistant})
+        # Append an independent synthetic tool result; do not rewrite any
+        # previous message or nonce the prefix.
+        messages.append({"role": "user", "content": fake_tool_result(turn) + "\nContinue. /no_think"})
+
+
+def write_request_row(
+    args: argparse.Namespace,
+    output_handle: Any,
+    case: str,
+    run: int,
+    warmup: bool,
+    messages: list[dict[str, Any]],
+    max_tokens: int,
+    meta: dict[str, Any],
+) -> None:
+    started = time.time()
+    prompt_info = prompt_metadata(messages, meta)
+    metrics = request_stream(
+        args.base_url, args.model, messages, max_tokens, args.seed, args.timeout, args.log_path
+    )
+    row = {
+        "schema": 1,
+        "campaign": "qwen27b-m5-campaign",
+        "arm": args.arm,
+        "case": case,
+        "run": run,
+        "warmup": warmup,
+        "seed": args.seed,
+        "request_started_unix": started,
+        "model": args.model,
+        "max_tokens": max_tokens,
+        "temperature": 0.0,
+        "stream": True,
+        "chat_template_kwargs": {"enable_thinking": False},
+        "thinking_enabled": False,
+        **prompt_info,
+        **metrics,
+    }
+    output_handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+    output_handle.flush()
+    status = "FAILED" if metrics.get("error") else "ok"
+    print(
+        f"{case} {'warmup' if warmup else f'run={run}'} {status} "
+        f"ttft={metrics.get('ttft_s')} e2e={metrics.get('end_to_end_s')} "
+        f"completion={metrics.get('completion_tokens')}",
+        flush=True,
+    )
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", required=True, help="Isolated oMLX URL, normally http://127.0.0.1:8845")
+    parser.add_argument("--allow-8843", action="store_true", help="Deliberately permit production port 8843")
+    parser.add_argument("--model", default=MODEL, help=argparse.SUPPRESS)
+    parser.add_argument("--output", default=DEFAULT_OUTPUT, help="Append-only JSONL destination")
+    parser.add_argument("--serve-log", help="Optional server log for per-request offsets and MTP extraction")
+    parser.add_argument("--arm", default="baseline", help="Experiment arm label recorded in every row")
+    parser.add_argument("--seed", type=int, default=3070, help="Explicit deterministic request/prompt seed")
+    parser.add_argument(
+        "--cases",
+        nargs="+",
+        choices=(
+            "count", "code", "count128", "code128", "context16k", "context16k-count", "context16k-code",
+            "context16k-retrieval", "context16k-continuation-count", "context16k-continuation-code",
+            "context57k", "context57k-count", "context57k-code", "context57k-retrieval",
+            "context57k-continuation-count", "context57k-continuation-code", "multiturn", "tool128",
+        ),
+        default=[
+            "count", "code", "count128", "code128", "context16k-count", "context16k-code", "context16k-retrieval",
+            "context57k-count", "context57k-code", "context57k-retrieval", "multiturn", "tool128",
+        ],
+    )
+    parser.add_argument("--runs", type=int, default=3, help="Recorded repetitions for one-shot cases")
+    parser.add_argument("--warmup", type=int, default=1, help="Discarded warmup repetitions for one-shot cases")
+    parser.add_argument("--turns", type=int, default=10, help="Number of append-only multi-turn requests")
+    parser.add_argument("--context-target", type=int, help="Override approximate context size for both context cases")
+    parser.add_argument("--timeout", type=float, default=1800.0, help="Per-request timeout in seconds")
+    parser.add_argument("--validate-only", action="store_true", help="Validate arguments and print plan without HTTP/GPU work")
+    args = parser.parse_args(argv)
+    try:
+        args.base_url = validate_base_url(args.base_url, args.allow_8843)
+    except ValueError as exc:
+        parser.error(str(exc))
+    if args.runs < 1 or args.warmup < 0 or args.turns < 1:
+        parser.error("--runs and --turns must be positive; --warmup cannot be negative")
+    args.log_path = Path(args.serve_log).expanduser() if args.serve_log else None
+    return args
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.validate_only:
+        print(
+            json.dumps(
+                {
+                    "base_url": args.base_url,
+                    "model": args.model,
+                    "arm": args.arm,
+                    "seed": args.seed,
+                    "cases": args.cases,
+                    "output": args.output,
+                    "serve_log": str(args.log_path) if args.log_path else None,
+                    "gpu_work": False,
+                },
+                indent=2,
+            )
+        )
+        return 0
+
+    output_path = Path(args.output).expanduser()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("a", encoding="utf-8") as output_handle:
+        for case in args.cases:
+            if case == "multiturn":
+                run_multiturn(args, output_handle)
+                continue
+            messages, max_tokens, meta = case_messages(case, args.seed, args.context_target)
+            for run in range(1, args.warmup + args.runs + 1):
+                write_request_row(args, output_handle, case, run, run <= args.warmup, messages, max_tokens, meta)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/bench_qwen35_restore.py
+++ b/benchmarks/bench_qwen35_restore.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: E402, I001
+"""CPU-preparable restore QA for the synthetic Qwen3.8 16K cache case.
+
+The cached phase primes the server, then checks three saved continuation
+fixtures for the expected recurrent-checkpoint walkback. The reference phase
+sends the same fixture bytes to a fresh no-cache server and requires zero
+cached tokens. ``--create-only`` performs local tokenization and fixture
+writes without HTTP or GPU work.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import re
+import sys
+import time
+import zlib
+from pathlib import Path
+from typing import Any
+
+from tokenizers import Tokenizer
+
+BENCHMARK_DIR = Path(__file__).resolve().parent
+REPOSITORY_ROOT = BENCHMARK_DIR.parent
+sys.path.insert(0, str(BENCHMARK_DIR))
+
+from bench_qwen35_cache import (  # noqa: E402
+    FACT,
+    MODEL,
+    case_messages,
+    prompt_metadata,
+    request_stream,
+    validate_base_url,
+)
+
+
+DEFAULT_TOKENIZER = (
+    Path.home() / ".mtplx/models/Qwen--Qwen3.8-27B-oQ4e-mtp/tokenizer.json"
+)
+DEFAULT_FIXTURES = REPOSITORY_ROOT / "results/qwen35-restore-fixtures.json"
+DEFAULT_OUTPUT = REPOSITORY_ROOT / "results/qwen35-restore-probe.jsonl"
+
+
+def _solid_red_png(width: int = 64, height: int = 64) -> bytes:
+    """Build a 64x64 RGB PNG without external image dependencies."""
+
+    import struct
+
+    signature = b"\x89PNG\r\n\x1a\n"
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    rows = b"".join(b"\x00" + b"\xff\x00\x00" * width for _ in range(height))
+
+    def chunk(kind: bytes, payload: bytes) -> bytes:
+        body = kind + payload
+        checksum = zlib.crc32(body) & 0xFFFFFFFF
+        return (
+            struct.pack(">I", len(payload))
+            + body
+            + struct.pack(">I", checksum)
+        )
+
+    return (
+        signature
+        + chunk(b"IHDR", ihdr)
+        + chunk(b"IDAT", zlib.compress(rows, 9))
+        + chunk(b"IEND", b"")
+    )
+
+
+def _vision_messages() -> list[dict[str, Any]]:
+    png = base64.b64encode(_solid_red_png()).decode("ascii")
+    return [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "What colour is the square? Answer one word.",
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/png;base64,{png}"},
+                },
+            ],
+        }
+    ]
+
+
+def _load_tokenizer(path: Path) -> Tokenizer:
+    if not path.is_file():
+        raise FileNotFoundError(f"tokenizer.json not found: {path}")
+    return Tokenizer.from_file(str(path))
+
+
+def _fixture_messages(
+    tokenizer: Tokenizer,
+    raw: str,
+    cut: int,
+    suffix: str,
+) -> tuple[list[dict[str, str]], int]:
+    ids = tokenizer.encode(raw).ids
+    prefix = tokenizer.decode(ids[:cut], skip_special_tokens=False)
+    content = prefix + suffix
+    return (
+        [{"role": "user", "content": content}],
+        len(tokenizer.encode(content).ids),
+    )
+
+
+def build_fixtures(tokenizer: Tokenizer, seed: int) -> dict[str, Any]:
+    prime, max_tokens, prime_meta = case_messages(
+        "context16k-retrieval", seed, None
+    )
+    raw = str(prime[0]["content"])
+    cuts = (
+        (
+            3500,
+            "cobalt-heron-7913",
+            2048,
+            "\n\nNew continuation fact: PLANTED_FACT_3070 is "
+            "cobalt-heron-7913. What is the exact new value? /no_think",
+        ),
+        (
+            5800,
+            "amber-otter-4821",
+            4096,
+            "\n\nContinue and answer the original PLANTED_FACT_3070 value only. "
+            "/no_think",
+        ),
+        (
+            8300,
+            "amber-otter-4821",
+            8192,
+            "\n\nAnswer the original PLANTED_FACT_3070 value only. /no_think",
+        ),
+    )
+    cases: dict[str, Any] = {}
+    for cut, expected, walkback, suffix in cuts:
+        messages, token_count = _fixture_messages(tokenizer, raw, cut, suffix)
+        cases[f"cut{cut}"] = {
+            "case": f"cut{cut}",
+            "cut_tokens": cut,
+            "messages": messages,
+            "token_count": token_count,
+            "expected_answer": expected,
+            "expected_cache_tokens": walkback,
+            "max_tokens": 32,
+            "seed": seed + cut,
+            "meta": prompt_metadata(
+                messages,
+                {"kind": "restore_probe", "cut_tokens": cut},
+            ),
+        }
+    return {
+        "schema": 1,
+        "synthetic": True,
+        "model": MODEL,
+        "tokenizer": "Qwen3.8 tokenizer.json",
+        "prime": {
+            "messages": prime,
+            "max_tokens": max_tokens,
+            "seed": seed,
+            "token_count": len(tokenizer.encode(raw).ids),
+            "meta": prompt_metadata(prime, prime_meta),
+        },
+        "cases": cases,
+    }
+
+
+def _write_fixture(path: Path, fixture: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(fixture, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _validate_fixture(fixture: dict[str, Any]) -> None:
+    """Verify that the cuts still exercise the intended fact cases."""
+
+    cases = fixture.get("cases", {})
+    for name, item in cases.items():
+        content = str((item.get("messages") or [{}])[0].get("content", ""))
+        if name == "cut3500" and "amber-otter-4821" in content:
+            raise ValueError("cut3500 unexpectedly retains the original fact")
+        if name in {"cut5800", "cut8300"} and FACT not in content:
+            raise ValueError(f"{name} does not retain the original planted fact")
+
+
+def _normalise_marker(value: Any) -> str:
+    """Ignore only whitespace and punctuation around an answer marker."""
+
+    return re.sub(r"[^a-z0-9]+", "", str(value).casefold())
+
+
+def _record_request(
+    *,
+    base_url: str,
+    model: str,
+    phase: str,
+    case: str,
+    item: dict[str, Any],
+    log_path: Path | None,
+    timeout: float,
+) -> dict[str, Any]:
+    started = time.time()
+    metrics = request_stream(
+        base_url,
+        model,
+        item["messages"],
+        item["max_tokens"],
+        item["seed"],
+        timeout,
+        log_path,
+    )
+    output = metrics.get("output") or metrics.get("content") or ""
+    expected_cache = item.get("expected_cache_tokens")
+    actual_cache = metrics.get("cache_tokens")
+    is_prime = case == "prime"
+    stream_ok = (
+        metrics.get("stream_valid") is True
+        and metrics.get("stream_done") is True
+        and not metrics.get("error")
+        and not metrics.get("stream_error")
+    )
+    checks = {
+        "answer_ok": _normalise_marker(item["expected_answer"])
+        in _normalise_marker(output),
+        "stream_ok": stream_ok,
+        "cache_ok": (
+            True
+            if is_prime
+            else actual_cache == 0
+            if phase == "reference"
+            else actual_cache == expected_cache
+        ),
+    }
+    return {
+        "schema": 1,
+        "synthetic": True,
+        "model": model,
+        "phase": phase,
+        "case": case,
+        "started_unix": started,
+        "expected_cache_tokens": expected_cache,
+        "actual_cache_tokens": actual_cache,
+        "ttft_s": metrics.get("ttft_s"),
+        "end_to_end_s": metrics.get("end_to_end_s"),
+        "usage": metrics.get("usage_raw"),
+        "output": output,
+        "checks": checks,
+        "metrics": metrics,
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-url",
+        required=True,
+        help="Explicit isolated server URL, normally http://127.0.0.1:8845",
+    )
+    parser.add_argument("--allow-8843", action="store_true")
+    parser.add_argument(
+        "--phase",
+        choices=("cached", "reference"),
+        default="cached",
+    )
+    parser.add_argument("--model", default=MODEL, help=argparse.SUPPRESS)
+    parser.add_argument("--tokenizer", type=Path, default=DEFAULT_TOKENIZER)
+    parser.add_argument("--fixtures", type=Path, default=DEFAULT_FIXTURES)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--serve-log", type=Path)
+    parser.add_argument("--seed", type=int, default=3070)
+    parser.add_argument("--timeout", type=float, default=1800.0)
+    parser.add_argument("--create-only", action="store_true")
+    parser.add_argument(
+        "--vision",
+        action="store_true",
+        help="Run the optional generated red-square vision request",
+    )
+    args = parser.parse_args(argv)
+    try:
+        args.base_url = validate_base_url(args.base_url, args.allow_8843)
+    except ValueError as exc:
+        parser.error(str(exc))
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    fixture_path = args.fixtures.expanduser()
+    if fixture_path.exists() and not args.create_only:
+        fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+        if fixture.get("synthetic") is not True:
+            raise ValueError(f"fixture is not marked synthetic: {fixture_path}")
+    else:
+        tokenizer = _load_tokenizer(args.tokenizer.expanduser())
+        fixture = build_fixtures(tokenizer, args.seed)
+        _write_fixture(fixture_path, fixture)
+    _validate_fixture(fixture)
+    if args.create_only:
+        print(
+            json.dumps(
+                {"created": str(fixture_path), "synthetic": True},
+                indent=2,
+            )
+        )
+        return 0
+
+    output_path = args.output.expanduser()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path = args.serve_log.expanduser() if args.serve_log else None
+    failures = 0
+    with output_path.open("a", encoding="utf-8") as output:
+        if args.phase == "cached":
+            prime = fixture["prime"]
+            prime_row = _record_request(
+                base_url=args.base_url,
+                model=args.model,
+                phase=args.phase,
+                case="prime",
+                item={
+                    **prime,
+                    "expected_answer": "amber-otter-4821",
+                    "expected_cache_tokens": 0,
+                },
+                log_path=log_path,
+                timeout=args.timeout,
+            )
+            output.write(json.dumps(prime_row, ensure_ascii=False) + "\n")
+            failures += sum(not value for value in prime_row["checks"].values())
+        for case, item in fixture["cases"].items():
+            row = _record_request(
+                base_url=args.base_url,
+                model=args.model,
+                phase=args.phase,
+                case=case,
+                item=item,
+                log_path=log_path,
+                timeout=args.timeout,
+            )
+            output.write(json.dumps(row, ensure_ascii=False) + "\n")
+            failures += sum(not value for value in row["checks"].values())
+        if args.vision:
+            item = {
+                "messages": _vision_messages(),
+                "max_tokens": 8,
+                "seed": args.seed + 9000,
+                "expected_answer": "red",
+                "expected_cache_tokens": 0,
+            }
+            row = _record_request(
+                base_url=args.base_url,
+                model=args.model,
+                phase=args.phase,
+                case="vision-red-square",
+                item=item,
+                log_path=log_path,
+                timeout=args.timeout,
+            )
+            row["checks"]["vision_answer_ok"] = row["checks"]["answer_ok"]
+            output.write(json.dumps(row, ensure_ascii=False) + "\n")
+            failures += sum(not value for value in row["checks"].values())
+        output.flush()
+    if failures:
+        print(f"restore probe failed checks={failures}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/qwen35-sparse-boundaries.md
+++ b/docs/qwen35-sparse-boundaries.md
@@ -14,12 +14,16 @@ Two public tools cover separate questions:
 
 ## Activation and scope
 
-Start an isolated server with both experiment controls set explicitly:
+From this checkout, use a source virtual environment and a separate settings
+base so the experiment does not change the normal server configuration:
 
 ```bash
+PYTHONPATH=. \
 OMLX_QWEN35_SPARSE_BOUNDARIES=1 \
 OMLX_GDN_SNAPSHOT_STORAGE=embedded \
-/path/to/venv/bin/omlx serve \
+/path/to/venv/bin/python -m omlx.cli serve \
+  --base-path /tmp/omlx-sparse-bench \
+  --model-dir /path/to/models \
   --port 8845 \
   --paged-ssd-cache-dir /tmp/omlx-sparse-cache \
   --arrays-cache-block-size 512

--- a/docs/qwen35-sparse-boundaries.md
+++ b/docs/qwen35-sparse-boundaries.md
@@ -170,3 +170,28 @@ PR 3439. Boundary timing follows the instrumentation lineage of PR 3391. The
 experiment measures the final-boundary opportunity discussed in issue 3070;
 these references do not imply that the changes are present in every oMLX
 release.
+
+## Three-sample default-path comparison
+
+A subsequent comparison used the same MLX 0.32.2 source backend in both
+arms, MTP depth 8, temperature zero, non-thinking requests, and three
+measured samples per case after warmup. It compared the automatic 2048-token
+cache blocks with sparse 512-token blocks. These are not measurements against
+the installed app's older bundled MLX runtime.
+
+| Workload | Default median total time | Sparse median total time | Reduction |
+|---|---:|---:|---:|
+| 16K, 400-token code continuation | 16.84 s | 12.76 s | 24.2% |
+| 57K, 400-token code continuation | 29.40 s | 22.08 s | 24.9% |
+| Matched 12-turn synthetic loop, total | 51.07 s | 32.56 s | 36.2% |
+
+All compared prompts matched. Every prompt and output in the 12-turn loop
+matched between arms. Long-form MTP outputs were not byte-identical across
+every run, including default-path repetitions, so these results do not
+establish a universal quality or decode-throughput improvement. The main
+benefit is less cache and prompt-processing work.
+
+The cache-only candidate passed 645 focused tests. Real restored-prefix
+probes used exactly 2048/4096/8192 cached tokens and returned the same facts
+as cache-disabled references. Long-context retrieval and vision probes also
+passed.

--- a/docs/qwen35-sparse-boundaries.md
+++ b/docs/qwen35-sparse-boundaries.md
@@ -1,0 +1,168 @@
+# Qwen3.8 sparse cache boundaries
+
+This branch contains an opt-in experiment for Qwen3.8 models using embedded
+Gated DeltaNet state. It keeps the normal 2048-token bulk prefill forwards
+while retaining a 512-token cache block and one final 512-aligned recurrent
+checkpoint near the prompt tail. The default serving policy is unchanged.
+
+Two public tools cover separate questions:
+
+- [bench_qwen35_cache.py](../benchmarks/bench_qwen35_cache.py) measures cold
+  and warm request performance with deterministic synthetic prompts.
+- [bench_qwen35_restore.py](../benchmarks/bench_qwen35_restore.py) creates
+  fixed continuation fixtures and checks restored-prefix correctness.
+
+## Activation and scope
+
+Start an isolated server with both experiment controls set explicitly:
+
+```bash
+OMLX_QWEN35_SPARSE_BOUNDARIES=1 \
+OMLX_GDN_SNAPSHOT_STORAGE=embedded \
+/path/to/venv/bin/omlx serve \
+  --port 8845 \
+  --paged-ssd-cache-dir /tmp/omlx-sparse-cache \
+  --arrays-cache-block-size 512
+```
+
+The sparse policy engages only when all of these conditions hold:
+
+- `OMLX_QWEN35_SPARSE_BOUNDARIES=1` was present at scheduler startup;
+- `--arrays-cache-block-size 512` selected an explicit 512-token block;
+- GDN snapshots use embedded storage, rather than split SSD sidecars;
+- the loaded model identifies as Qwen3.5/3.8; and
+- `make_cache()` returns only top-level `ArraysCache` and `KVCache` entries,
+  with both types present.
+
+If any condition fails, the sparse policy stays inactive. An explicit
+512-token block still retains the established every-512-boundary behaviour.
+Without the environment gate, serving defaults remain unchanged. A missing
+block override, `None`, or `0` keeps automatic ArraysCache block sizing.
+
+The sparse path captures absolute 2048-token recurrent checkpoints and the
+final 512-aligned position reachable during prefill. Prefill deliberately
+leaves the final prompt token for generation kickoff, so an exactly
+512-aligned prompt normally has its final prefill checkpoint 512 tokens
+earlier. Restores inside a sparse region walk back to the newest captured
+recurrent checkpoint and prefill the remaining suffix. They do not claim the
+largest ordinary 512-token block below the shared prefix.
+
+Use an isolated port and cache directory. The tools refuse production port
+8843 unless `--allow-8843` is supplied deliberately.
+
+## Performance benchmark
+
+`bench_qwen35_cache.py` is the campaign harness. It accepts `--arm`,
+`--cases`, `--runs`, `--warmup`, `--output`, and `--serve-log`; it does not
+accept restore-probe options such as `--phase`, `--fixtures`, or
+`--create-only`.
+
+Validate a performance plan without HTTP or GPU work:
+
+```bash
+/path/to/venv/bin/python benchmarks/bench_qwen35_cache.py \
+  --base-url http://127.0.0.1:8845 \
+  --arm sparse512 \
+  --cases context16k-retrieval context57k-retrieval \
+  --runs 2 \
+  --warmup 0 \
+  --output /tmp/qwen35-cache-performance.jsonl \
+  --validate-only
+```
+
+Remove `--validate-only` to run the plan against the isolated server. The
+default append-only output is `results/qwen-cache-bench.jsonl`. Each row
+records prompt hashes, usage counts, cached tokens, output, TTFT, end-to-end
+latency, generation timing, and optional server-log diagnostics.
+
+Compare arms in separate server runs with identical model settings, prompt
+seed, cases, concurrency, and cache cleanliness. For an ordinary 512-block
+control, omit `OMLX_QWEN35_SPARSE_BOUNDARIES`; keep embedded GDN and the same
+`--arrays-cache-block-size 512`. For a no-cache reference, start a fresh server
+with caching disabled:
+
+```bash
+/path/to/venv/bin/omlx serve --port 8845 --no-cache
+```
+
+Reusing an existing cache directory can turn a planned cold row into a warm
+hit.
+
+## Restore QA
+
+The restore probe owns fixture creation and cached/reference phases. Its
+defaults are `results/qwen35-restore-fixtures.json` and
+`results/qwen35-restore-probe.jsonl`.
+
+Create deterministic fixtures locally:
+
+```bash
+/path/to/venv/bin/python benchmarks/bench_qwen35_restore.py \
+  --base-url http://127.0.0.1:8845 \
+  --create-only \
+  --fixtures /tmp/qwen35-restore-fixtures.json
+```
+
+Run the cached phase against a clean isolated sparse-boundary server:
+
+```bash
+/path/to/venv/bin/python benchmarks/bench_qwen35_restore.py \
+  --base-url http://127.0.0.1:8845 \
+  --phase cached \
+  --fixtures /tmp/qwen35-restore-fixtures.json \
+  --output /tmp/qwen35-restore-cached.jsonl \
+  --serve-log /tmp/omlx-sparse-server.log
+```
+
+Then run the byte-identical fixtures against a fresh no-cache server:
+
+```bash
+/path/to/venv/bin/python benchmarks/bench_qwen35_restore.py \
+  --base-url http://127.0.0.1:8845 \
+  --phase reference \
+  --fixtures /tmp/qwen35-restore-fixtures.json \
+  --output /tmp/qwen35-restore-reference.jsonl \
+  --serve-log /tmp/omlx-reference-server.log
+```
+
+The cached phase primes the deterministic 16K retrieval prompt, then checks
+three continuations. Expected reuse is the newest captured recurrent
+checkpoint shared with each fixture:
+
+| Fixture cut | Expected answer | Expected cached tokens |
+|---:|---|---:|
+| 3500 | `cobalt-heron-7913` | 2048 |
+| 5800 | `amber-otter-4821` | 4096 |
+| 8300 | `amber-otter-4821` | 8192 |
+
+The reference phase requires zero cached tokens. A wrong fact, cache-count
+mismatch, malformed stream, missing stream terminator, or server error makes
+the probe exit nonzero. `--vision` adds an independent generated 64x64 red
+square check.
+
+## Recorded evidence
+
+The following single-session observations come from the isolated campaign
+JSONL `2026-09-07-qwen27b-http.jsonl`. Corresponding rows have identical
+prompt hashes within each context, were stream-valid, and returned
+`amber-otter-4821`. The ordinary and sparse rows are recorded under the arm
+labels `cache512-e1` and `sparse512-f1`, respectively.
+
+| Arm | Prompt tokens | Cold TTFT | Warm TTFT | Warm cached tokens |
+|---|---:|---:|---:|---:|
+| ordinary 512 | 16,061 | 36.980 s | 3.021 s | 15,872 |
+| sparse 512 | 16,061 | 35.338 s | 2.243 s | 15,872 |
+| ordinary 512 | 57,072 | 177.370 s | 8.462 s | 56,832 |
+| sparse 512 | 57,072 | 161.975 s | 5.420 s | 56,832 |
+
+These are targeted observations, rather than a production recommendation or
+a universal block-size result. Repeat the paired arms in one thermal session
+before making a performance claim.
+
+## Provenance
+
+The cache-size plumbing follows the block-size override approach in upstream
+PR 3439. Boundary timing follows the instrumentation lineage of PR 3391. The
+experiment measures the final-boundary opportunity discussed in issue 3070;
+these references do not imply that the changes are present in every oMLX
+release.

--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -42,6 +42,20 @@ def _positive_int(value: str) -> int:
     return parsed
 
 
+def _nonnegative_int(value: str) -> int:
+    """Parse a cache block override, accepting 0 as the automatic sentinel."""
+
+    if isinstance(value, bool):
+        raise argparse.ArgumentTypeError("must be a non-negative integer")
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be a non-negative integer")
+    return parsed
+
+
 def _has_cli_overrides(args) -> bool:
     """Check if CLI args contain non-default values that should be saved.
 
@@ -64,6 +78,7 @@ def _has_cli_overrides(args) -> bool:
         "hot_cache_max_size",
         "hot_cache_write_through",
         "initial_cache_blocks",
+        "arrays_cache_block_size",
         "mcp_config",
         "hf_endpoint",
         "hf_cache_enabled",
@@ -319,6 +334,9 @@ def serve_command(args):
             scheduler_config.hot_cache_write_through = bool(
                 args.hot_cache_write_through
             )
+
+        if getattr(args, "arrays_cache_block_size", None) is not None:
+            scheduler_config.arrays_cache_block_size = args.arrays_cache_block_size
 
         if args.no_cache:
             print(
@@ -1147,6 +1165,12 @@ Example directory structure:
         default=None,
         help="Number of cache blocks to pre-allocate at startup (default: 256). "
         "Higher values reduce dynamic allocation overhead for large contexts.",
+    )
+    serve_parser.add_argument(
+        "--arrays-cache-block-size",
+        type=_nonnegative_int,
+        default=None,
+        help="ArraysCache hybrid block size in tokens; 0 selects automatic sizing.",
     )
 
     # MCP options

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1809,6 +1809,7 @@ class Scheduler:
         # For ArraysCache-only models (no RotatingKVCache), use a larger block
         # size to reduce boundary snapshot overhead during prefill.
         self._enlarge_block_size_for_arrays_cache()
+        self._qwen35_sparse_boundaries = self._enable_qwen35_sparse_boundaries()
 
         # TurboQuant KV cache (set by engine if model_settings has it enabled)
         self._turboquant_kv_bits: float | None = None
@@ -2776,6 +2777,8 @@ class Scheduler:
     # e.g. a 4096-token block cannot serve a 3k-token prefix. A geometry change
     # also leaves old SSD blocks cold until normal eviction removes them.
     _ARRAYS_CACHE_BLOCK_SIZE = 2048
+    _QWEN35_SPARSE_BOUNDARY_BLOCK_SIZE = 512
+    _QWEN35_SPARSE_BOUNDARY_STRIDE = 2048
 
     def _enlarge_block_size_for_arrays_cache(self) -> None:
         """Enlarge block size for ArraysCache-only hybrid models.
@@ -2851,6 +2854,110 @@ class Scheduler:
             target,
         )
         self.config.paged_cache_block_size = target
+
+    def _enable_qwen35_sparse_boundaries(self) -> bool:
+        """Enable the narrow embedded-GDN sparse-boundary experiment.
+
+        Qwen3.5/3.8 exposes a flat mixture of ArraysCache and KVCache layers.
+        In embedded mode, blocks without an Arrays snapshot carry an explicit
+        placeholder and reconstruction walks back to the newest real state.
+        Composite, rotating, split-GDN, and other cache layouts keep the
+        established every-block capture path.
+        """
+
+        if os.environ.get("OMLX_QWEN35_SPARSE_BOUNDARIES", "").strip().lower() not in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }:
+            return False
+        if (
+            self.config.arrays_cache_block_size
+            != self._QWEN35_SPARSE_BOUNDARY_BLOCK_SIZE
+            or self.config.paged_cache_block_size
+            != self._QWEN35_SPARSE_BOUNDARY_BLOCK_SIZE
+            or self.config.gdn_ssd_split_enabled
+            or not self.config.paged_ssd_cache_dir
+        ):
+            logger.info(
+                "Qwen sparse boundaries skipped: requires explicit embedded "
+                "ArraysCache block_size=512 with paged SSD cache"
+            )
+            return False
+
+        model_type = str(getattr(self.model, "model_type", "") or "")
+        if not model_type:
+            model_type = str(
+                getattr(getattr(self.model, "config", None), "model_type", "") or ""
+            )
+        if not model_type.startswith("qwen3_5") or not hasattr(
+            self.model, "make_cache"
+        ):
+            return False
+        try:
+            cache = self.model.make_cache()
+        except Exception:
+            return False
+        names = [type(layer).__name__ for layer in (cache or [])]
+        allowed = {"ArraysCache", "KVCache"}
+        if (
+            not names
+            or any(name not in allowed for name in names)
+            or "ArraysCache" not in names
+            or "KVCache" not in names
+        ):
+            logger.info(
+                "Qwen sparse boundaries skipped: cache layout must be a flat "
+                "ArraysCache/KVCache mixture (got %s)",
+                names,
+            )
+            return False
+
+        logger.info(
+            "Qwen sparse prefill boundaries enabled: block_size=512, "
+            "capture_stride=2048 plus final reachable boundary"
+        )
+        return True
+
+    def _next_prefill_snapshot_boundary(
+        self,
+        current_total: int,
+        final_forwarded_total: int,
+        block_size: int,
+    ) -> int | None:
+        """Return the next boundary that a prefill forward must not cross."""
+
+        if not self._qwen35_sparse_boundaries:
+            return ((current_total // block_size) + 1) * block_size
+
+        final_boundary = (final_forwarded_total // block_size) * block_size
+        candidates = []
+        stride = self._QWEN35_SPARSE_BOUNDARY_STRIDE
+        stride_boundary = ((current_total // stride) + 1) * stride
+        if stride_boundary <= final_forwarded_total:
+            candidates.append(stride_boundary)
+        if current_total < final_boundary <= final_forwarded_total:
+            candidates.append(final_boundary)
+        return min(candidates) if candidates else None
+
+    def _should_capture_prefill_boundary(
+        self,
+        token_count: int,
+        final_forwarded_total: int,
+        block_size: int,
+    ) -> bool:
+        """Return whether this exact materialized position needs a snapshot."""
+
+        if token_count <= 0 or block_size <= 0 or token_count % block_size:
+            return False
+        if not self._qwen35_sparse_boundaries:
+            return True
+        final_boundary = (final_forwarded_total // block_size) * block_size
+        return (
+            token_count % self._QWEN35_SPARSE_BOUNDARY_STRIDE == 0
+            or token_count == final_boundary
+        )
 
     def _model_has_arrays_cache(self) -> bool:
         """Whether the model's cache layout contains ArraysCache layers."""
@@ -3599,6 +3706,7 @@ class Scheduler:
         prefill_tokens = tokens[:-1]
         last_token = tokens[-1:]
         total_length = len(tokens)
+        final_forwarded_total = base_size + len(prefill_tokens)
 
         # Build the input row on the engine stream: the chunk forwards below
         # run inside mx.stream(self._stream), and a worker-default-stream
@@ -3632,11 +3740,15 @@ class Scheduler:
             # Boundary-limited step size
             if boundary_enabled and block_size > 0:
                 current_total = base_size + processed_tokens
-                next_boundary = ((current_total // block_size) + 1) * block_size
-                target_boundary_prefill = next_boundary - base_size
-                delta = target_boundary_prefill - processed_tokens
-                if delta > 0:
-                    n_to_process = min(n_to_process, delta)
+                next_boundary = self._next_prefill_snapshot_boundary(
+                    current_total,
+                    final_forwarded_total,
+                    block_size,
+                )
+                if next_boundary is not None:
+                    delta = next_boundary - current_total
+                    if delta > 0:
+                        n_to_process = min(n_to_process, delta)
                 n_to_process = max(1, n_to_process)
 
             try:
@@ -3764,8 +3876,11 @@ class Scheduler:
             if boundary_enabled:
                 total_tokens = base_size + processed_tokens
                 if (
-                    total_tokens > 0
-                    and total_tokens % block_size == 0
+                    self._should_capture_prefill_boundary(
+                        total_tokens,
+                        final_forwarded_total,
+                        block_size,
+                    )
                     and emitted_boundaries.get(request.request_id, -1) < total_tokens
                 ):
                     self._emit_prefill_boundary_snapshot(
@@ -3905,8 +4020,11 @@ class Scheduler:
         if boundary_enabled:
             total_tokens = base_size + processed_tokens
             if (
-                total_tokens > 0
-                and total_tokens % block_size == 0
+                self._should_capture_prefill_boundary(
+                    total_tokens,
+                    final_forwarded_total,
+                    block_size,
+                )
                 and emitted_boundaries.get(request.request_id, -1) < total_tokens
             ):
                 self._emit_prefill_boundary_snapshot(
@@ -5409,10 +5527,16 @@ class Scheduler:
         # Clamp to the next block boundary so boundary snapshots fire exactly.
         if state.boundary_enabled and state.block_size > 0:
             current_total = state.base_size + state.tokens_processed
-            next_boundary = ((current_total // state.block_size) + 1) * state.block_size
-            delta = (next_boundary - state.base_size) - state.tokens_processed
-            if delta > 0:
-                n = min(n, delta)
+            final_forwarded_total = state.base_size + max(0, state.total_length - 1)
+            next_boundary = self._next_prefill_snapshot_boundary(
+                current_total,
+                final_forwarded_total,
+                state.block_size,
+            )
+            if next_boundary is not None:
+                delta = next_boundary - current_total
+                if delta > 0:
+                    n = min(n, delta)
             n = max(1, n)
 
         # Adaptive throttle — see _adaptive_chunk_size docstring. Raises
@@ -5506,10 +5630,14 @@ class Scheduler:
         # Boundary snapshot
         if state.boundary_enabled:
             total_tokens = state.base_size + state.tokens_processed
+            final_forwarded_total = state.base_size + max(0, state.total_length - 1)
             rid = state.request.request_id
             if (
-                total_tokens > 0
-                and total_tokens % state.block_size == 0
+                self._should_capture_prefill_boundary(
+                    total_tokens,
+                    final_forwarded_total,
+                    state.block_size,
+                )
                 and state.emitted_boundaries.get(rid, -1) < total_tokens
             ):
                 self._emit_prefill_boundary_snapshot(
@@ -5639,10 +5767,14 @@ class Scheduler:
         if not state.boundary_enabled:
             return
         total_tokens = state.base_size + state.tokens_processed
+        final_forwarded_total = state.base_size + max(0, state.total_length - 1)
         rid = state.request.request_id
         if (
-            total_tokens > 0
-            and total_tokens % state.block_size == 0
+            self._should_capture_prefill_boundary(
+                total_tokens,
+                final_forwarded_total,
+                state.block_size,
+            )
             and state.emitted_boundaries.get(rid, -1) < total_tokens
         ):
             self._emit_prefill_boundary_snapshot(

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -6611,36 +6611,56 @@ class Scheduler:
             )
             return
 
-        # Offload snapshot to SSD if store is available, keeping only a
-        # None marker in the dict.  Falls back to in-memory storage when
-        # the SSD store is unavailable or the write fails.
-        if self._boundary_snapshot_store is not None:
-            # Keep the extraction + serialization eval on the per-engine
-            # stream, mirroring _eval_snapshot_cache on the in-memory path
-            # below. save() slices the live cache state and mx.eval's it on
-            # this (owner) thread; unwrapped, those ops bind to gpu,0 and
-            # split the prefill graph across streams (#2330 hardening).
-            with mx.stream(self._stream):
-                saved = self._boundary_snapshot_store.save(
-                    request_id,
-                    token_count,
-                    snapshot_cache,
-                    self._extract_snapshot_cache_states,
-                    block_size=block_size,
-                )
-            if saved:
-                self._boundary_cache_snapshots[request_id][token_count] = None
-                storage = "ssd"
+        # The persist branch runs synchronously inside prefill (slice + eval of
+        # the recurrent state, serialization, SSD pending-slot wait). Time it
+        # so the cost shows up in the phase log next to the decode-side capture
+        # phases instead of hiding inside prefill wall time (#3070).
+        phase = (
+            "prefill_boundary_capture"
+            if source == "prefill"
+            else "terminal_boundary_capture"
+        )
+        with self._phase_timer(phase):
+            # Offload snapshot to SSD if store is available, keeping only a
+            # None marker in the dict. Falls back to in-memory storage when
+            # the SSD store is unavailable or the write fails.
+            if self._boundary_snapshot_store is not None:
+                # Keep the extraction + serialization eval on the per-engine
+                # stream, mirroring _eval_snapshot_cache on the in-memory path
+                # below. save() slices the live cache state and mx.eval's it on
+                # this (owner) thread; unwrapped, those ops bind to gpu,0 and
+                # split the prefill graph across streams (#2330 hardening).
+                with mx.stream(self._stream):
+                    saved = self._boundary_snapshot_store.save(
+                        request_id,
+                        token_count,
+                        snapshot_cache,
+                        self._extract_snapshot_cache_states,
+                        block_size=block_size,
+                    )
+                if saved:
+                    self._boundary_cache_snapshots[request_id][token_count] = None
+                    storage = "ssd"
+                else:
+                    self._boundary_snapshot_diagnostics.record(
+                        "ssd_fallback",
+                        reason="ssd_save_failed",
+                        request_id=request_id,
+                        token_count=token_count,
+                        block_size=block_size,
+                        source=source,
+                        storage="memory",
+                    )
+                    self._boundary_cache_snapshots[request_id][token_count] = (
+                        _compact_boundary_snapshot_value(
+                            self._prefill_snapshot_value(snapshot_cache),
+                            token_count,
+                            block_size,
+                            self._stream,
+                        )
+                    )
+                    storage = "memory"
             else:
-                self._boundary_snapshot_diagnostics.record(
-                    "ssd_fallback",
-                    reason="ssd_save_failed",
-                    request_id=request_id,
-                    token_count=token_count,
-                    block_size=block_size,
-                    source=source,
-                    storage="memory",
-                )
                 self._boundary_cache_snapshots[request_id][token_count] = (
                     _compact_boundary_snapshot_value(
                         self._prefill_snapshot_value(snapshot_cache),
@@ -6650,16 +6670,6 @@ class Scheduler:
                     )
                 )
                 storage = "memory"
-        else:
-            self._boundary_cache_snapshots[request_id][token_count] = (
-                _compact_boundary_snapshot_value(
-                    self._prefill_snapshot_value(snapshot_cache),
-                    token_count,
-                    block_size,
-                    self._stream,
-                )
-            )
-            storage = "memory"
 
         self._boundary_snapshot_required = True
         self._enable_mtp_boundary_alignment()

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1569,6 +1569,9 @@ class SchedulerConfig:
 
     # Paged cache settings (internal defaults)
     paged_cache_block_size: int = 256  # Tokens per block
+    # None/0 selects automatic ArraysCache sizing. An explicit value is only
+    # applied to ArraysCache-only hybrid models and never changes prefill size.
+    arrays_cache_block_size: int | None = None
     max_cache_blocks: int | None = (
         None  # Auto-calculated from available KV cache memory
     )
@@ -2810,6 +2813,28 @@ class Scheduler:
         )
         if not has_arrays_cache:
             return
+
+        explicit = self.config.arrays_cache_block_size
+        if explicit is not None:
+            if (
+                isinstance(explicit, bool)
+                or not isinstance(explicit, int)
+                or explicit < 0
+            ):
+                logger.warning(
+                    "Ignoring invalid arrays_cache_block_size=%r; "
+                    "using automatic sizing",
+                    explicit,
+                )
+            elif explicit > 0:
+                if self.config.paged_cache_block_size != explicit:
+                    logger.info(
+                        "Using configured arrays_cache_block_size=%s for "
+                        "ArraysCache hybrid model",
+                        explicit,
+                    )
+                    self.config.paged_cache_block_size = explicit
+                return
 
         target = max(
             self._ARRAYS_CACHE_BLOCK_SIZE,

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -342,6 +342,8 @@ class CacheSettings:
     # once, at the first ANE compile, so a change applies on restart.
     ane_compile_cache: bool = False
     initial_cache_blocks: int = 256  # Starting blocks (grows dynamically)
+    # None/0 selects the scheduler's automatic ArraysCache block target.
+    arrays_cache_block_size: int | None = None
     # None selects the policy automatically: use an SSD sidecar when the SSD
     # cache is enabled, otherwise keep GDN state embedded with the main cache.
     # True/False preserve the legacy explicit split/embedded choices.
@@ -439,6 +441,7 @@ class CacheSettings:
             "hot_cache_write_through": self.hot_cache_write_through,
             "ane_compile_cache": self.ane_compile_cache,
             "initial_cache_blocks": self.initial_cache_blocks,
+            "arrays_cache_block_size": self.arrays_cache_block_size,
         }
 
     @classmethod
@@ -489,6 +492,7 @@ class CacheSettings:
             ),
             ane_compile_cache=bool(data.get("ane_compile_cache", False)),
             initial_cache_blocks=data.get("initial_cache_blocks", 256),
+            arrays_cache_block_size=data.get("arrays_cache_block_size"),
         )
 
 
@@ -1304,6 +1308,11 @@ class GlobalSettings:
             and args.initial_cache_blocks is not None
         ):
             self.cache.initial_cache_blocks = args.initial_cache_blocks
+        if (
+            hasattr(args, "arrays_cache_block_size")
+            and args.arrays_cache_block_size is not None
+        ):
+            self.cache.arrays_cache_block_size = args.arrays_cache_block_size
         if getattr(args, "no_cache", False):
             self.cache.enabled = False
 
@@ -1612,6 +1621,16 @@ class GlobalSettings:
                 f"{self.cache.initial_cache_blocks} (must be > 0)"
             )
 
+        block_size = self.cache.arrays_cache_block_size
+        if block_size is not None and (
+            isinstance(block_size, bool)
+            or not isinstance(block_size, int)
+            or block_size < 0
+        ):
+            errors.append(
+                "Invalid arrays_cache_block_size: must be a non-negative integer"
+            )
+
         # Sampling validation
         if (
             self.sampling.max_context_window_policy is not None
@@ -1727,6 +1746,7 @@ class GlobalSettings:
                 self.cache.gdn_ssd_pending_max_size
             ),
             gdn_sidecar_state_dtype=self.cache.gdn_sidecar_state_dtype,
+            arrays_cache_block_size=self.cache.arrays_cache_block_size,
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -275,6 +275,7 @@ class TestServeCommandOptions:
         assert "--paged-ssd-cache-dir" in result.stdout
         assert "--paged-ssd-cache-max-size" in result.stdout
         assert "--no-cache" in result.stdout
+        assert "--arrays-cache-block-size" in result.stdout
 
     def test_serve_has_mcp_option(self):
         """Test that serve command has --mcp-config option."""

--- a/tests/test_prefix_cache_cachelist_mixed.py
+++ b/tests/test_prefix_cache_cachelist_mixed.py
@@ -302,6 +302,7 @@ def test_prefill_snapshot_decoupled_from_live_cache():
     """In-memory prefill boundary snapshots must capture the state AT the
     boundary. Storing the live cache objects aliased every boundary to
     the prefill's final state (KVCache mutates its buffer in place)."""
+    from collections import defaultdict
     from types import SimpleNamespace
 
     from omlx.scheduler import Scheduler
@@ -320,7 +321,10 @@ def test_prefill_snapshot_decoupled_from_live_cache():
         _boundary_snapshot_required=False,
         _stream=mx.default_stream(mx.default_device()),
         _PREFILL_SNAPSHOT_MARKER=Scheduler._PREFILL_SNAPSHOT_MARKER,
+        _phase_total_ms=defaultdict(float),
+        _phase_count=defaultdict(int),
     )
+    stub._phase_timer = lambda phase: Scheduler._phase_timer(stub, phase)
     stub._extract_cache_states = lambda caches: Scheduler._extract_cache_states(
         stub, caches
     )

--- a/tests/test_qwen35_sparse_boundaries.py
+++ b/tests/test_qwen35_sparse_boundaries.py
@@ -1,0 +1,348 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the opt-in Qwen embedded-GDN sparse-boundary experiment."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import mlx.core as mx
+from mlx_lm.models.cache import ArraysCache as MLXArraysCache
+from mlx_lm.models.cache import KVCache as MLXKVCache
+
+from omlx.cache.paged_cache import PagedCacheManager
+from omlx.cache.paged_ssd_cache import PagedSSDCacheManager
+from omlx.cache.prefix_cache import BlockAwarePrefixCache
+from omlx.request import Request, SamplingParams
+from omlx.scheduler import Scheduler, SchedulerConfig
+
+
+class ArraysCache:
+    def __init__(self, offset: int = 0):
+        self.offset = offset
+        self.cache = [mx.zeros((1, 1, 1)), mx.zeros((1, 1, 1))]
+
+    @property
+    def state(self):
+        return self.cache
+
+    def size(self):
+        return self.offset
+
+
+class KVCache:
+    def __init__(self, offset: int = 0):
+        self.offset = offset
+        self._state = (mx.zeros((1, 1, 1, 1)), mx.zeros((1, 1, 1, 1)))
+
+    @property
+    def state(self):
+        return self._state
+
+    def size(self):
+        return self.offset
+
+
+class CacheList:
+    def __init__(self):
+        self.caches = [KVCache(), ArraysCache()]
+
+
+class _ChunkModel:
+    model_type = "qwen3_5"
+
+    def __init__(self, cache_names=("ArraysCache", "KVCache")):
+        self.config = SimpleNamespace(
+            model_type="qwen3_5",
+            num_hidden_layers=2,
+            hidden_size=8,
+            num_attention_heads=1,
+            num_key_value_heads=1,
+        )
+        self.cache_names = cache_names
+        self.prefill_calls = []
+
+    def make_cache(self):
+        constructors = {
+            "ArraysCache": ArraysCache,
+            "KVCache": KVCache,
+            "CacheList": CacheList,
+        }
+        return [constructors[name]() for name in self.cache_names]
+
+    def __call__(self, tokens, cache=None, **kwargs):
+        count = int(tokens.shape[1])
+        self.prefill_calls.append(count)
+        for layer in cache or []:
+            if hasattr(layer, "offset"):
+                layer.offset += count
+        return mx.zeros((1, count, 1))
+
+
+def _scheduler(
+    monkeypatch,
+    tmp_path,
+    model=None,
+    *,
+    split=False,
+    explicit=512,
+    enabled=True,
+):
+    if enabled:
+        monkeypatch.setenv("OMLX_QWEN35_SPARSE_BOUNDARIES", "1")
+    else:
+        monkeypatch.delenv("OMLX_QWEN35_SPARSE_BOUNDARIES", raising=False)
+    model = model or _ChunkModel()
+    with (
+        patch("omlx.settings.get_system_memory", return_value=32 * 1024**3),
+        patch("omlx.custom_kernels.nax.is_nax_available", return_value=True),
+    ):
+        scheduler = Scheduler(
+            model=model,
+            tokenizer=MagicMock(),
+            config=SchedulerConfig(
+                prefill_step_size=2048,
+                paged_ssd_cache_dir=str(tmp_path / "cache"),
+                paged_ssd_cache_max_size=32 * 1024**2,
+                paged_cache_block_size=256,
+                arrays_cache_block_size=explicit,
+                gdn_ssd_split_enabled=split,
+            ),
+        )
+    scheduler._adaptive_chunk_size = lambda n, **kwargs: n
+    scheduler._guard_prefill_chunk = lambda n, **kwargs: n
+    scheduler._record_chunk_transient = lambda *args, **kwargs: None
+    scheduler._maybe_record_fixed_state_bytes = lambda cache: None
+    scheduler._consume_pressure_clear = lambda: False
+    scheduler._check_pending_aborts_for_uids = lambda uids: set()
+    scheduler._memory_limit_bytes = 0
+    return scheduler
+
+
+def _run_external_prefill(scheduler, token_count, *, base=0):
+    request = Request(
+        request_id=f"prefill-{base}-{token_count}",
+        prompt="",
+        sampling_params=SamplingParams(),
+    )
+    request.cached_tokens = base
+    cache = scheduler.model.make_cache()
+    for layer in cache:
+        if hasattr(layer, "offset"):
+            layer.offset = base
+    captured = []
+    scheduler._emit_prefill_boundary_snapshot = (
+        lambda request, prompt_cache, total: captured.append(total)
+    )
+    scheduler.model.prefill_calls.clear()
+    scheduler._do_external_prefill(
+        request,
+        list(range(token_count)),
+        cache if base else None,
+    )
+    return scheduler.model.prefill_calls, captured
+
+
+def test_sparse_fresh_prefill_keeps_wide_chunks_and_one_final_split(
+    monkeypatch, tmp_path
+):
+    scheduler = _scheduler(monkeypatch, tmp_path)
+    try:
+        chunks, captures = _run_external_prefill(scheduler, 5000)
+        assert chunks == [2048, 2048, 512, 391]
+        assert captures == [2048, 4096, 4608]
+    finally:
+        scheduler.shutdown()
+
+
+def test_sparse_restored_prefill_honours_absolute_boundaries(monkeypatch, tmp_path):
+    scheduler = _scheduler(monkeypatch, tmp_path)
+    try:
+        chunks, captures = _run_external_prefill(scheduler, 2441, base=2560)
+        assert chunks == [1536, 512, 392]
+        assert captures == [4096, 4608]
+    finally:
+        scheduler.shutdown()
+
+
+def test_sparse_exact_multiple_prompt_keeps_last_token_for_insert(
+    monkeypatch, tmp_path
+):
+    scheduler = _scheduler(monkeypatch, tmp_path)
+    try:
+        chunks, captures = _run_external_prefill(scheduler, 5120)
+        assert chunks == [2048, 2048, 512, 511]
+        assert captures == [2048, 4096, 4608]
+        assert 5120 not in captures
+    finally:
+        scheduler.shutdown()
+
+
+def test_sparse_gate_requires_exact_embedded_flat_qwen_layout(monkeypatch, tmp_path):
+    valid = _scheduler(monkeypatch, tmp_path / "valid")
+    try:
+        assert valid._qwen35_sparse_boundaries is True
+    finally:
+        valid.shutdown()
+
+    for model, split, explicit in (
+        (_ChunkModel(("ArraysCache", "KVCache")), True, 512),
+        (_ChunkModel(("ArraysCache", "KVCache")), False, 0),
+        (_ChunkModel(("CacheList",)), False, 512),
+        (_ChunkModel(("ArraysCache",)), False, 512),
+    ):
+        scheduler = _scheduler(
+            monkeypatch,
+            tmp_path / f"invalid-{split}-{explicit}-{model.cache_names[0]}",
+            model,
+            split=split,
+            explicit=explicit,
+        )
+        try:
+            assert scheduler._qwen35_sparse_boundaries is False
+        finally:
+            scheduler.shutdown()
+
+    disabled = _scheduler(monkeypatch, tmp_path / "disabled", enabled=False)
+    try:
+        assert disabled._qwen35_sparse_boundaries is False
+    finally:
+        disabled.shutdown()
+
+
+def test_split_gdn_explicit_512_keeps_every_block_checkpoint(monkeypatch, tmp_path):
+    scheduler = _scheduler(monkeypatch, tmp_path, split=True, explicit=512)
+    try:
+        assert scheduler.config.paged_cache_block_size == 512
+        assert scheduler._qwen35_sparse_boundaries is False
+
+        final_forwarded_total = 2048
+        targets = []
+        current = 0
+        while current < final_forwarded_total:
+            target = scheduler._next_prefill_snapshot_boundary(
+                current,
+                final_forwarded_total,
+                512,
+            )
+            assert target is not None
+            targets.append(target)
+            current = target
+
+        assert targets == [512, 1024, 1536, 2048]
+        assert [
+            target
+            for target in targets
+            if scheduler._should_capture_prefill_boundary(
+                target,
+                final_forwarded_total,
+                512,
+            )
+        ] == targets
+    finally:
+        scheduler.shutdown()
+
+
+def _embedded_extracted(token_count: int, recurrent_value: float):
+    return [
+        {
+            "state": (
+                mx.full((1, 1, token_count, 2), recurrent_value),
+                mx.full((1, 1, token_count, 2), recurrent_value + 1),
+            ),
+            "class_name": "KVCache",
+            "cache_type": "KVCache",
+            "meta_state": (token_count,),
+        },
+        {
+            "state": (
+                mx.full((1, 1, 2), recurrent_value),
+                mx.full((1, 1, 1, 2), recurrent_value),
+            ),
+            "class_name": "ArraysCache",
+            "cache_type": "ArraysCache",
+            "meta_state": (),
+        },
+    ]
+
+
+def _block_hashes(prefix, table):
+    return [
+        prefix.paged_cache.allocated_blocks[block_id].block_hash
+        for block_id in table.block_ids
+    ]
+
+
+def test_embedded_sparse_snapshots_walk_back_without_skipping_suffix_and_dedup(
+    tmp_path,
+):
+    block_size = 4
+    tokens = list(range(16))
+    paged = PagedCacheManager(
+        block_size=block_size,
+        max_blocks=32,
+        initial_blocks=32,
+        model_name="sparse-embedded",
+    )
+    ssd = PagedSSDCacheManager(
+        cache_dir=tmp_path / "embedded",
+        max_size_bytes=32 * 1024**2,
+        expected_model_name="sparse-embedded",
+        expected_num_layers=2,
+        expected_block_size=block_size,
+        expected_layer_cache_types=["KVCache", "ArraysCache"],
+        gdn_ssd_split_enabled=False,
+    )
+    prefix = BlockAwarePrefixCache(
+        model=SimpleNamespace(
+            make_cache=lambda: [
+                MLXKVCache(),
+                MLXArraysCache(size=2),
+            ]
+        ),
+        paged_cache_manager=paged,
+        paged_ssd_cache_manager=ssd,
+        gdn_ssd_split_enabled=False,
+    )
+    sparse = {8: _embedded_extracted(8, 8.0)}
+
+    try:
+        first = prefix.store_cache(
+            "first",
+            tokens,
+            _embedded_extracted(16, 16.0),
+            boundary_snapshots=sparse,
+        )
+        assert first is not None and first.num_tokens == 16
+        hashes = _block_hashes(prefix, first)
+
+        second = prefix.store_cache(
+            "dedup",
+            tokens,
+            _embedded_extracted(16, 16.0),
+            boundary_snapshots=sparse,
+        )
+        assert second is not None and second.num_tokens == 16
+        assert _block_hashes(prefix, second) == hashes
+
+        mid_prompt = tokens[:12]
+        table, initial_remaining = prefix.fetch_cache("restore-mid", mid_prompt)
+        assert table is not None and initial_remaining == []
+        restored = prefix.reconstruct_cache(table)
+        assert restored is not None
+        assert table.num_tokens == 8
+        corrected_remaining = mid_prompt[table.num_tokens :]
+        assert corrected_remaining == tokens[8:12]
+        assert restored[0].state[0].shape[2] == 8
+        assert restored[1].size() == 8
+        prefix.release_cache("restore-mid")
+
+        extended = tokens + [16, 17]
+        table, remaining = prefix.fetch_cache("restore-final", extended)
+        assert table is not None and remaining == [16, 17]
+        restored = prefix.reconstruct_cache(table)
+        assert restored is not None and table.num_tokens == 16
+        assert restored[1].size() == 16
+        prefix.release_cache("restore-final")
+    finally:
+        ssd.close()

--- a/tests/test_qwen4_qsa_reservation_integration.py
+++ b/tests/test_qwen4_qsa_reservation_integration.py
@@ -33,6 +33,7 @@ def test_chunked_reservation_includes_restored_prefix(snapshots_enabled):
         model=object(),
         config=SimpleNamespace(paged_cache_block_size=64),
         block_aware_cache=object() if snapshots_enabled else None,
+        _qwen35_sparse_boundaries=False,
         _stream=mx.default_stream(mx.gpu),
     )
     state = Scheduler._begin_prefill(
@@ -42,6 +43,12 @@ def test_chunked_reservation_includes_restored_prefix(snapshots_enabled):
         [cache, SimpleNamespace(offset=128)],
     )
     ns._prefill_step_size_for_progress = lambda *a: 64
+    ns._next_prefill_snapshot_boundary = (
+        lambda *args: Scheduler._next_prefill_snapshot_boundary(ns, *args)
+    )
+    ns._should_capture_prefill_boundary = (
+        lambda *args: Scheduler._should_capture_prefill_boundary(ns, *args)
+    )
     ns._reserve_qsa_index_capacity = (
         lambda caches, tokens: Scheduler._reserve_qsa_index_capacity(ns, caches, tokens)
     )

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -110,6 +110,7 @@ class TestSchedulerConfig:
         assert config.embedding_batch_size == 32
         assert config.prefill_step_size == 2048
         assert config.paged_cache_block_size == 256
+        assert config.arrays_cache_block_size is None
         assert config.max_cache_blocks is None
         assert config.initial_cache_blocks == 256
         assert config.paged_ssd_cache_dir is None
@@ -3772,6 +3773,26 @@ class TestSchedulerArraysCacheBlockAlignment:
                 return mx.zeros((1, tokens.shape[1], 1))
 
         return HybridModel()
+
+    def test_explicit_arrays_block_override_does_not_change_prefill_step(
+        self, mock_tokenizer, tmp_path
+    ):
+        scheduler = Scheduler(
+            model=self._hybrid_model(),
+            tokenizer=mock_tokenizer,
+            config=SchedulerConfig(
+                prefill_step_size=2048,
+                paged_ssd_cache_dir=str(tmp_path),
+                paged_cache_block_size=256,
+                arrays_cache_block_size=512,
+            ),
+        )
+        try:
+            assert scheduler.config.paged_cache_block_size == 512
+            assert scheduler.config.prefill_step_size == 2048
+            assert scheduler._prefill_step_size_for_progress(0, 4096) == 2048
+        finally:
+            scheduler.shutdown()
 
     def test_qwen35_wide_prefill_aligns_block_size_to_4096(
         self, mock_tokenizer, tmp_path

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3338,6 +3338,105 @@ class TestSchedulerBoundarySnapshots:
         assert scheduler._boundary_snapshot_required is True
         assert mock_model._omlx_mtp_commit_align == 4
 
+    def _prefill_boundary_scheduler(self, mock_model, mock_tokenizer, store=None):
+        """Scheduler, request, and stateful stub cache for timer tests."""
+        scheduler = Scheduler(
+            model=mock_model,
+            tokenizer=mock_tokenizer,
+            config=SchedulerConfig(paged_cache_block_size=4),
+        )
+        scheduler.block_aware_cache = MagicMock()
+        scheduler._boundary_snapshot_store = store
+        request = Request(
+            request_id="req-prefill-timer",
+            prompt="hello",
+            sampling_params=SamplingParams(),
+        )
+        scheduler.requests[request.request_id] = request
+        scheduler.running[request.request_id] = request
+        snapshot_cache = [type("RotatingKVCache", (), {})()]
+        return scheduler, request, snapshot_cache
+
+    def test_prefill_boundary_snapshot_times_memory_capture(
+        self, mock_model, mock_tokenizer
+    ):
+        """The in-memory persist path must land in phase timers (#3070)."""
+        scheduler, request, snapshot_cache = self._prefill_boundary_scheduler(
+            mock_model, mock_tokenizer
+        )
+
+        scheduler._on_prefill_boundary_snapshot(request.request_id, snapshot_cache, 4)
+
+        assert scheduler.get_phase_stats()["prefill_boundary_capture"]["count"] == 1
+        assert (
+            scheduler._boundary_cache_snapshots[request.request_id][4] == snapshot_cache
+        )
+        assert scheduler._boundary_snapshot_required is True
+        assert mock_model._omlx_mtp_commit_align == 4
+
+    def test_terminal_boundary_snapshot_uses_terminal_phase(
+        self, mock_model, mock_tokenizer
+    ):
+        """Verified terminal captures do not inflate prefill timing."""
+        scheduler, request, snapshot_cache = self._prefill_boundary_scheduler(
+            mock_model, mock_tokenizer
+        )
+
+        scheduler._on_prefill_boundary_snapshot(
+            request.request_id,
+            snapshot_cache,
+            4,
+            source="terminal",
+        )
+
+        stats = scheduler.get_phase_stats()
+        assert stats["terminal_boundary_capture"]["count"] == 1
+        assert "prefill_boundary_capture" not in stats
+
+    def test_prefill_boundary_snapshot_times_ssd_capture(
+        self, mock_model, mock_tokenizer
+    ):
+        """The SSD persist path is timed; the snapshot remains a marker."""
+        store = MagicMock()
+        store.save.return_value = True
+        scheduler, request, snapshot_cache = self._prefill_boundary_scheduler(
+            mock_model, mock_tokenizer, store=store
+        )
+        scheduler._on_prefill_boundary_snapshot(request.request_id, snapshot_cache, 4)
+
+        assert scheduler.get_phase_stats()["prefill_boundary_capture"]["count"] == 1
+        assert scheduler._boundary_cache_snapshots[request.request_id][4] is None
+
+    def test_prefill_boundary_snapshot_times_ssd_fallback(
+        self, mock_model, mock_tokenizer
+    ):
+        """A failed SSD save falls back to memory inside the timed phase."""
+        store = MagicMock()
+        store.save.return_value = False
+        scheduler, request, snapshot_cache = self._prefill_boundary_scheduler(
+            mock_model, mock_tokenizer, store=store
+        )
+        scheduler._on_prefill_boundary_snapshot(request.request_id, snapshot_cache, 4)
+
+        assert scheduler.get_phase_stats()["prefill_boundary_capture"]["count"] == 1
+        assert scheduler._boundary_cache_snapshots[request.request_id][4] is not None
+        diagnostics = scheduler._boundary_snapshot_diagnostics.snapshot()
+        assert diagnostics["ssd_fallbacks"] == 1
+        assert diagnostics["captures_memory"] == 1
+
+    def test_prefill_boundary_snapshot_unaligned_is_not_timed(
+        self, mock_model, mock_tokenizer
+    ):
+        """Early returns happen before the persist branch and record no phase."""
+        scheduler, request, snapshot_cache = self._prefill_boundary_scheduler(
+            mock_model, mock_tokenizer
+        )
+        scheduler._on_prefill_boundary_snapshot(request.request_id, snapshot_cache, 3)
+
+        assert "prefill_boundary_capture" not in scheduler.get_phase_stats()
+        diagnostics = scheduler._boundary_snapshot_diagnostics.snapshot()
+        assert diagnostics["reasons"]["unaligned_token_count"] == 1
+
     def test_prefill_boundary_snapshot_ignores_non_boundary_token_count(
         self, mock_model, mock_tokenizer
     ):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -421,6 +421,7 @@ class TestCacheSettings:
         assert settings.gdn_sidecar_state_dtype == "fp32"
         assert settings.ane_compile_cache is False
         assert settings.initial_cache_blocks == 256
+        assert settings.arrays_cache_block_size is None
 
     def test_get_ssd_cache_dir_default(self):
         """Test default SSD cache directory."""
@@ -467,6 +468,7 @@ class TestCacheSettings:
             "hot_cache_write_through": False,
             "ane_compile_cache": False,
             "initial_cache_blocks": 256,
+            "arrays_cache_block_size": None,
         }
 
     def test_from_dict(self):
@@ -614,6 +616,21 @@ class TestCacheSettings:
         }
         settings = CacheSettings.from_dict(data)
         assert settings.initial_cache_blocks == 16384
+
+    def test_arrays_cache_block_size_roundtrip_and_scheduler_config(self):
+        settings = CacheSettings.from_dict({"arrays_cache_block_size": 512})
+        assert settings.arrays_cache_block_size == 512
+        restored = CacheSettings.from_dict(settings.to_dict())
+        assert restored.arrays_cache_block_size == 512
+        global_settings = GlobalSettings(cache=restored)
+        assert global_settings.to_scheduler_config().arrays_cache_block_size == 512
+
+    @pytest.mark.parametrize("value", [-1, 1.5, True, "512"])
+    def test_arrays_cache_block_size_rejects_invalid_values(self, value):
+        settings = GlobalSettings(cache=CacheSettings(arrays_cache_block_size=value))
+        assert any(
+            "arrays_cache_block_size" in error for error in settings.validate()
+        )
 
     def test_from_dict_migrates_hot_cache_auto_to_disabled(self):
         """Legacy hot_cache_max_size=auto should load as disabled."""


### PR DESCRIPTION
Small cache blocks improve prefix reuse on embedded Qwen/GDN models, but splitting every prefill at 512 tokens creates many recurrent-state snapshots. This adds an opt-in policy that keeps 2048-token bulk forwards and captures the final reachable 512-token boundary. Restore continues to walk back to the newest real checkpoint and reprocess the missing suffix.

Defaults remain unchanged. The policy requires an explicit 512-token block, embedded GDN storage, and a flat Qwen ArraysCache/KVCache layout. Split-GDN, rotating and nested cache layouts retain their existing capture path.

On an M5 Pro with 64 GB, Qwen3.8-27B oQ4e, MTP depth 8 and MLX 0.32.2, three measured non-thinking requests per retrieval/continuation case showed:

- 16K, 400-token code continuation: median end-to-end time 16.84 -> 12.76 seconds.
- 57K, 400-token code continuation: 29.40 -> 22.08 seconds.
- A matched 12-turn synthetic loop: 51.07 -> 32.56 seconds; all prompt and output hashes matched.

These are targeted cache-latency results, not a universal decode-speed claim. Long-form MTP outputs were not byte-identical across every run, including repeated default-path runs.

Validation: 649 focused cache/settings/scheduler/CLI and reservation-compatibility tests passed. [Upstream CI](https://github.com/jundot/omlx/actions/runs/34193253585) passed on Python 3.11, 3.12 and 3.13. Real partial-prefix restores used exactly 2048/4096/8192 cached tokens and matched cache-disabled factual references; 57K retrieval and vision probes passed. Public performance and restore reproducers are included.

This branch includes configuration plumbing adapted from #3439 and timing instrumentation adapted from #3391 in separate commits, followed by the sparse-checkpoint policy. Those PRs are still open; this should be coordinated/rebased with them. Related: #3430 and #3070; this does not claim the historical #3070 penalty is fixed.
