### PR TITLE
fix: separate partial prefill costs from representative memory estimates

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -13,3 +13,15 @@ Run `python -m pytest -q tests/test_prefill_transient_tracker.py tests/test_pref
 # Prefix cache completion tests
 
 Run `python -m pytest -q tests/test_scheduler.py tests/test_scheduler_boundary_completion.py tests/test_prefix_cache_gdn_split.py` to check cache-freshness admission and completed boundary recovery. The completion tests use a small initialized Qwen3.5 hybrid model and the real BatchGenerator, then compare restored-prefix logits with a fresh forward pass. They cover embedded snapshots, GDN sidecars, off-boundary completion, and unknown or inconsistent cache positions.
+
+# Prefill reclaim and restored-context regressions
+
+The prefill accounting suites also check repeated versus contiguous footprint releases, partial repayment on skipped chunks, and growth between chunks. A one-off spike followed by a normal sample must retain main's EWMA recovery; repeated large allocations must remain visible to the scheduler. These are controlled observations, not actual OOM reproductions.
+
+Run `python -m pytest -q tests/test_scheduler.py tests/test_qwen4_qsa_reservation_integration.py` to check that restored context reaches chunk pricing even when boundary snapshots are disabled, for both external and chunked prefill.
+
+GLM projection preparation is covered by `tests/test_mlx_vlm_glm5_next_compat.py`: lazy versus load-time preparation, floating-point and quantized prefill/decode parity, idempotence, and mixed-quantization fallback. `tests/test_memory_monitor.py` checks that Qwen4 short-query estimates follow the runtime threshold, including environment overrides.
+
+Generic context-priority partials stop updating the representative EWMA and last representative sample once a full step has been observed. The largest pending partial allocation is kept separately: larger candidates never multiply it by their width, while smaller candidates retain the existing proportional reduction. Floor observations and reclaim accounting remain active. A full sample retires this bound only when its per-token rate covers it at every width; cheap partial/full reuse and process-wide releases cannot erase it. Routes and model resets remain independent.
+
+`TestPartialCostIsolation` covers partial-spike progress, cheap partials, repeated large allocations, transfer to a covering representative sample, and avoiding a new global floor. Unseeded generic partials retain the existing calibration: these tests do not claim to solve first-short-request poisoning or all long-context GLM failures. A pending partial bound can still reject work when the observed cost itself does not fit.

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1728,6 +1728,8 @@ class VLMBatchedEngine(BaseEngine):
                         self._model_name,
                         **load_kwargs,
                     )
+                    if model_type == "glm5_next":
+                        loaded[0].language_model.prepare_fused_projections()
                     return loaded
 
         loop = asyncio.get_running_loop()

--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -13,6 +13,7 @@ Key features:
 from __future__ import annotations
 
 import logging
+import os
 import threading
 import time
 from collections import Counter
@@ -28,6 +29,19 @@ from omlx.patches.deepseek_v4.indexer_dispatch import native_indexer_eligible
 from omlx.utils.hardware import format_bytes, get_max_working_set_bytes
 
 logger = logging.getLogger(__name__)
+
+
+def qwen4_gathered_min_query_tokens() -> int:
+    """Share the Qwen4 runtime's minimum gathered-prefill query width."""
+    raw = os.environ.get("OMLX_QWEN4_GATHERED_MIN_QUERY", "").strip()
+    if raw:
+        try:
+            return max(2, int(raw))
+        except ValueError:
+            pass
+    return 16
+
+
 
 # Check if MLX Metal is available
 try:
@@ -1312,7 +1326,15 @@ class _Qwen4ExpPrefillMemoryProfile:
             + self.indexer_n_heads * query_tokens * self.indexer_head_dim * 4
         )
         core_kv = kv_len
-        if gathered_core and kv_len > self.indexer_budget:
+        if (
+            gathered_core
+            # Single-token calls use the separate gathered decode gate.
+            and (
+                query_tokens == 1
+                or query_tokens >= qwen4_gathered_min_query_tokens()
+            )
+            and kv_len > self.indexer_budget
+        ):
             core_kv = min(kv_len, self.indexer_budget + self.compress_ratio - 1)
 
         # The head_dim-256 sdpa256 patch keeps long-context prefill O(L):

--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/language.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/language.py
@@ -161,7 +161,7 @@ class Glm5NextLinearAttention(nn.Module):
         self.fuse_in = True
         self._fused_ready = False
 
-    def _fused_in_proj(self, inputs):
+    def prepare_fused_in_proj(self) -> bool:
         # q,k,v,f_a,g_a,b all take `inputs`; fuse into one matmul via a lossless
         # output-axis concat of the (quantized) weights, built once and cached.
         if not self._fused_ready:
@@ -175,13 +175,13 @@ class Glm5NextLinearAttention(nn.Module):
             ]
             quantized = [hasattr(m, "scales") for m in mods]
             if any(quantized) and not all(quantized):
-                return tuple(linear_forward(m, inputs) for m in mods)
+                return False
             if all(quantized):
                 specs = {
                     (m.group_size, m.bits, getattr(m, "mode", "affine")) for m in mods
                 }
                 if len(specs) != 1:
-                    return tuple(linear_forward(m, inputs) for m in mods)
+                    return False
             pts, acc = [], 0
             for m in mods[:-1]:
                 acc += m.weight.shape[0]
@@ -194,6 +194,17 @@ class Glm5NextLinearAttention(nn.Module):
                 self._fb = mx.concatenate([m.biases for m in mods], axis=0)
                 self._gs, self._bits = mods[0].group_size, mods[0].bits
             self._fused_ready = True
+        return True
+
+    def _fused_in_proj(self, inputs):
+        if not self.prepare_fused_in_proj():
+            return tuple(
+                linear_forward(m, inputs)
+                for m in (
+                    self.q_proj, self.k_proj, self.v_proj,
+                    self.forget_gate.f_a_proj, self.g_a_proj, self.b_proj,
+                )
+            )
         if self._fq:
             out = fused_quantized_matmul(
                 inputs,
@@ -904,6 +915,20 @@ class LanguageModel(nn.Module):
         self.model = Glm5NextModel(args)
         if not args.tie_word_embeddings:
             self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def prepare_fused_projections(self) -> None:
+        """Materialize persistent projection weights before prefill accounting."""
+        for layer in self.model.layers:
+            attention = layer.self_attn
+            if (
+                isinstance(attention, Glm5NextLinearAttention)
+                and attention.fuse_in
+                and attention.prepare_fused_in_proj()
+            ):
+                arrays = [attention._fw]
+                if attention._fq:
+                    arrays.extend((attention._fs, attention._fb))
+                mx.eval(arrays)
 
     def __call__(
         self,

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -18,6 +18,10 @@ import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 
+from omlx.memory_monitor import (
+    qwen4_gathered_min_query_tokens as _gathered_min_query_tokens,
+)
+
 from .cache import ArraysCache, BatchKVCache, KVCache, QuantizedKVCache, dynamic_roll
 from ..qwen3_5.language import LanguageModel as Qwen3_5LanguageModel
 from ..qwen3_5.language import (
@@ -75,17 +79,6 @@ def _broadcast_text_mrope_position_ids(
     if len(_TEXT_MROPE_EQUAL_PLANES) > 8:
         del _TEXT_MROPE_EQUAL_PLANES[:-8]
     return same
-
-
-def _gathered_min_query_tokens() -> int:
-    """Keep narrow Lightning MTP windows on masked SDPA (M5 crossover)."""
-    raw = os.environ.get("OMLX_QWEN4_GATHERED_MIN_QUERY", "").strip()
-    if raw:
-        try:
-            return max(2, int(raw))
-        except ValueError:
-            pass
-    return 16
 
 
 def _split_text_mrope_positions(

--- a/omlx/prefill_transient_tracker.py
+++ b/omlx/prefill_transient_tracker.py
@@ -25,6 +25,9 @@ class _TransientHistory:
     last_delta_bytes: int = 0
     last_n_tokens: int = 0
     observed_max_bytes: int = 0
+    partial_bytes: int = 0
+    partial_per_token: float = 0.0
+    has_representative_sample: bool = False
     flat_overhead_bytes: int = 0
     reclaim_debt_bytes: int = 0
 
@@ -61,28 +64,84 @@ class PrefillTransientTracker:
         self._model_id = model_id
         self._dense_history = _TransientHistory()
         self._gathered_history = _TransientHistory()
-        # Net process footprint released by negative post-chunk deltas. MLX may
-        # need to allocate that pool again on the next chunk, so the scheduler
-        # prices it once until a positive measurement confirms reallocation.
-        self._recent_reclaim_bytes: int = 0
+        self._reclaim_state: tuple[int | None, int] = (None, 0)
 
     def _history(self, gathered_core: bool) -> _TransientHistory:
         return self._gathered_history if gathered_core is True else self._dense_history
 
-    def record_reclaim(self, reclaimed_bytes: int) -> None:
-        """Accumulate footprint released since the last positive sample."""
-        if reclaimed_bytes > 0:
-            self._recent_reclaim_bytes += int(reclaimed_bytes)
+    def observe_footprint(self, pre_bytes: int, post_bytes: int) -> None:
+        """Account for releases against an absolute footprint reference.
 
-    def clear_reclaim(self) -> None:
-        """Drop the charge once any positive measurement confirms realloc.
-
-        Callers invoke this for every positive delta, including samples the
-        EWMA gates skip (sub-floor tails, speed-priority partials) — the
-        footprint has grown back, so keeping the charge would double count
-        against the guard's gates.
+        Between-chunk growth pays down the outstanding release as well. Two
+        measurements of 100 -> 98 are one 2-byte gap, whereas 100 -> 98 -> 96
+        really releases 4 bytes. Partial reallocation only pays its own bytes.
         """
-        self._recent_reclaim_bytes = 0
+        reference, _ = self._reclaim_state
+        if reference is not None and pre_bytes >= reference:
+            reference = None
+        if post_bytes < pre_bytes:
+            reference = max(reference or 0, pre_bytes)
+        gap = max(0, reference - post_bytes) if reference is not None else 0
+        # Publish the reference and gap together: early admission also reads
+        # this state from the event loop while the executor records chunks.
+        self._reclaim_state = (reference if gap else None, gap)
+
+    def reclaim_bytes_at(self, current_bytes: int) -> int:
+        """Read the unpaid gap without mutating executor-owned history."""
+        reference, gap = self._reclaim_state
+        if reference is None:
+            return 0
+        return min(gap, max(0, reference - current_bytes))
+
+    def observe_floor(
+        self, transient_bytes: int, *, floor_sample: bool, gathered_core: bool
+    ) -> None:
+        history = self._history(gathered_core)
+        # The very first sample in each execution regime carries weight
+        # page-fault and load-residue noise, so it seeds that regime's EWMA
+        # but is excluded from its running max.
+        if floor_sample and history.samples > 0:
+            if transient_bytes <= self._OBSERVED_MAX_CLAMP_BYTES:
+                history.observed_max_bytes = max(
+                    history.observed_max_bytes, transient_bytes
+                )
+            else:
+                logger.debug(
+                    "PrefillTransientTracker(%s): rejected %d-byte outlier "
+                    "from observed max (clamp %d)",
+                    self._model_id,
+                    transient_bytes,
+                    self._OBSERVED_MAX_CLAMP_BYTES,
+                )
+
+    def observe_partial(
+        self, n_tokens: int, transient_bytes: int, *, gathered_core: bool = False
+    ) -> None:
+        """Keep partial allocation evidence outside the representative rate.
+
+        Cheap reuse does not retire this evidence. A positive representative
+        sample can replace it only when its rate covers this bound at every width.
+        """
+        history = self._history(gathered_core)
+        if n_tokens > 0 and transient_bytes > 0:
+            history.partial_bytes = max(history.partial_bytes, transient_bytes)
+            history.partial_per_token = max(
+                history.partial_per_token, transient_bytes / n_tokens
+            )
+
+    def partial_bytes_for(self, gathered_core: bool) -> int:
+        return self._history(gathered_core).partial_bytes
+
+    def partial_bound(self, n_tokens: int, gathered_core: bool) -> float:
+        history = self._history(gathered_core)
+        if n_tokens <= 0:
+            return 0.0
+        # Preserve the existing downward scaling for smaller candidates;
+        # never amplify a partial allocation when considering a larger step.
+        return min(history.partial_bytes, n_tokens * history.partial_per_token)
+
+    def has_representative_sample_for(self, gathered_core: bool) -> bool:
+        return self._history(gathered_core).has_representative_sample
 
     def update(
         self,
@@ -91,6 +150,7 @@ class PrefillTransientTracker:
         *,
         floor_sample: bool = False,
         gathered_core: bool = False,
+        representative: bool = True,
     ) -> None:
         """Record one chunk observation.
 
@@ -118,29 +178,16 @@ class PrefillTransientTracker:
         if transient_bytes <= 0:
             return
 
-        self._recent_reclaim_bytes = 0
-
         history = self._history(gathered_core)
 
-        # The very first sample in each execution regime carries weight
-        # page-fault and load-residue noise, so it seeds that regime's EWMA
-        # but is excluded from its running max.
-        if floor_sample and history.samples > 0:
-            if transient_bytes <= self._OBSERVED_MAX_CLAMP_BYTES:
-                history.observed_max_bytes = max(
-                    history.observed_max_bytes, transient_bytes
-                )
-            else:
-                logger.debug(
-                    "PrefillTransientTracker(%s): rejected %d-byte outlier "
-                    "from observed max (clamp %d)",
-                    self._model_id,
-                    transient_bytes,
-                    self._OBSERVED_MAX_CLAMP_BYTES,
-                )
+        self.observe_floor(
+            transient_bytes, floor_sample=floor_sample, gathered_core=gathered_core
+        )
 
         per_token = transient_bytes / n_tokens
-        if history.samples == 0:
+        if history.samples == 0 or (
+            representative and not history.has_representative_sample
+        ):
             history.ewma_per_token = per_token
         elif per_token > history.ewma_per_token * self._EWMA_OUTLIER_RATIO:
             # Reject from the EWMA blend: a single sample this far above
@@ -162,6 +209,11 @@ class PrefillTransientTracker:
                 self._EWMA_ALPHA * per_token
                 + (1.0 - self._EWMA_ALPHA) * history.ewma_per_token
             )
+        if representative:
+            if per_token >= history.partial_per_token:
+                history.partial_bytes = 0
+                history.partial_per_token = 0.0
+            history.has_representative_sample = True
         history.samples += 1
         history.last_delta_bytes = transient_bytes
         history.last_n_tokens = n_tokens
@@ -288,8 +340,8 @@ class PrefillTransientTracker:
 
     @property
     def recent_reclaim_bytes(self) -> int:
-        """Footprint released since the last positive chunk measurement."""
-        return self._recent_reclaim_bytes
+        """Outstanding release at the last completed footprint observation."""
+        return self._reclaim_state[1]
 
     def reset_history(self, *, gathered_core: bool = False) -> None:
         """Drop observations for one execution regime."""
@@ -302,4 +354,4 @@ class PrefillTransientTracker:
         """Drop all observations (e.g. on model reload or after a long idle)."""
         self.reset_history()
         self.reset_history(gathered_core=True)
-        self._recent_reclaim_bytes = 0
+        self._reclaim_state = (None, 0)

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -3522,17 +3522,13 @@ class Scheduler:
         if getattr(request, "benchmark_trace", False):
             request.benchmark_boundary_enabled = boundary_enabled
             request.benchmark_cache_block_size = block_size if boundary_enabled else 0
-        base_size = _cache_base_sizes(prompt_cache) if boundary_enabled else 0
+        base_size = _cache_base_sizes(prompt_cache)
         # Sanity check: base_size from cache offsets should match the number
         # of tokens actually cached. A mismatch indicates stale meta_state
         # in a restored RotatingKVCache (e.g. shared layer_meta_states from
         # an earlier store_cache bug). Use cached_tokens which is always
         # derived from block_table.num_tokens and therefore trustworthy.
-        if (
-            boundary_enabled
-            and hasattr(request, "cached_tokens")
-            and request.cached_tokens > 0
-        ):
+        if hasattr(request, "cached_tokens") and request.cached_tokens > 0:
             if base_size != request.cached_tokens:
                 logger.debug(
                     "Cache base_size mismatch: computed %d, expected %d "
@@ -3967,6 +3963,7 @@ class Scheduler:
         per_token = 0.0
         static_per_token = 0.0
         recent_reclaim = 0
+        partial_bytes = 0
         tracker = self._prefill_transient_tracker
         if self.memory_monitor is not None:
             static = self.memory_monitor.estimate_chunk_transient_bytes(
@@ -3990,8 +3987,10 @@ class Scheduler:
             # tracker keeps their measured histories separate, so switching
             # paths cannot reintroduce a stale dense charge after the first
             # gathered sample.
+            partial_bytes = tracker.partial_bound(n_tokens, gathered_core)
             ewma = tracker.bytes_per_token_for(gathered_core)
-            recent_reclaim = tracker.recent_reclaim_bytes
+            if tracker.recent_reclaim_bytes:
+                recent_reclaim = tracker.reclaim_bytes_at(get_phys_footprint())
             if ewma > 0:
                 per_token = max(per_token, ewma)
             last_n_tokens = tracker.last_n_tokens_for(gathered_core)
@@ -4005,7 +4004,10 @@ class Scheduler:
             static_per_token * n_tokens * self._PREFILL_TRANSIENT_SAFETY
             + recent_reclaim
         )
-        return max(base_prediction, reallocation_prediction)
+        return max(
+            base_prediction, reallocation_prediction,
+            partial_bytes * self._PREFILL_TRANSIENT_SAFETY,
+        )
 
     def _admission_transient_bound(
         self, n_tokens: int, kv_len: int, *, gathered_core: bool = False
@@ -4921,15 +4923,9 @@ class Scheduler:
                 / 1024**2,
             )
             return
-        # The reclaim ledger sees every measurement, including samples the
-        # EWMA gates below skip: a release on a sub-floor tail must still be
-        # priced, and any positive growth confirms the pool reallocation and
-        # drops the one-shot charge — leaving it armed after the footprint
-        # recovered would double count against the guard's gates.
-        if delta <= 0:
-            self._prefill_transient_tracker.record_reclaim(-delta)
-        else:
-            self._prefill_transient_tracker.clear_reclaim()
+        # Include samples skipped by the EWMA gates. A positive delta repays
+        # only the footprint actually recovered, not the entire prior release.
+        self._prefill_transient_tracker.observe_footprint(pre_bytes, post_bytes)
         min_chunk = max(1, self._prefill_min_chunk_tokens)
         if n_tokens < min_chunk:
             logger.debug(
@@ -4967,11 +4963,30 @@ class Scheduler:
                 requested_step,
             )
             return
+        partial = requested_step is not None and n_tokens < requested_step
+        if partial:
+            self._prefill_transient_tracker.observe_partial(
+                n_tokens, delta, gathered_core=gathered_core
+            )
+        if partial and self._prefill_transient_tracker.has_representative_sample_for(
+            gathered_core
+        ):
+            self._prefill_transient_tracker.observe_floor(
+                delta, floor_sample=n_tokens <= min_chunk,
+                gathered_core=gathered_core,
+            )
+            logger.debug(
+                "[throttle:%s] partial rid=%s n=%d delta=%.2fMB "
+                "(retained as bytes; representative rate unchanged)",
+                loop_label, request_id, n_tokens, delta / 1024**2,
+            )
+            return
         self._prefill_transient_tracker.update(
             n_tokens,
             delta,
             floor_sample=n_tokens <= min_chunk,
             gathered_core=gathered_core,
+            representative=not partial,
         )
         logger.debug(
             "[throttle:%s] measure rid=%s n=%d kv_len=%d transient=%.2fMB per_token=%.1fKB ewma=%.1fKB observed_max=%.1fMB samples=%d",
@@ -5321,10 +5336,9 @@ class Scheduler:
         if getattr(request, "benchmark_trace", False):
             request.benchmark_boundary_enabled = boundary_enabled
             request.benchmark_cache_block_size = block_size if boundary_enabled else 0
-        base_size = _cache_base_sizes(prompt_cache) if boundary_enabled else 0
+        base_size = _cache_base_sizes(prompt_cache)
         if (
-            boundary_enabled
-            and hasattr(request, "cached_tokens")
+            hasattr(request, "cached_tokens")
             and request.cached_tokens > 0
             and base_size != request.cached_tokens
         ):

--- a/tests/test_memory_monitor.py
+++ b/tests/test_memory_monitor.py
@@ -1367,3 +1367,24 @@ class TestAnePrefillTransientReserve:
         # Negative input clamps to zero instead of widening headroom.
         monitor.set_ane_prefill_transient_bytes(-5)
         assert monitor._ane_prefill_transient_bytes == 0
+
+
+@pytest.mark.parametrize(
+    "override, minimum", [("", 16), ("32", 32), ("1", 2), ("invalid", 16)]
+)
+def test_qwen4_short_prefill_prices_runtime_dense_route(
+    monkeypatch, override, minimum
+):
+    monkeypatch.setenv("OMLX_QWEN4_GATHERED_MIN_QUERY", override)
+    profile = TestQwen4ExpPrefillMemoryProfile._profile()
+    for width in range(2, minimum):
+        assert profile.estimate_prefill_transient_bytes(
+            width, 160_000, gathered_core=True
+        ) == profile.estimate_prefill_transient_bytes(
+            width, 160_000, gathered_core=False
+        )
+    assert profile.estimate_prefill_transient_bytes(
+        minimum, 160_000, gathered_core=True
+    ) < profile.estimate_prefill_transient_bytes(
+        minimum, 160_000, gathered_core=False
+    )

--- a/tests/test_mlx_vlm_glm5_next_compat.py
+++ b/tests/test_mlx_vlm_glm5_next_compat.py
@@ -9,6 +9,7 @@ import io
 import json
 
 import mlx.core as mx
+import mlx.nn as nn
 import pytest
 from PIL import Image
 
@@ -713,3 +714,57 @@ def test_glm5_next_fused_qmm_handles_strided_input(bits, tokens):
     mx.eval(actual, reference)
 
     assert mx.allclose(actual, reference, atol=2e-3, rtol=2e-3).item()
+
+
+@pytest.mark.parametrize("quantized", [False, True])
+def test_prepared_projections_match_lazy_prefill_and_decode(quantized):
+    from mlx_vlm.models.glm5_next.language import LanguageModel
+
+    mx.random.seed(3417)
+    config = _tiny_config().text_config
+    model = LanguageModel(config)
+    if quantized:
+        nn.quantize(
+            model, group_size=32, bits=4,
+            class_predicate=lambda _, module: isinstance(module, nn.Linear)
+            and module.weight.shape[1] % 32 == 0,
+        )
+    tokens = mx.array([[1, 2, 3, 4]])
+    lazy_cache = model.make_cache()
+    expected = model(tokens, cache=lazy_cache).logits
+    mx.eval(expected)
+    attention = model.model.layers[0].self_attn
+    attention._fused_ready = False
+    model.prepare_fused_projections()
+    assert attention._fused_ready
+    weights = attention._fw
+    prepared_cache = model.make_cache()
+    actual = model(tokens, cache=prepared_cache).logits
+    mx.eval(actual)
+    assert mx.allclose(expected, actual, atol=1e-5, rtol=1e-5).item()
+    model.prepare_fused_projections()
+    assert attention._fw is weights
+    for _ in range(3):
+        token = mx.argmax(expected[:, -1], axis=-1)[:, None]
+        expected = model(token, cache=lazy_cache).logits
+        actual = model(token, cache=prepared_cache).logits
+        mx.eval(expected, actual)
+        assert mx.allclose(expected, actual, atol=1e-5, rtol=1e-5).item()
+
+
+def test_projection_preparation_preserves_mixed_quantization_fallback():
+    from mlx_vlm.models.glm5_next.language import LanguageModel
+
+    model = LanguageModel(_tiny_config().text_config)
+    attention = model.model.layers[0].self_attn
+    attention.q_proj = nn.QuantizedLinear.from_linear(
+        attention.q_proj, group_size=32, bits=4
+    )
+    model.prepare_fused_projections()
+    assert not attention._fused_ready
+    tokens = mx.array([[1, 2]])
+    actual = model(tokens, cache=model.make_cache()).logits
+    attention.fuse_in = False
+    expected = model(tokens, cache=model.make_cache()).logits
+    mx.eval(actual, expected)
+    assert mx.allclose(actual, expected, atol=1e-5, rtol=1e-5).item()

--- a/tests/test_prefill_oom_graceful.py
+++ b/tests/test_prefill_oom_graceful.py
@@ -871,8 +871,8 @@ def test_sub_floor_tail_release_is_charged():
     assert ns._prefill_transient_tracker.recent_reclaim_bytes == released
 
 
-def test_skipped_positive_sample_clears_reclaim_charge():
-    """Any positive delta drops the charge, even on EWMA-skipped samples."""
+def test_skipped_positive_sample_repays_only_recovered_footprint():
+    """A skipped positive sample must preserve the unrecovered release."""
     released = 6 * _GB
     ns = _throttle_ctx(current=97 * _GB, hard=119 * _GB)
     ns._record_chunk_transient = Scheduler._record_chunk_transient.__get__(
@@ -889,7 +889,7 @@ def test_skipped_positive_sample_clears_reclaim_charge():
     assert ns._prefill_transient_tracker.recent_reclaim_bytes == released
 
     # Positive growth on a sub-floor tail is excluded from the EWMA but the
-    # footprint recovered, so the one-shot charge must not stay armed.
+    # footprint recovered only five of the six released GiB.
     ns._record_chunk_transient(
         17,
         94 * _GB,
@@ -898,10 +898,10 @@ def test_skipped_positive_sample_clears_reclaim_charge():
         loop_label="test",
         requested_step=2048,
     )
-    assert ns._prefill_transient_tracker.recent_reclaim_bytes == 0
+    assert ns._prefill_transient_tracker.recent_reclaim_bytes == _GB
 
 
-def test_speed_partial_positive_clears_reclaim_charge():
+def test_speed_partial_positive_preserves_remaining_reclaim():
     """Speed-priority partial chunks also confirm reallocation."""
     released = 6 * _GB
     ns = _throttle_ctx(current=97 * _GB, hard=119 * _GB)
@@ -927,7 +927,7 @@ def test_speed_partial_positive_clears_reclaim_charge():
         loop_label="test",
         requested_step=512,
     )
-    assert ns._prefill_transient_tracker.recent_reclaim_bytes == 0
+    assert ns._prefill_transient_tracker.recent_reclaim_bytes == _GB
 
 
 def test_record_chunk_transient_skips_tail_samples():
@@ -1620,3 +1620,126 @@ def test_adaptive_throttle_tail_below_floor_never_grows_chunk():
     # above the tail (152).
     n = _call(ns, 152, kv_len=122_000)
     assert n <= 152
+
+
+@pytest.mark.parametrize("current, remaining", [(97, 3), (99, 1), (100, 0)])
+def test_reclaim_prediction_uses_live_unrecovered_gap(current, remaining):
+    ns = _throttle_ctx(current=current * _GB, hard=119 * _GB)
+    ns.memory_monitor = None
+    ns._prefill_transient_tracker.observe_footprint(100 * _GB, 94 * _GB)
+    with patch.object(sched_mod, "get_phys_footprint", return_value=current * _GB):
+        assert ns._predicted_chunk_transient(512, 0) == remaining * _GB
+
+
+def test_repeated_large_sample_still_bounds_scheduler_prediction():
+    ns = _throttle_ctx(current=97 * _GB, hard=119 * _GB)
+    ns.memory_monitor = None
+    for mib in (100, 2048, 2048):
+        ns._prefill_transient_tracker.update(512, mib * 1024**2)
+    assert ns._predicted_chunk_transient(512, 0) >= 2 * _GB * 1.3
+
+
+class TestPartialCostIsolation:
+    @staticmethod
+    def context():
+        ns = _throttle_ctx(current=10 * _GB, hard=16 * _GB)
+        ns._fake_current = 10 * _GB
+        ns._record_chunk_transient = Scheduler._record_chunk_transient.__get__(
+            ns, Scheduler
+        )
+        return ns
+
+    @staticmethod
+    def record(ns, width, mib, step=512):
+        ns._record_chunk_transient(
+            width, 10 * _GB, 10 * _GB + mib * 1024**2,
+            request_id="partial", loop_label="test", requested_step=step,
+        )
+
+    def test_partial_spike_does_not_stop_next_full_chunk(self):
+        ns = self.context()
+        self.record(ns, 512, 333)
+        rate = ns._prefill_transient_tracker.bytes_per_token
+        for _ in range(4):
+            self.record(ns, 128, 1319)
+        tracker = ns._prefill_transient_tracker
+        assert tracker.bytes_per_token == rate
+        assert tracker.last_n_tokens == 512
+        assert tracker.last_delta_bytes == 333 * 1024**2
+        assert ns._predicted_chunk_transient(512, 90000) == pytest.approx(
+            1319 * 1024**2 * 1.3
+        )
+        assert _call(ns, 512, kv_len=90000) == 512
+        assert _guard_call(ns, 512, kv_len=90000) == 512
+
+    def test_cheap_partial_cannot_lower_representative_cost(self):
+        ns = self.context()
+        self.record(ns, 512, 2048)
+        before = ns._predicted_chunk_transient(512, 0)
+        for _ in range(5):
+            self.record(ns, 128, 10)
+        assert ns._predicted_chunk_transient(512, 0) == before
+
+    def test_cheap_full_chunk_cannot_erase_partial_allocation(self):
+        ns = self.context()
+        self.record(ns, 512, 333)
+        self.record(ns, 128, 1319)
+        self.record(ns, 512, 333)
+        assert ns._prefill_transient_tracker.partial_bytes_for(False) == 1319 * 1024**2
+        ns._fake_current = 13.5 * _GB
+        assert _guard_call(ns, 128, kv_len=90000) < 128
+        ns._prefill_speed_priority = True
+        with pytest.raises(PrefillMemoryExceededError):
+            _guard_call(ns, 128, kv_len=90000)
+
+    def test_covering_full_sample_replaces_partial_evidence(self):
+        ns = self.context()
+        self.record(ns, 512, 333)
+        self.record(ns, 128, 200)
+        before = [ns._predicted_chunk_transient(n, 0) for n in (32, 128, 512)]
+        self.record(ns, 512, 800)
+        assert ns._prefill_transient_tracker.partial_bytes_for(False) == 0
+        assert all(
+            ns._predicted_chunk_transient(n, 0) >= cost
+            for n, cost in zip((32, 128, 512), before)
+        )
+
+    def test_unseeded_partial_keeps_existing_calibration(self):
+        ns = self.context()
+        self.record(ns, 128, 1319)
+        tracker = ns._prefill_transient_tracker
+        assert not tracker.has_representative_sample_for(False)
+        assert tracker.bytes_per_token == 1319 * 1024**2 / 128
+        self.record(ns, 128, 333)
+        assert not tracker.has_representative_sample_for(False)
+
+    def test_partial_floor_keeps_existing_admission_protection(self):
+        ns = self.context()
+        self.record(ns, 512, 333)
+        self.record(ns, 32, 1000)
+        assert ns._prefill_transient_tracker.observed_max_bytes == 1000 * 1024**2
+
+
+    def test_large_partial_does_not_become_a_new_global_floor(self):
+        ns = self.context()
+        self.record(ns, 512, 333)
+        self.record(ns, 128, 1319)
+        assert ns._predicted_chunk_transient(32, 0) == pytest.approx(
+            1319 * 1024**2 * 32 / 128 * 1.3
+        )
+        ns._fake_current = 13.5 * _GB
+        assert _guard_call(ns, 32, kv_len=90000) == 32
+
+
+    def test_gradual_partial_growth_below_outlier_gate_does_not_raise_ewma(self):
+        ns = self.context()
+        self.record(ns, 512, 333)
+        tracker = ns._prefill_transient_tracker
+        rate = tracker.bytes_per_token
+        for _ in range(6):
+            cost_mib = tracker.bytes_per_token * 3 * 128 / 1024**2
+            self.record(ns, 128, cost_mib)
+        assert tracker.bytes_per_token == rate
+        assert ns._predicted_chunk_transient(512, 0) == pytest.approx(
+            333 * 1024**2 * 1.3
+        )

--- a/tests/test_prefill_transient_tracker.py
+++ b/tests/test_prefill_transient_tracker.py
@@ -359,3 +359,87 @@ class TestPoolReleaseAccounting:
         )
         assert tracker.flat_overhead_charge_for(True) == 0
         assert tracker.flat_overhead_charge_for(False) == 3 * 1024**3
+
+
+class TestFootprintReclaim:
+    def test_repeated_and_contiguous_releases(self):
+        tracker = PrefillTransientTracker()
+        tracker.observe_footprint(100, 98)
+        tracker.observe_footprint(100, 98)
+        assert tracker.recent_reclaim_bytes == 2
+        tracker.observe_footprint(98, 96)
+        assert tracker.recent_reclaim_bytes == 4
+        tracker.observe_footprint(96, 97)
+        tracker.update(32, 1)
+        assert tracker.recent_reclaim_bytes == 3
+        tracker.observe_footprint(97, 100)
+        assert tracker.recent_reclaim_bytes == 0
+
+    def test_live_growth_reduces_charge_without_mutating_history(self):
+        tracker = PrefillTransientTracker()
+        tracker.observe_footprint(100, 94)
+        assert tracker.reclaim_bytes_at(99) == 1
+        assert tracker.reclaim_bytes_at(101) == 0
+        assert tracker.reclaim_bytes_at(90) == 6
+        assert tracker.recent_reclaim_bytes == 6
+        tracker.reset()
+        assert tracker.reclaim_bytes_at(94) == 0
+
+    def test_one_off_spike_does_not_pin_unseen_width(self):
+        tracker = PrefillTransientTracker()
+        mib = 1024**2
+        for cost in (100, 2048, 100):
+            tracker.update(512, cost * mib)
+        assert tracker.predict(2048, safety_factor=1) == 400 * mib
+
+    def test_repeated_large_allocation_remains_visible(self):
+        tracker = PrefillTransientTracker()
+        for cost in (100, 2048, 2048):
+            tracker.update(512, cost * 1024**2)
+        assert tracker.last_delta_bytes == 2048 * 1024**2
+
+
+class TestPartialHistory:
+    def test_routes_and_reset_are_independent(self):
+        tracker = PrefillTransientTracker()
+        tracker.observe_partial(128, 1000, gathered_core=False)
+        tracker.observe_partial(64, 200, gathered_core=True)
+        assert tracker.partial_bound(512, False) == 1000
+        assert tracker.partial_bound(512, True) == 200
+        tracker.reset_history(gathered_core=True)
+        assert tracker.partial_bound(512, True) == 0
+        assert tracker.partial_bound(512, False) == 1000
+        tracker.reset()
+        assert tracker.partial_bound(512, False) == 0
+
+    def test_larger_byte_full_sample_with_lower_rate_cannot_retire_partial_evidence(self):
+        tracker = PrefillTransientTracker()
+        tracker.update(512, 333)
+        tracker.observe_partial(128, 1319)
+        tracker.update(512, 1400)
+        assert tracker.partial_bytes_for(False) == 1319
+        assert tracker.partial_bound(128, False) == 1319
+
+    def test_release_does_not_erase_partial_evidence(self):
+        tracker = PrefillTransientTracker()
+        tracker.update(512, 333)
+        tracker.observe_partial(128, 1319)
+        tracker.observe_footprint(10000, 1000)
+        assert tracker.partial_bound(512, False) == 1319
+
+
+    def test_larger_partial_cannot_erase_a_narrower_allocation(self):
+        tracker = PrefillTransientTracker()
+        tracker.observe_partial(64, 1000)
+        tracker.observe_partial(128, 1100)
+        assert tracker.partial_bound(64, False) == 1000
+        assert tracker.partial_bound(512, False) == 1100
+
+
+    def test_first_full_step_replaces_bootstrap_rate_but_keeps_partial_bound(self):
+        tracker = PrefillTransientTracker()
+        tracker.observe_partial(128, 1319)
+        tracker.update(128, 1319, representative=False)
+        tracker.update(512, 333)
+        assert tracker.bytes_per_token == 333 / 512
+        assert tracker.partial_bound(512, False) == 1319

--- a/tests/test_qwen4_qsa_reservation_integration.py
+++ b/tests/test_qwen4_qsa_reservation_integration.py
@@ -47,6 +47,7 @@ def test_chunked_reservation_includes_restored_prefix(snapshots_enabled):
     )
 
     def stop(*args, **kwargs):
+        assert kwargs["kv_len"] == 128
         raise RuntimeError("reservation complete")
 
     ns._adaptive_chunk_size = stop

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -6343,6 +6343,7 @@ class TestVLMPositionStateClearing:
 
     def test_cached_text_only_prefill_seeds_zero_mrope_delta(self, mock_tokenizer):
         """Cached text-only mRoPE suffixes must start at the restored offset."""
+
         model = self._make_vlm_model()
         model._language_model = MagicMock()
         model._language_model._rope_deltas = mx.array([[123]])
@@ -6357,11 +6358,16 @@ class TestVLMPositionStateClearing:
         request.num_prompt_tokens = 4
         request.cached_tokens = 2048
 
-        with patch.object(
-            scheduler_module,
-            "_seed_text_only_mrope_delta_for_cached_prefill",
-            wraps=scheduler_module._seed_text_only_mrope_delta_for_cached_prefill,
-        ) as seed_mrope:
+        with (
+            patch.object(
+                scheduler, "_adaptive_chunk_size", wraps=scheduler._adaptive_chunk_size
+            ) as sizing,
+            patch.object(
+                scheduler_module,
+                "_seed_text_only_mrope_delta_for_cached_prefill",
+                wraps=scheduler_module._seed_text_only_mrope_delta_for_cached_prefill,
+            ) as seed_mrope,
+        ):
             scheduler._do_external_prefill(
                 request,
                 tokens=[1, 2, 3, 4],
@@ -6375,6 +6381,8 @@ class TestVLMPositionStateClearing:
         assert seeded.shape == (1, 1)
         assert seeded.dtype == mx.int64
         assert seeded.item() == 0
+
+        assert sizing.call_args.kwargs["kv_len"] == 2048
 
     def test_cached_text_only_mrope_seed_is_materialized(self):
         """The exact restore-only seed must be concrete before prefill starts."""


### PR DESCRIPTION
Partial prefill chunks can include fixed allocations that inflate their per-token cost. Applying that rate to larger chunks can cause unnecessary throttling or rejection. Cheap partials can also lower the estimate below the cost of a full chunk.

This change keeps partial observations out of the representative EWMA and latest representative sample once a full chunk has been measured. Partial allocation evidence remains a separate guard term, capped at the observed byte cost when considering larger chunks. Cheap reuse does not discard that evidence.

| Area | Before | After |
|---|---|---|
| Partial observations | Context-priority partials can raise or lower representative estimates | Once a full chunk is measured, partials no longer update the representative EWMA or latest sample |
| Partial allocation protection | A partial's per-token rate can amplify its cost for larger chunks | Separate protection capped at observed bytes for larger candidates; existing downward scaling retained |
| First short request | Partial observations seed the initial estimate | Conservative bootstrap retained; the first full observation replaces the bootstrap rate |
| Reclaim accounting | Releases accumulate; any positive sample clears the entire charge | Absolute footprint tracking avoids duplicate charges and preserves unpaid releases |
| GLM initialization | Persistent fused weights are allocated during the first forward | Weights are prepared during model loading, outside chunk measurement |
| Qwen4 short prefill | Gathered pricing can disagree with the actual dense route | Estimator and runtime share the minimum gathered-query threshold |
| Restored prefixes | Some estimates omit the prefix when boundary snapshots are disabled | External and chunked prefill both include the restored length |

Validation:
- A 512-token/333 MiB sample followed by repeated 128-token/1,319 MiB partials predicts about 1.67 GiB for the next full chunk instead of 6.70 GiB, including the safety factor.
- Regression tests cover cheap partials, gradual increases below the outlier threshold, repeated large allocations, guard enforcement, and preserved floor/reclaim accounting.
- Qwen3.6 server runs completed normal, short, partial, and 16.9K-token requests before and after the change. Cache-hit differences prevent a direct performance comparison.
- GLM projection preparation preserves small-model prefill/decode outputs for floating-point and quantized weights. The observed first-chunk footprint growth fell from 3.44 GiB to 0.73 GiB. This moves persistent allocation into loading rather than reducing the model's eventual footprint.
- The focused scheduler, preflight, tracker, memory-profile, VLM, and context-benchmark suites pass after applying the change to current remote main.

Generic models retain conservative bootstrap behavior until a full chunk is measured. Pending partial costs can still restrict requests when the observed allocation does not fit. This does not claim complete coverage of #3417, #3362, or #3450; GLM 100K/159K and the reported SSD expert-streaming workload have not been validated on this revision.

Related: #3417, #3362, #3450, #3350
