### PR TITLE
[feature] Support DFlash for ParoQuant Qwen models

### DIFF
--- a/benchmarks/paroquant_dflash/engine_smoke.py
+++ b/benchmarks/paroquant_dflash/engine_smoke.py
@@ -49,6 +49,50 @@ async def main(args):
         start = time.perf_counter()
         await engine.start()
         print("ENGINE_LOADED", time.perf_counter() - start, flush=True)
+        if args.vision_smoke_only:
+            import base64
+            import io
+
+            from PIL import Image
+
+            await generate("before_image", "Continue the count: one, two, three, four,")
+            image = io.BytesIO()
+            Image.new("RGB", (224, 224), (255, 0, 0)).save(image, format="PNG")
+            image_url = (
+                "data:image/png;base64," + base64.b64encode(image.getvalue()).decode()
+            )
+            output = await engine.chat(
+                [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "image_url", "image_url": {"url": image_url}},
+                            {
+                                "type": "text",
+                                "text": "What color fills this image? Answer with only the color name.",
+                            },
+                        ],
+                    }
+                ],
+                max_tokens=64,
+                temperature=0.0,
+                chat_template_kwargs={"enable_thinking": False},
+            )
+            row = {
+                "label": "image_fallback",
+                "text": output.text,
+                "in_vlm_fallback": engine._in_fallback_mode,
+                "vision_tower_present": hasattr(
+                    engine._fallback_engine._vlm_model, "vision_tower"
+                ),
+            }
+            records.append(row)
+            Path(args.output).write_text(
+                json.dumps(records, indent=2, default=str) + "\n"
+            )
+            assert "red" in output.text.lower(), output.text
+            assert row["in_vlm_fallback"] and row["vision_tower_present"]
+            return
         tok = engine.tokenizer
         for length in args.contexts:
             filler = tok.encode(
@@ -104,4 +148,5 @@ if __name__ == "__main__":
     parser.add_argument("--draft", required=True)
     parser.add_argument("--output", required=True)
     parser.add_argument("--contexts", type=int, nargs="+", default=[4096, 16384, 32768])
+    parser.add_argument("--vision-smoke-only", action="store_true")
     asyncio.run(main(parser.parse_args()))

--- a/benchmarks/paroquant_dflash/engine_smoke.py
+++ b/benchmarks/paroquant_dflash/engine_smoke.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exercise the oMLX engine with local ParoQuant and DFlash2 checkpoints."""
+
+import argparse
+import asyncio
+import dataclasses
+import json
+import time
+from pathlib import Path
+
+from omlx.engine.dflash import DFlashEngine
+from omlx.model_settings import ModelSettings
+
+
+async def main(args):
+    settings = ModelSettings(
+        dflash_enabled=True,
+        dflash_block_size=5,
+        dflash_verify_mode="off",
+        dflash_in_memory_cache=True,
+    )
+    engine = DFlashEngine(
+        args.target, args.draft, model_settings=settings, fallback_engine_type="vlm"
+    )
+    records = []
+
+    async def generate(label, prompt, **kwargs):
+        start = time.perf_counter()
+        first = None
+        final = None
+        async for output in engine.stream_generate(
+            prompt, max_tokens=32, temperature=0.0, **kwargs
+        ):
+            if first is None and output.new_text:
+                first = time.perf_counter() - start
+            final = output
+        row = {
+            "label": label,
+            "seconds": time.perf_counter() - start,
+            "ttft": first,
+            "output": dataclasses.asdict(final),
+        }
+        records.append(row)
+        Path(args.output).write_text(json.dumps(records, indent=2, default=str) + "\n")
+        print(json.dumps(row, default=str), flush=True)
+        return final
+
+    try:
+        start = time.perf_counter()
+        await engine.start()
+        print("ENGINE_LOADED", time.perf_counter() - start, flush=True)
+        tok = engine.tokenizer
+        for length in args.contexts:
+            filler = tok.encode(
+                "The library holds books on history, science, mathematics, and art.\n"
+            )
+            tail = tok.encode("\nContinue the count: one, two, three, four,")
+            prompt = (filler * ((length // len(filler)) + 1))[
+                : length - len(tail)
+            ] + tail
+            cold = await generate(f"cold_{length}", prompt)
+            warm = await generate(f"warm_{length}", prompt)
+            assert cold.text == warm.text, "Prefix-cache reuse changed greedy output"
+            assert warm.cached_tokens > 0, "Repeated prompt did not reuse its cache"
+        # Seed reproducibility checks exercise speculative rejection sampling.
+        prompt = tok.encode("The capital of France is")
+        outputs = []
+        for _ in range(2):
+            final = None
+            async for output in engine.stream_generate(
+                prompt,
+                max_tokens=32,
+                temperature=0.7,
+                top_p=0.9,
+                top_k=20,
+                min_p=0.05,
+                seed=123,
+            ):
+                final = output
+            outputs.append(final.text)
+        print("SEEDED_EQUAL", outputs[0] == outputs[1], flush=True)
+        assert outputs[0] == outputs[1]
+        # Close a stream early, then serve another request on the same engine.
+        stream = engine.stream_generate(prompt, max_tokens=512, temperature=0.0)
+        async for output in stream:
+            if output.new_text:
+                break
+        await stream.aclose()
+        after_cancel = await generate("after_cancel", prompt)
+    finally:
+        await engine.stop()
+    # A second start uses a fresh target and must re-arm the restored class hooks.
+    try:
+        await engine.start()
+        after_reload = await generate("after_reload", "The capital of France is")
+        assert after_reload.text == after_cancel.text, "Reload changed greedy output"
+    finally:
+        await engine.stop()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--draft", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--contexts", type=int, nargs="+", default=[4096, 16384, 32768])
+    asyncio.run(main(parser.parse_args()))

--- a/benchmarks/paroquant_dflash/validate.py
+++ b/benchmarks/paroquant_dflash/validate.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Validate a local ParoQuant target and DFlash draft on Metal.
+
+Run from the checkout with python -m benchmarks.paroquant_dflash.validate
+--target PATH --draft PATH. No model files or serving settings are changed.
+"""
+
+import argparse
+import dataclasses
+import importlib
+import json
+import time
+
+import mlx.core as mx
+from mlx.utils import tree_flatten
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--draft", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--max-tokens", type=int, default=64)
+    args = parser.parse_args()
+    results = {"target": args.target, "draft": args.draft}
+    from importlib.metadata import version
+
+    results["versions"] = {
+        name: version(name) for name in ("mlx", "mlx-lm", "dflash-mlx", "paroquant")
+    }
+    results["device"] = mx.device_info()
+    from omlx.patches.dflash_lifecycle import (
+        install_dflash_lifecycle_wrap,
+        restore_dflash_class_patches,
+    )
+    from omlx.patches.dflash_paroquant import (
+        load_target_bundle,
+        validate_paroquant_draft,
+    )
+    from omlx.utils.model_loading import maybe_apply_pre_load_patches
+
+    maybe_apply_pre_load_patches(args.target)
+    install_dflash_lifecycle_wrap()
+    loader = importlib.import_module("paroquant.inference.backends.mlx.load")
+    create = loader._create_model
+
+    def audited_create(*a, **kw):
+        model = create(*a, **kw)
+        original = model.load_weights
+
+        def audited_load(weights, *a, **kw):
+            expected = dict(tree_flatten(model.parameters()))
+            actual = dict(weights)
+            audit = {
+                "missing": sorted(set(expected) - set(actual)),
+                "extra": sorted(set(actual) - set(expected)),
+                "shape_mismatch": [
+                    k
+                    for k in expected.keys() & actual.keys()
+                    if expected[k].shape != actual[k].shape
+                ],
+            }
+            results["weight_audit"] = audit
+            print("WEIGHT_AUDIT", json.dumps(audit), flush=True)
+            return original(weights, *a, **kw)
+
+        object.__setattr__(model, "load_weights", audited_load)
+        return model
+
+    loader._create_model = audited_create
+    begin = time.perf_counter()
+    bundle = load_target_bundle(args.target, lazy=False)
+    loader._create_model = create
+    results["load_seconds"] = time.perf_counter() - begin
+    model, tok, ops = bundle.model, bundle.tokenizer, bundle.target_ops
+    print("LOADED", results["load_seconds"], flush=True)
+    capture = {6, 20, 34, 48, 62}
+    ids = tok.encode("The capital of France is")
+    x = mx.array([ids])
+    # Restore hooks to establish an ordinary-forward reference.
+    restore_dflash_class_patches()
+    native = model(x, cache=model.make_cache())
+    mx.eval(native)
+    ops.text_model(model)._dflash_speculative_hooks_installed = False
+    ops.install_speculative_hooks(model)
+    actual, hidden = ops.forward_with_hidden_capture(
+        model,
+        input_ids=x,
+        cache=ops.make_cache(model, enable_speculative_linear_cache=True),
+        capture_layer_ids=capture,
+    )
+    mx.eval(actual)
+    results["forward_max_abs"] = float(mx.max(mx.abs(actual - native)))
+    assert bool(mx.all(mx.argmax(actual, axis=-1) == mx.argmax(native, axis=-1)))
+    results["rollback"] = []
+    for width in (3, 5, 8):
+        candidate_ids = tok.encode(
+            " Paris is a beautiful city with many famous landmarks."
+        )[:width]
+        assert len(candidate_ids) == width
+        candidates = mx.array([candidate_ids])
+        for accepted in range(width):
+            cache = ops.make_cache(model, enable_speculative_linear_cache=True)
+            out, _ = ops.forward_with_hidden_capture(
+                model, input_ids=x, cache=cache, capture_layer_ids=capture
+            )
+            mx.eval(out)
+            ops.arm_rollback(cache, prefix_len=len(ids))
+            out, _ = ops.verify_block(
+                target_model=model,
+                verify_ids=candidates,
+                target_cache=cache,
+                capture_layer_ids=capture,
+            )
+            mx.eval(out)
+            ops.restore_after_acceptance(
+                cache,
+                target_len=len(ids) + accepted + 1,
+                acceptance_length=accepted,
+                drafted_tokens=width - 1,
+            )
+            next_id = mx.array([[tok.encode(" Next")[0]]])
+            after, _ = ops.forward_with_hidden_capture(
+                model, input_ids=next_id, cache=cache, capture_layer_ids=capture
+            )
+            reference = model(
+                mx.array([ids + candidate_ids[: accepted + 1] + next_id[0].tolist()]),
+                cache=model.make_cache(),
+            )[:, -1:, :]
+            mx.eval(after, reference)
+            row = {
+                "width": width,
+                "accepted": accepted,
+                "max_abs": float(mx.max(mx.abs(after - reference))),
+                "same_argmax": bool(
+                    mx.all(mx.argmax(after, axis=-1) == mx.argmax(reference, axis=-1))
+                ),
+            }
+            results["rollback"].append(row)
+            print("ROLLBACK", json.dumps(row), flush=True)
+            del cache
+    from dflash_mlx.draft_backend import EagerDraftBackend
+    from dflash_mlx.engine.events import SummaryEvent, TokenEvent
+    from dflash_mlx.engine.target_ops import bind_draft_to_target
+    from dflash_mlx.runtime import stream_dflash_generate
+    from dflash_mlx.runtime.context import build_offline_runtime_context
+    from dflash_mlx.runtime.loading import load_draft_bundle
+
+    draft, meta = load_draft_bundle(args.draft)
+    validate_paroquant_draft(bundle.meta, meta)
+    bind_draft_to_target(draft, model, target_ops=ops)
+    results["generation"] = []
+    for prompt in [
+        "The capital of France is",
+        "def fibonacci(n):\n",
+        "Count from one to twenty: one,",
+    ]:
+        prompt_ids = tok.encode(prompt)
+        restore_dflash_class_patches()
+        cache = model.make_cache()
+        inp = mx.array([prompt_ids])
+        baseline = []
+        start = time.perf_counter()
+        ttft = None
+        for _ in range(args.max_tokens):
+            logits = model(inp, cache=cache)
+            token = int(mx.argmax(logits[0, -1]))
+            if ttft is None:
+                ttft = time.perf_counter() - start
+            baseline.append(token)
+            inp = mx.array([[token]])
+        baseline_s = time.perf_counter() - start
+        del cache
+        ops.text_model(model)._dflash_speculative_hooks_installed = False
+        ops.install_speculative_hooks(model)
+        for width in (3, 5, 8):
+            runtime = build_offline_runtime_context(
+                verify_mode="off", draft_sink_size=0, draft_window_size=2048
+            )
+            tokens = []
+            summary = None
+            for event in stream_dflash_generate(
+                target_model=model,
+                target_ops=ops,
+                tokenizer=tok,
+                draft_model=draft,
+                draft_backend=EagerDraftBackend(),
+                prompt="",
+                prompt_tokens_override=prompt_ids,
+                max_new_tokens=args.max_tokens,
+                stop_token_ids=set(),
+                temperature=0.0,
+                block_tokens=width,
+                runtime_context=runtime,
+            ):
+                if isinstance(event, TokenEvent):
+                    tokens.append(int(event.token_id))
+                elif isinstance(event, SummaryEvent):
+                    summary = dataclasses.asdict(event)
+            row = {
+                "prompt": prompt,
+                "width": width,
+                "baseline_seconds": baseline_s,
+                "baseline_ttft": ttft,
+                "same_tokens": tokens == baseline,
+                "first_difference": next(
+                    (i for i, (a, b) in enumerate(zip(tokens, baseline)) if a != b),
+                    None,
+                ),
+                "baseline_ids": baseline,
+                "dflash_ids": tokens,
+                "text": tok.decode(tokens),
+                "summary": summary,
+            }
+            results["generation"].append(row)
+            print(
+                "GENERATION",
+                json.dumps(
+                    {
+                        k: v
+                        for k, v in row.items()
+                        if k not in ("baseline_ids", "dflash_ids")
+                    }
+                ),
+                flush=True,
+            )
+    results["peak_memory_bytes"] = mx.get_peak_memory()
+    restore_dflash_class_patches()
+    from pathlib import Path
+
+    Path(args.output).write_text(json.dumps(results, indent=2, default=str) + "\n")
+    assert not any(
+        results["weight_audit"].values()
+    ), "Checkpoint text-weight audit failed"
+    assert all(
+        row["same_argmax"] for row in results["rollback"]
+    ), "Rollback changed the next token"
+    assert all(
+        row["same_tokens"] for row in results["generation"]
+    ), "Greedy generation diverged"
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/paroquant_dflash/validation_summary.json
+++ b/benchmarks/paroquant_dflash/validation_summary.json
@@ -1,0 +1,261 @@
+{
+  "date": "2026-09-08",
+  "base_commit": "5f62b09f",
+  "target": "z-lab/Qwen3.8-27B-PARO",
+  "draft": "z-lab/Qwen3.8-27B-DFlash2",
+  "draft_revision": "50307d4c4cde6860d4eee73e2547cd786fe8e8a4",
+  "versions": {
+    "mlx": "0.32.2",
+    "mlx-lm": "0.31.3",
+    "dflash-mlx": "0.1.10+omlx.7",
+    "paroquant": "0.1.16"
+  },
+  "device": {
+    "device_name": "Apple M3 Max",
+    "max_recommended_working_set_size": 55662788608,
+    "memory_size": 68719476736,
+    "architecture": "applegpu_g15s",
+    "max_buffer_length": 41747087360,
+    "resource_limit": 499000
+  },
+  "weight_audit": {
+    "missing": [],
+    "extra": [],
+    "shape_mismatch": []
+  },
+  "forward_max_abs": 0.0,
+  "rollback": [
+    {
+      "width": 3,
+      "accepted": 0,
+      "max_abs": 0.03125,
+      "same_argmax": true
+    },
+    {
+      "width": 3,
+      "accepted": 1,
+      "max_abs": 0.033203125,
+      "same_argmax": true
+    },
+    {
+      "width": 3,
+      "accepted": 2,
+      "max_abs": 0.02734375,
+      "same_argmax": true
+    },
+    {
+      "width": 5,
+      "accepted": 0,
+      "max_abs": 0.03125,
+      "same_argmax": true
+    },
+    {
+      "width": 5,
+      "accepted": 1,
+      "max_abs": 0.033203125,
+      "same_argmax": true
+    },
+    {
+      "width": 5,
+      "accepted": 2,
+      "max_abs": 0.02734375,
+      "same_argmax": true
+    },
+    {
+      "width": 5,
+      "accepted": 3,
+      "max_abs": 0.029296875,
+      "same_argmax": true
+    },
+    {
+      "width": 5,
+      "accepted": 4,
+      "max_abs": 0.02734375,
+      "same_argmax": true
+    },
+    {
+      "width": 8,
+      "accepted": 0,
+      "max_abs": 0.0234375,
+      "same_argmax": true
+    },
+    {
+      "width": 8,
+      "accepted": 1,
+      "max_abs": 0.0283203125,
+      "same_argmax": true
+    },
+    {
+      "width": 8,
+      "accepted": 2,
+      "max_abs": 0.029296875,
+      "same_argmax": true
+    },
+    {
+      "width": 8,
+      "accepted": 3,
+      "max_abs": 0.03125,
+      "same_argmax": true
+    },
+    {
+      "width": 8,
+      "accepted": 4,
+      "max_abs": 0.021484375,
+      "same_argmax": true
+    },
+    {
+      "width": 8,
+      "accepted": 5,
+      "max_abs": 0.02734375,
+      "same_argmax": true
+    },
+    {
+      "width": 8,
+      "accepted": 6,
+      "max_abs": 0.03125,
+      "same_argmax": true
+    },
+    {
+      "width": 8,
+      "accepted": 7,
+      "max_abs": 0.03125,
+      "same_argmax": true
+    }
+  ],
+  "greedy": [
+    {
+      "prompt": "The capital of France is",
+      "block_size": 3,
+      "tokens": 64,
+      "same_tokens": true,
+      "token_sha256": "a26f852cad3ac157d95856d37f641d9b09310eb73e31c10c25ed7b30aac34cfd",
+      "acceptance_ratio": 0.625
+    },
+    {
+      "prompt": "The capital of France is",
+      "block_size": 5,
+      "tokens": 64,
+      "same_tokens": true,
+      "token_sha256": "a26f852cad3ac157d95856d37f641d9b09310eb73e31c10c25ed7b30aac34cfd",
+      "acceptance_ratio": 0.734375
+    },
+    {
+      "prompt": "The capital of France is",
+      "block_size": 8,
+      "tokens": 64,
+      "same_tokens": true,
+      "token_sha256": "a26f852cad3ac157d95856d37f641d9b09310eb73e31c10c25ed7b30aac34cfd",
+      "acceptance_ratio": 0.75
+    },
+    {
+      "prompt": "def fibonacci(n):\n",
+      "block_size": 3,
+      "tokens": 64,
+      "same_tokens": true,
+      "token_sha256": "188cf187f615db5e089a0f047ebd78b00c804d97a9ea806d4fa278bd47293200",
+      "acceptance_ratio": 0.609375
+    },
+    {
+      "prompt": "def fibonacci(n):\n",
+      "block_size": 5,
+      "tokens": 64,
+      "same_tokens": true,
+      "token_sha256": "188cf187f615db5e089a0f047ebd78b00c804d97a9ea806d4fa278bd47293200",
+      "acceptance_ratio": 0.765625
+    },
+    {
+      "prompt": "def fibonacci(n):\n",
+      "block_size": 8,
+      "tokens": 64,
+      "same_tokens": true,
+      "token_sha256": "188cf187f615db5e089a0f047ebd78b00c804d97a9ea806d4fa278bd47293200",
+      "acceptance_ratio": 0.8125
+    },
+    {
+      "prompt": "Count from one to twenty: one,",
+      "block_size": 3,
+      "tokens": 64,
+      "same_tokens": true,
+      "token_sha256": "7c1176e581dfe16b8ea945cb0fb7e1f45e4a39d4a9b2cd3f9ae42f72865cb174",
+      "acceptance_ratio": 0.65625
+    },
+    {
+      "prompt": "Count from one to twenty: one,",
+      "block_size": 5,
+      "tokens": 64,
+      "same_tokens": true,
+      "token_sha256": "7c1176e581dfe16b8ea945cb0fb7e1f45e4a39d4a9b2cd3f9ae42f72865cb174",
+      "acceptance_ratio": 0.78125
+    },
+    {
+      "prompt": "Count from one to twenty: one,",
+      "block_size": 8,
+      "tokens": 64,
+      "same_tokens": true,
+      "token_sha256": "7c1176e581dfe16b8ea945cb0fb7e1f45e4a39d4a9b2cd3f9ae42f72865cb174",
+      "acceptance_ratio": 0.859375
+    }
+  ],
+  "serving": [
+    {
+      "case": "cold_4096",
+      "prompt_tokens": 4096,
+      "cached_tokens": 0,
+      "output_tokens": 32,
+      "text": "five, six, seven, eight, nine, ten, eleven, twelve, thirteen, fourteen, fifteen, sixteen, seventeen, eighteen, nineteen, twenty,"
+    },
+    {
+      "case": "warm_4096",
+      "prompt_tokens": 4096,
+      "cached_tokens": 4096,
+      "output_tokens": 32,
+      "text": "five, six, seven, eight, nine, ten, eleven, twelve, thirteen, fourteen, fifteen, sixteen, seventeen, eighteen, nineteen, twenty,"
+    },
+    {
+      "case": "cold_16384",
+      "prompt_tokens": 16384,
+      "cached_tokens": 0,
+      "output_tokens": 32,
+      "text": "five, six, seven, eight, nine, ten, eleven, twelve, thirteen, fourteen, fifteen, sixteen, seventeen, eighteen, nineteen, twenty,"
+    },
+    {
+      "case": "warm_16384",
+      "prompt_tokens": 16384,
+      "cached_tokens": 16384,
+      "output_tokens": 32,
+      "text": "five, six, seven, eight, nine, ten, eleven, twelve, thirteen, fourteen, fifteen, sixteen, seventeen, eighteen, nineteen, twenty,"
+    },
+    {
+      "case": "cold_32768",
+      "prompt_tokens": 32768,
+      "cached_tokens": 0,
+      "output_tokens": 32,
+      "text": "five, six, seven, eight, nine, ten, eleven, twelve, thirteen, fourteen, fifteen, sixteen, seventeen, eighteen, nineteen, twenty,"
+    },
+    {
+      "case": "warm_32768",
+      "prompt_tokens": 32768,
+      "cached_tokens": 32768,
+      "output_tokens": 32,
+      "text": "five, six, seven, eight, nine, ten, eleven, twelve, thirteen, fourteen, fifteen, sixteen, seventeen, eighteen, nineteen, twenty,"
+    },
+    {
+      "case": "after_cancel",
+      "prompt_tokens": 5,
+      "cached_tokens": 0,
+      "output_tokens": 32,
+      "text": "Paris.\nThe capital of Germany is Berlin.\nThe capital of Italy is Rome.\nThe capital of Spain is Madrid.\nThe capital of Portugal is"
+    },
+    {
+      "case": "after_reload",
+      "prompt_tokens": 5,
+      "cached_tokens": 0,
+      "output_tokens": 32,
+      "text": "Paris.\nThe capital of Germany is Berlin.\nThe capital of Italy is Rome.\nThe capital of Spain is Madrid.\nThe capital of Portugal is"
+    }
+  ],
+  "seeded_sampling_reproducible": true,
+  "regression_tests_passed": 309,
+  "final_focused_tests_passed": 24,
+  "scope": "Correctness and integration validation; not a controlled speed comparison. Image routing covered by existing unit tests, not a live image run."
+}

--- a/benchmarks/paroquant_dflash/validation_summary.json
+++ b/benchmarks/paroquant_dflash/validation_summary.json
@@ -257,5 +257,23 @@
   "seeded_sampling_reproducible": true,
   "regression_tests_passed": 309,
   "final_focused_tests_passed": 24,
-  "scope": "Correctness and integration validation; not a controlled speed comparison. Image routing covered by existing unit tests, not a live image run."
+  "scope": "Correctness and integration validation; not a controlled speed comparison. Image routing covered by existing unit tests, not a live image run.",
+  "vision_followup": {
+    "implementation_commit": "10c0f050",
+    "image_fallback": {
+      "text_before_image": "five, six, seven, eight, nine, ten, eleven, twelve,",
+      "image_response": "Red",
+      "in_vlm_fallback": true,
+      "vision_tower_present": true
+    },
+    "direct_vlm_adapter_probe": {
+      "model_class": "mlx_vlm.models.qwen3_5.qwen3_5",
+      "language_model_class": "mlx_vlm.models.qwen3_5.language",
+      "adapter_resolves": true,
+      "ordinary_forward_finite": true,
+      "exception_type": "TypeError",
+      "error": "_install_speculative_linear_cache_hook.<locals>.speculative_call() got an unexpected keyword argument 'gdn_sink'"
+    },
+    "scope": "Real full-checkpoint text-to-image fallback; direct adapter interface tested on a small mlx-vlm model."
+  }
 }

--- a/docs/experimental/paroquant-dflash.md
+++ b/docs/experimental/paroquant-dflash.md
@@ -1,13 +1,21 @@
 # ParoQuant with DFlash
 
-DFlash text generation supports the dense Qwen3.8-27B ParoQuant layout
-(4-bit weights, group size 128, eight rotation stages). A matching draft is
-`z-lab/Qwen3.8-27B-DFlash2`.
+DFlash text generation accepts ParoQuant Qwen2, Qwen3, Qwen3-MoE, and
+Qwen3.5-family dense/MoE targets (including Qwen3.6/Qwen3.8 checkpoints using
+those model types). Model size is read from configuration rather than fixed
+to the 27B layout. Supported quantization is 4-bit with group size 32, 64, or
+128; rotation count is taken from checkpoint tensors.
 
-Install oMLX with the `paroquant` extra, register the target and draft, then
-select the draft under the target's DFlash settings. Start with block size 5;
-block sizes 3 and 8 are also covered by the correctness checks. A Hugging Face
-cache reference must resolve to the snapshot containing the checkpoint files,
+This is not universal ParoQuant support: other architectures need their own
+loader/adapter validation, and every target needs a DFlash draft trained for
+the same base model. The supplied `z-lab/Qwen3.8-27B-DFlash2` draft must not be
+reused with differently sized targets.
+
+Install oMLX with the `paroquant` extra, register the target and its matching
+draft, then select the draft under the target's DFlash settings. For the
+fully validated Qwen3.8-27B pair, start with block size 5; block sizes 3 and 8
+also passed correctness checks. For other pairs, follow the draft's limits.
+A Hugging Face cache reference must resolve to the snapshot containing the checkpoint files,
 not the cache's `models--...` container directory.
 
 ParoQuant targets load through ParoQuant's text loader. Its rotation-aware
@@ -17,7 +25,7 @@ verification, and recurrent/attention cache rollback. Ordinary MLX targets retai
 their original loading and verification paths.
 
 Eligibility is checked consistently by the dashboard, settings API, and target
-loader. Other ParoQuant architectures and quantization layouts remain unsupported.
+loader. Uncovered ParoQuant architectures and quantization layouts remain unsupported.
 Draft hidden size, vocabulary size, target-layer count, and capture-layer indices
 must match the target. Matching dimensions do not establish semantic compatibility:
 choose a draft trained for the same base model.
@@ -95,3 +103,20 @@ Machine-readable evidence is in
 [`validation_summary.json`](../../benchmarks/paroquant_dflash/validation_summary.json).
 Live image generation and a controlled comparison against the batched engine
 were not part of this validation.
+
+## Family-level validation
+
+The extension covers the actual mlx-lm types `qwen2`, `qwen3`, `qwen3_moe`,
+`qwen3_5`, and `qwen3_5_moe`. Small numerical fixtures cover all five types,
+including quantized MoE experts with shared ParoQuant rotations. They verify
+hidden capture and every rejection position in a five-token block. Additional
+fixtures exercise group sizes 32/64 and rotation counts 2/4, alongside 128/8.
+Real ParoQuant loader round-trips verify rotation preservation and forward
+parity for these small MLX-format checkpoints; only tokenizer construction is
+stubbed. This is structural/numerical coverage, not full-checkpoint validation
+of every published model or its draft.
+
+The full-model results above remain specific to Qwen3.8-27B. Native/AutoAWQ
+conversion for other published checkpoints and their draft acceptance quality
+have not been newly measured. Non-four-bit formats remain rejected because
+the installed ParoQuant AutoAWQ converter unpacks four-bit nibbles.

--- a/docs/experimental/paroquant-dflash.md
+++ b/docs/experimental/paroquant-dflash.md
@@ -31,7 +31,20 @@ must match the target. Matching dimensions do not establish semantic compatibili
 choose a draft trained for the same base model.
 
 This enables text speculation. Image requests continue through oMLX's existing
-VLM fallback. It does not enable ParoQuant's separately gated MTP, SpecPrefill,
+VLM fallback, which loads the original checkpoint including its vision tower.
+The text-only target is an architecture-specific adapter choice, not a generic
+DFlash rule for VLMs. With the currently pinned Qwen backend, loading the
+mlx-vlm model directly resolves an adapter but fails on its first captured
+forward: the recurrent hook does not accept mlx-vlm's `gdn_sink` argument.
+
+Image requests therefore retain visual input, but do not use DFlash acceleration.
+The first image request evicts the text target/draft and loads the full VLM;
+the engine stays in fallback mode until it is stopped/reloaded. Native
+image-conditioned DFlash would require a VLM-aware Qwen adapter that preserves
+processor/vision embeddings, multimodal positions, and recurrent rollback.
+Simply removing `force_text=True` does not implement that support.
+
+It does not enable ParoQuant's separately gated MTP, SpecPrefill,
 IndexCache, or TurboQuant settings.
 
 ## Validation
@@ -82,6 +95,10 @@ claims require matched cache state, runtime/memory policy, repeated alternating
 runs, and equal correct output. DFlash phase timers can include asynchronous work;
 they are not exclusive GPU kernel timings.
 
+To check a text request followed by a real image request through VLM fallback,
+use `engine_smoke` with `--vision-smoke-only`. It constructs a red image,
+requires a red-color answer, and checks that the fallback loaded a vision tower.
+
 ## Recorded validation (2026-09-08)
 
 On an M3 Max with 64 GiB unified memory, MLX 0.32.2, the pinned mlx-lm
@@ -101,8 +118,10 @@ On an M3 Max with 64 GiB unified memory, MLX 0.32.2, the pinned mlx-lm
 
 Machine-readable evidence is in
 [`validation_summary.json`](../../benchmarks/paroquant_dflash/validation_summary.json).
-Live image generation and a controlled comparison against the batched engine
-were not part of this validation.
+A follow-up real-checkpoint image-input test returned "Red" for a generated
+red image after text generation, with VLM fallback active and a vision tower
+present. This is a bounded image-input smoke check, not broad vision-quality
+validation. A controlled comparison against the batched engine was not run.
 
 ## Family-level validation
 

--- a/docs/experimental/paroquant-dflash.md
+++ b/docs/experimental/paroquant-dflash.md
@@ -1,0 +1,97 @@
+# ParoQuant with DFlash
+
+DFlash text generation supports the dense Qwen3.8-27B ParoQuant layout
+(4-bit weights, group size 128, eight rotation stages). A matching draft is
+`z-lab/Qwen3.8-27B-DFlash2`.
+
+Install oMLX with the `paroquant` extra, register the target and draft, then
+select the draft under the target's DFlash settings. Start with block size 5;
+block sizes 3 and 8 are also covered by the correctness checks. A Hugging Face
+cache reference must resolve to the snapshot containing the checkpoint files,
+not the cache's `models--...` container directory.
+
+ParoQuant targets load through ParoQuant's text loader. Its rotation-aware
+projection modules remain intact; target verify-linear replacements are skipped.
+The existing Qwen hybrid-attention adapter supplies hidden-state capture,
+verification, and recurrent/attention cache rollback. Ordinary MLX targets retain
+their original loading and verification paths.
+
+Eligibility is checked consistently by the dashboard, settings API, and target
+loader. Other ParoQuant architectures and quantization layouts remain unsupported.
+Draft hidden size, vocabulary size, target-layer count, and capture-layer indices
+must match the target. Matching dimensions do not establish semantic compatibility:
+choose a draft trained for the same base model.
+
+This enables text speculation. Image requests continue through oMLX's existing
+VLM fallback. It does not enable ParoQuant's separately gated MTP, SpecPrefill,
+IndexCache, or TurboQuant settings.
+
+## Validation
+
+Focused tests:
+
+```sh
+python -m pytest tests/test_dflash_paroquant.py tests/test_dflash_engine.py \
+  tests/test_dflash_lifecycle.py tests/test_dflash_multimodal_fallback.py \
+  tests/test_model_loading.py tests/test_admin_api_key.py
+```
+
+Tests involving real rotation modules require the optional ParoQuant package and
+Metal. The small numerical fixture includes both recurrent and full-attention
+layers, nonzero rotations, and all possible rejection positions in a five-token
+verification block. The first position is a confirmed root; accepted draft tokens
+are counted separately.
+
+To audit a real checkpoint, compare captured forward logits, force rejection at
+block sizes 3/5/8, and compare 64 greedy output tokens on prose, code, and counting:
+
+```sh
+python -m benchmarks.paroquant_dflash.validate \
+  --target /path/to/Qwen3.8-27B-PARO \
+  --draft /path/to/Qwen3.8-27B-DFlash2/snapshot \
+  --output /tmp/paroquant-validation.json
+```
+
+The loader audit checks missing, unexpected, and mismatched text tensors after
+ParoQuant conversion/sanitization. The baseline and speculative runs share the
+same loaded weights and tokenizer. The harness explicitly re-arms instance hook
+flags when switching from ordinary decoding back to DFlash.
+
+To exercise the oMLX engine's streaming, cold/warm long-context requests, seeded
+sampling, cancellation, and reload:
+
+```sh
+python -m benchmarks.paroquant_dflash.engine_smoke \
+  --target /path/to/Qwen3.8-27B-PARO \
+  --draft /path/to/Qwen3.8-27B-DFlash2/snapshot \
+  --output /tmp/paroquant-engine.json \
+  --contexts 4096 16384 32768
+```
+
+These scripts are correctness and integration probes. Their timing fields are
+not a controlled comparison against the regular oMLX batched engine. Performance
+claims require matched cache state, runtime/memory policy, repeated alternating
+runs, and equal correct output. DFlash phase timers can include asynchronous work;
+they are not exclusive GPU kernel timings.
+
+## Recorded validation (2026-09-08)
+
+On an M3 Max with 64 GiB unified memory, MLX 0.32.2, the pinned mlx-lm
+0.31.3 revision, dflash-mlx 0.1.10+omlx.7, and ParoQuant 0.1.16:
+
+- The real target's sanitized text-weight audit had no missing, extra, or
+  mismatched tensors. Hidden-capture logits matched ordinary forward exactly.
+- All nine 64-token greedy comparisons matched token for token (three prompts
+  at block sizes 3, 5, and 8).
+- All 16 rejection cases preserved the next-token argmax. Maximum logit
+  difference was 0.033203125 across FP16 block/sequential evaluation paths.
+- oMLX cold/warm requests at 4K, 16K, and 32K returned identical text, and
+  repeated requests reused the entire prompt prefix.
+- Seeded sampling, post-cancellation generation, and unload/reload passed.
+- The related regression run passed 309 tests; the final focused suite passed
+  24 tests after narrowing eligibility to the loader-supported top-level type.
+
+Machine-readable evidence is in
+[`validation_summary.json`](../../benchmarks/paroquant_dflash/validation_summary.json).
+Live image generation and a controlled comparison against the batched engine
+were not part of this validation.

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -595,9 +595,6 @@ def _dflash_compat_for_model(model_info: dict) -> tuple[bool, str]:
     Returns ``(False, "")`` when dflash-mlx is not installed so the UI hides
     the compat hint instead of pointing the user at an unrelated reason.
     """
-    is_paro, paro_reason = _paroquant_compat_for_model(model_info)
-    if is_paro:
-        return False, paro_reason
     try:
         from ..engine.dflash import is_dflash_compatible
     except ImportError:

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -89,6 +89,14 @@ def is_dflash_compatible(model_path: str | Path) -> tuple[bool, str]:
 
     model_type = str(cfg.get("model_type") or "").lower()
 
+    from ..patches.dflash_paroquant import (
+        is_paroquant_config,
+        paroquant_dflash_compatibility,
+    )
+
+    if is_paroquant_config(cfg):
+        return paroquant_dflash_compatibility(cfg)
+
     is_qwen = "qwen" in model_type
     is_gemma4 = model_type in ("gemma4", "gemma4_text", "gemma4_unified")
     is_laguna = model_type == "laguna"
@@ -537,9 +545,11 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         def _load_models():
             from dflash_mlx.draft_backend import EagerDraftBackend
             from dflash_mlx.engine.target_ops import bind_draft_to_target
-            from dflash_mlx.runtime.loading import (
-                load_draft_bundle,
+            from dflash_mlx.runtime.loading import load_draft_bundle
+
+            from ..patches.dflash_paroquant import (
                 load_target_bundle,
+                validate_paroquant_draft,
             )
 
             # Apply the same pre-load patches BatchedEngine uses before
@@ -611,6 +621,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                     else None
                 ),
             )
+            validate_paroquant_draft(target_bundle.meta, draft_meta)
             bind_draft_to_target(
                 draft,
                 target_bundle.model,

--- a/omlx/patches/dflash_paroquant.py
+++ b/omlx/patches/dflash_paroquant.py
@@ -79,6 +79,10 @@ def load_target_bundle(model_ref: str | Path, **kwargs: Any) -> Any:
     from dflash_mlx.engine.target_ops import resolve_target_ops
     from dflash_mlx.runtime.loading import LoadedTargetBundle
 
+    # This is specific to the current Qwen TargetOps implementation: its
+    # recurrent hooks accept mlx-lm calls, not mlx-vlm's gdn_sink/position
+    # interface. Image requests reload the full model via the VLM fallback.
+    # It is not a general requirement for every DFlash architecture.
     model, tokenizer, is_vlm = load(
         str(model_ref), lazy=kwargs.get("lazy", True), force_text=True
     )

--- a/omlx/patches/dflash_paroquant.py
+++ b/omlx/patches/dflash_paroquant.py
@@ -17,23 +17,37 @@ def is_paroquant_config(config: dict) -> bool:
 
 
 def paroquant_dflash_compatibility(config: dict) -> tuple[bool, str]:
-    """Keep initial support restricted to the dense Qwen3.8-27B layout."""
+    """Accept Qwen layouts covered by the ParoQuant loader and DFlash adapter."""
     text = config.get("text_config") or config
     quant = config.get("quantization_config") or {}
+    # Use actual mlx-lm module names, not a substring match: text-only aliases
+    # and unrelated Qwen architectures need their own loader/adapter coverage.
+    if config.get("model_type") not in {
+        "qwen2",
+        "qwen3",
+        "qwen3_moe",
+        "qwen3_5",
+        "qwen3_5_moe",
+    }:
+        return (
+            False,
+            "ParoQuant DFlash supports Qwen2, Qwen3 and Qwen3.5-family dense/MoE text targets",
+        )
     if (
-        config.get("model_type") != "qwen3_5"
-        or not isinstance(text, dict)
-        or text.get("num_hidden_layers") != 64
-        or text.get("hidden_size") != 5120
-        or text.get("vocab_size") != 248320
-        or text.get("num_experts", 0) not in (0, None)
+        not isinstance(text, dict)
+        or not isinstance(quant, dict)
+        or any(
+            type(text.get(key)) is not int or text[key] <= 0
+            for key in ("num_hidden_layers", "hidden_size", "vocab_size")
+        )
+        # AutoAWQ conversion in ParoQuant currently unpacks four-bit nibbles.
         or quant.get("bits") != 4
-        or quant.get("group_size") != 128
-        or quant.get("krot") != 8
+        or quant.get("group_size") not in (32, 64, 128)
+        or ("krot" in quant and (type(quant["krot"]) is not int or quant["krot"] <= 0))
     ):
         return (
             False,
-            "ParoQuant DFlash currently supports only the dense Qwen3.8-27B 4-bit, group-128, krot-8 layout",
+            "ParoQuant DFlash requires positive text dimensions, 4-bit weights, group size 32/64/128, and positive rotation count when specified",
         )
     return True, ""
 

--- a/omlx/patches/dflash_paroquant.py
+++ b/omlx/patches/dflash_paroquant.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Load ParoQuant targets without replacing their rotation-aware projections."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def is_paroquant_config(config: dict) -> bool:
+    quant = config.get("quantization_config") or {}
+    return (
+        isinstance(quant, dict)
+        and str(quant.get("quant_method", "")).lower() == "paroquant"
+    )
+
+
+def paroquant_dflash_compatibility(config: dict) -> tuple[bool, str]:
+    """Keep initial support restricted to the dense Qwen3.8-27B layout."""
+    text = config.get("text_config") or config
+    quant = config.get("quantization_config") or {}
+    if (
+        config.get("model_type") != "qwen3_5"
+        or not isinstance(text, dict)
+        or text.get("num_hidden_layers") != 64
+        or text.get("hidden_size") != 5120
+        or text.get("vocab_size") != 248320
+        or text.get("num_experts", 0) not in (0, None)
+        or quant.get("bits") != 4
+        or quant.get("group_size") != 128
+        or quant.get("krot") != 8
+    ):
+        return (
+            False,
+            "ParoQuant DFlash currently supports only the dense Qwen3.8-27B 4-bit, group-128, krot-8 layout",
+        )
+    return True, ""
+
+
+def load_target_bundle(model_ref: str | Path, **kwargs: Any) -> Any:
+    """Dispatch locally registered ParoQuant checkpoints to their own loader.
+
+    Ordinary targets retain dflash-mlx's loader and verification optimizations.
+    ParoQuant's rotation modules must execute their original forward methods;
+    the first supported path deliberately skips target verify-linear rewrites.
+    """
+    from dflash_mlx.runtime.loading import load_target_bundle as standard_load
+
+    config_path = Path(model_ref) / "config.json"
+    config = json.loads(config_path.read_text()) if config_path.exists() else {}
+    if not is_paroquant_config(config):
+        return standard_load(model_ref, **kwargs)
+
+    compatible, reason = paroquant_dflash_compatibility(config)
+    if not compatible:
+        raise ValueError(reason)
+    try:
+        from paroquant.inference.backends.mlx.load import load
+    except ImportError as exc:
+        raise ImportError(
+            'ParoQuant DFlash requires ParoQuant; install "omlx[paroquant]"'
+        ) from exc
+
+    from dflash_mlx.engine.target_ops import resolve_target_ops
+    from dflash_mlx.runtime.loading import LoadedTargetBundle
+
+    model, tokenizer, is_vlm = load(
+        str(model_ref), lazy=kwargs.get("lazy", True), force_text=True
+    )
+    if is_vlm:
+        raise ValueError("ParoQuant DFlash requires a text-only target")
+    ops = resolve_target_ops(model)
+    ops.install_speculative_hooks(model)
+    return LoadedTargetBundle(
+        model=model,
+        tokenizer=tokenizer,
+        target_ops=ops,
+        meta={
+            "resolved_model_ref": str(model_ref),
+            "config": config,
+            "quantize_kv_cache": bool(kwargs.get("quantize_kv_cache", False)),
+            "target_family": ops.family(model),
+            "quant_method": "paroquant",
+            "verify_linear_enabled": False,
+            "verify_linear_swapped": 0,
+            "verify_mode": "off",
+        },
+    )
+
+
+def validate_paroquant_draft(target_meta: dict, draft_meta: dict) -> None:
+    """Reject incompatible drafts before their first projection or cache update."""
+    if target_meta.get("quant_method") != "paroquant":
+        return
+    target = target_meta["config"]
+    text = target.get("text_config") or target
+    draft = draft_meta.get("config") or {}
+    spec = draft.get("dflash_config") or {}
+    layers = spec.get("target_layer_ids") or []
+    if (
+        draft.get("hidden_size") != text["hidden_size"]
+        or draft.get("vocab_size") != text["vocab_size"]
+        or draft.get("num_target_layers", spec.get("num_target_layers"))
+        != text["num_hidden_layers"]
+        or not layers
+        or any(
+            type(i) is not int or not 0 <= i < text["num_hidden_layers"] for i in layers
+        )
+    ):
+        raise ValueError(
+            "DFlash draft dimensions or capture layers do not match the ParoQuant target"
+        )

--- a/tests/test_dflash_paroquant.py
+++ b/tests/test_dflash_paroquant.py
@@ -1,0 +1,306 @@
+# SPDX-License-Identifier: Apache-2.0
+"""ParoQuant loading, eligibility, and rotation/cache correctness contracts."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from omlx.patches.dflash_paroquant import (
+    is_paroquant_config,
+    load_target_bundle,
+    paroquant_dflash_compatibility,
+    validate_paroquant_draft,
+)
+
+
+def config():
+    return {
+        "model_type": "qwen3_5",
+        "text_config": {
+            "num_hidden_layers": 64,
+            "hidden_size": 5120,
+            "vocab_size": 248320,
+            "num_experts": 0,
+        },
+        "quantization_config": {
+            "quant_method": "paroquant",
+            "bits": 4,
+            "group_size": 128,
+            "krot": 8,
+        },
+    }
+
+
+def test_compatibility_and_case_normalization():
+    cfg = config()
+    cfg["quantization_config"]["quant_method"] = "ParoQuant"
+    assert is_paroquant_config(cfg)
+    assert paroquant_dflash_compatibility(cfg) == (True, "")
+    assert not is_paroquant_config({})
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("num_experts", 8),
+        ("hidden_size", 4096),
+        ("num_hidden_layers", 32),
+        ("vocab_size", 100),
+    ],
+)
+def test_reject_other_target_layouts(field, value):
+    cfg = config()
+    cfg["text_config"][field] = value
+    assert not paroquant_dflash_compatibility(cfg)[0]
+
+
+@pytest.mark.parametrize("field,value", [("bits", 8), ("group_size", 64), ("krot", 4)])
+def test_reject_other_quantization_layouts(field, value):
+    cfg = config()
+    cfg["quantization_config"][field] = value
+    assert not paroquant_dflash_compatibility(cfg)[0]
+
+
+def test_standard_loader_keeps_options(tmp_path, monkeypatch):
+    from dflash_mlx.runtime import loading
+
+    original = Mock(return_value=object())
+    monkeypatch.setattr(loading, "load_target_bundle", original)
+    assert (
+        load_target_bundle(tmp_path, lazy=False, quantize_kv_cache=True)
+        is original.return_value
+    )
+    original.assert_called_once_with(tmp_path, lazy=False, quantize_kv_cache=True)
+
+
+def test_paroquant_loader_preserves_rotations_and_disables_verify_rewrites(
+    tmp_path, monkeypatch
+):
+    loader = pytest.importorskip("paroquant.inference.backends.mlx.load")
+    from dflash_mlx import verify_linear
+    from dflash_mlx.engine import target_ops
+    from dflash_mlx.runtime import loading
+
+    (tmp_path / "config.json").write_text(json.dumps(config()))
+    model, tokenizer = object(), object()
+    load = Mock(return_value=(model, tokenizer, False))
+    ops = SimpleNamespace(
+        install_speculative_hooks=Mock(), family=lambda _: "hybrid_gdn"
+    )
+    monkeypatch.setattr(loader, "load", load)
+    monkeypatch.setattr(target_ops, "resolve_target_ops", lambda _: ops)
+    standard = Mock(side_effect=AssertionError("standard loader used"))
+    rewrite = Mock(side_effect=AssertionError("rotation rewrite attempted"))
+    monkeypatch.setattr(loading, "load_target_bundle", standard)
+    monkeypatch.setattr(verify_linear, "install_verify_linears", rewrite)
+    bundle = load_target_bundle(tmp_path, verify_config=SimpleNamespace(mode="on"))
+    load.assert_called_once_with(str(tmp_path), lazy=True, force_text=True)
+    assert bundle.model is model and bundle.tokenizer is tokenizer
+    assert bundle.meta["verify_linear_enabled"] is False
+    ops.install_speculative_hooks.assert_called_once_with(model)
+    standard.assert_not_called()
+    rewrite.assert_not_called()
+
+
+def test_draft_shape_and_capture_validation():
+    target = {"quant_method": "paroquant", "config": config()}
+    draft = {
+        "config": {
+            "hidden_size": 5120,
+            "vocab_size": 248320,
+            "num_target_layers": 64,
+            "dflash_config": {"target_layer_ids": [5, 19, 33, 47, 61]},
+        }
+    }
+    validate_paroquant_draft(target, draft)
+    draft["config"]["dflash_config"]["target_layer_ids"] = [64]
+    with pytest.raises(ValueError, match="capture layers"):
+        validate_paroquant_draft(target, draft)
+    validate_paroquant_draft({}, {})
+
+
+def test_admin_and_engine_agree(tmp_path):
+    from omlx.admin.routes import _dflash_compat_for_model
+    from omlx.engine.dflash import is_dflash_compatible
+
+    (tmp_path / "config.json").write_text(json.dumps(config()))
+    assert is_dflash_compatible(tmp_path) == (True, "")
+    assert _dflash_compat_for_model({"model_path": str(tmp_path)}) == (True, "")
+    cfg = config()
+    cfg["text_config"]["num_experts"] = 8
+    (tmp_path / "config.json").write_text(json.dumps(cfg))
+    assert _dflash_compat_for_model(
+        {"model_path": str(tmp_path)}
+    ) == is_dflash_compatible(tmp_path)
+    assert not is_dflash_compatible(tmp_path)[0]
+
+
+@pytest.fixture
+def rotated_qwen():
+    mx = pytest.importorskip("mlx.core")
+    nn = pytest.importorskip("mlx.nn")
+    paro = pytest.importorskip("paroquant.inference.backends.mlx.modules")
+    from mlx.utils import tree_unflatten
+    from mlx_lm.models.qwen3_5 import Model, ModelArgs
+
+    from omlx.patches.dflash_lifecycle import (
+        install_dflash_lifecycle_wrap,
+        restore_dflash_class_patches,
+    )
+
+    restore_dflash_class_patches()
+    mx.random.seed(7)
+    model = Model(
+        ModelArgs(
+            model_type="qwen3_5",
+            text_config=dict(
+                model_type="qwen3_5_text",
+                hidden_size=128,
+                intermediate_size=256,
+                num_hidden_layers=4,
+                num_attention_heads=4,
+                num_key_value_heads=2,
+                head_dim=32,
+                vocab_size=128,
+                linear_num_value_heads=4,
+                linear_num_key_heads=2,
+                linear_key_head_dim=32,
+                linear_value_head_dim=32,
+            ),
+        )
+    )
+    replacements = []
+    for name, layer in model.named_modules():
+        if isinstance(layer, nn.Linear) and not name.endswith("lm_head"):
+            out_dim, in_dim = layer.weight.shape
+            rotated = paro.RotateQuantizedLinear(
+                in_dim, out_dim, bias=False, group_size=128, krot=8
+            )
+            rotated.weight, rotated.scales, rotated.biases = mx.quantize(
+                layer.weight, group_size=128, bits=4
+            )
+            rotated.theta = mx.random.normal((8, in_dim // 2)) * 0.2
+            rotated.pairs = mx.broadcast_to(
+                mx.arange(in_dim, dtype=mx.int16) % 128, (8, in_dim)
+            )
+            rotated.channel_scales = mx.ones((1, in_dim)) * 0.9
+            replacements.append((name, rotated))
+    model.update_modules(tree_unflatten(replacements))
+    model.eval()
+    mx.eval(model.parameters())
+    install_dflash_lifecycle_wrap()
+    yield model
+    restore_dflash_class_patches()
+
+
+def test_rotated_target_hidden_capture_matches_unpatched_forward(rotated_qwen):
+    import mlx.core as mx
+    from dflash_mlx.engine.target_ops import resolve_target_ops
+
+    model = rotated_qwen
+    ids = mx.array([[1, 2, 3, 4]])
+    expected = model(ids, cache=model.make_cache())
+    mx.eval(expected)
+    ops = resolve_target_ops(model)
+    ops.install_speculative_hooks(model)
+    actual, hidden = ops.forward_with_hidden_capture(
+        model,
+        input_ids=ids,
+        cache=ops.make_cache(model, enable_speculative_linear_cache=True),
+        capture_layer_ids={1, 4},
+    )
+    mx.eval(actual)
+    assert set(hidden) == {1, 4}
+    assert float(mx.max(mx.abs(actual - expected))) < 1e-4
+
+
+@pytest.mark.parametrize("accepted", range(5))
+def test_rotated_target_rejection_restores_recurrent_and_attention_state(
+    rotated_qwen, accepted
+):
+    import mlx.core as mx
+    from dflash_mlx.engine.target_ops import resolve_target_ops
+
+    model = rotated_qwen
+    prefix, proposed, next_token = [1, 2, 3], [4, 5, 6, 7, 8], [9]
+    expected = model(
+        mx.array([prefix + proposed[: accepted + 1] + next_token]),
+        cache=model.make_cache(),
+    )[:, -1:, :]
+    mx.eval(expected)
+    ops = resolve_target_ops(model)
+    ops.install_speculative_hooks(model)
+    cache = ops.make_cache(model, enable_speculative_linear_cache=True)
+    out, _ = ops.forward_with_hidden_capture(
+        model, input_ids=mx.array([prefix]), cache=cache
+    )
+    mx.eval(out)
+    ops.arm_rollback(cache, prefix_len=len(prefix))
+    out, _ = ops.verify_block(
+        target_model=model,
+        verify_ids=mx.array([proposed]),
+        target_cache=cache,
+        capture_layer_ids={1, 4},
+    )
+    mx.eval(out)
+    ops.restore_after_acceptance(
+        cache,
+        target_len=len(prefix) + accepted + 1,
+        acceptance_length=accepted,
+        drafted_tokens=len(proposed) - 1,
+    )
+    actual, _ = ops.forward_with_hidden_capture(
+        model, input_ids=mx.array([next_token]), cache=cache
+    )
+    mx.eval(actual)
+    assert float(mx.max(mx.abs(actual - expected))) < 1e-4
+
+
+def test_unsupported_paroquant_never_reaches_standard_loader(tmp_path, monkeypatch):
+    from dflash_mlx.runtime import loading
+
+    cfg = config()
+    cfg["text_config"]["num_experts"] = 8
+    (tmp_path / "config.json").write_text(json.dumps(cfg))
+    standard = Mock(side_effect=AssertionError("standard loader used"))
+    monkeypatch.setattr(loading, "load_target_bundle", standard)
+    with pytest.raises(ValueError, match="dense Qwen3.8"):
+        load_target_bundle(tmp_path)
+    standard.assert_not_called()
+
+
+def test_missing_paroquant_reports_install_hint(tmp_path, monkeypatch):
+    import sys
+
+    (tmp_path / "config.json").write_text(json.dumps(config()))
+    monkeypatch.setitem(sys.modules, "paroquant.inference.backends.mlx.load", None)
+    with pytest.raises(ImportError, match=r"omlx\[paroquant\]"):
+        load_target_bundle(tmp_path)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [("hidden_size", 4096), ("vocab_size", 100), ("num_target_layers", 32)],
+)
+def test_draft_dimension_mismatch(field, value):
+    draft = {
+        "config": {
+            "hidden_size": 5120,
+            "vocab_size": 248320,
+            "num_target_layers": 64,
+            "dflash_config": {"target_layer_ids": [5, 19, 33, 47, 61]},
+        }
+    }
+    draft["config"][field] = value
+    with pytest.raises(ValueError, match="dimensions"):
+        validate_paroquant_draft(
+            {"quant_method": "paroquant", "config": config()}, draft
+        )
+
+
+def test_unregistered_text_architecture_is_not_advertised():
+    cfg = config()
+    cfg["model_type"] = "qwen3_5_text"
+    assert not paroquant_dflash_compatibility(cfg)[0]

--- a/tests/test_dflash_paroquant.py
+++ b/tests/test_dflash_paroquant.py
@@ -44,10 +44,9 @@ def test_compatibility_and_case_normalization():
 @pytest.mark.parametrize(
     "field,value",
     [
-        ("num_experts", 8),
-        ("hidden_size", 4096),
-        ("num_hidden_layers", 32),
-        ("vocab_size", 100),
+        ("hidden_size", 0),
+        ("num_hidden_layers", -1),
+        ("vocab_size", True),
     ],
 )
 def test_reject_other_target_layouts(field, value):
@@ -56,7 +55,7 @@ def test_reject_other_target_layouts(field, value):
     assert not paroquant_dflash_compatibility(cfg)[0]
 
 
-@pytest.mark.parametrize("field,value", [("bits", 8), ("group_size", 64), ("krot", 4)])
+@pytest.mark.parametrize("field,value", [("bits", 8), ("group_size", 16), ("krot", 0)])
 def test_reject_other_quantization_layouts(field, value):
     cfg = config()
     cfg["quantization_config"][field] = value
@@ -129,7 +128,7 @@ def test_admin_and_engine_agree(tmp_path):
     assert is_dflash_compatible(tmp_path) == (True, "")
     assert _dflash_compat_for_model({"model_path": str(tmp_path)}) == (True, "")
     cfg = config()
-    cfg["text_config"]["num_experts"] = 8
+    cfg["text_config"]["hidden_size"] = 0
     (tmp_path / "config.json").write_text(json.dumps(cfg))
     assert _dflash_compat_for_model(
         {"model_path": str(tmp_path)}
@@ -137,13 +136,25 @@ def test_admin_and_engine_agree(tmp_path):
     assert not is_dflash_compatible(tmp_path)[0]
 
 
-@pytest.fixture
-def rotated_qwen():
+@pytest.fixture(
+    params=[
+        ("qwen2", 128, 8),
+        ("qwen3", 128, 8),
+        ("qwen3_moe", 128, 8),
+        ("qwen3_5", 128, 8),
+        ("qwen3_5_moe", 128, 8),
+        ("qwen3_5", 32, 2),
+        ("qwen3_5_moe", 64, 4),
+    ]
+)
+def rotated_qwen(request):
+    import importlib
+
     mx = pytest.importorskip("mlx.core")
     nn = pytest.importorskip("mlx.nn")
     paro = pytest.importorskip("paroquant.inference.backends.mlx.modules")
     from mlx.utils import tree_unflatten
-    from mlx_lm.models.qwen3_5 import Model, ModelArgs
+    from mlx_lm.models.switch_layers import SwitchGLU, SwitchLinear
 
     from omlx.patches.dflash_lifecycle import (
         install_dflash_lifecycle_wrap,
@@ -152,42 +163,83 @@ def rotated_qwen():
 
     restore_dflash_class_patches()
     mx.random.seed(7)
-    model = Model(
-        ModelArgs(
-            model_type="qwen3_5",
-            text_config=dict(
-                model_type="qwen3_5_text",
-                hidden_size=128,
-                intermediate_size=256,
-                num_hidden_layers=4,
-                num_attention_heads=4,
-                num_key_value_heads=2,
-                head_dim=32,
-                vocab_size=128,
-                linear_num_value_heads=4,
-                linear_num_key_heads=2,
-                linear_key_head_dim=32,
-                linear_value_head_dim=32,
-            ),
-        )
+    architecture, group_size, krot = request.param
+    text = dict(
+        model_type=architecture,
+        hidden_size=128,
+        intermediate_size=256,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=32,
+        vocab_size=128,
+        rms_norm_eps=1e-6,
+        rope_theta=100000.0,
+        max_position_embeddings=4096,
+        tie_word_embeddings=False,
+        linear_num_value_heads=4,
+        linear_num_key_heads=2,
+        linear_key_head_dim=32,
+        linear_value_head_dim=32,
     )
+    if "moe" in architecture:
+        text.update(
+            num_experts=4,
+            num_experts_per_tok=2,
+            decoder_sparse_step=1,
+            mlp_only_layers=[],
+            moe_intermediate_size=256,
+            shared_expert_intermediate_size=256,
+            norm_topk_prob=True,
+        )
+    cfg = (
+        dict(model_type=architecture, text_config=text)
+        if architecture.startswith("qwen3_5")
+        else text
+    )
+    module = importlib.import_module("mlx_lm.models." + architecture)
+    model = module.Model(module.ModelArgs.from_dict(cfg))
     replacements = []
     for name, layer in model.named_modules():
         if isinstance(layer, nn.Linear) and not name.endswith("lm_head"):
             out_dim, in_dim = layer.weight.shape
             rotated = paro.RotateQuantizedLinear(
-                in_dim, out_dim, bias=False, group_size=128, krot=8
+                in_dim, out_dim, bias="bias" in layer, group_size=group_size, krot=krot
             )
             rotated.weight, rotated.scales, rotated.biases = mx.quantize(
-                layer.weight, group_size=128, bits=4
+                layer.weight, group_size=group_size, bits=4
             )
-            rotated.theta = mx.random.normal((8, in_dim // 2)) * 0.2
+            rotated.theta = mx.random.normal((krot, in_dim // 2)) * 0.2
             rotated.pairs = mx.broadcast_to(
-                mx.arange(in_dim, dtype=mx.int16) % 128, (8, in_dim)
+                mx.arange(in_dim, dtype=mx.int16) % group_size, (krot, in_dim)
             )
             rotated.channel_scales = mx.ones((1, in_dim)) * 0.9
+            if "bias" in layer:
+                rotated.bias = layer.bias
             replacements.append((name, rotated))
     model.update_modules(tree_unflatten(replacements))
+    nn.quantize(
+        model,
+        group_size=group_size,
+        bits=4,
+        class_predicate=lambda _, m: isinstance(m, SwitchLinear),
+    )
+    for name, layer in list(model.named_modules()):
+        if isinstance(layer, SwitchGLU):
+            rotated = paro.RotateSwitchGLU(layer, group_size, krot)
+            for prefix in ("gate_up_rot", "down_rot"):
+                dim = getattr(rotated, prefix + "_theta").shape[1] * 2
+                setattr(
+                    rotated, prefix + "_theta", mx.random.normal((krot, dim // 2)) * 0.2
+                )
+                setattr(
+                    rotated,
+                    prefix + "_pairs",
+                    mx.broadcast_to(
+                        mx.arange(dim, dtype=mx.int16) % group_size, (krot, dim)
+                    ),
+                )
+            model.update_modules(tree_unflatten([(name, rotated)]))
     model.eval()
     mx.eval(model.parameters())
     install_dflash_lifecycle_wrap()
@@ -201,7 +253,7 @@ def test_rotated_target_hidden_capture_matches_unpatched_forward(rotated_qwen):
 
     model = rotated_qwen
     ids = mx.array([[1, 2, 3, 4]])
-    expected = model(ids, cache=model.make_cache())
+    expected = model(ids, cache=_ordinary_cache(model))
     mx.eval(expected)
     ops = resolve_target_ops(model)
     ops.install_speculative_hooks(model)
@@ -227,7 +279,7 @@ def test_rotated_target_rejection_restores_recurrent_and_attention_state(
     prefix, proposed, next_token = [1, 2, 3], [4, 5, 6, 7, 8], [9]
     expected = model(
         mx.array([prefix + proposed[: accepted + 1] + next_token]),
-        cache=model.make_cache(),
+        cache=_ordinary_cache(model),
     )[:, -1:, :]
     mx.eval(expected)
     ops = resolve_target_ops(model)
@@ -262,11 +314,11 @@ def test_unsupported_paroquant_never_reaches_standard_loader(tmp_path, monkeypat
     from dflash_mlx.runtime import loading
 
     cfg = config()
-    cfg["text_config"]["num_experts"] = 8
+    cfg["text_config"]["hidden_size"] = 0
     (tmp_path / "config.json").write_text(json.dumps(cfg))
     standard = Mock(side_effect=AssertionError("standard loader used"))
     monkeypatch.setattr(loading, "load_target_bundle", standard)
-    with pytest.raises(ValueError, match="dense Qwen3.8"):
+    with pytest.raises(ValueError, match="positive text dimensions"):
         load_target_bundle(tmp_path)
     standard.assert_not_called()
 
@@ -304,3 +356,103 @@ def test_unregistered_text_architecture_is_not_advertised():
     cfg = config()
     cfg["model_type"] = "qwen3_5_text"
     assert not paroquant_dflash_compatibility(cfg)[0]
+
+
+def _ordinary_cache(model):
+    from mlx_lm.models.cache import make_prompt_cache
+
+    return make_prompt_cache(model)
+
+
+@pytest.mark.parametrize(
+    "architecture", ["qwen2", "qwen3", "qwen3_moe", "qwen3_5", "qwen3_5_moe"]
+)
+def test_other_qwen_sizes_are_eligible(architecture):
+    cfg = config()
+    cfg["model_type"] = architecture
+    cfg["text_config"].update(
+        hidden_size=2048, num_hidden_layers=24, vocab_size=151936, num_experts=8
+    )
+    cfg["quantization_config"].update(group_size=64, krot=4)
+    assert paroquant_dflash_compatibility(cfg) == (True, "")
+
+
+@pytest.mark.parametrize(
+    "architecture", ["llama", "gemma4", "qwen3_next", "unrelated_qwen_model"]
+)
+def test_uncovered_architectures_are_rejected(architecture):
+    cfg = config()
+    cfg["model_type"] = architecture
+    assert not paroquant_dflash_compatibility(cfg)[0]
+
+
+def test_real_paroquant_loader_keeps_dense_and_moe_rotations(
+    rotated_qwen, tmp_path, monkeypatch
+):
+    """Round-trip small MLX-format checkpoints through the real Paro loader."""
+    from dataclasses import asdict
+
+    import mlx.core as mx
+    from mlx.utils import tree_flatten
+    from paroquant.inference.backends.mlx import load as paro_loader
+    from paroquant.inference.backends.mlx.modules import (
+        RotateQuantizedLinear,
+        RotateSwitchGLU,
+    )
+
+    from omlx.patches.dflash_lifecycle import restore_dflash_class_patches
+
+    model = rotated_qwen
+    cfg = asdict(model.args)
+    rotation = next(
+        m for _, m in model.named_modules() if isinstance(m, RotateQuantizedLinear)
+    )
+    cfg["quantization_config"] = dict(
+        quant_method="paroquant",
+        bits=4,
+        group_size=rotation.group_size,
+        krot=rotation.theta.shape[0],
+    )
+    (tmp_path / "config.json").write_text(json.dumps(cfg))
+    mx.save_safetensors(
+        str(tmp_path / "model.safetensors"), dict(tree_flatten(model.parameters()))
+    )
+    # Tokenizer contents are unrelated to module replacement; everything in
+    # checkpoint conversion, model construction, and weight loading stays real.
+    monkeypatch.setattr(paro_loader, "_load_processor", lambda *_: object())
+    bundle = load_target_bundle(tmp_path, lazy=False)
+    before = {
+        n: m
+        for n, m in model.named_modules()
+        if isinstance(m, (RotateQuantizedLinear, RotateSwitchGLU))
+    }
+    after = {
+        n: m
+        for n, m in bundle.model.named_modules()
+        if isinstance(m, (RotateQuantizedLinear, RotateSwitchGLU))
+    }
+    assert before.keys() == after.keys()
+    for name, module in before.items():
+        field = (
+            "theta"
+            if isinstance(module, RotateQuantizedLinear)
+            else "gate_up_rot_theta"
+        )
+        assert bool(mx.all(getattr(module, field) == getattr(after[name], field)))
+    restore_dflash_class_patches()
+    ids = mx.array([[1, 2, 3]])
+    expected = bundle.model(ids, cache=_ordinary_cache(bundle.model))
+    mx.eval(expected)
+    bundle.target_ops.text_model(bundle.model)._dflash_speculative_hooks_installed = (
+        False
+    )
+    bundle.target_ops.install_speculative_hooks(bundle.model)
+    actual, _ = bundle.target_ops.forward_with_hidden_capture(
+        bundle.model,
+        input_ids=ids,
+        cache=_ordinary_cache(bundle.model),
+        capture_layer_ids={1, 4},
+    )
+    mx.eval(actual)
+    assert bool(mx.all(mx.isfinite(actual)))
+    assert float(mx.max(mx.abs(actual - expected))) < 1e-4


### PR DESCRIPTION
## Summary

Enable DFlash text generation for ParoQuant Qwen2, Qwen3, Qwen3-MoE, and Qwen3.5-family dense/MoE targets, including Qwen3.6/Qwen3.8 exports using those model types. Previously the dashboard rejected all ParoQuant targets, and DFlash used a generic MLX loader that does not handle their packed weights and rotations.

Route these targets through ParoQuant's text loader and reuse the existing Qwen adapter. Eligibility uses architecture and format rather than hard-coded 27B dimensions: positive model dimensions, 4-bit weights, group size 32/64/128, and a positive rotation count when specified. Draft dimensions and capture indices must match the selected target. Each target still needs a draft trained for its own base model.

This is not universal ParoQuant support: Llama, Gemma, and other uncovered architectures remain rejected pending adapter/loader validation. Ordinary MLX targets retain their existing loader, and image requests retain the existing VLM fallback.

## Qwen3.8-27B-PARO with/without DFlash2 benchmark

Measured on the PR implementation (`10c0f050`) using the same loaded `Qwen3.8-27B-PARO` target with ordinary autoregressive decoding (AR) versus `z-lab/Qwen3.8-27B-DFlash2`, block size 5. This is an **offline single-request runtime comparison**, not an oMLX BatchedEngine/HTTP-serving throughput comparison.

| Prompt tokens | Mode | Median TTFT (s) | Median completion (s), min–max | Median decode tokens/s |
| --- | --- | ---: | ---: | ---: |
| 32 | Without DFlash2 | 0.56 | 53.89 (37.90–74.56) | 4.79 |
| 32 | With DFlash2 (B5) | 0.60 | 15.47 (13.28–15.80) | 17.23 |
| 4,096 | Without DFlash2 | 32.67 | 76.89 (66.53–97.15) | 5.85 |
| 4,096 | With DFlash2 (B5) | 37.05 | 53.21 (49.63–56.96) | 14.89 |

**Measured direction:** DFlash2 reduced median completion latency by 71.3% at 32 prompt tokens (3.48× completion speedup); 30.8% at 4,096 prompt tokens (1.45× completion speedup). Prompt processing limits the end-to-end gain at 4K even when the decode phase accelerates.

### Conditions and correctness

- Apple M3 Max, 64 GiB unified memory; MLX 0.32.2, mlx-lm 0.31.3, dflash-mlx 0.1.10+omlx.7, ParoQuant 0.1.16. Target is ParoQuant 4-bit/group-128/krot-8; draft snapshot `50307d4c4cde6860d4eee73e2547cd786fe8e8a4`.
- 256 generated tokens per run, greedy sampling, concurrency 1, fresh target cache for every measured run. Target and draft remain resident for both modes; loading and tokenization are outside the timed region. Both paths warm up before each context.
- Two A–B–B–A blocks per context: four observations per mode/context, sixteen measured runs total. A = AR, B = DFlash2. No measured runs discarded.
- Both paths use last-token-only prompt logits and the same prompt-minus-last-token/final-token split. AR uses the existing TargetOps forward path with speculative hooks restored; DFlash uses the offline runtime. This compares those execution paths, not the draft algorithm in isolation.
- Native hybrid GDN/full attention; quantized KV cache disabled, prefill step 4096, draft window 2048, sink 0, target full-attention window 0; target verify-linear rewrites disabled. DFlash uses its default cache-boundary clearing; AR has no equivalent runtime clearing step.
- Completion is time through the final generated token. Decode rate is `(256−1)/(last-token time−first-token time)`; it is a bounded 256-token measurement, not sustained 1K+ decoding. DFlash host phase timers are lazy/overlapping and are not summed as exclusive GPU time.
- Every measured output matched the corresponding AR reference token-for-token. An independent full-text check verified the complete counting sequence from five through ninety-seven. All DFlash runs used speculation rather than AR fallback.
- Workload: repeat the tokenized filler `The library holds books on history, science, mathematics, and art.\n`, truncate to the requested token length minus the suffix, then append `\nContinue the count: one, two, three, four,`. This predictable synthetic task can produce optimistic draft acceptance; results do not establish performance on prose, code, reasoning, long generations, or concurrent serving.
- The desktop was not isolated: other applications remained running. A mid-run snapshot showed about 10.1 GB of existing system swap and no recorded thermal/performance warning. This does not establish swap activity during a particular run or the cause of timing variation. Treat the ranges as material, especially for AR.

<details>
<summary>Per-run completion times and reference hashes</summary>

| Prompt tokens | Run order | Completion seconds |
| --- | --- | --- |
| 32 | A, B, B, A, A, B, B, A | 37.896, 13.280, 15.800, 74.558, 55.453, 15.764, 15.170, 52.325 |
| 4,096 | A, B, B, A, A, B, B, A | 97.151, 56.964, 55.292, 85.974, 67.812, 49.633, 51.119, 66.526 |

Token hashes use SHA-256 of Python `json.dumps(token_ids)`:

- 32-token prompt: `d325296ba03a49bfe5271c558e82c1a1a724982e24ecf70a0ff2f84ded588804`; output: `e723500f49618571de84af14f412f621dc521e779ed2ba5a0d6455a1f37a1200`.
- 4,096-token prompt: `7c077c33a248c70ca7436e417504e807127123ef9ed113c823b70ec045b94e7e`; output: `e723500f49618571de84af14f412f621dc521e779ed2ba5a0d6455a1f37a1200`.

</details>

## Code-necessity ablation

The study examined removal of individual additions rather than decoding performance. The ablation documents, harness, and raw results are excluded from this PR; the findings are recorded here. The table distinguishes required functionality from defensive policy and redundant setup rather than claiming every line is indispensable.

| Change | Evidence and reason for inclusion |
| --- | --- |
| Remove the admin blanket rejection | Executing the old and new compatibility functions against the actual target configuration changed rejection to acceptance. Required for the supported pair to be available through the dashboard. |
| Route the engine through the ParoQuant-aware target loader | Generic `mlx_lm` quantization dispatch has no ParoQuant branch. The actual checkpoint has 3,184 tensors, including packed `qweight`/`qzeros` and 400 rotation groups. ParoQuant's loader provides the required conversion and rotation modules. This conclusion uses source/header inspection and the successful custom-loader integration, not a fresh full-model negative load. |
| Select `force_text=True` | Specific to the current Qwen adapter, not a generic DFlash/VLM requirement. A small model created by the actual mlx-vlm loader passes ordinary forward and resolves Qwen TargetOps, but captured forward fails because the recurrent hook rejects the VLM-only `gdn_sink` argument. The checkpoint has 333 vision tensors, so removing the flag selects that incompatible interface. The flag affects only the text-speculation copy: image requests reload the full checkpoint through VLM fallback. |
| Resolve TargetOps and install speculative hooks | Reuses existing hidden-state capture and recurrent/attention rollback. On a small model with real nonzero ParoQuant rotations, suppressing all hook installation changed the next-token argmax after partial rejection (maximum logit error 0.65346). However, omitting only the eager loader call still passed because cache creation installs hooks itself. The eager call is retained to mirror the standard loader setup contract; it is redundant in the tested offline path. |
| Shared target-layout checks in eligibility and loader | Upstream already recognizes `qwen3_5`; these checks do not enable the valid pair. They deliberately restrict advertised and direct-load support to the five covered model types and four-bit formats, reject malformed dimensions, and keep the dashboard and engine consistent. The original fixed 27B dimensions were removed after family-level numerical and loader tests passed. |
| Draft dimensions/capture-layer validation | Provides early errors for incompatible hidden size, vocabulary, target-layer count, or capture indices. Existing draft binding only sets embedding scale. Defensive validation, not necessary for an already-valid pair; matching dimensions alone do not prove semantic compatibility. |
| Omit stock verify-linear installation | The installer does not accept `RotateQuantizedLinear`. The original 27B model has 400 such modules and one affine output head whose 248,320 outputs exceed the default 100,000 eligibility threshold. The small fixture's QMM-enabled installer swapped zero modules. No demonstrated functional benefit from this omission under the tested defaults, and no claim that the stock installer would corrupt rotations. For the original 27B checkpoint, calling it would add no useful replacements. Other accepted targets can have eligible ordinary projections; this implementation still omits optional rewrites rather than claiming they are inapplicable to every model. |
| Bundle metadata and optional-dependency handling | Preserve the engine's bundle/config contract, report that verify rewrites were not installed, and provide an actionable installation error when ParoQuant is absent. These are integration/diagnostic provisions. |
| Regression tests, validation scripts, and usage documentation | Cover loader routing, unsupported layouts, draft validation, numerical hidden capture, forced rollback, and serving lifecycle; document the narrow supported configuration and provide reproducible correctness probes. These are validation/support artifacts, not decoding requirements. |

The primary agent independently reran the three hook conditions: explicit installation and omission of only the eager call both preserved argmax with maximum logit difference 8.34e-7; suppression of all installation did not. The original narrow implementation also passed fifteen direct target/draft configuration checks; its model-size restrictions have since been replaced by the broader policy above and updated tests. This is bounded correctness evidence, not a performance claim.

## Validation

- Related test suite rerun on the PR branch against upstream/main `b908f563`: **361 passed** (`test_dflash_paroquant`, `test_dflash_engine`, `test_dflash_lifecycle`, `test_dflash_multimodal_fallback`, `test_model_loading`, `test_admin_api_key`).
- New family coverage: 75 focused tests, including small numerical fixtures for all five accepted architectures, real quantized MoE experts/shared rotations, every rejection position in a five-token block, and ParoQuant loader round-trips of small MLX-format checkpoints. Group-size/rotation-count variants include 32/2, 64/4, and 128/8. Tokenizer construction alone is stubbed in the loader round-trips.
- Earlier full-model validation on M3 Max, MLX 0.32.2, mlx-lm 0.31.3, dflash-mlx 0.1.10+omlx.7, ParoQuant 0.1.16: no missing, extra, or mismatched sanitized text tensors; captured forward logits matched ordinary forward.
- Nine 64-token greedy comparisons matched exactly: three prompts at block sizes 3, 5, and 8.
- All 16 forced-rejection cases preserved next-token argmax; maximum FP16 block/sequential logit difference 0.033203125.
- Actual oMLX engine checks passed for cold/warm 4K, 16K, and 32K requests, complete prefix reuse, seeded sampling, cancellation recovery, and unload/reload.

The full-model checks were performed before the final upstream refresh; the related automated suite was rerun afterward. No controlled serving-performance claim is made. The later image-input smoke check is reported below.

The family extension has small-model structural/numerical coverage. Only Qwen3.8-27B has full-checkpoint generation/lifecycle evidence. Other published native/AutoAWQ checkpoints and their matching drafts have not been newly loaded or evaluated end to end.


## Visual-input follow-up

A real Qwen3.8-27B-PARO test first generated text with DFlash2, then submitted a 224×224 red PNG with “What color fills this image? Answer with only the color name.” The answer was **“Red”**, VLM fallback was active, and the loaded fallback model retained its vision tower. The 22 multimodal-routing regression tests also passed. A repeatable `engine_smoke --vision-smoke-only` option and the result summary are included.

Thus visual input is preserved, but it is not currently DFlash-accelerated: the first image request evicts the text target/draft and reloads the complete VLM; that engine remains in fallback until stop/reload. Direct image-conditioned speculation needs a Qwen VLM-aware adapter covering processor/vision embeddings, multimodal positions, and rollback. Simply removing `force_text=True` breaks the current captured-forward path; this PR retains it as an adapter-specific boundary, not a restriction inherent to ParoQuant or to all DFlash VLMs. The red-image test is a smoke check, not broad vision-quality validation.

## Ordinary Qwen3.8-27B-4bit baseline with/without DFlash2

The prepared `mlx-community/Qwen3.8-27B-4bit` checkpoint was measured on PR commit `1ccec554`. It has the same 64-layer/5120-hidden Qwen architecture, but uses ordinary affine 4-bit quantization with group size 64 rather than ParoQuant. The draft is the same `z-lab/Qwen3.8-27B-DFlash2` snapshot and block size 5.

| Prompt tokens | Mode | Median TTFT (s) | Median completion (s), min–max | Median decode tokens/s |
| --- | --- | ---: | ---: | ---: |
| 32 | Without DFlash2 | 0.26 | 13.66 (13.63–14.38) | 19.02 |
| 32 | With DFlash2 (B5) | 0.26 | 5.65 (5.41–5.79) | 47.36 |

**Validated result:** DFlash2 is 2.42× faster by median completion latency (58.6% less time) for this short-context counting task. All eight measured runs returned the identical 256-token sequence; an independent full-text check verified counting from five through ninety-seven.

Conditions match the ParoQuant benchmark methodology above: M3 Max/64 GiB, MLX 0.32.2, mlx-lm 0.31.3, dflash-mlx 0.1.10+omlx.7; fresh caches, greedy sampling, concurrency 1, resident target and draft, warm-up of both modes, two A–B–B–A blocks, last-token-only prompt logits, prefill step 4096, draft window 2048/sink 0, native full attention/GDN, and quantized KV disabled. Target verify-linear rewrites were explicitly disabled to match the earlier controls; this is not a maximum-tuned stock-backend benchmark. Loading/tokenization are excluded; decode rate is `(256−1)/(last-token time−first-token time)`. DFlash speculation remained active, with no AR fallback.

### 4K correctness failure — no speedup reported

The same 4,096-token counting prompt failed the correctness gate, and the remaining sweep stopped. Both outputs were wrong after “twenty-seven”: AR continued with “two hundred and eight,” while DFlash2 continued with “two hundred and twenty-eight.” Exact output diverged at token 57 (zero-based index 56). A separate 80-token run through the ordinary model’s native forward method reproduced the benchmark AR tokens exactly. This rules out the custom TargetOps reference as the source of that AR continuation; it does not establish the root cause or a general model-quality conclusion.

Only one measured AR/DFlash pair was collected at 4K before stopping. Neither its timing nor the earlier prefix-only correctness check qualifies it for a speedup claim. The full counting check and token parity, rather than a matching initial prefix, determine whether a result is usable.

<details>
<summary>Raw timings and reproducibility identifiers</summary>

- Short-context order: A, B, B, A, A, B, B, A (A = AR; B = DFlash2). Completion seconds: 14.376, 5.406, 5.785, 13.633, 13.676, 5.603, 5.697, 13.649.
- Failed 4K diagnostic pair: ar 32.525 s, dflash 25.343 s. These timings are excluded from performance conclusions.
- 32-token prompt SHA-256: `d325296ba03a49bfe5271c558e82c1a1a724982e24ecf70a0ff2f84ded588804`; AR reference token SHA-256: `e723500f49618571de84af14f412f621dc521e779ed2ba5a0d6455a1f37a1200` (Python `json.dumps(token_ids)` encoding).
- 4,096-token prompt SHA-256: `7c077c33a248c70ca7436e417504e807127123ef9ed113c823b70ec045b94e7e`; AR reference token SHA-256: `76b28e241fa5ec7e088625b5d33d22dd750a85c1e5d5656249501cbe2794dd8d` (Python `json.dumps(token_ids)` encoding).

</details>

This is the same predictable synthetic offline-runtime workload, not an oMLX BatchedEngine/HTTP comparison or a sustained-generation benchmark. The desktop was not isolated; a mid-run observation showed about 8.6 GB of existing system swap and no recorded thermal/performance warning. The ordinary-4bit and ParoQuant runs occurred in separate sessions. The ordinary-4bit short-context timings are lower in both modes, but these separate measurements do not isolate quantization cost or establish a general cross-format speed/quality ranking.
