### PR TITLE
fix(cluster): allow a PTY for the CUDA worker's controller key

### DIFF
--- a/omlx/cluster/cuda_worker_bootstrap.py
+++ b/omlx/cluster/cuda_worker_bootstrap.py
@@ -240,7 +240,11 @@ def _install_controller_key(
     existing = authorized_keys.read_text(encoding="utf-8") if authorized_keys.exists() else ""
     key_parts = public_key.strip().split()
     key_identity = " ".join(key_parts[:2])
-    restricted_line = f'from="{controller_ip}",restrict {public_key.strip()}'
+    # ``restrict`` implies ``no-pty``, but MLX's distributed launcher runs
+    # ``ssh -tt``; without a PTY the rank exits 255 with "PTY allocation
+    # request failed on channel 0". Re-enable only the PTY — port, agent
+    # and X11 forwarding and user rc stay disabled.
+    restricted_line = f'from="{controller_ip}",restrict,pty {public_key.strip()}'
     updated: list[str] = []
     installed = False
     for line in existing.splitlines():

--- a/tests/test_cluster_worker_bundle.py
+++ b/tests/test_cluster_worker_bundle.py
@@ -129,7 +129,7 @@ def test_bootstrap_authorizes_only_the_pinned_controller_address(
 
     authorized = (tmp_path / ".ssh" / "authorized_keys").read_text()
     assert authorized == (
-        'from="10.42.0.10",restrict '
+        'from="10.42.0.10",restrict,pty '
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAworker controller\n"
     )
 
@@ -162,7 +162,7 @@ def test_reenrollment_moves_the_controller_key_source_restriction(
 
     authorized = authorized_keys.read_text()
     assert authorized == (
-        'from="10.42.0.11",restrict '
+        'from="10.42.0.11",restrict,pty '
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAworker controller\n"
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAunrelated operator\n"
     )


### PR DESCRIPTION
## Problem

`_install_controller_key` (`omlx/cluster/cuda_worker_bootstrap.py`) writes:

```python
restricted_line = f'from="{controller_ip}",restrict {public_key.strip()}'
```

OpenSSH's `restrict` implies `no-pty`. MLX's distributed launcher invokes `ssh -tt`, so every rank on a GUI-enrolled CUDA worker fails to start:

```
PTY allocation request failed on channel 0
```

## Why it's hard to diagnose

The launcher surfaces only an exit status:

```
[WARN] Node with rank 1 exited with code 255
[WARN] Node with rank 0 exited with code -15
```

Nothing says SSH refused a PTY. The rank never gets far enough to write `~/.omlx/cluster/runtime/<deployment>-rank-N.json`, so there is no worker-side state to inspect either.

It also **recurs**: `_install_controller_key` rewrites the matching line on every enrollment, so an operator who patches `authorized_keys` by hand loses the fix on the next worker upgrade or re-enrollment.

## Fix

`,restrict` → `,restrict,pty`. That re-enables PTY allocation only — port forwarding, agent forwarding, X11 forwarding and user rc execution all remain disabled, so the key's reach is otherwise unchanged.

## Testing

Updated the two assertions in `tests/test_cluster_worker_bundle.py` that pin the emitted line.

I could not run the full suite locally (`tests/conftest.py` pulls in the whole mlx stack), so I exercised `_install_controller_key` directly against both existing scenarios:

- repeated install stays idempotent and emits `from="10.42.0.10",restrict,pty …`
- re-enrollment from a different controller IP rewrites our line and preserves unrelated operator keys

Both pass.

## Environment

Found bringing up the heterogeneous Metal + CUDA pool (#2591): Mac Studio M5 Max coordinator + NVIDIA DGX Spark (GB10, Ubuntu 24.04 aarch64) worker, enrolled through the admin UI's CUDA worker card. With this change the rank starts and the deployment activates.