### PR TITLE
fix(admin): guard mtp_compatibility_reason before calling .includes

### DIFF
--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -707,7 +707,7 @@
                                                class="text-xs text-amber-600 mt-1"
                                                x-text="modelSettings.mtp_compatibility_reason"></p>
                                             <button type="button"
-                                                    x-show="!modelSettings.mtp_compatible && modelSettings.mtp_compatibility_reason.includes('MTPLX side-car')"
+                                                    x-show="!modelSettings.mtp_compatible && modelSettings.mtp_compatibility_reason?.includes('MTPLX side-car')"
                                                     @click="importMtplxSidecar()"
                                                     :disabled="importingMtplx"
                                                     :class="importingMtplx ? 'opacity-40 cursor-not-allowed' : ''"


### PR DESCRIPTION
## Problem

Opening the model settings modal throws when the settings payload has no `mtp_compatibility_reason`:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'includes')
  at [Alpine] !modelSettings.mtp_compatible
              && modelSettings.mtp_compatibility_reason.includes('MTPLX side-car')
```

`omlx/admin/templates/dashboard/_modal_model_settings.html:710`.

## Why it looks like an oversight

The two sibling expressions in the same block already handle the field being absent:

```html
706:  x-show="!modelSettings.mtp_compatible && modelSettings.mtp_compatibility_reason"
710:  x-show="!modelSettings.mtp_compatible && modelSettings.mtp_compatibility_reason.includes('MTPLX side-car')"
723:  ? (modelSettings.mtp_compatibility_reason || 'Unsupported model')
```

Only line 710 dereferences it unguarded.

## Fix

Optional chaining. When the reason is absent the button stays hidden, which matches what the truthiness guard on line 706 already does for the paragraph above it.

## Environment

oMLX `main` @ 94530d8d, Safari/Chrome dashboard, Mac Studio M5 Max. Hit while configuring a cluster deployment.