### PR TITLE
fix(cache): keep a reasoning request's output cacheable when the history preserves it

### DIFF
--- a/omlx/api/utils.py
+++ b/omlx/api/utils.py
@@ -45,6 +45,19 @@ def uses_native_reasoning_content(
     return "minimax" in lowered and "m3" in lowered
 
 
+def cache_reasoning_output(
+    settings: Any,
+    *,
+    native_reasoning: bool,
+    chat_template_kwargs: dict[str, Any] | None,
+) -> bool:
+    """Whether a reasoning request's output tokens can prefix-match the next turn."""
+    forced = getattr(settings, "cache_reasoning_output", None)
+    if forced is not None:
+        return bool(forced)
+    return bool(native_reasoning) or (chat_template_kwargs or {}).get("preserve_thinking") is True
+
+
 def merge_reasoning_effort_chat_template_kwargs(
     chat_template_kwargs: dict[str, Any] | None,
     reasoning_effort: Any | None,

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -994,6 +994,7 @@ class BatchedEngine(BaseEngine):
             sampling_params=sampling_params,
             tools=tools,
             skip_cache_store=bool(kwargs.get("skip_cache_store", False)),
+            preserve_reasoning=bool(kwargs.get("preserve_reasoning", False)),
             benchmark_trace=bool(kwargs.get("benchmark_trace", False)),
             benchmark_ane_sequence_length=int(
                 kwargs.get("benchmark_ane_sequence_length", 0) or 0

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -915,6 +915,7 @@ class BatchedEngine(BaseEngine):
             prompt=prompt,
             sampling_params=sampling_params,
             tools=tools,
+            preserve_reasoning=bool(kwargs.get("preserve_reasoning", False)),
             **specprefill_kwargs,
         )
 

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -3693,6 +3693,7 @@ class VLMBatchedEngine(BaseEngine):
             vlm_cache_key_start=vlm_cache_key_start,
             vlm_cache_key_ranges=vlm_cache_key_ranges,
             skip_cache_store=bool(kwargs.get("skip_cache_store", False)),
+            preserve_reasoning=bool(kwargs.get("preserve_reasoning", False)),
             benchmark_trace=bool(kwargs.get("benchmark_trace", False)),
             benchmark_ane_sequence_length=int(
                 kwargs.get("benchmark_ane_sequence_length", 0) or 0

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -3580,6 +3580,7 @@ class VLMBatchedEngine(BaseEngine):
             vlm_cache_key_start=vlm_cache_key_start,
             vlm_cache_key_ranges=vlm_cache_key_ranges,
             tools=tools,
+            preserve_reasoning=bool(kwargs.get("preserve_reasoning", False)),
             **specprefill_kwargs,
         )
 

--- a/omlx/engine_core.py
+++ b/omlx/engine_core.py
@@ -569,6 +569,7 @@ class EngineCore:
         specprefill_threshold: Optional[int] = None,
         specprefill_system_end: Optional[int] = None,
         skip_cache_store: bool = False,
+        preserve_reasoning: bool = False,
         benchmark_trace: bool = False,
         benchmark_ane_sequence_length: int = 0,
         tools: list[dict[str, Any]] | None = None,
@@ -611,6 +612,7 @@ class EngineCore:
             vlm_cache_key_start=vlm_cache_key_start,
             vlm_cache_key_ranges=vlm_cache_key_ranges,
             skip_cache_store=skip_cache_store,
+            preserve_reasoning=preserve_reasoning,
             benchmark_trace=benchmark_trace,
             benchmark_ane_sequence_length=benchmark_ane_sequence_length,
         )

--- a/omlx/model_profiles.py
+++ b/omlx/model_profiles.py
@@ -30,6 +30,7 @@ UNIVERSAL_PROFILE_FIELDS = (
     "force_sampling",
     "enable_thinking",
     "preserve_thinking",
+    "cache_reasoning_output",
     "thinking_budget_enabled",
     "thinking_budget_tokens",
     "reasoning_parser",

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -223,6 +223,9 @@ class ModelSettings:
     preserve_thinking: Optional[bool] = (
         None  # Keep <think> blocks in historical turns (None = auto, True when template supports it)
     )
+    cache_reasoning_output: Optional[bool] = (
+        None  # Cache <think> output for the next turn (None = auto: when history keeps it)
+    )
     thinking_budget_enabled: bool = False
     thinking_budget_tokens: Optional[int] = None
     reasoning_parser: Optional[str] = (

--- a/omlx/request.py
+++ b/omlx/request.py
@@ -206,6 +206,7 @@ class Request:
 
     # Reasoning model support (for models with <think> tags)
     needs_think_prefix: bool = False  # True if prompt ends with <think> token
+    preserve_reasoning: bool = False  # history keeps the <think> output, so output tokens are cacheable
     think_prefix_sent: bool = False  # Track if prefix already sent
 
     # Harmony model support (gpt-oss models)

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1270,6 +1270,13 @@ class _BoundaryStoreUnavailable(Exception):
     """
 
 
+def _output_tokens_cacheable(request: "Request") -> bool:
+    """Output tokens are reusable unless the next turn drops a <think> block."""
+    return not getattr(request, "needs_think_prefix", False) or bool(
+        getattr(request, "preserve_reasoning", False)
+    )
+
+
 def _first_leaf_cache_offset(cache_obj: Any) -> int | None:
     """First integer ``offset`` found walking into composite caches.
 
@@ -7511,9 +7518,9 @@ class Scheduler:
         if self._boundary_cache_snapshots.get(request.request_id):
             return
         token_count = (
-            len(request.prompt_token_ids)
-            if request.needs_think_prefix
-            else request.num_tokens
+            request.num_tokens
+            if _output_tokens_cacheable(request)
+            else len(request.prompt_token_ids)
         )
         block_size = self.config.paged_cache_block_size
         if (
@@ -11580,13 +11587,12 @@ class Scheduler:
                                 ) = prompt_boundary_store
                                 cacheable_sequence = list(token_sequence_to_store)
                             else:
-                                # For reasoning models, only cache prompt tokens.
-                                # Output contains <think> tokens that the API layer
-                                # strips before the next turn, so they never match.
-                                if getattr(request, "needs_think_prefix", False):
-                                    cacheable_sequence = list(request.prompt_token_ids)
-                                else:
+                                if _output_tokens_cacheable(request):
                                     cacheable_sequence = full_token_sequence
+                                else:
+                                    # <think> output is stripped before the next
+                                    # turn, so it can never prefix-match.
+                                    cacheable_sequence = list(request.prompt_token_ids)
                                 token_sequence_to_store = cacheable_sequence
                                 cache_to_store = request._extracted_cache
                                 model_cache_config = getattr(

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -8756,6 +8756,10 @@ class Scheduler:
                 request.prompt_token_ids = list(request.prompt)
             request.num_prompt_tokens = len(request.prompt_token_ids)
 
+        if self.block_aware_cache is not None:
+            # Arm MTP boundary alignment now: a prompt shorter than a block meets
+            # its first boundary mid-decode, before any capture would arm it.
+            self._detect_boundary_snapshot_need()
         # Prefix-cache lookup is intentionally delayed until admission. That
         # lets a same-prefix request wait for a relevant in-flight store_cache
         # without blocking the scheduler lane that continues decode/prefill.

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -7564,8 +7564,8 @@ class Scheduler:
         Parser-side stops (for example tool-call end markers) can finish a request
         after a normal streaming token response. That response has no
         ``prompt_cache``, so the usual final-response cache extraction never runs.
-        This fallback stores only prompt tokens up to a prefill block boundary,
-        never generated output tokens.
+        This fallback stores the prompt, plus the output when the next turn
+        keeps it (``_output_tokens_cacheable``), up to a block boundary.
         """
         if self.block_aware_cache is None:
             return None
@@ -7577,6 +7577,8 @@ class Scheduler:
             return None
 
         prompt_tokens = list(request.prompt_token_ids or [])
+        if _output_tokens_cacheable(request):
+            prompt_tokens += list(getattr(request, "output_token_ids", None) or [])
         boundary_len = (len(prompt_tokens) // block_size) * block_size
         if boundary_len <= 0:
             return None
@@ -7633,12 +7635,12 @@ class Scheduler:
                 model_cache_config = boundary_model_config
 
             logger.info(
-                "Using prompt boundary cache snapshot for %s: storing %s/%s prompt "
-                "tokens after scheduler-side stop (skipping output tokens, %s "
-                "intermediate snapshots)",
+                "Using prompt boundary cache snapshot for %s: storing %s/%s "
+                "tokens after scheduler-side stop (%s, %s intermediate snapshots)",
                 request_id,
                 len(token_sequence),
                 len(prompt_tokens),
+                "prompt + output" if _output_tokens_cacheable(request) else "prompt only",
                 len(intermediate_snapshots) if intermediate_snapshots else 0,
             )
             return (

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -175,6 +175,7 @@ from .api.utils import (
     has_nonleading_system_message,
     merge_reasoning_effort_chat_template_kwargs,
     prepare_system_messages_for_template,
+    cache_reasoning_output,
     uses_native_reasoning_content,
 )
 from .engine import BaseEngine, VLMBatchedEngine
@@ -4015,6 +4016,9 @@ async def create_chat_completion(
 
         # Forward partial-mode decision to the engine explicitly
         chat_kwargs["is_partial"] = is_partial
+        chat_kwargs["preserve_reasoning"] = cache_reasoning_output(
+            ms, native_reasoning=native_reasoning, chat_template_kwargs=merged_ct_kwargs
+        )
 
         # SpecPrefill: per-request overrides (fall back to model_settings)
         if request.specprefill is not None:
@@ -6275,6 +6279,9 @@ async def create_anthropic_message(
 
         # Forward partial-mode decision to the engine explicitly
         chat_kwargs["is_partial"] = is_partial
+        chat_kwargs["preserve_reasoning"] = cache_reasoning_output(
+            ms, native_reasoning=native_reasoning, chat_template_kwargs=merged_ct_kwargs
+        )
 
         await _ensure_tokenizer_for_system_probe(engine, messages)
         messages = prepare_system_messages_for_template(

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -3596,3 +3596,34 @@ class TestToolResultWithToolAwareTokenizer:
         assert result[0]["tool_calls"][0]["function"]["name"] == "get_weather"
         # Arguments are parsed into dict for the chat template.
         assert result[0]["tool_calls"][0]["function"]["arguments"] == {"city": "Seoul"}
+
+
+class TestCacheReasoningOutput:
+    """Whether a reasoning request's output tokens are cacheable for the next turn."""
+
+    def test_follows_history_retention_by_default(self):
+        from omlx.api.utils import cache_reasoning_output
+
+        assert cache_reasoning_output(None, native_reasoning=False, chat_template_kwargs={}) is False
+        assert cache_reasoning_output(None, native_reasoning=True, chat_template_kwargs={}) is True
+        assert (
+            cache_reasoning_output(
+                None, native_reasoning=False, chat_template_kwargs={"preserve_thinking": True}
+            )
+            is True
+        )
+
+    def test_model_setting_overrides_detection(self):
+        from types import SimpleNamespace
+
+        from omlx.api.utils import cache_reasoning_output
+
+        forced_on = SimpleNamespace(cache_reasoning_output=True)
+        forced_off = SimpleNamespace(cache_reasoning_output=False)
+        assert cache_reasoning_output(forced_on, native_reasoning=False, chat_template_kwargs={}) is True
+        assert (
+            cache_reasoning_output(
+                forced_off, native_reasoning=True, chat_template_kwargs={"preserve_thinking": True}
+            )
+            is False
+        )

--- a/tests/test_batched_engine.py
+++ b/tests/test_batched_engine.py
@@ -902,6 +902,21 @@ class TestBatchedEngineSpecPrefillForwarding:
         assert call_kwargs["specprefill_threshold"] == 100
 
     @pytest.mark.asyncio
+    async def test_generate_forwards_preserve_reasoning(self):
+        """The non-streaming path must carry the flag the streaming path already does."""
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine(model_name="test-model")
+        engine._loaded = True
+        engine._engine = SimpleNamespace(
+            generate=AsyncMock(return_value=self._fake_output())
+        )
+
+        await engine.generate("a prompt", preserve_reasoning=True)
+
+        assert engine._engine.generate.call_args.kwargs["preserve_reasoning"] is True
+
+    @pytest.mark.asyncio
     async def test_generate_forwards_tools(self):
         from omlx.engine.batched import BatchedEngine
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3060,6 +3060,37 @@ class TestSchedulerBoundarySnapshots:
         assert args[0] == "req-reasoning"
         assert args[1] == [1, 2, 3, 4, 5, 6, 7, 8]  # prompt only
 
+    def test_cleanup_finished_stores_output_tokens_when_reasoning_is_preserved(
+        self, mock_model, mock_tokenizer
+    ):
+        """A reasoning request whose history keeps the <think> output caches prompt + output."""
+        config = SchedulerConfig(paged_cache_block_size=4)
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer, config=config)
+        scheduler.block_aware_cache = MagicMock()
+        scheduler.paged_cache_manager = None
+
+        request = Request(
+            request_id="req-reasoning-kept",
+            prompt="hello",
+            sampling_params=SamplingParams(),
+            preserve_reasoning=True,
+        )
+        request.prompt_token_ids = [1, 2, 3, 4, 5, 6, 7, 8]
+        request.num_prompt_tokens = 8
+        request.output_token_ids = [9, 10, 11, 12]
+        request.needs_think_prefix = True
+        request._extracted_cache = [{"state": "cache"}]
+        request._model_cache_config = None
+
+        scheduler.running["req-reasoning-kept"] = request
+        scheduler.requests["req-reasoning-kept"] = request
+
+        scheduler._cleanup_finished({"req-reasoning-kept"})
+
+        scheduler.block_aware_cache.store_cache.assert_called_once()
+        args, kwargs = scheduler.block_aware_cache.store_cache.call_args
+        assert args[1] == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+
     def test_cleanup_finished_stores_output_tokens_for_non_reasoning_model(
         self, mock_model, mock_tokenizer
     ):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3369,6 +3369,30 @@ class TestSchedulerBoundarySnapshots:
         assert scheduler._boundary_snapshot_required is True
         assert mock_model._omlx_mtp_commit_align == 4
 
+    def test_add_request_arms_mtp_boundary_alignment_before_decode(
+        self, mock_model, mock_tokenizer
+    ):
+        """A prompt shorter than a block meets its first boundary mid-decode, so the
+        MTP commit alignment must be armed at admission, not at the first capture."""
+        RotatingStub = type("RotatingKVCache", (), {})
+        mock_model.make_cache = lambda: [RotatingStub()]
+        scheduler = Scheduler(
+            model=mock_model,
+            tokenizer=mock_tokenizer,
+            config=SchedulerConfig(paged_cache_block_size=4),
+        )
+        scheduler.block_aware_cache = MagicMock()
+        request = Request(
+            request_id="req-short-prompt",
+            prompt="hello",
+            sampling_params=SamplingParams(),
+        )
+
+        scheduler.add_request(request)
+
+        assert scheduler._boundary_snapshot_required is True
+        assert mock_model._omlx_mtp_commit_align == 4
+
     def test_prefill_boundary_snapshot_ignores_non_boundary_token_count(
         self, mock_model, mock_tokenizer
     ):

--- a/tests/test_scheduler_boundary_completion.py
+++ b/tests/test_scheduler_boundary_completion.py
@@ -167,3 +167,33 @@ def test_completion_boundary_requires_known_consistent_positions(
 
     assert scheduler._on_prefill_boundary_snapshot.called is expected
     scheduler.shutdown()
+
+
+@pytest.mark.parametrize("preserve_reasoning, expected", [(False, False), (True, True)])
+def test_completion_boundary_counts_output_only_when_reasoning_is_preserved(
+    mock_model, mock_tokenizer, preserve_reasoning, expected
+):
+    """With a think prefix the terminal boundary covers prompt + output only if the history keeps the reasoning."""
+    scheduler = Scheduler(
+        model=mock_model,
+        tokenizer=mock_tokenizer,
+        config=SchedulerConfig(paged_cache_block_size=4),
+    )
+    scheduler._boundary_snapshot_required = True
+    scheduler._on_prefill_boundary_snapshot = MagicMock()
+    request = Request(
+        request_id="finished-think",
+        prompt=[3, 4, 5],
+        sampling_params=SamplingParams(max_tokens=1),
+        preserve_reasoning=preserve_reasoning,
+    )
+    request.prompt_token_ids = [3, 4, 5]
+    request.num_prompt_tokens = 3
+    request.output_token_ids = [6]
+    request.needs_think_prefix = True
+    cache = [SimpleNamespace(caches=[SimpleNamespace(offset=4), SimpleNamespace()])]
+
+    scheduler._capture_finished_boundary_snapshot(request, cache)
+
+    assert scheduler._on_prefill_boundary_snapshot.called is expected
+    scheduler.shutdown()

--- a/tests/test_scheduler_prompt_boundary_store.py
+++ b/tests/test_scheduler_prompt_boundary_store.py
@@ -298,3 +298,32 @@ def test_cleanup_finished_skip_cache_store_takes_leak_guard_branch(
     )
     assert request.request_id not in scheduler.running
     assert request.request_id not in scheduler.requests
+
+
+@pytest.mark.parametrize(
+    "preserve_reasoning, expected_sequence",
+    [(False, list(range(6))), (True, list(range(12)))],
+)
+def test_prompt_boundary_store_covers_output_when_reasoning_is_preserved(
+    preserve_reasoning, expected_sequence
+):
+    """A think-prefix request whose history keeps the reasoning stores prompt + output after a parser stop."""
+    scheduler = _scheduler()
+    request = SimpleNamespace(
+        prompt_token_ids=list(range(6)),
+        output_token_ids=list(range(6, 12)),
+        needs_think_prefix=True,
+        preserve_reasoning=preserve_reasoning,
+        specprefill_indices=None,
+    )
+    scheduler._get_boundary_store_override = MagicMock(return_value=None)
+    scheduler._detect_boundary_snapshot_need = MagicMock(return_value=False)
+    scheduler._extract_live_request_cache_for_store = MagicMock(
+        return_value=([{"state": ("kv",), "class_name": "KVCache", "cache_type": "KVCache"}], "cfg")
+    )
+
+    result = scheduler._prepare_prompt_boundary_cache_store("req", request, uid=3)
+
+    scheduler._get_boundary_store_override.assert_called_once_with("req", expected_sequence)
+    assert result is not None
+    assert result[0] == expected_sequence[: (len(expected_sequence) // 4) * 4]

--- a/tests/test_vlm_engine.py
+++ b/tests/test_vlm_engine.py
@@ -2545,6 +2545,21 @@ class TestVLMEngineFrequencyPenalty:
     @pytest.mark.skipif(
         not HAS_MLX, reason="mlx is required to import VLMBatchedEngine"
     )
+    async def test_generate_forwards_preserve_reasoning(self):
+        """The non-streaming path must carry the flag the streaming path already does."""
+        engine = _make_loaded_engine(model_type="test-vlm")
+        engine._engine = SimpleNamespace(
+            generate=AsyncMock(return_value=self._fake_output())
+        )
+
+        await engine.generate("a prompt", preserve_reasoning=True)
+
+        assert engine._engine.generate.call_args.kwargs["preserve_reasoning"] is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not HAS_MLX, reason="mlx is required to import VLMBatchedEngine"
+    )
     async def test_generate_defaults_frequency_penalty_to_zero(self):
         engine = _make_loaded_engine(model_type="test-vlm")
         engine._engine = SimpleNamespace(


### PR DESCRIPTION
### TLDR

1. Reasoning fix: when the chat history keeps a model's thinking, its answer is now cached too, so the next turn re-prefills only what is new instead of the whole previous answer.
2. Tool-call fix: the same rule now covers turns that end in a tool call, so an agent loop's reasoning and call are cached for the next step.
3. Along the way, a pre-existing MTP bug got fixed: the block-boundary alignment was only armed by the first snapshot capture, so a prompt shorter than one block lost its first boundary and, with output caching on, its whole answer.

### Summary

A request whose prompt ends in an open `<think>` tag stores only its prompt tokens at completion (c8ee5eaf, issue #93): at the time the API stripped the reasoning before the next turn, so cached output could never prefix-match and only cost SSD space and thrashing. Two later features changed the premise. `preserve_thinking` (0749e3fd, #814) keeps the `<think>` blocks of earlier turns in the rendered history for Qwen 3.6+ templates, and native `reasoning_content` templates (MiniMax M3, Inkling, …) render the reasoning back verbatim. On those paths the next turn *does* contain the previous output, yet the store still discarded it, so every follow-up re-prefilled the whole previous answer. With long reasoning that is the dominant cost of a conversation: a 26k-token answer on Qwen3.8-Flash-Next costs about minute of prefill on the next turn, and the server had already captured the boundary snapshots needed to avoid it (decode-time captures every 2048 tokens, then thrown away).

### Change

- `Request.preserve_reasoning`: set by the chat completions and messages handlers through a new helper, `cache_reasoning_output(settings, native_reasoning, chat_template_kwargs)`. True when the model uses native reasoning content, when the effective template kwargs carry `preserve_thinking=True`, or when the new per-model setting `cache_reasoning_output` forces it; that setting also forces it off. The engines forward the flag into `add_request`.
- Scheduler: one predicate, `_output_tokens_cacheable(request)`, replaces the two `needs_think_prefix` checks. The completion-time boundary snapshot then covers prompt + output, and the final store sequences prompt + output, so the decode-time snapshots already on disk become the intermediate blocks. Requests whose reasoning is stripped keep the prompt-only behaviour exactly as before.
- `ModelSettings.cache_reasoning_output: Optional[bool]` (default `None` = auto). Useful for a custom chat template that renders reasoning in history without advertising `preserve_thinking`.

### Measured

Two-turn probe on an M5 Max, Qwen3.8-Flash-Next-oQ4e-mtp, MTP on, block size 2048: a 3,126-token prompt, a 6,000-token answer, then a follow-up whose history carries the answer with its reasoning.

| | stored at end of turn 1 | reused by turn 2 | turn 2 re-prefill |
|---|---|---|---|
| main b908f563 | 2048 / 9126 tokens, 0 intermediate | 2048 | 7,103 tokens |
| this branch | 8192 / 9126 tokens, 3 intermediate | 8192 (shares the first 8192 of 8192) | 6,962 tokens, all new content |

The same probe with the reasoning *not* sent back matches only the first 3,125 tokens on both, which is the case c8ee5eaf was written for and is unchanged.

### Tests

`tests/test_scheduler_prompt_boundary_store.py` (parser-stop store covers output only when reasoning is preserved), `tests/test_scheduler.py` (prompt + output stored for a think-prefix request with `preserve_reasoning`, alongside the existing prompt-only and non-reasoning cases), `tests/test_scheduler_boundary_completion.py` (completion boundary counts output only when reasoning is preserved), `tests/test_api_utils.py` (helper: auto detection and the setting override). 

### Related


- #3335 skips the decode-time captures as wasted work; with this change they are what makes the next turn hit, so the two should be reconciled: skip them only when `preserve_reasoning` is false.
- The parser-side stop fallback (`_prepare_prompt_boundary_cache_store`) now applies the same predicate, so a tool-call turn's reasoning and call are cacheable for the next request in an agent loop. Both the stock Qwen template and a derived one re-render such a turn token-exactly (tool-call probe: 3595/3595 and 3452/3452 tokens; the server parses argument strings into mappings before templating).
- The MTP commit alignment that lands verify cycles on block boundaries was armed lazily by the first capture attempt. A prompt shorter than one block reaches its first boundary during decode, so the cycle crossing it ran unaligned, the capture was skipped ("speculative decode skew"), and the split-GDN store rejected that block, leaving the whole answer uncached; long prompts never showed it because their prefill captures arm the alignment first. Fixed by detecting at `add_request`. Reproduced in the bench with a 101-token prompt and a 12k-token sampled answer (skew at 2048 in about one run in three, cache offset 2047 or 2049), clean after the change.
- The non-streaming `generate()` of both engines submits through the core engine with an explicit argument list, so the flag first reached only streamed requests (a non-streaming tool-call turn stored 2048 of 4130 tokens while the same request streamed stored 4096); fixed by forwarding it there. `skip_cache_store` has the same gap on that path and is left as is.
