### PR TITLE
fix(cluster): read MemAvailable for the unified-memory CUDA ceiling

### DIFF
--- a/omlx/cluster/memory_guard.py
+++ b/omlx/cluster/memory_guard.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 
 import _thread
 import logging
+import sys
 import threading
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
@@ -134,6 +135,30 @@ def _operator_memory_settings() -> tuple[str, float, bool]:
         return ("balanced", 0.0, True)
 
 
+def _unified_host_available(physical: int, free: int | None) -> int | None:
+    """Raise ``free`` to MemAvailable on a unified-memory Linux device."""
+
+    if free is None or not sys.platform.startswith("linux"):
+        return free
+    try:
+        fields: dict[str, int] = {}
+        with open("/proc/meminfo", encoding="utf-8") as handle:
+            for line in handle:
+                key, _, rest = line.partition(":")
+                if key in ("MemTotal", "MemAvailable"):
+                    fields[key] = int(rest.split()[0]) * 1024
+        total = fields.get("MemTotal", 0)
+        available = fields.get("MemAvailable", 0)
+    except (OSError, ValueError, IndexError):
+        return free
+    if total <= 0 or available <= 0:
+        return free
+    # Unified memory: the device's "total" is the host's RAM.
+    if abs(total - physical) > physical * 0.15:
+        return free
+    return max(free, available)
+
+
 def _cuda_ceiling_breakdown(
     tier: str,
     *,
@@ -164,6 +189,14 @@ def _cuda_ceiling_breakdown(
         return None
     if physical <= 0:
         return None
+    # On a unified-memory CUDA device (DGX Spark GB10) ``free_memory`` tracks
+    # the host's MemFree, which reclaimable page cache depresses. Reading a
+    # model's own mmap'd safetensors is enough to drive it to ~0, so a rank
+    # that has just loaded is judged against a ceiling its own file-backed
+    # pages created. MemAvailable is the figure that answers "will this fit":
+    # the kernel evicts clean cache on demand. Only applied when device total
+    # matches host RAM, so a discrete GPU still reports VRAM.
+    free = _unified_host_available(physical, free)
     normalized = tier if tier in _CUDA_CEILING_FRACTION else "balanced"
     if normalized == "custom" and custom_ceiling_gb > 0:
         budget = min(physical, int(custom_ceiling_gb * 1024**3))


### PR DESCRIPTION
## Problem

`_cuda_ceiling_breakdown` (`omlx/cluster/memory_guard.py`) computes:

```python
dynamic = max(0, int(free * _CUDA_CEILING_FRACTION[normalized]))
```

from `mx.device_info()["free_memory"]`. On a unified-memory device (NVIDIA GB10 / DGX Spark) that tracks the host's **MemFree**, so ordinary reclaimable page cache collapses the ceiling.

Reading a model's own mmap'd safetensors is enough to do it. Same host state, before and after this change:

```
free=66GB  cache=51GB  available=116GB   ->  hard_limit   63.5 GB   (before)
free=65GB  cache=51GB  available=116GB   ->  hard_limit  112.4 GB   (after)
```

That 51 GB of cache was left by `POST /cluster/stage` writing the model — so staging a large model directly caused the activation that follows it to be refused:

```
Model does not fit the current per-node memory limits; no ranks were started.
rank 1 (spark-a2ae) needs 63.6 GiB but can admit 59.1 GiB right now
```

Running `sync; echo 3 > /proc/sys/vm/drop_caches` on the worker made the identical activation succeed. Nothing surfaces that as the cause, and an operator has no reason to guess it.

## Fix

Prefer `MemAvailable` from `/proc/meminfo`. It is the figure that answers "will this fit" — the kernel evicts clean cache on demand.

The substitution is gated on the device's reported total matching host `MemTotal` (within 15%), so a discrete CUDA GPU still reports VRAM and the "do not advertise host RAM as model capacity" property the docstring calls out is preserved. Non-Linux and unparseable `/proc/meminfo` fall through unchanged.

## Result

With this applied, a 198.6 GB model (`mlx-community/GLM-4.7-4bit`, `glm4_moe`, 92 layers) activates and serves across a 3-rank cluster — Mac Studio M5 Max coordinator plus two DGX Sparks, ring backend over 2.5 GbE — at ~7.2 tok/s, holding 68.3 / 68.3 / 66.7 GB per rank.

Note the same cluster needed one further change to get there, which I have not included here because the right fix is less clear-cut: `build_guard` samples `hard_limit` immediately after the weights load, catching the transient trough. Measured on the same host, the guard's ceiling reads ~46-52 GB during the load and ~112 GB once settled, and the snapshot is then fixed for the rank's lifetime. Filed separately.

## Environment

oMLX `main` @ 94530d8d built from source. Coordinator: Mac Studio M5 Max 128 GB, macOS 26.5.2. Workers: 2x NVIDIA DGX Spark (GB10, 128 GB, Ubuntu 24.04.4 aarch64), mlx 0.32.2.