### PR TITLE
fix(oq): record the dtype the output config reports

### DIFF
--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -166,6 +166,36 @@ def _validate_oq_dtype_for_model(config: dict, dtype: str) -> None:
         )
 
 
+def _canonical_output_dtype(dtype: str) -> str:
+    """Name the dtype oQ will actually store, mirroring ``target_dtype``.
+
+    Both write paths store fp16 for anything not exactly ``"bfloat16"``, so
+    deriving the label from the same test keeps the config from disagreeing
+    with the tensors. Assumes ``dtype`` already passed the ``OQ_DTYPES``
+    check, which is what keeps the fallback from mislabelling a third value.
+    """
+    return "bfloat16" if dtype == "bfloat16" else "float16"
+
+
+def _apply_output_dtype(config: dict, dtype: str) -> None:
+    """Record the dtype oQ wrote, replacing the source's inherited claim.
+
+    A source config describes the checkpoint oQ read, not the one it writes,
+    and nothing in the load path corrects it, so a float16 build of a bfloat16
+    source reads back as bfloat16. Follows ``_clone_config`` in
+    ``tools/clone_mlx_model_fp16.py``, but only rewrites keys the source
+    declared rather than adding any. ``vision_config`` is left alone: under a
+    float16 target, vision and audio weights are stored as float32.
+    """
+    resolved = _canonical_output_dtype(dtype)
+    for section in (config, config.get("text_config")):
+        if not isinstance(section, dict):
+            continue
+        for key in ("dtype", "torch_dtype"):
+            if key in section:
+                section[key] = resolved
+
+
 def _is_vlm_load(config: dict) -> bool:
     """VLM routing predicate for oQ's model-load helpers.
 
@@ -6507,6 +6537,7 @@ def quantize_oq_streaming(
         quant_info[key] = val
     output_config["quantization"] = quant_info
     output_config["quantization_config"] = quant_info
+    _apply_output_dtype(output_config, dtype)
     with open(output / "config.json", "w") as f:
         json.dump(output_config, f, indent=2, ensure_ascii=False)
     if imatrix_report is not None:
@@ -8799,6 +8830,7 @@ def _build_streaming_proxy_for_sensitivity(
         quant_info[key] = val
     output_config["quantization"] = quant_info
     output_config["quantization_config"] = quant_info
+    _apply_output_dtype(output_config, dtype)
     with open(output / "config.json", "w") as f:
         json.dump(output_config, f, indent=2, ensure_ascii=False)
 

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -4489,6 +4489,63 @@ class TestQuantizeOqStreamingPassthroughDtypes:
         assert tensors["model.layers.0.input_layernorm.weight"].dtype == mx.float16
         assert tensors["model.layers.0.self_attn.q_proj.weight"].dtype == mx.uint32
 
+    @pytest.mark.parametrize(
+        ("source_dtype", "target_dtype"),
+        [("bfloat16", "float16"), ("float16", "bfloat16")],
+    )
+    def test_output_config_reports_the_dtype_it_wrote(
+        self, tmp_path, source_dtype, target_dtype
+    ):
+        """A build must report its own dtype, not the one it read."""
+        from safetensors.numpy import save_file as np_save
+
+        src = tmp_path / "src"
+        src.mkdir()
+        hidden = 64
+        np_save(
+            {
+                "model.layers.0.input_layernorm.weight": np.ones(
+                    hidden, dtype=np.float32
+                ),
+                "model.layers.0.self_attn.q_proj.weight": np.ones(
+                    (hidden, hidden), dtype=np.float32
+                ),
+            },
+            str(src / "model.safetensors"),
+        )
+        (src / "config.json").write_text(
+            json.dumps(
+                {
+                    "architectures": ["TestModelForCausalLM"],
+                    "model_type": "test_passthrough",
+                    "num_hidden_layers": 1,
+                    "hidden_size": hidden,
+                    "vocab_size": 256,
+                    "dtype": source_dtype,
+                    "torch_dtype": source_dtype,
+                    "text_config": {"dtype": source_dtype},
+                }
+            ),
+            encoding="utf-8",
+        )
+        (src / "oq_sensitivity_map.json").write_text(
+            json.dumps({"0": 0.1}), encoding="utf-8"
+        )
+
+        out = tmp_path / "out"
+        quantize_oq_streaming(str(src), str(out), oq_level=4, dtype=target_dtype)
+
+        config = json.loads((out / "config.json").read_text(encoding="utf-8"))
+        assert config["dtype"] == target_dtype
+        assert config["torch_dtype"] == target_dtype
+        assert config["text_config"]["dtype"] == target_dtype
+
+        tensors = {}
+        for sf in out.glob("*.safetensors"):
+            tensors.update(mx.load(str(sf)))
+        stored = mx.float16 if target_dtype == "float16" else mx.bfloat16
+        assert tensors["model.layers.0.input_layernorm.weight"].dtype == stored
+
 
 # =============================================================================
 # End-to-end: quantize_oq_streaming with FP8 sources


### PR DESCRIPTION
oQ's output `config.json` inherits `dtype` from the source, so a `dtype="float16"` build stores fp16 tensors and still reports `bfloat16`. In the same run oQ appends `-fp16` to the output directory name, so the name and the config contradict each other, and the config is the one that is wrong.

Nothing downstream corrects it. mlx-lm and mlx-vlm load weights at their stored dtype and let MLX promote activations from them, and the only reader of the key in this tree is `_target_precision_tag` in `omlx/engine/dflash.py`, which is gated behind a checkpoint having no `quantization`/`quantization_config` section — an oQ output always writes both, so that branch is unreachable for an oQ checkpoint. The field cannot change execution, then; it only changes what a reader concludes about the file, which is the reason it is worth correcting rather than a reason to leave it.

## What changed

`_apply_output_dtype` records the resolved dtype at both config write paths, `quantize_oq_streaming` and the temporary sensitivity proxy. The label comes from the same `dtype == "bfloat16"` test that selects `target_dtype`, so the config agrees with every tensor the quantizer writes.

It does not follow that the key is true of every tensor in a finished checkpoint. A gemma4 build with a Lightning MTP head carries 48 bfloat16 tensors beside the float16 base — all of `language_model.mtp.*` — merged afterwards by `combine_gemma4_assistant_mtp`, which keeps the assistant at its shipped dtype and leaves the quantization config alone. So the key moves from wrong about the 1243 tensors oQ wrote to wrong about the 48 it did not, and it is best read as describing the quantizer's own output.

This follows `_clone_config` in `tools/clone_mlx_model_fp16.py`, which already normalizes `dtype` and `text_config.dtype` for its own clone path. The one deliberate difference is that only keys the source declared are rewritten rather than added, so no checkpoint gains metadata it did not have before.

`vision_config` is left alone. Under a float16 target, `_cast_passthrough_tensor` stores vision and audio weights as float32 rather than float16, so no single key describes both towers and writing `float16` there would be actively false rather than merely stale.

## Testing

`test_output_config_reports_the_dtype_it_wrote` runs the real `quantize_oq_streaming` in both directions — a bfloat16 source built to float16, and a float16 source built to bfloat16 — and checks the written config against the dtype of the tensors actually stored. Both cases fail without the change, with `assert 'bfloat16' == 'float16'` and its mirror.

509 passed and 1 skipped across the oQ suites (`test_oq`, `test_oq_manager`, `test_oq_combine`, `test_oq_fp8_dequant`, `test_oq_fused_qkv_virtual`, `test_oqe_calibration_packaging`). The remaining six test files that touch oQ also pass (220 passed, 8 skipped), as do the admin tests that import it (415 passed).