### PR TITLE
fix(api): parse attribute-style <function name> tool calls (MiniCPM5)

### DIFF
--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -494,6 +494,29 @@ def _iter_xml_parameters(params_text: str) -> Iterator[Tuple[str, str]]:
         pos = value_end + len(_XML_PARAMETER_CLOSE)
 
 
+_ATTR_FUNCTION_OPEN_RE = re.compile(r'<function\s+name="([^"]+)"\s*>')
+# Both <param> (MiniCPM5's chat template) and <parameter> spellings occur in
+# the wild; the backreference pairs open/close spellings so a literal
+# "</param>" cannot close a <parameter> element. The non-greedy CDATA
+# alternative ensures nested literal tags inside CDATA do not end elements early.
+_ATTR_PARAM_RE = re.compile(
+    r'<(param|parameter)\s+name="([^"]+)"\s*>(?:\s*<!\[CDATA\[(.*?)\]\]>\s*|(.*?))</\1>',
+    re.DOTALL,
+)
+
+
+def _iter_attr_xml_parameters(params_text: str) -> Iterator[Tuple[str, str]]:
+    """Yield ``(key, value)`` for each ``<param name="k">v</param>`` element.
+
+    MiniCPM5's chat template tells the model to wrap values containing
+    ``<``, ``&`` or newlines in a CDATA block; the wrapper is removed here so
+    the argument carries the literal value, verbatim.
+    """
+    for match in _ATTR_PARAM_RE.finditer(params_text):
+        value = match.group(3) if match.group(3) is not None else match.group(4).strip()
+        yield match.group(2), value
+
+
 def _find_marker_span_end(
     text: str, payload_start: int, end_marker: str
 ) -> Optional[Tuple[int, int]]:
@@ -586,6 +609,7 @@ def _parse_xml_tool_calls(
     Handles models that use <tool_call>...</tool_call> XML format, including:
     - GLM format: <tool_call>func<arg_key>k</arg_key><arg_value>v</arg_value></tool_call>
     - Qwen/Llama format: <tool_call><function=name><parameter=key>value</parameter></function></tool_call>
+    - Attribute style: <tool_call><function name="name"><param name="key">value</param></function></tool_call>
     - Generic JSON: <tool_call>{"name": ..., "arguments": ...}</tool_call>
 
     When ``tools`` is provided, parameter values are coerced to their
@@ -623,6 +647,24 @@ def _parse_xml_tool_calls(
             props = _tool_param_properties(func_name, tools)
             arguments = {}
             for key, val in _iter_xml_parameters(params_text):
+                arguments[key] = _coerce_param_value(val, key, props, func_name)
+            _built = _build_tool_call(func_name, arguments)
+            if _built is not None:
+                tool_calls.append(_built)
+            continue
+
+        # Attribute style: <function name="name"><param name="key">value</param></function>
+        # (MiniCPM5 family, #3429). Bounded by rfind like the keyword-style
+        # branch above so a literal close tag inside a value cannot end the
+        # element early.
+        attr_open = _ATTR_FUNCTION_OPEN_RE.match(content)
+        attr_close = content.rfind(_XML_FUNCTION_CLOSE)
+        if attr_open and attr_close >= attr_open.end():
+            func_name = attr_open.group(1)
+            params_text = content[attr_open.end() : attr_close]
+            props = _tool_param_properties(func_name, tools)
+            arguments = {}
+            for key, val in _iter_attr_xml_parameters(params_text):
                 arguments[key] = _coerce_param_value(val, key, props, func_name)
             _built = _build_tool_call(func_name, arguments)
             if _built is not None:
@@ -702,6 +744,71 @@ def _parse_namespaced_tool_calls(
 
     cleaned = re.sub(pattern, "", text, flags=re.DOTALL).strip()
     return cleaned, tool_calls
+
+
+_ATTR_FUNCTION_ELEMENT_RE = re.compile(
+    r'<function\s+name="([^"]+)"\s*>((?:(?!<function[\s>]).)*?)</function>',
+    re.DOTALL,
+)
+
+
+def _parse_attribute_function_tool_calls(
+    text: str, tools: Optional[List] = None
+) -> Tuple[str, Optional[List[ToolCall]]]:
+    """
+    Fallback parser for bare attribute-style tool calls (#3429).
+
+    MiniCPM5-family chat templates emit
+    ``<function name="name"><param name="key">value</param></function>``
+    with no wrapper marker at all, so none of the envelope-anchored parsers
+    ever see it.
+
+    Without an envelope the only safe anchor is the request's own tool
+    declarations: an element is parsed only when its name exactly matches a
+    declared tool, so prose that merely mentions ``<function name="...">``
+    markup for an unknown function passes through untouched, and the parser
+    is inert when the request declares no tools.
+
+    Elements are bounded at the first ``</function>`` (there is no outer
+    envelope to bound by, and rfind would merge sibling calls), accepting
+    that a literal close tag inside a value ends the element early.
+    An element also cannot span a later ``<function`` open tag, so an
+    unclosed tag in prose cannot swallow a following real call.
+
+    Returns:
+        Tuple of (cleaned_text, tool_calls or None)
+    """
+    if not tools:
+        return text, None
+    registered = _extract_tool_names(tools)
+    if not registered:
+        return text, None
+
+    tool_calls = []
+    spans: List[Tuple[int, int]] = []
+    for match in _ATTR_FUNCTION_ELEMENT_RE.finditer(text):
+        func_name = match.group(1)
+        if func_name not in registered:
+            continue
+        props = _tool_param_properties(func_name, tools)
+        arguments = {}
+        for key, val in _iter_attr_xml_parameters(match.group(2)):
+            arguments[key] = _coerce_param_value(val, key, props, func_name)
+        _built = _build_tool_call(func_name, arguments)
+        if _built is not None:
+            tool_calls.append(_built)
+            spans.append(match.span())
+
+    if not tool_calls:
+        return text, None
+
+    out: List[str] = []
+    last = 0
+    for span_start, span_end in spans:
+        out.append(text[last:span_start])
+        last = span_end
+    out.append(text[last:])
+    return "".join(out).strip(), tool_calls
 
 
 def _parse_hermes_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]:
@@ -1690,6 +1797,14 @@ def _parse_tool_calls_impl(
         ns = ns_match.group(1)
         return _parse_namespaced_tool_calls(cleaned_text, ns, tools)
 
+    # Fallback: bare attribute-style <function name="..."> elements with no
+    # wrapper marker (MiniCPM5 family, #3429). Anchored on declared tool
+    # names; see the parser's docstring.
+    if _ATTR_FUNCTION_OPEN_RE.search(cleaned_text):
+        attr_result = _parse_attribute_function_tool_calls(cleaned_text, tools)
+        if attr_result[1] is not None:
+            return attr_result
+
     # Fallback: Hermes-style tool calls (<|tool_call_start|>[func(args)]<|tool_call_end|>)
     if "<|tool_call_start|>" in cleaned_text:
         hermes_result = _parse_hermes_tool_calls(cleaned_text)
@@ -1912,6 +2027,11 @@ class ToolCallStreamFilter:
             ("]<]minimax[>[<tool_call>", "]<]minimax[>[</tool_call>"),
             ("<|tool_call_start|>", "<|tool_call_end|>"),
             ("<tool_call>", "</tool_call>"),
+            # Bare attribute-style dialect (MiniCPM5 family, #3429). The open
+            # marker is a tag prefix rather than a complete tag; like the
+            # unconditional <tool_call> pair above, it only ever runs on
+            # tool-enabled streams.
+            ('<function name="', "</function>"),
         ]
         self._suppress_after_markers: List[str] = []
         if marker:

--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -517,6 +517,58 @@ def _iter_attr_xml_parameters(params_text: str) -> Iterator[Tuple[str, str]]:
         yield match.group(2), value
 
 
+def _find_attr_function_span(
+    text: str,
+    open_match: Any,
+) -> Optional[Tuple[int, int, str]]:
+    """Locate the true end of a <function name="..."> element.
+
+    Returns (span_start, span_end, payload) or None if unclosed or malformed.
+    A literal '</function>' or '<function' inside a '<![CDATA[...]]>' block
+    does NOT terminate or split the element.
+    An unclosed '<function' tag followed by another '<function' open tag
+    outside CDATA causes this candidate to be rejected so the following
+    real call is not swallowed.
+    """
+    span_start = open_match.start()
+    payload_start = open_match.end()
+    cursor = payload_start
+    n = len(text)
+
+    while cursor < n:
+        cdata_start = text.find("<![CDATA[", cursor)
+        close_tag = text.find("</function>", cursor)
+        next_open = _ATTR_FUNCTION_OPEN_RE.search(text, cursor)
+
+        if close_tag < 0:
+            return None
+
+        if (
+            next_open is not None
+            and (cdata_start < 0 or next_open.start() < cdata_start)
+            and next_open.start() < close_tag
+        ):
+            # Another <function name="..."> begins outside CDATA before </function>:
+            # this candidate was unclosed.
+            return None
+
+        if cdata_start >= 0 and cdata_start < close_tag:
+            # CDATA block precedes the close tag. Skip past CDATA.
+            cdata_end = text.find("]]>", cdata_start + len("<![CDATA["))
+            if cdata_end < 0:
+                # Unclosed CDATA block.
+                return None
+            cursor = cdata_end + len("]]>")
+            continue
+
+        # close_tag is outside CDATA!
+        span_end = close_tag + len("</function>")
+        payload = text[payload_start:close_tag]
+        return span_start, span_end, payload
+
+    return None
+
+
 def _find_marker_span_end(
     text: str, payload_start: int, end_marker: str
 ) -> Optional[Tuple[int, int]]:
@@ -540,6 +592,23 @@ def _find_marker_span_end(
     exists.  Every other case falls back to the historical first-match
     behaviour, so this can only change outputs that are broken today.
     """
+    if end_marker == "</function>":
+        cursor = payload_start
+        n = len(text)
+        while cursor < n:
+            cdata_start = text.find("<![CDATA[", cursor)
+            close_tag = text.find("</function>", cursor)
+            if close_tag < 0:
+                return None
+            if cdata_start >= 0 and cdata_start < close_tag:
+                cdata_end = text.find("]]>", cdata_start + len("<![CDATA["))
+                if cdata_end < 0:
+                    return None
+                cursor = cdata_end + len("]]>")
+                continue
+            return close_tag, close_tag + len("</function>")
+        return None
+
     plain = text.find(end_marker, payload_start)
     if plain < 0:
         return None
@@ -654,22 +723,31 @@ def _parse_xml_tool_calls(
             continue
 
         # Attribute style: <function name="name"><param name="key">value</param></function>
-        # (MiniCPM5 family, #3429). Bounded by rfind like the keyword-style
-        # branch above so a literal close tag inside a value cannot end the
-        # element early.
+        # (MiniCPM5 family, #3429). Uses _find_attr_function_span so a literal
+        # close tag or embedded function example inside CDATA cannot end or
+        # truncate the element early.
         attr_open = _ATTR_FUNCTION_OPEN_RE.match(content)
-        attr_close = content.rfind(_XML_FUNCTION_CLOSE)
-        if attr_open and attr_close >= attr_open.end():
+        if attr_open:
             func_name = attr_open.group(1)
-            params_text = content[attr_open.end() : attr_close]
-            props = _tool_param_properties(func_name, tools)
-            arguments = {}
-            for key, val in _iter_attr_xml_parameters(params_text):
-                arguments[key] = _coerce_param_value(val, key, props, func_name)
-            _built = _build_tool_call(func_name, arguments)
-            if _built is not None:
-                tool_calls.append(_built)
-            continue
+            found = _find_attr_function_span(content, attr_open)
+            if found is not None:
+                params_text = found[2]
+            else:
+                attr_close = content.rfind(_XML_FUNCTION_CLOSE)
+                params_text = (
+                    content[attr_open.end() : attr_close]
+                    if attr_close >= attr_open.end()
+                    else None
+                )
+            if params_text is not None:
+                props = _tool_param_properties(func_name, tools)
+                arguments = {}
+                for key, val in _iter_attr_xml_parameters(params_text):
+                    arguments[key] = _coerce_param_value(val, key, props, func_name)
+                _built = _build_tool_call(func_name, arguments)
+                if _built is not None:
+                    tool_calls.append(_built)
+                continue
 
         # GLM XML format: func_name<arg_key>k</arg_key><arg_value>v</arg_value>...
         arg_keys = re.findall(r"<arg_key>(.*?)</arg_key>", content)
@@ -746,12 +824,6 @@ def _parse_namespaced_tool_calls(
     return cleaned, tool_calls
 
 
-_ATTR_FUNCTION_ELEMENT_RE = re.compile(
-    r'<function\s+name="([^"]+)"\s*>((?:(?!<function[\s>]).)*?)</function>',
-    re.DOTALL,
-)
-
-
 def _parse_attribute_function_tool_calls(
     text: str, tools: Optional[List] = None
 ) -> Tuple[str, Optional[List[ToolCall]]]:
@@ -769,11 +841,11 @@ def _parse_attribute_function_tool_calls(
     markup for an unknown function passes through untouched, and the parser
     is inert when the request declares no tools.
 
-    Elements are bounded at the first ``</function>`` (there is no outer
-    envelope to bound by, and rfind would merge sibling calls), accepting
-    that a literal close tag inside a value ends the element early.
-    An element also cannot span a later ``<function`` open tag, so an
-    unclosed tag in prose cannot swallow a following real call.
+    Elements are bounded at the first ``</function>`` outside CDATA blocks
+    (so literal ``</function>`` or embedded function examples inside CDATA
+    do not terminate the call early or misextract nested calls).
+    An element also cannot span a later ``<function`` open tag outside CDATA,
+    so an unclosed tag in prose cannot swallow a following real call.
 
     Returns:
         Tuple of (cleaned_text, tool_calls or None)
@@ -786,18 +858,33 @@ def _parse_attribute_function_tool_calls(
 
     tool_calls = []
     spans: List[Tuple[int, int]] = []
-    for match in _ATTR_FUNCTION_ELEMENT_RE.finditer(text):
+    pos = 0
+    while pos < len(text):
+        match = _ATTR_FUNCTION_OPEN_RE.search(text, pos)
+        if not match:
+            break
         func_name = match.group(1)
         if func_name not in registered:
+            pos = match.end()
             continue
+
+        found = _find_attr_function_span(text, match)
+        if found is None:
+            pos = match.end()
+            continue
+
+        span_start, span_end, payload = found
         props = _tool_param_properties(func_name, tools)
         arguments = {}
-        for key, val in _iter_attr_xml_parameters(match.group(2)):
+        for key, val in _iter_attr_xml_parameters(payload):
             arguments[key] = _coerce_param_value(val, key, props, func_name)
         _built = _build_tool_call(func_name, arguments)
         if _built is not None:
             tool_calls.append(_built)
-            spans.append(match.span())
+            spans.append((span_start, span_end))
+            pos = span_end
+        else:
+            pos = match.end()
 
     if not tool_calls:
         return text, None
@@ -1851,7 +1938,9 @@ def _parse_tool_calls_impl(
     return cleaned_text, None
 
 
-def sanitize_tool_call_markup(text: str, tokenizer: Any) -> str:
+def sanitize_tool_call_markup(
+    text: str, tokenizer: Any, tools: Optional[List] = None
+) -> str:
     """Remove tool-call control markup while preserving surrounding prose."""
     if not text:
         return ""
@@ -1859,7 +1948,9 @@ def sanitize_tool_call_markup(text: str, tokenizer: Any) -> str:
     # Every caller sanitizes thinking-channel text; keep it byte-identical
     # with the streamed reasoning deltas, which do not consume DeepSeek
     # V4's separator either.
-    stream_filter = ToolCallStreamFilter(tokenizer, consume_dsml_separator=False)
+    stream_filter = ToolCallStreamFilter(
+        tokenizer, tools=tools, consume_dsml_separator=False
+    )
     cleaned = stream_filter.feed(text)
     cleaned += stream_filter.finish()
     return cleaned.strip()
@@ -1900,7 +1991,7 @@ def extract_tool_calls_with_thinking(
       of whether regular text was also produced.
     """
     cleaned_text, tool_calls = parse_tool_calls(regular_content, tokenizer, tools)
-    cleaned_thinking = sanitize_tool_call_markup(thinking_content, tokenizer)
+    cleaned_thinking = sanitize_tool_call_markup(thinking_content, tokenizer, tools=tools)
     tool_calls_from_thinking = False
 
     if not tool_calls and thinking_content:
@@ -2013,6 +2104,7 @@ class ToolCallStreamFilter:
         self,
         tokenizer: Any,
         *,
+        tools: Optional[Any] = None,
         consume_dsml_separator: bool = True,
         capture_ordered_segments: bool = False,
     ):
@@ -2027,13 +2119,18 @@ class ToolCallStreamFilter:
             ("]<]minimax[>[<tool_call>", "]<]minimax[>[</tool_call>"),
             ("<|tool_call_start|>", "<|tool_call_end|>"),
             ("<tool_call>", "</tool_call>"),
-            # Bare attribute-style dialect (MiniCPM5 family, #3429). The open
-            # marker is a tag prefix rather than a complete tag; like the
-            # unconditional <tool_call> pair above, it only ever runs on
-            # tool-enabled streams.
-            ('<function name="', "</function>"),
         ]
         self._suppress_after_markers: List[str] = []
+        if tools:
+            if isinstance(tools, (set, frozenset)):
+                self._registered_tool_names = set(tools)
+            elif isinstance(tools, (list, tuple)) and tools and isinstance(tools[0], str):
+                self._registered_tool_names = set(tools)
+            else:
+                self._registered_tool_names = _extract_tool_names(tools)
+        else:
+            self._registered_tool_names = set()
+        self._attr_func_in_cdata = False
         if marker:
             if marker_end:
                 self._marker_pairs.insert(0, (marker, marker_end))
@@ -2197,6 +2294,7 @@ class ToolCallStreamFilter:
         self._json_escaped = False
         self._json_scan_off = 0
         self._json_complete_off = 0
+        self._attr_func_in_cdata = False
         # Tail of already-consumed payload, kept so a `</function>` straddling
         # the pending/buffer boundary is still visible to the xml check.
         self._xml_prev_tail = ""
@@ -2296,6 +2394,37 @@ class ToolCallStreamFilter:
             i += 1
         self._json_scan_off = i
 
+    def _find_attr_function_suppression_end(self, buffer: str) -> int:
+        cursor = 0
+        n = len(buffer)
+        while cursor < n:
+            if self._attr_func_in_cdata:
+                cdata_end = buffer.find("]]>", cursor)
+                if cdata_end < 0:
+                    return -1
+                self._attr_func_in_cdata = False
+                cursor = cdata_end + len("]]>")
+                continue
+
+            cdata_start = buffer.find("<![CDATA[", cursor)
+            close_tag = buffer.find("</function>", cursor)
+
+            if close_tag < 0:
+                if cdata_start >= 0:
+                    self._attr_func_in_cdata = True
+                    cursor = cdata_start + len("<![CDATA[")
+                    continue
+                return -1
+
+            if cdata_start >= 0 and cdata_start < close_tag:
+                self._attr_func_in_cdata = True
+                cursor = cdata_start + len("<![CDATA[")
+                continue
+
+            return close_tag
+
+        return -1
+
     def _find_suppression_end(self, buffer: str) -> int:
         """Index in ``buffer`` of the close marker that really ends the envelope.
 
@@ -2320,6 +2449,9 @@ class ToolCallStreamFilter:
         marker = self._suppressing_until
         if not marker:
             return -1
+
+        if marker == "</function>":
+            return self._find_attr_function_suppression_end(buffer)
 
         self._advance_json_scan(buffer)
 
@@ -2467,6 +2599,18 @@ class ToolCallStreamFilter:
             if hit is not None:
                 starts.append(hit)
 
+        def compute_attr_func() -> Optional[Tuple[int, int, Optional[str]]]:
+            if not self._registered_tool_names:
+                return None
+            for m in _ATTR_FUNCTION_OPEN_RE.finditer(text, start):
+                if m.group(1) in self._registered_tool_names:
+                    return (m.start(), len(m.group(0)), "</function>")
+            return None
+
+        hit = lookup("attr_func", compute_attr_func)
+        if hit is not None:
+            starts.append(hit)
+
         if not starts:
             return None
         return min(starts, key=lambda x: x[0])
@@ -2502,6 +2646,39 @@ class ToolCallStreamFilter:
             return False
         return "tool_call".startswith(suffix)
 
+    def _could_be_partial_attr_function_open(self, candidate: str) -> bool:
+        """Return True if candidate could prefix a bare <function name="..."> tag for a declared tool."""
+        if not self._registered_tool_names:
+            return False
+        if not candidate.startswith("<") or ">" in candidate:
+            return False
+        if "<function".startswith(candidate):
+            return True
+        if not candidate.startswith("<function"):
+            return False
+        rest = candidate[len("<function") :]
+        if not rest:
+            return True
+        if not rest[0].isspace():
+            return False
+        rest = rest.lstrip()
+        if not rest:
+            return True
+        for prefix in ("n", "na", "nam", "name", 'name='):
+            if rest == prefix:
+                return True
+        if rest.startswith('name="'):
+            after_quote = rest[len('name="') :]
+            if '"' not in after_quote:
+                return any(
+                    t.startswith(after_quote) for t in self._registered_tool_names
+                )
+            tool_name, after_closing_quote = after_quote.split('"', 1)
+            if tool_name not in self._registered_tool_names:
+                return False
+            return after_closing_quote.isspace() or after_closing_quote == ""
+        return False
+
     def _partial_suffix_len(self, text: str) -> int:
         """Length of trailing suffix that might be an opening-marker prefix."""
         keep = 0
@@ -2511,7 +2688,9 @@ class ToolCallStreamFilter:
         last_lt = text.rfind("<")
         if last_lt >= 0:
             candidate = text[last_lt:]
-            if self._could_be_partial_namespaced_open(candidate):
+            if self._could_be_partial_namespaced_open(
+                candidate
+            ) or self._could_be_partial_attr_function_open(candidate):
                 keep = max(keep, len(candidate))
 
         # Partial prefix detection for bracket markers (e.g. "[", "[C",
@@ -2576,6 +2755,9 @@ class ToolCallStreamFilter:
         for sa_marker in self._suppress_after_markers:
             if sa_marker.startswith(tail) or tail.startswith(sa_marker):
                 return True
+
+        if self._could_be_partial_attr_function_open(tail):
+            return True
 
         if not tail.startswith("<"):
             return False
@@ -2731,9 +2913,22 @@ class ToolCallStreamFilter:
             if self._suppressing_until is not None:
                 end_idx = self._find_suppression_end(self._buffer)
                 if end_idx < 0:
-                    keep = self._partial_prefix_len(
-                        self._buffer, self._suppressing_until
-                    )
+                    if self._suppressing_until == "</function>":
+                        if self._attr_func_in_cdata:
+                            keep = self._partial_prefix_len(self._buffer, "]]>")
+                        else:
+                            keep = max(
+                                self._partial_prefix_len(
+                                    self._buffer, "</function>"
+                                ),
+                                self._partial_prefix_len(
+                                    self._buffer, "<![CDATA["
+                                ),
+                            )
+                    else:
+                        keep = self._partial_prefix_len(
+                            self._buffer, self._suppressing_until
+                        )
                     if keep:
                         moved = self._buffer[:-keep]
                         self._pending_envelope_parts.append(moved)

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -5195,13 +5195,16 @@ async def stream_chat_completion(
         stream_completed_qwen_tools = qwen_tool_envelope_streaming_capable
         _content_filter = ToolCallStreamFilter(
             engine.tokenizer,
+            tools=kwargs.get("tools"),
             capture_ordered_segments=stream_completed_qwen_tools,
         )
         # The thinking channel never contains a separator-prefixed DSML
         # block; holding trailing newlines would flush them as a late
         # reasoning delta after the channel closed.
         _thinking_filter = ToolCallStreamFilter(
-            engine.tokenizer, consume_dsml_separator=False
+            engine.tokenizer,
+            tools=kwargs.get("tools"),
+            consume_dsml_separator=False,
         )
         if _content_filter.active:
             tool_filter = _content_filter
@@ -5844,12 +5847,17 @@ async def stream_anthropic_messages(
     tool_filter = None
     thinking_filter = None
     if has_tools:
-        _content_filter = ToolCallStreamFilter(engine.tokenizer)
+        _content_filter = ToolCallStreamFilter(
+            engine.tokenizer,
+            tools=kwargs.get("tools"),
+        )
         # The thinking channel never contains a separator-prefixed DSML
         # block; holding trailing newlines would flush them as a late
         # reasoning delta after the channel closed.
         _thinking_filter = ToolCallStreamFilter(
-            engine.tokenizer, consume_dsml_separator=False
+            engine.tokenizer,
+            tools=kwargs.get("tools"),
+            consume_dsml_separator=False,
         )
         if _content_filter.active:
             tool_filter = _content_filter
@@ -7447,12 +7455,17 @@ async def stream_responses_api(
     thinking_filter = None
     stream_content = True
     if has_tools:
-        _content_filter = ToolCallStreamFilter(engine.tokenizer)
+        _content_filter = ToolCallStreamFilter(
+            engine.tokenizer,
+            tools=kwargs.get("tools"),
+        )
         # The thinking channel never contains a separator-prefixed DSML
         # block; holding trailing newlines would flush them as a late
         # reasoning delta after the channel closed.
         _thinking_filter = ToolCallStreamFilter(
-            engine.tokenizer, consume_dsml_separator=False
+            engine.tokenizer,
+            tools=kwargs.get("tools"),
+            consume_dsml_separator=False,
         )
         if _content_filter.active:
             tool_filter = _content_filter

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -28,6 +28,7 @@ from omlx.api.tool_calling import (
     _json_value_end,
     _marker_payloads,
     _parse_gemma4_tool_call_fallback,
+    _parse_attribute_function_tool_calls,
     _parse_hermes_tool_calls,
     _parse_namespaced_tool_calls,
     _parse_xml_tool_calls,
@@ -4519,3 +4520,203 @@ def test_bracket_deep_decode_never_runs_raw_arguments():
         for call in calls or []:
             if call.function.name == "bad":
                 assert not call.function.arguments.startswith('{"raw":')
+
+
+class TestAttributeStyleFunctionDialect:
+    """Tests for the attribute-style <function name="..."> dialect (#3429).
+
+    MiniCPM5-family chat templates emit
+    ``<function name="name"><param name="key">value</param></function>``,
+    combining the ``<invoke name="...">`` attribute convention with the
+    ``<function=...>`` element name — previously the one unhandled
+    combination, both bare and wrapped in ``<tool_call>``.
+    """
+
+    READ_TOOL = {
+        "type": "function",
+        "function": {
+            "name": "read",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "limit": {"type": "integer"},
+                },
+                "required": ["path"],
+            },
+        },
+    }
+
+    BARE_CALL = (
+        '<function name="read"><param name="path">/workspace/TASK.md</param>'
+        "</function>"
+    )
+
+    def _tokenizer(self):
+        tok = MagicMock(spec=[])
+        tok.has_tool_calling = False
+        return tok
+
+    def test_bare_element_parses_with_declared_tool(self):
+        cleaned, calls = parse_tool_calls(
+            self.BARE_CALL, self._tokenizer(), [self.READ_TOOL]
+        )
+        assert cleaned == ""
+        assert len(calls) == 1
+        assert calls[0].function.name == "read"
+        assert json.loads(calls[0].function.arguments) == {
+            "path": "/workspace/TASK.md"
+        }
+
+    def test_bare_element_keeps_surrounding_prose(self):
+        text = f"I'll read the file. {self.BARE_CALL} Standing by."
+        cleaned, calls = parse_tool_calls(
+            text, self._tokenizer(), [self.READ_TOOL]
+        )
+        assert calls is not None
+        assert "function" not in cleaned
+        assert "I'll read the file." in cleaned
+        assert "Standing by." in cleaned
+
+    def test_parameter_spelling_variant(self):
+        text = (
+            '<function name="read"><parameter name="path">/x</parameter>'
+            "</function>"
+        )
+        _, calls = parse_tool_calls(text, self._tokenizer(), [self.READ_TOOL])
+        assert json.loads(calls[0].function.arguments) == {"path": "/x"}
+
+    def test_wrapped_in_tool_call_envelope(self):
+        text = f"<tool_call>{self.BARE_CALL}</tool_call>"
+        cleaned, calls = parse_tool_calls(
+            text, self._tokenizer(), [self.READ_TOOL]
+        )
+        assert cleaned == ""
+        assert calls[0].function.name == "read"
+
+    def test_wrapped_form_needs_no_tools(self):
+        # Inside a <tool_call> envelope the wrapper is the anchor, matching
+        # the other wrapped branches: no tool declarations required.
+        text = f"<tool_call>{self.BARE_CALL}</tool_call>"
+        _, calls = _parse_xml_tool_calls(text)
+        assert calls[0].function.name == "read"
+
+    def test_multiple_bare_calls(self):
+        text = (
+            '<function name="read"><param name="path">/a</param></function>\n'
+            '<function name="read"><param name="path">/b</param></function>'
+        )
+        cleaned, calls = parse_tool_calls(
+            text, self._tokenizer(), [self.READ_TOOL]
+        )
+        assert cleaned == ""
+        assert [json.loads(c.function.arguments)["path"] for c in calls] == [
+            "/a",
+            "/b",
+        ]
+
+    def test_schema_coercion_of_integer_param(self):
+        text = (
+            '<function name="read"><param name="path">/x</param>'
+            '<param name="limit">5</param></function>'
+        )
+        _, calls = parse_tool_calls(text, self._tokenizer(), [self.READ_TOOL])
+        assert json.loads(calls[0].function.arguments) == {
+            "path": "/x",
+            "limit": 5,
+        }
+
+    def test_cdata_wrapped_value_is_unwrapped(self):
+        # The MiniCPM5 template asks for CDATA around values containing
+        # "<", "&" or newlines; the argument must carry the literal value.
+        text = (
+            '<function name="read"><param name="path">'
+            "<![CDATA[/dir with <odd> & chars/TASK.md]]></param></function>"
+        )
+        _, calls = parse_tool_calls(text, self._tokenizer(), [self.READ_TOOL])
+        assert json.loads(calls[0].function.arguments) == {
+            "path": "/dir with <odd> & chars/TASK.md"
+        }
+
+    def test_undeclared_name_is_left_untouched(self):
+        text = '<function name="evil"><param name="path">/x</param></function>'
+        cleaned, calls = parse_tool_calls(
+            text, self._tokenizer(), [self.READ_TOOL]
+        )
+        assert calls is None
+        assert cleaned == text
+
+    def test_bare_parser_inert_without_tools(self):
+        for tools in (None, []):
+            cleaned, calls = _parse_attribute_function_tool_calls(
+                self.BARE_CALL, tools
+            )
+            assert calls is None
+            assert cleaned == self.BARE_CALL
+
+    def test_stream_filter_suppresses_bare_dialect_across_chunks(self):
+        f = ToolCallStreamFilter(_make_tokenizer())
+        chunks = [
+            "Sure. ",
+            "<funct",
+            'ion name="read"><param name="pa',
+            'th">/x</param></funct',
+            "ion>",
+            " Done.",
+        ]
+        out = "".join(f.feed(chunk) for chunk in chunks) + f.finish()
+        assert out == "Sure.  Done."
+
+    def test_stream_filter_flushes_incomplete_marker_prose(self):
+        # "<function " (no name attribute) can never complete the open
+        # marker, so withheld prose must flush rather than vanish.
+        f = ToolCallStreamFilter(_make_tokenizer())
+        out = f.feed("see <function") + f.feed(" docs for details") + f.finish()
+        assert out == "see <function docs for details"
+
+    def test_cdata_containing_literal_param_tags(self):
+        # CDATA must protect nested <param> tags from premature truncation.
+        text = (
+            '<function name="read"><param name="path">config.xml</param>'
+            '<param name="content"><![CDATA['
+            '<param name="nested">inside</param>'
+            ']]></param></function>'
+        )
+        _, calls = parse_tool_calls(text, self._tokenizer(), [self.READ_TOOL])
+        args = json.loads(calls[0].function.arguments)
+        assert args["path"] == "config.xml"
+        assert args["content"] == '<param name="nested">inside</param>'
+
+    def test_unclosed_preceding_tag_does_not_swallow_valid_call(self):
+        # A preceding unclosed <function> tag in prose must not swallow
+        # subsequent registered tool calls.
+        text = (
+            'Example: <function name="unclosed"> not closed. '
+            f'Real call: {self.BARE_CALL}'
+        )
+        cleaned, calls = parse_tool_calls(text, self._tokenizer(), [self.READ_TOOL])
+        assert calls is not None
+        assert len(calls) == 1
+        assert calls[0].function.name == "read"
+        assert 'Example: <function name="unclosed"> not closed.' in cleaned
+
+    def test_tag_whitespace_tolerance(self):
+        # Whitespace before closing '>' in tags should be tolerated.
+        text = (
+            '<function name="read" ><param name="path" >/x</param></function>'
+        )
+        _, calls = parse_tool_calls(text, self._tokenizer(), [self.READ_TOOL])
+        assert calls is not None
+        assert json.loads(calls[0].function.arguments) == {"path": "/x"}
+
+    def test_no_argument_call(self):
+        ping_tool = {
+            "type": "function",
+            "function": {"name": "ping", "parameters": {"type": "object"}},
+        }
+        text = '<function name="ping"></function>'
+        _, calls = parse_tool_calls(text, self._tokenizer(), [ping_tool])
+        assert calls is not None
+        assert calls[0].function.name == "ping"
+        assert json.loads(calls[0].function.arguments) == {}
+

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -27,15 +27,15 @@ from omlx.api.tool_calling import (
     _gemma4_args_to_json_robust,
     _json_value_end,
     _marker_payloads,
-    _parse_gemma4_tool_call_fallback,
     _parse_attribute_function_tool_calls,
+    _parse_gemma4_tool_call_fallback,
     _parse_hermes_tool_calls,
     _parse_namespaced_tool_calls,
     _parse_xml_tool_calls,
-    _strip_marker_spans,
     _remap_tool_call_names,
     _repair_json_value,
     _serialize_tool_call_arguments,
+    _strip_marker_spans,
     build_json_system_prompt,
     convert_tools_for_template,
     enrich_tool_params_for_gemma4,
@@ -4655,7 +4655,7 @@ class TestAttributeStyleFunctionDialect:
             assert cleaned == self.BARE_CALL
 
     def test_stream_filter_suppresses_bare_dialect_across_chunks(self):
-        f = ToolCallStreamFilter(_make_tokenizer())
+        f = ToolCallStreamFilter(_make_tokenizer(), tools=[self.READ_TOOL])
         chunks = [
             "Sure. ",
             "<funct",
@@ -4719,4 +4719,108 @@ class TestAttributeStyleFunctionDialect:
         assert calls is not None
         assert calls[0].function.name == "ping"
         assert json.loads(calls[0].function.arguments) == {}
+
+    def test_stream_filter_preserves_undeclared_function_in_prose(self):
+        # Gap 1: undeclared function markup in prose must not be suppressed
+        # during streaming, aligning with non-streaming behavior.
+        f = ToolCallStreamFilter(_make_tokenizer(), tools=[self.READ_TOOL])
+        text = 'Here is an example: <function name="example"><param name="k">v</param></function> in prose.'
+        out = f.feed(text) + f.finish()
+        assert out == text
+
+    def test_stream_filter_inert_for_bare_dialect_without_tools(self):
+        # Bare dialect is inert when no tools are declared.
+        for tools in (None, []):
+            f = ToolCallStreamFilter(_make_tokenizer(), tools=tools)
+            text = f"Prose {self.BARE_CALL} end."
+            out = f.feed(text) + f.finish()
+            assert out == text
+
+    def test_cdata_with_literal_function_close_tag(self):
+        # Gap 2: literal </function> inside CDATA must not truncate the call
+        # or produce empty arguments.
+        literal_code = 'def test():\n    return "</function>"\n'
+        text = (
+            '<function name="read"><param name="path"><![CDATA['
+            f'{literal_code}'
+            ']]></param></function>'
+        )
+        _, calls = parse_tool_calls(text, self._tokenizer(), [self.READ_TOOL])
+        assert calls is not None
+        assert len(calls) == 1
+        assert calls[0].function.name == "read"
+        assert json.loads(calls[0].function.arguments) == {"path": literal_code}
+
+    def test_cdata_with_embedded_function_call_example(self):
+        # Gap 2: a complete function call example inside CDATA should be
+        # preserved verbatim as argument value without triggering nested call extraction.
+        inner_example = '<function name="read"><param name="path">nested.py</param></function>'
+        text = (
+            f'Output: <function name="read"><param name="path"><![CDATA['
+            f'{inner_example}'
+            ']]></param></function> End.'
+        )
+        cleaned, calls = parse_tool_calls(text, self._tokenizer(), [self.READ_TOOL])
+        assert calls is not None
+        assert len(calls) == 1
+        assert calls[0].function.name == "read"
+        assert json.loads(calls[0].function.arguments) == {"path": inner_example}
+        assert "Output:" in cleaned
+        assert "End." in cleaned
+        assert "nested.py" not in cleaned
+
+    def test_stream_filter_cdata_with_literal_function_close_across_chunks(self):
+        # Gap 2 streaming: literal </function> inside CDATA across chunk boundaries
+        # must not end suppression prematurely or leak subsequent XML into visible output.
+        f = ToolCallStreamFilter(_make_tokenizer(), tools=[self.READ_TOOL])
+        chunks = [
+            "Before call. ",
+            '<function name="read"><param name="path"><![CDATA[',
+            'def foo():\n    return "</func',
+            'tion>"\n',
+            ']]></param></function>',
+            " After call.",
+        ]
+        out = "".join(f.feed(chunk) for chunk in chunks) + f.finish()
+        assert out == "Before call.  After call."
+
+    def test_stream_filter_cdata_delimiters_split_across_chunks(self):
+        # Gap 2 streaming: <![CDATA[ and ]]> delimiters split across chunks
+        f = ToolCallStreamFilter(_make_tokenizer(), tools=[self.READ_TOOL])
+        chunks = [
+            "Prefix: ",
+            '<function name="read"><param name="path"><![CD',
+            'ATA[</function>]]',
+            '></param></function>',
+            " Suffix.",
+        ]
+        out = "".join(f.feed(chunk) for chunk in chunks) + f.finish()
+        assert out == "Prefix:  Suffix."
+
+    def test_stream_filter_multiple_spaces_in_tag(self):
+        # Gap 3: multiple spaces in opening tag must be suppressed during streaming.
+        f = ToolCallStreamFilter(_make_tokenizer(), tools=[self.READ_TOOL])
+        chunks = [
+            "Start ",
+            '<function  ',
+            ' name="read"  ><param  name="path">/test.py</param></function>',
+            " End",
+        ]
+        out = "".join(f.feed(chunk) for chunk in chunks) + f.finish()
+        assert out == "Start  End"
+
+    def test_stream_filter_capture_ordered_segments(self):
+        # Verify capture_ordered_segments retains the complete envelope
+        f = ToolCallStreamFilter(
+            _make_tokenizer(),
+            tools=[self.READ_TOOL],
+            capture_ordered_segments=True,
+        )
+        raw_call = '<function name="read"><param name="path">/x</param></function>'
+        chunks = ["Hello ", raw_call, " world"]
+        out = "".join(f.feed(c) for c in chunks) + f.finish()
+        assert out == "Hello  world"
+        envelopes = f.take_completed_envelopes()
+        assert envelopes == [raw_call]
+
 


### PR DESCRIPTION
## Summary

MiniCPM5-family chat templates emit tool calls as

```
<function name="read"><param name="path">/workspace/TASK.md</param></function>
```

optionally wrapping values in `<![CDATA[...]]>`. None of the XML fallbacks in `omlx/api/tool_calling.py` recognised the attribute-style `<function name="...">` element (the table had keyword-style `<function=NAME>` and attribute-style `<invoke name="...">`, but not this combination), so the call came back as assistant text with `finish_reason: stop` and `tool_calls: null` — the client concludes the model cannot use tools. This is **direction 1** from #3429.

## Changes

- **Wrapped form** — `_parse_xml_tool_calls` gains an attribute-style branch for `<tool_call>`-wrapped payloads, bounded with `rfind("</function>")` like the keyword-style branch.
- **Bare form** — new `_parse_attribute_function_tool_calls`, tried after the namespaced fallback. There is no envelope to anchor on, so it is **gated on the request's own tool declarations**: an element is parsed only when its name exactly matches a declared tool. It is inert without `tools`, and prose that merely mentions `<function name="...">` for an unknown function passes through untouched. An element cannot span a later `<function` open tag, so an unclosed tag in prose cannot swallow a following real call.
- **Streaming** — `ToolCallStreamFilter` registers the `('<function name="', "</function>")` marker pair so the markup is suppressed from content deltas. Like the existing unconditional `<tool_call>` pair, this only runs on tool-enabled streams.
- **CDATA** — the MiniCPM5 template instructs the model to wrap values containing `<`, `&` or newlines in CDATA; values are unwrapped verbatim, and a literal `</param>` inside CDATA does not end the element. Both `<param>` and `<parameter>` spellings are accepted, with a backreference pairing open/close.

Deliberately out of scope: the K2-Horizon `<ifm|...>` dialect from the same issue, which @An0nya has a parser for and offered separately. That half has since landed in #3486; the two touch disjoint regions and this branch merges cleanly onto current main.

## Verification

- `tests/test_tool_calling.py`: 408 passed (16 new tests: bare/wrapped forms, both spellings, multiple calls, prose around calls, schema coercion, CDATA incl. nested literal tags, undeclared-name negative case, no-tools inertness, whitespace tolerance, no-argument call, stream filter across chunk boundaries and incomplete-marker flush).
- Full `pytest tests/ -m "not slow and not integration"`: no new failures compared with a clean `main` worktree in the same environment.
- End-to-end against a real `MiniCPM5-2B-MLX-8bit` (`model_type: llama`), same request from the issue, `temperature: 0`:

  | | before (0.6.4) | after |
  |---|---|---|
  | `finish_reason` | `stop` | `tool_calls` |
  | `tool_calls` | `null` | `read(path="/workspace/TASK.md")` |
  | `content` | raw XML | empty |

  Streaming returns the same tool call as deltas with no XML leaking into content, and a `write` call with multi-line content arrives via CDATA and is decoded to the literal value.
- Agent-level A/B with pi-agent: against the unpatched server it prints the raw `<function ...>` text and stops; against this branch it executes the `read` tool and answers from the file contents.

Fixes #3429
Fixes #1580

🤖 Generated with [Claude Code](https://claude.com/claude-code)

