### PR TITLE
fix(mtp): attach the gemma4 assistant head on the mlx-lm path

### DIFF
--- a/docs/experimental/dflash_mlx_integration.md
+++ b/docs/experimental/dflash_mlx_integration.md
@@ -118,7 +118,7 @@ are deliberately disabled for Laguna until they have dedicated
 numerical-parity coverage; ordinary adaptive DFlash verification remains
 available.
 
-Note: the `-DFlash` suffix is specific to DFlash draft checkpoints. Gemma4 also ships an `-assistant` variant (e.g. `gemma-4-26B-A4B-it-assistant`) that targets MTP speculative decoding via mlx-vlm — do not mix these in the DFlash toggle. Meta breaks this naming convention: `Muse-Glimmer-30B-assistant` IS a DFlash drafter (block-diffusion, `block_size` 16), not an MTP checkpoint. Drafter routing therefore keys on `config_model_type` (`muse_glimmer_assistant` is in the dashboard's DFlash drafter set), not on the checkpoint name. The Muse Glimmer target is a VLM: DFlash drives its text backbone through dflash-mlx's bundled text-only mlx-lm module, and image requests divert to the VLM fallback engine as usual.
+Note: the `-DFlash` suffix is specific to DFlash draft checkpoints. Gemma4 also ships an `-assistant` variant (e.g. `gemma-4-26B-A4B-it-assistant`) that targets MTP speculative decoding — do not mix these in the DFlash toggle. Meta breaks this naming convention: `Muse-Glimmer-30B-assistant` IS a DFlash drafter (block-diffusion, `block_size` 16), not an MTP checkpoint. Drafter routing therefore keys on `config_model_type` (`muse_glimmer_assistant` is in the dashboard's DFlash drafter set), not on the checkpoint name. The Muse Glimmer target is a VLM: DFlash drives its text backbone through dflash-mlx's bundled text-only mlx-lm module, and image requests divert to the VLM fallback engine as usual.
 
 ### Per-model settings
 

--- a/omlx/patches/gemma4_verify_attention.py
+++ b/omlx/patches/gemma4_verify_attention.py
@@ -1,12 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Small-L attention route for gemma4 speculative verify forwards.
 
-Installed on either engine. The routing below depends only on the Attention
-module's own attributes and on a module-level ``scaled_dot_product_attention``,
-both of which mlx-vlm's ``gemma4.language`` and mlx-lm's ``gemma4_text``
-provide under the same names and with the same call signature -- so the two
-engines share one copy of the kernel decision rather than each carrying a
-version that can drift from the other.
+Installed on either engine: the routing depends only on the Attention
+module's own attributes and a module-level
+``scaled_dot_product_attention``, which both provide under those names.
 
 Gemma4 uses head_dim 256 for sliding layers and 512 for global layers. MLX
 0.32.2 now handles small multi-row head-dim-256 calls with its native vector

--- a/omlx/patches/gemma4_verify_attention.py
+++ b/omlx/patches/gemma4_verify_attention.py
@@ -1,6 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 """Small-L attention route for gemma4 speculative verify forwards.
 
+Installed on either engine. The routing below depends only on the Attention
+module's own attributes and on a module-level ``scaled_dot_product_attention``,
+both of which mlx-vlm's ``gemma4.language`` and mlx-lm's ``gemma4_text``
+provide under the same names and with the same call signature -- so the two
+engines share one copy of the kernel decision rather than each carrying a
+version that can drift from the other.
+
 Gemma4 uses head_dim 256 for sliding layers and 512 for global layers. MLX
 0.32.2 now handles small multi-row head-dim-256 calls with its native vector
 kernel, so this patch explicitly leaves those shapes alone. Head-dim 512 still
@@ -77,15 +84,39 @@ def apply() -> bool:
     except Exception as e:
         logger.debug(f"mlx_vlm.gemma4 not importable for verify attention: {e}")
         return False
+    return _install(
+        g4_lang.Attention, g4_lang.scaled_dot_product_attention, "mlx-vlm"
+    )
 
+
+def apply_mlx_lm() -> bool:
+    """Wrap ``mlx_lm.models.gemma4_text.Attention.__call__``. Idempotent.
+
+    The same two routes, on the engine that serves text-only checkpoints.
+    Without this the mlx-lm verify forward drops to the unfused pass on
+    head_dim 512 global layers, which is the cost that grows with context and
+    makes a verify cycle lose to plain decoding on low-accept content.
+    """
+    try:
+        from mlx_lm.models import gemma4_text as g4_text
+    except Exception as e:
+        logger.debug(
+            f"mlx_lm.gemma4_text not importable for verify attention: {e}"
+        )
+        return False
+    return _install(
+        g4_text.Attention, g4_text.scaled_dot_product_attention, "mlx-lm"
+    )
+
+
+def _install(cls, sdpa, engine: str) -> bool:
+    """Install the small-L verify routes on one engine's Attention class."""
     from . import gemma4_verify_kernel
 
-    cls = g4_lang.Attention
     if getattr(cls, "_omlx_verify_attn_patched", False):
         return True
 
     original_call = cls.__call__
-    sdpa = g4_lang.scaled_dot_product_attention
 
     def _zero_left_padding(cache) -> bool:
         left = getattr(cache, "left_padding", None)
@@ -200,5 +231,8 @@ def apply() -> bool:
 
     cls.__call__ = __call__
     cls._omlx_verify_attn_patched = True
-    logger.info("gemma4 small-L verify attention patch applied (kernel + per-token)")
+    logger.info(
+        "gemma4 small-L verify attention patch applied on %s (kernel + per-token)",
+        engine,
+    )
     return True

--- a/omlx/patches/mlx_lm_gemma4_assistant.py
+++ b/omlx/patches/mlx_lm_gemma4_assistant.py
@@ -1,26 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """The gemma4 assistant draft step, shared by the mlx-lm and mlx-vlm paths.
 
-Google ships the gemma4 draft head as a separate ``gemma4_assistant``
-model, and the only implementation of it lives in mlx-vlm. Serving a
-merged checkpoint through mlx-lm therefore needs mlx-vlm installed —
-which is true of gemma4 and of nothing else in ``mlx_lm_mtp``.
-
-Which model needs mlx-vlm is load-bearing, not tidiness.
-``cluster.autoconfigure.required_imports`` tells a rank what to install by
-scanning each patch package for third-party imports, and it scans the whole
-package directory. An ``import mlx_vlm`` anywhere under ``mlx_lm_mtp`` would
-therefore ask every rank serving any model — a plain llama included — to
-bring mlx-vlm, and over-asking blocks a cluster that would have worked.
-Living here instead, imported from the dispatcher under a gemma4 guard,
-asks exactly the ranks that need it. Deferring the import to dodge that
-scan would hide the requirement and put the failure back in the middle of
-a load, which is the bug the scan exists to prevent.
-
-Both engines drive the head identically, so ``draft_step`` lives here too
-and both call it. Everything it needs a host to provide — ``mtp``,
-``model.embed_tokens``, and the stash a ``return_hidden`` forward leaves
-behind — the two hosts already expose under the same names.
+The draft head only exists in mlx-vlm, so serving a merged checkpoint
+through mlx-lm needs mlx-vlm installed -- true of gemma4 and of nothing
+else in ``mlx_lm_mtp``. This module sits outside that package on purpose:
+``cluster.autoconfigure.required_imports`` scans a patch package whole, so
+an ``import mlx_vlm`` under ``mlx_lm_mtp`` would ask every rank serving any
+model to install it.
 """
 
 from __future__ import annotations
@@ -32,11 +18,8 @@ import mlx.core as mx
 
 logger = logging.getLogger(__name__)
 
-# Resolved once and kept. The rejection path then costs a global read rather
-# than the import machinery. It stays deferred rather than module-level for
-# the reason in the docstring above: an ``import mlx_vlm`` at module scope
-# would make importing this module fail outright without mlx-vlm, which is
-# the failure ``warn_if_unavailable`` exists to replace with a sentence.
+# Resolved once and kept. Deferred rather than module-level, for the reason
+# in the docstring above.
 _slice_after_reject = None
 
 

--- a/omlx/patches/mlx_lm_gemma4_assistant.py
+++ b/omlx/patches/mlx_lm_gemma4_assistant.py
@@ -1,23 +1,26 @@
 # SPDX-License-Identifier: Apache-2.0
-"""The mlx-vlm half of gemma4 assistant MTP, kept out of ``mlx_lm_mtp``.
+"""The gemma4 assistant draft step, shared by the mlx-lm and mlx-vlm paths.
 
 Google ships the gemma4 draft head as a separate ``gemma4_assistant``
 model, and the only implementation of it lives in mlx-vlm. Serving a
 merged checkpoint through mlx-lm therefore needs mlx-vlm installed —
 which is true of gemma4 and of nothing else in ``mlx_lm_mtp``.
 
-That distinction is load-bearing, not tidiness.
+Which model needs mlx-vlm is load-bearing, not tidiness.
 ``cluster.autoconfigure.required_imports`` tells a rank what to install by
 scanning each patch package for third-party imports, and it scans the whole
 package directory. An ``import mlx_vlm`` anywhere under ``mlx_lm_mtp`` would
 therefore ask every rank serving any model — a plain llama included — to
 bring mlx-vlm, and over-asking blocks a cluster that would have worked.
-Keeping these two functions in their own module, imported from the
-dispatcher under a gemma4 guard, asks exactly the ranks that need it.
+Living here instead, imported from the dispatcher under a gemma4 guard,
+asks exactly the ranks that need it. Deferring the import to dodge that
+scan would hide the requirement and put the failure back in the middle of
+a load, which is the bug the scan exists to prevent.
 
-Deferring the import instead would hide the requirement from that scan and
-put the failure back in the middle of a load, which is the bug the scan
-exists to prevent.
+Both engines drive the head identically, so ``draft_step`` lives here too
+and both call it. Everything it needs a host to provide — ``mtp``,
+``model.embed_tokens``, and the stash a ``return_hidden`` forward leaves
+behind — the two hosts already expose under the same names.
 """
 
 from __future__ import annotations
@@ -45,6 +48,79 @@ def slice_shared_kv_after_reject(shared_kv: dict, rejected: int) -> dict:
     )
 
     return _slice_shared_kv_after_reject(shared_kv, rejected)
+
+
+def query_position(host: Any) -> int:
+    """Committed length, from the cache stashed at the last verify forward.
+
+    Host-side ints only, never the per-row ``offset`` array, so the chain
+    cycle stays sync-free. Rotating caches expose ``_offset`` (absolute
+    processed length, where ``_idx`` is a ring index), batched plain caches
+    ``_idx`` (storage length, equal to committed under the singleton gating
+    MTP requires), and stock caches an int ``offset``. ``trim`` and the
+    rollback undo adjust all three, so a post-rollback read is committed
+    length rather than verify length.
+    """
+    for cache in getattr(host, "_omlx_mtp_cache_ref", None) or []:
+        rotating = getattr(cache, "_offset", None)
+        if isinstance(rotating, int):
+            return rotating
+        offset = getattr(cache, "offset", None)
+        if isinstance(offset, int):
+            return offset
+        idx = getattr(cache, "_idx", None)
+        if isinstance(idx, int):
+            return idx
+    raise RuntimeError("gemma4 mtp_forward: no cache offset available")
+
+
+def draft_step(host: Any, hidden_states, next_token_ids, return_hidden: bool = False):
+    """One assistant-head draft against the host's stashed backbone K/V.
+
+    The head is single-position: only the last (hidden, token) pair matters,
+    so a multi-row history fold slices to the final row. ``hidden_states``
+    is the backbone's hidden on the first call of a cycle and the head's own
+    ``post_projection`` output on chain steps — both backbone-width, which
+    is what ``draft_block`` feeds back as ``h_prev``. The head is stateless,
+    so there is no cache to thread.
+    """
+    import mlx.core as mx
+
+    drafter = host.mtp
+    # nn.quantize() swaps embed_tokens for a QuantizedEmbedding after
+    # construction, so a bind taken in __init__ can point at a random-init
+    # module — which drafts garbage and reads as a ~10% accept rate.
+    if drafter._input_embed is not host.model.embed_tokens:
+        drafter.bind(host)
+
+    shared_kv = getattr(host, "_omlx_mtp_shared_kv", None)
+    if not shared_kv:
+        raise RuntimeError(
+            "gemma4 mtp_forward called without a prior return_hidden "
+            "backbone forward (no shared K/V stash)"
+        )
+
+    h = hidden_states[:, -1:, :]
+    tok_embed = drafter._input_embed(next_token_ids[:, -1:])
+    tok_embed = tok_embed * drafter._input_embed_scale
+    inputs_embeds = mx.concatenate([tok_embed.astype(h.dtype), h], axis=-1)
+
+    # The stash was captured at the verify forward, which ran before
+    # rollback trimmed the cache, so on a rejection its tail still holds the
+    # rejected rows. The difference is exactly how many to drop.
+    valid_len = query_position(host)
+    rejected = getattr(host, "_omlx_mtp_kv_offset", valid_len) - valid_len
+    if rejected > 0:
+        shared_kv = slice_shared_kv_after_reject(shared_kv, rejected)
+
+    drafter._kv_valid_len = valid_len
+    # The head's query position is the hidden's own token — the last
+    # committed slot, not the next one.
+    position_ids = mx.array([[max(valid_len - 1, 0)]])
+    head_hidden, logits = drafter(inputs_embeds, shared_kv, position_ids)
+    if return_hidden:
+        return logits, head_hidden
+    return logits
 
 
 def warn_if_unavailable(model_name: str) -> bool:

--- a/omlx/patches/mlx_lm_gemma4_assistant.py
+++ b/omlx/patches/mlx_lm_gemma4_assistant.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The mlx-vlm half of gemma4 assistant MTP, kept out of ``mlx_lm_mtp``.
+
+Google ships the gemma4 draft head as a separate ``gemma4_assistant``
+model, and the only implementation of it lives in mlx-vlm. Serving a
+merged checkpoint through mlx-lm therefore needs mlx-vlm installed —
+which is true of gemma4 and of nothing else in ``mlx_lm_mtp``.
+
+That distinction is load-bearing, not tidiness.
+``cluster.autoconfigure.required_imports`` tells a rank what to install by
+scanning each patch package for third-party imports, and it scans the whole
+package directory. An ``import mlx_vlm`` anywhere under ``mlx_lm_mtp`` would
+therefore ask every rank serving any model — a plain llama included — to
+bring mlx-vlm, and over-asking blocks a cluster that would have worked.
+Keeping these two functions in their own module, imported from the
+dispatcher under a gemma4 guard, asks exactly the ranks that need it.
+
+Deferring the import instead would hide the requirement from that scan and
+put the failure back in the middle of a load, which is the bug the scan
+exists to prevent.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def build_draft_model(assistant_config: dict) -> Any:
+    """Size the assistant head from the config oQ merged into the checkpoint."""
+    from mlx_vlm.speculative.drafters.gemma4_assistant import (
+        Gemma4AssistantDraftModel,
+        ModelConfig,
+    )
+
+    return Gemma4AssistantDraftModel(ModelConfig.from_dict(assistant_config))
+
+
+def slice_shared_kv_after_reject(shared_kv: dict, rejected: int) -> dict:
+    """Drop the rejected tail from a captured K/V stash."""
+    from mlx_vlm.speculative.mtp import (  # noqa: SLF001
+        _slice_shared_kv_after_reject,
+    )
+
+    return _slice_shared_kv_after_reject(shared_kv, rejected)
+
+
+def warn_if_unavailable(model_name: str) -> bool:
+    """Say up front when a merged head cannot be attached, and why.
+
+    Without this the load reaches ``Model.__init__``, fails to import the
+    drafter, and the operator sees a ModuleNotFoundError from inside model
+    construction rather than a sentence naming the missing package.
+    """
+    try:
+        import mlx_vlm.speculative.drafters.gemma4_assistant  # noqa: F401
+    except ImportError:
+        logger.warning(
+            "Gemma 4 assistant MTP for %s needs mlx-vlm, which supplies the "
+            "draft head; speculative decoding will stay inactive",
+            model_name,
+        )
+        return False
+    return True

--- a/omlx/patches/mlx_lm_gemma4_assistant.py
+++ b/omlx/patches/mlx_lm_gemma4_assistant.py
@@ -28,7 +28,16 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+import mlx.core as mx
+
 logger = logging.getLogger(__name__)
+
+# Resolved once and kept. The rejection path then costs a global read rather
+# than the import machinery. It stays deferred rather than module-level for
+# the reason in the docstring above: an ``import mlx_vlm`` at module scope
+# would make importing this module fail outright without mlx-vlm, which is
+# the failure ``warn_if_unavailable`` exists to replace with a sentence.
+_slice_after_reject = None
 
 
 def build_draft_model(assistant_config: dict) -> Any:
@@ -43,11 +52,15 @@ def build_draft_model(assistant_config: dict) -> Any:
 
 def slice_shared_kv_after_reject(shared_kv: dict, rejected: int) -> dict:
     """Drop the rejected tail from a captured K/V stash."""
-    from mlx_vlm.speculative.mtp import (  # noqa: SLF001
-        _slice_shared_kv_after_reject,
-    )
+    global _slice_after_reject
 
-    return _slice_shared_kv_after_reject(shared_kv, rejected)
+    if _slice_after_reject is None:
+        from mlx_vlm.speculative.mtp import (  # noqa: SLF001
+            _slice_shared_kv_after_reject,
+        )
+
+        _slice_after_reject = _slice_shared_kv_after_reject
+    return _slice_after_reject(shared_kv, rejected)
 
 
 def query_position(host: Any) -> int:
@@ -84,8 +97,6 @@ def draft_step(host: Any, hidden_states, next_token_ids, return_hidden: bool = F
     is what ``draft_block`` feeds back as ``h_prev``. The head is stateless,
     so there is no cache to thread.
     """
-    import mlx.core as mx
-
     drafter = host.mtp
     # nn.quantize() swaps embed_tokens for a QuantizedEmbedding after
     # construction, so a bind taken in __init__ can point at a random-init

--- a/omlx/patches/mlx_lm_mtp/__init__.py
+++ b/omlx/patches/mlx_lm_mtp/__init__.py
@@ -65,8 +65,8 @@ def is_mtp_active() -> bool:
 # next model load. Same construction-time-flag pattern as _MTP_ACTIVE: the
 # patched ``TextModel.__init__`` copies it onto the instance
 # (``_omlx_mtp_depth``) so decode never reads the global. Depth > 1 only
-# engages on models whose patch marks ``_omlx_mtp_chain`` (Qwen3.5/3.6);
-# DeepSeek-V4 stays on the depth-1 legacy cycle.
+# engages on models whose patch marks ``_omlx_mtp_chain``; the rest stay on
+# the depth-1 legacy cycle.
 _MTP_DEPTH = 1
 
 

--- a/omlx/patches/mlx_lm_mtp/__init__.py
+++ b/omlx/patches/mlx_lm_mtp/__init__.py
@@ -113,7 +113,7 @@ def apply_mlx_lm_mtp_patch() -> bool:
     if not cache_rollback.apply():
         return False
     if not gemma4_text_model.apply():
-        logger.debug("gemma4 text sanitize patch did not apply (likely import error)")
+        logger.debug("gemma4 MTP patch did not apply (likely import error)")
     if not qwen35_model.apply():
         # Qwen models are the main target; if the qwen patch refuses we
         # still continue so DeepSeek-V4 users aren't blocked.

--- a/omlx/patches/mlx_lm_mtp/gemma4_text_model.py
+++ b/omlx/patches/mlx_lm_mtp/gemma4_text_model.py
@@ -388,5 +388,23 @@ def apply() -> bool:
     _patch_text_model(lm_gemma4_text)
     _patch_inner_model(lm_gemma4_text)
     _patch_outer_model(lm_gemma4)
+
+    # The verify forward is the other half of what makes drafting pay. Gemma 4
+    # global layers carry head_dim 512, which MLX fuses only at L=1, so every
+    # multi-row verify drops to the unfused pass and that cost grows with
+    # context -- the mlx-vlm path has carried this route since #2683 and the
+    # mlx-lm path had no equivalent, which is the shape of our own weakest
+    # measurement (+28% short context against +11.6% at 2.7k).
+    #
+    # Failure is not fatal: without it the verify forward is slower, not
+    # wrong, so a missing kernel or an unpatchable Attention leaves drafting
+    # working on the stock route.
+    try:
+        from ..gemma4_verify_attention import apply_mlx_lm as _apply_verify_attn
+
+        _apply_verify_attn()
+    except Exception as exc:
+        logger.debug("gemma4 verify attention unavailable on mlx-lm: %s", exc)
+
     logger.debug("mlx-lm gemma4 assistant MTP patch applied")
     return True

--- a/omlx/patches/mlx_lm_mtp/gemma4_text_model.py
+++ b/omlx/patches/mlx_lm_mtp/gemma4_text_model.py
@@ -261,9 +261,9 @@ def _patch_inner_model(mod: Any) -> None:
 
         Gemma 4 is attention-only, so unlike qwen35 there is no recurrent
         state to restore and replay: every layer drops
-        ``num_drafts - accepted`` positions. Trimmability is checked across
-        all layers before any are trimmed, because a half-rolled-back cache
-        is unrecoverable.
+        ``num_drafts - accepted`` positions. Every layer is asked whether it
+        can trim before any of them is trimmed, because a half-rolled-back
+        cache is unrecoverable.
 
         A sliding layer whose ring has wrapped still trims: ``cache_rollback``
         arms an undo log around the verify forward, so ``is_trimmable()``

--- a/omlx/patches/mlx_lm_mtp/gemma4_text_model.py
+++ b/omlx/patches/mlx_lm_mtp/gemma4_text_model.py
@@ -134,6 +134,13 @@ def _patch_inner_model(mod: Any) -> None:
     if getattr(cls, "_omlx_mtp_attach_patched", False):
         return
 
+    # Bound here, at patch time, not inside the methods below: both run once
+    # per decode step, so a function-level import pays the import machinery on
+    # every draft. Relative imports, so the cluster scanner still reads the
+    # mlx-vlm requirement off mlx_lm_gemma4_assistant rather than off anything
+    # under mlx_lm_mtp -- see that module's docstring.
+    from ..mlx_lm_gemma4_assistant import draft_step, query_position
+
     original_init = cls.__init__
     original_call = cls.__call__
 
@@ -175,8 +182,6 @@ def _patch_inner_model(mod: Any) -> None:
         if sink is not None and getattr(self, "mtp", None) is not None:
             # mtp_forward is a separate top-level call, so this outlives the
             # forward; see the module docstring for why that is safe.
-            from ..mlx_lm_gemma4_assistant import query_position
-
             self._omlx_mtp_shared_kv = sink
             self._omlx_mtp_cache_ref = cache
             self._omlx_mtp_kv_offset = query_position(self)
@@ -206,8 +211,6 @@ def _patch_inner_model(mod: Any) -> None:
     ):
         """Drive the assistant head; the mlx-vlm path drives it the same way."""
         del mtp_cache, logits_keep  # stateless head, one output position
-        from ..mlx_lm_gemma4_assistant import draft_step
-
         return draft_step(self, hidden_states, next_token_ids, return_hidden)
 
     def make_mtp_cache(self):

--- a/omlx/patches/mlx_lm_mtp/gemma4_text_model.py
+++ b/omlx/patches/mlx_lm_mtp/gemma4_text_model.py
@@ -146,7 +146,7 @@ def _patch_inner_model(mod: Any) -> None:
     def __init__(self, args):
         original_init(self, args)
         assistant = getattr(args, "mtp_assistant_config", None)
-        from . import is_mtp_active
+        from . import get_mtp_depth, is_mtp_active
 
         enabled = bool(assistant) and is_mtp_active()
         self._omlx_mtp_decode_enabled = enabled
@@ -160,11 +160,8 @@ def _patch_inner_model(mod: Any) -> None:
         self.mtp = Gemma4AssistantDraftModel(Gemma4AssistantConfig.from_dict(assistant))
         # Function refs read weights at call time, so binding pre-load is safe.
         self.mtp.bind(self)
-        # Deliberately NOT _omlx_mtp_chain. Depth-k needs partial rollback, and
-        # on this path _chain_rollback looks for ``mtp_partial_rollback`` (the
-        # qwen35 patch's method) because gemma4 reports no gdn_states. Without
-        # it every cycle raises _MtpStepFallback and the step is redone, which
-        # costs far more than drafting saves. Depth-1, as DeepSeek-V4 does.
+        self._omlx_mtp_chain = True
+        self._omlx_mtp_depth = get_mtp_depth()
 
     def __call__(self, inputs, cache=None, **kwargs):
         want_hidden = bool(kwargs.pop("return_hidden", False))
@@ -259,11 +256,35 @@ def _patch_inner_model(mod: Any) -> None:
         """The assistant head is stateless."""
         return []
 
+    def mtp_partial_rollback(self, cache, accepted: int, num_drafts: int) -> bool:
+        """Trim the rejected tail after a depth-k verify over [confirmed, d1..dk].
+
+        Gemma 4 is attention-only, so unlike qwen35 there is no recurrent
+        state to restore and replay: every layer drops
+        ``num_drafts - accepted`` positions. Trimmability is checked across
+        all layers before any are trimmed, because a half-rolled-back cache
+        is unrecoverable. A sliding layer whose ring has wrapped reports
+        ``is_trimmable()`` False and the caller takes the standard step.
+        """
+        trim_n = num_drafts - accepted
+        if trim_n <= 0:
+            return True
+        live = [c for c in cache if c is not None]
+        if not live:
+            return False
+        for c in live:
+            if not (hasattr(c, "is_trimmable") and c.is_trimmable()):
+                return False
+        for c in live:
+            c.trim(trim_n)
+        return True
+
     cls.__init__ = __init__
     cls.__call__ = __call__
     cls._omlx_logits = _omlx_logits
     cls.mtp_forward = mtp_forward
     cls.make_mtp_cache = make_mtp_cache
+    cls.mtp_partial_rollback = mtp_partial_rollback
     cls._omlx_mtp_attach_patched = True
 
 

--- a/omlx/patches/mlx_lm_mtp/gemma4_text_model.py
+++ b/omlx/patches/mlx_lm_mtp/gemma4_text_model.py
@@ -7,32 +7,28 @@ model, which ``oq.combine_gemma4_assistant_mtp`` merges under
 side (``mlx_vlm_mtp.gemma4_vlm_runtime``), so a checkpoint served through
 mlx-lm — a text-only quant, a DFlash target, the VLM->LLM fallback — had
 no binding site and this module simply discarded the head. It still does
-when MTP is off; when MTP is on it attaches the head instead.
-
-Three things make that cheap. ``Gemma4AssistantDraftModel`` is not
-vision-coupled and its ``bind`` already accepts an mlx-lm host; mlx-lm's
-``gemma4_text`` already implements gemma4's cross-layer K/V sharing; and
-``batch_generator``'s MTP machinery is model-agnostic. What is missing is
-the two outputs the head consumes, so this adds them: the per-layer-type
-K/V banks (``shared_kv_sink``) and the pre-norm hidden.
+when MTP is off; when MTP is on it attaches the head and supplies the two
+things the head reads from a backbone forward — the per-layer-type K/V
+banks (``shared_kv_sink``) and the pre-norm hidden. ``draft_step`` in
+``mlx_lm_gemma4_assistant`` then drives it, shared with the mlx-vlm path.
 
 Hidden is captured BEFORE the trunk RMSNorm. ``_trunk_norm_module``
 re-applies it for any model that does not set
 ``_omlx_mtp_head_hidden_normed``, so capturing post-norm would double-norm
 the head's inputs — silently, as a weak acceptance rate.
 
-The layer loop is not copied. Each ``DecoderLayer`` already returns its
-``kvs``, so wrapping the layer records them and swapping ``norm`` for a
-recorder captures its input, which keeps this independent of the
-per-layer-input plumbing around the loop.
+Both outputs come from wrapping gemma4's layer loop rather than copying
+it: each ``DecoderLayer`` already returns its ``kvs``, and swapping
+``norm`` for a recorder captures its input. Reading the K/V back out of
+the cache instead would be wrong, because ``RotatingKVCache.state``
+returns the raw ring and a wrapped sliding layer would hand the head
+out-of-order banks.
 
-Concurrency. The per-layer sink and the model-level stash both carry state
-out of a forward, and neither can cross requests: every MLX call runs on
-the one-worker executor in ``omlx.engine_core`` (``max_workers=1``, since
-mlx-lm's BatchGenerator uses a module-level Metal stream — issue #85), and
-MTP is admitted only for singleton batches. The sink is a
-``threading.local`` regardless, which costs nothing and bounds a failure
-that would otherwise return confident logits over another request's K/V.
+The sink and the stash both carry state out of a forward, and neither can
+cross requests: MLX runs on the one-worker executor in
+``omlx.engine_core`` (issue #85), and MTP is admitted only for singleton
+batches. The sink is a ``threading.local`` anyway, which costs nothing and
+bounds a failure that would otherwise draft over another request's K/V.
 """
 
 from __future__ import annotations
@@ -138,8 +134,6 @@ def _patch_inner_model(mod: Any) -> None:
     if getattr(cls, "_omlx_mtp_attach_patched", False):
         return
 
-    import mlx.core as mx
-
     original_init = cls.__init__
     original_call = cls.__call__
 
@@ -181,9 +175,11 @@ def _patch_inner_model(mod: Any) -> None:
         if sink is not None and getattr(self, "mtp", None) is not None:
             # mtp_forward is a separate top-level call, so this outlives the
             # forward; see the module docstring for why that is safe.
+            from ..mlx_lm_gemma4_assistant import query_position
+
             self._omlx_mtp_shared_kv = sink
             self._omlx_mtp_cache_ref = cache
-            self._omlx_mtp_kv_offset = _query_position(self)
+            self._omlx_mtp_kv_offset = query_position(self)
 
         if not want_hidden:
             return self._omlx_logits(out)
@@ -208,44 +204,11 @@ def _patch_inner_model(mod: Any) -> None:
         return_hidden: bool = False,
         logits_keep: int = 0,
     ):
-        """Assistant-head forward under the Lightning chain contract.
+        """Drive the assistant head; the mlx-vlm path drives it the same way."""
+        del mtp_cache, logits_keep  # stateless head, one output position
+        from ..mlx_lm_gemma4_assistant import draft_step
 
-        Single-position: only the last (hidden, token) pair matters. The
-        head keeps no state, so ``mtp_cache`` is unused.
-        """
-        del mtp_cache, logits_keep
-        drafter = self.mtp
-        # nn.quantize() swaps embed_tokens after construction; a stale bind
-        # drafts from a random-init embedding and degrades silently.
-        if drafter._input_embed is not self.model.embed_tokens:
-            drafter.bind(self)
-        shared_kv = getattr(self, "_omlx_mtp_shared_kv", None)
-        if not shared_kv:
-            raise RuntimeError(
-                "gemma4 mtp_forward called without a prior return_hidden "
-                "backbone forward (no shared K/V stash)"
-            )
-
-        h = hidden_states[:, -1:, :]
-        tok_embed = drafter._input_embed(next_token_ids[:, -1:])
-        tok_embed = tok_embed * drafter._input_embed_scale
-        inputs_embeds = mx.concatenate([tok_embed.astype(h.dtype), h], axis=-1)
-
-        # The stash was taken at the verify forward, so after a rejection it
-        # still carries the rejected rows in its tail; drop them.
-        valid_len = _query_position(self)
-        rejected = getattr(self, "_omlx_mtp_kv_offset", valid_len) - valid_len
-        if rejected > 0:
-            from ..mlx_lm_gemma4_assistant import slice_shared_kv_after_reject
-
-            shared_kv = slice_shared_kv_after_reject(shared_kv, rejected)
-
-        drafter._kv_valid_len = valid_len
-        position_ids = mx.array([[max(valid_len - 1, 0)]])
-        head_hidden, logits = drafter(inputs_embeds, shared_kv, position_ids)
-        if return_hidden:
-            return logits, head_hidden
-        return logits
+        return draft_step(self, hidden_states, next_token_ids, return_hidden)
 
     def make_mtp_cache(self):
         """The assistant head is stateless."""
@@ -288,28 +251,6 @@ def _patch_inner_model(mod: Any) -> None:
     cls.make_mtp_cache = make_mtp_cache
     cls.mtp_partial_rollback = mtp_partial_rollback
     cls._omlx_mtp_attach_patched = True
-
-
-def _query_position(model: Any) -> int:
-    """Committed length, from the cache stashed at the last verify forward.
-
-    Host-side ints only, never the per-row ``offset`` array, so the chain
-    cycle stays sync-free. Batched rotating caches expose ``_offset``
-    (absolute processed length), batched plain caches ``_idx`` (storage
-    length, equal to committed under the singleton gating MTP requires),
-    and stock caches an int ``offset``.
-    """
-    for c in getattr(model, "_omlx_mtp_cache_ref", None) or []:
-        rotating = getattr(c, "_offset", None)
-        if isinstance(rotating, int):
-            return rotating
-        offset = getattr(c, "offset", None)
-        if isinstance(offset, int):
-            return offset
-        idx = getattr(c, "_idx", None)
-        if isinstance(idx, int):
-            return idx
-    raise RuntimeError("gemma4 mtp_forward: no cache offset available")
 
 
 def _is_head_key(key: str) -> bool:

--- a/omlx/patches/mlx_lm_mtp/gemma4_text_model.py
+++ b/omlx/patches/mlx_lm_mtp/gemma4_text_model.py
@@ -1,34 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 """Lightning MTP for merged gemma4 checkpoints on the mlx-lm path.
 
-Google ships the gemma4 draft head as a separate ``gemma4_assistant``
-model, which ``oq.combine_gemma4_assistant_mtp`` merges under
-``language_model.mtp.*``. The head was only ever attached on the mlx-vlm
-side (``mlx_vlm_mtp.gemma4_vlm_runtime``), so a checkpoint served through
-mlx-lm — a text-only quant, a DFlash target, the VLM->LLM fallback — had
-no binding site and this module simply discarded the head. It still does
-when MTP is off; when MTP is on it attaches the head and supplies the two
-things the head reads from a backbone forward — the per-layer-type K/V
-banks (``shared_kv_sink``) and the pre-norm hidden. ``draft_step`` in
-``mlx_lm_gemma4_assistant`` then drives it, shared with the mlx-vlm path.
+``oq.combine_gemma4_assistant_mtp`` merges Google's separate
+``gemma4_assistant`` model under ``language_model.mtp.*``. The head only
+ever had a binding site on the mlx-vlm side, so a checkpoint served
+through mlx-lm -- a text-only quant, a DFlash target, the VLM->LLM
+fallback -- discarded it. With MTP on this attaches it and supplies what
+it reads from a backbone forward: the per-layer-type K/V banks and the
+pre-norm hidden. ``mlx_lm_gemma4_assistant.draft_step`` drives it, shared
+with the mlx-vlm path.
 
-Hidden is captured BEFORE the trunk RMSNorm. ``_trunk_norm_module``
-re-applies it for any model that does not set
-``_omlx_mtp_head_hidden_normed``, so capturing post-norm would double-norm
-the head's inputs — silently, as a weak acceptance rate.
-
-Both outputs come from wrapping gemma4's layer loop rather than copying
-it: each ``DecoderLayer`` already returns its ``kvs``, and swapping
-``norm`` for a recorder captures its input. Reading the K/V back out of
-the cache instead would be wrong, because ``RotatingKVCache.state``
-returns the raw ring and a wrapped sliding layer would hand the head
-out-of-order banks.
-
-The sink and the stash both carry state out of a forward, and neither can
-cross requests: MLX runs on the one-worker executor in
-``omlx.engine_core`` (issue #85), and MTP is admitted only for singleton
-batches. The sink is a ``threading.local`` anyway, which costs nothing and
-bounds a failure that would otherwise draft over another request's K/V.
+Hidden is captured BEFORE the trunk RMSNorm, which
+``_trunk_norm_module`` re-applies -- a post-norm capture would
+double-norm the head's input and show up only as a weak accept rate.
 """
 
 from __future__ import annotations
@@ -134,11 +118,8 @@ def _patch_inner_model(mod: Any) -> None:
     if getattr(cls, "_omlx_mtp_attach_patched", False):
         return
 
-    # Bound here, at patch time, not inside the methods below: both run once
-    # per decode step, so a function-level import pays the import machinery on
-    # every draft. Relative imports, so the cluster scanner still reads the
-    # mlx-vlm requirement off mlx_lm_gemma4_assistant rather than off anything
-    # under mlx_lm_mtp -- see that module's docstring.
+    # Bound at patch time: both run per decode step, where a function-level
+    # import would pay the import machinery on every draft.
     from ..mlx_lm_gemma4_assistant import draft_step, query_position
 
     original_init = cls.__init__
@@ -218,28 +199,13 @@ def _patch_inner_model(mod: Any) -> None:
         return []
 
     def mtp_partial_rollback(self, cache, accepted: int, num_drafts: int) -> bool:
-        """Trim the rejected tail after a depth-k verify over [confirmed, d1..dk].
+        """Trim the rejected tail after a depth-k verify.
 
-        Gemma 4 is attention-only, so unlike qwen35 there is no recurrent
-        state to restore and replay: every layer drops
-        ``num_drafts - accepted`` positions. Every layer is asked whether it
-        can trim before any of them is trimmed, because a half-rolled-back
-        cache is unrecoverable.
-
-        A sliding layer whose ring has wrapped still trims: ``cache_rollback``
-        arms an undo log around the verify forward, so ``is_trimmable()``
-        answers for that snapshot rather than for the ring. A layer carrying
-        neither returns False and the caller takes the standard step.
-
-        The cache holds one entry per distinct K/V owner, which is not one per
-        layer. E2B and E4B share the last ``num_kv_shared_layers`` layers' K/V
-        with an earlier layer of the same type (20 of 35, 18 of 42), so
-        ``make_cache`` returns ``num_hidden_layers - num_kv_shared_layers``
-        entries and a per-layer count refuses every rollback on those
-        checkpoints -- silently, since the caller just rebuilds and takes a
-        standard step. mlx-lm materializes the mapping as ``previous_kvs``,
-        whose distinct values are exactly the caches that exist; a backbone
-        that does not publish one keeps the per-layer count.
+        Every layer is asked before any is trimmed, because a half
+        rolled-back cache is unrecoverable. The cache holds one entry per
+        distinct K/V owner, not one per layer -- E2B/E4B share the last
+        ``num_kv_shared_layers``, so a per-layer count refuses every
+        rollback there.
         """
         layers = self.model.layers
         previous_kvs = getattr(self.model, "previous_kvs", None)
@@ -275,31 +241,9 @@ def _is_head_key(key: str) -> bool:
 def _align_head_dtype(weights: dict) -> dict:
     """Store the assistant head at the backbone's float dtype.
 
-    The head ships bfloat16 and the combine step preserves that, so in a
-    float16 build every head matmul meets float16 activations and MLX
-    promotes the result to float32 — the head then runs at twice the
-    memory traffic it needs, on the decode hot path. Mirrors the
-    bfloat16 -> float16 normalization deepseek_v4_model already applies to
-    its own MTP metadata.
-
-    Either direction is safe to cast, for a reason specific to drafting:
-    the head only proposes. Every token the engine emits is one the
-    backbone verified, so head precision moves the acceptance rate and can
-    never move the output.
-
-    Measured on the 31B, two loads of one checkpoint over 120 depth-1
-    draft steps: float16 and bfloat16 heads accepted the same 32 drafts,
-    at 76ms against 152ms per step. bfloat16 -> float16 costs nothing
-    here, as expected (float16 carries 10 mantissa bits against
-    bfloat16's 7, and the head's largest weight is 23.1 against a 65504
-    ceiling). float16 -> bfloat16 does drop 3 mantissa bits, and needs a
-    checkpoint whose head and backbone were written by different tools;
-    it is still worth it against a float32 hot path.
-
-    The target is the dtype most of the backbone is stored in, not the
-    first one seen: in a quantized checkpoint most tensors are packed
-    uint32 with float scales beside them, and dict order would otherwise
-    let one unrepresentative tensor choose for the whole model.
+    The head ships bfloat16, so on a float16 build every head matmul
+    promotes to float32. Safe in either direction: the head only proposes,
+    and every token emitted is one the backbone verified.
     """
     from collections import Counter
 
@@ -392,16 +336,8 @@ def apply() -> bool:
     _patch_inner_model(lm_gemma4_text)
     _patch_outer_model(lm_gemma4)
 
-    # The verify forward is the other half of what makes drafting pay. Gemma 4
-    # global layers carry head_dim 512, which MLX fuses only at L=1, so every
-    # multi-row verify drops to the unfused pass and that cost grows with
-    # context -- the mlx-vlm path has carried this route since #2683 and the
-    # mlx-lm path had no equivalent, which is the shape of our own weakest
-    # measurement (+28% short context against +11.6% at 2.7k).
-    #
-    # Failure is not fatal: without it the verify forward is slower, not
-    # wrong, so a missing kernel or an unpatchable Attention leaves drafting
-    # working on the stock route.
+    # head_dim 512 global layers fuse only at L=1, so a multi-row verify
+    # drops to the unfused pass. Absent, the verify is slower, not wrong.
     try:
         from ..gemma4_verify_attention import apply_mlx_lm as _apply_verify_attn
 

--- a/omlx/patches/mlx_lm_mtp/gemma4_text_model.py
+++ b/omlx/patches/mlx_lm_mtp/gemma4_text_model.py
@@ -1,54 +1,390 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Sanitize compatibility for merged gemma4 MTP checkpoints on the mlx-lm path.
+"""Lightning MTP for merged gemma4 checkpoints on the mlx-lm path.
 
-Merged gemma4 checkpoints carry the assistant MTP head under
-``language_model.mtp.*`` (see ``mlx_vlm_mtp.gemma4_vlm_runtime``). The
-Lightning MTP head only exists on the mlx-vlm classes, so any load that
-goes through mlx-lm's text-only ``models/gemma4`` adapter — DFlash targets
-and the VLM→LLM fallback — has no binding site for those tensors and
-strict ``load_weights`` fails with "Received N parameters not in model".
+Google ships the gemma4 draft head as a separate ``gemma4_assistant``
+model, which ``oq.combine_gemma4_assistant_mtp`` merges under
+``language_model.mtp.*``. The head was only ever attached on the mlx-vlm
+side (``mlx_vlm_mtp.gemma4_vlm_runtime``), so a checkpoint served through
+mlx-lm — a text-only quant, a DFlash target, the VLM->LLM fallback — had
+no binding site and this module simply discarded the head. It still does
+when MTP is off; when MTP is on it attaches the head instead.
 
-Stock ``mlx_lm.models.gemma4.Model.sanitize`` already discards the other
-multimodal-only trees (vision_tower, audio_tower, ...); this patch makes
-it discard the MTP head the same way.
+Three things make that cheap. ``Gemma4AssistantDraftModel`` is not
+vision-coupled and its ``bind`` already accepts an mlx-lm host; mlx-lm's
+``gemma4_text`` already implements gemma4's cross-layer K/V sharing; and
+``batch_generator``'s MTP machinery is model-agnostic. What is missing is
+the two outputs the head consumes, so this adds them: the per-layer-type
+K/V banks (``shared_kv_sink``) and the pre-norm hidden.
+
+Hidden is captured BEFORE the trunk RMSNorm. ``_trunk_norm_module``
+re-applies it for any model that does not set
+``_omlx_mtp_head_hidden_normed``, so capturing post-norm would double-norm
+the head's inputs — silently, as a weak acceptance rate.
+
+The layer loop is not copied. Each ``DecoderLayer`` already returns its
+``kvs``, so wrapping the layer records them and swapping ``norm`` for a
+recorder captures its input, which keeps this independent of the
+per-layer-input plumbing around the loop.
+
+Concurrency. The per-layer sink and the model-level stash both carry state
+out of a forward, and neither can cross requests: every MLX call runs on
+the one-worker executor in ``omlx.engine_core`` (``max_workers=1``, since
+mlx-lm's BatchGenerator uses a module-level Metal stream — issue #85), and
+MTP is admitted only for singleton batches. The sink is a
+``threading.local`` regardless, which costs nothing and bounds a failure
+that would otherwise return confident logits over another request's K/V.
 """
 
 from __future__ import annotations
 
 import logging
+import threading
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
 _MTP_KEY_PREFIXES = ("mtp.", "model.mtp.", "language_model.mtp.")
 
+_active = threading.local()
 
-def apply() -> bool:
-    """Wrap ``mlx_lm.models.gemma4.Model.sanitize`` to strip mtp.* keys.
 
-    Idempotent via a class marker. Returns False when mlx-lm's gemma4
-    module is not importable.
+class _NormRecorder:
+    """Stand in for the trunk RMSNorm and keep its input."""
+
+    def __init__(self, norm):
+        self._norm = norm
+        self.pre_norm = None
+
+    def __call__(self, x):
+        self.pre_norm = x
+        return self._norm(x)
+
+
+def _patch_model_args(mod: Any) -> None:
+    """Carry ``mtp_assistant_config`` past ``BaseModelArgs.from_dict``.
+
+    ``from_dict`` keeps only keys matching the dataclass signature, so the
+    merged assistant config is dropped before the head can be sized.
     """
-    try:
-        from mlx_lm.models import gemma4 as lm_gemma4
-    except ImportError:
-        logger.debug("mlx_lm.models.gemma4 not importable; sanitize patch skipped")
-        return False
+    cls = mod.ModelArgs
+    if getattr(cls, "_omlx_mtp_from_dict_patched", False):
+        return
+    original = cls.from_dict.__func__
 
-    cls = lm_gemma4.Model
-    if getattr(cls, "_omlx_gemma4_mtp_sanitize_patched", False):
-        return True
+    def from_dict(inner_cls, params):
+        args = original(inner_cls, params)
+        assistant = params.get("mtp_assistant_config")
+        if assistant is not None:
+            args.mtp_assistant_config = assistant
+        return args
 
-    original_sanitize = cls.sanitize
+    cls.from_dict = classmethod(from_dict)
+    cls._omlx_mtp_from_dict_patched = True
+
+
+def _patch_decoder_layer(mod: Any) -> None:
+    cls = mod.DecoderLayer
+    if getattr(cls, "_omlx_kv_sink_patched", False):
+        return
+    original = cls.__call__
+
+    def __call__(self, *args, **kwargs):
+        h, kvs, offset = original(self, *args, **kwargs)
+        sink = getattr(_active, "sink", None)
+        if sink is not None and kvs is not None:
+            sink[self.layer_type] = kvs
+        return h, kvs, offset
+
+    cls.__call__ = __call__
+    cls._omlx_kv_sink_patched = True
+
+
+def _patch_text_model(mod: Any) -> None:
+    """Accept ``shared_kv_sink`` and expose the pre-norm hidden."""
+    cls = mod.Gemma4TextModel
+    if getattr(cls, "_omlx_hidden_hook_patched", False):
+        return
+    original = cls.__call__
+
+    def __call__(self, *args, **kwargs):
+        sink = kwargs.pop("shared_kv_sink", None)
+        want_hidden = bool(kwargs.pop("return_hidden", False))
+        if sink is None and not want_hidden:
+            return original(self, *args, **kwargs)
+
+        recorder = _NormRecorder(self.norm) if want_hidden else None
+        previous = getattr(_active, "sink", None)
+        _active.sink = sink
+        if recorder is not None:
+            self.norm = recorder
+        try:
+            out = original(self, *args, **kwargs)
+        finally:
+            if recorder is not None:
+                self.norm = recorder._norm
+            _active.sink = previous
+
+        if recorder is not None:
+            self._omlx_last_pre_norm = recorder.pre_norm
+        return out
+
+    cls.__call__ = __call__
+    cls._omlx_hidden_hook_patched = True
+
+
+def _patch_inner_model(mod: Any) -> None:
+    """Attach the head and serve ``mtp_forward`` on ``gemma4_text.Model``."""
+    cls = mod.Model
+    if getattr(cls, "_omlx_mtp_attach_patched", False):
+        return
+
+    import mlx.core as mx
+
+    original_init = cls.__init__
+    original_call = cls.__call__
+
+    def __init__(self, args):
+        original_init(self, args)
+        assistant = getattr(args, "mtp_assistant_config", None)
+        from . import is_mtp_active
+
+        enabled = bool(assistant) and is_mtp_active()
+        self._omlx_mtp_decode_enabled = enabled
+        if not enabled:
+            return
+        from mlx_vlm.speculative.drafters.gemma4_assistant import (
+            Gemma4AssistantDraftModel,
+            ModelConfig as Gemma4AssistantConfig,
+        )
+
+        self.mtp = Gemma4AssistantDraftModel(Gemma4AssistantConfig.from_dict(assistant))
+        # Function refs read weights at call time, so binding pre-load is safe.
+        self.mtp.bind(self)
+        # Deliberately NOT _omlx_mtp_chain. Depth-k needs partial rollback, and
+        # on this path _chain_rollback looks for ``mtp_partial_rollback`` (the
+        # qwen35 patch's method) because gemma4 reports no gdn_states. Without
+        # it every cycle raises _MtpStepFallback and the step is redone, which
+        # costs far more than drafting saves. Depth-1, as DeepSeek-V4 does.
+
+    def __call__(self, inputs, cache=None, **kwargs):
+        want_hidden = bool(kwargs.pop("return_hidden", False))
+        kwargs.pop("n_confirmed", None)  # no GDN split on gemma4
+        sink = kwargs.pop("shared_kv_sink", None)
+        if not want_hidden and sink is None:
+            return original_call(self, inputs, cache=cache, **kwargs)
+
+        # The engine asks for return_hidden without supplying a sink.
+        if sink is None and getattr(self, "mtp", None) is not None:
+            sink = {}
+
+        inner = dict(kwargs)
+        if sink is not None:
+            inner["shared_kv_sink"] = sink
+        if want_hidden:
+            inner["return_hidden"] = True
+        out = self.model(inputs, cache=cache, **inner)
+
+        if sink is not None and getattr(self, "mtp", None) is not None:
+            # mtp_forward is a separate top-level call, so this outlives the
+            # forward; see the module docstring for why that is safe.
+            self._omlx_mtp_shared_kv = sink
+            self._omlx_mtp_cache_ref = cache
+            self._omlx_mtp_kv_offset = _query_position(self)
+
+        if not want_hidden:
+            return self._omlx_logits(out)
+        # Set on the inner Gemma4TextModel by _patch_text_model, not here.
+        pre_norm = getattr(self.model, "_omlx_last_pre_norm", None)
+        return self._omlx_logits(out), pre_norm
+
+    def _omlx_logits(self, hidden):
+        if self.tie_word_embeddings:
+            out = self.model.embed_tokens.as_linear(hidden)
+        else:
+            out = self.lm_head(hidden)
+        if self.final_logit_softcapping is not None:
+            out = mod.logit_softcap(self.final_logit_softcapping, out)
+        return out
+
+    def mtp_forward(
+        self,
+        hidden_states,
+        next_token_ids,
+        mtp_cache,
+        return_hidden: bool = False,
+        logits_keep: int = 0,
+    ):
+        """Assistant-head forward under the Lightning chain contract.
+
+        Single-position: only the last (hidden, token) pair matters. The
+        head keeps no state, so ``mtp_cache`` is unused.
+        """
+        del mtp_cache, logits_keep
+        drafter = self.mtp
+        # nn.quantize() swaps embed_tokens after construction; a stale bind
+        # drafts from a random-init embedding and degrades silently.
+        if drafter._input_embed is not self.model.embed_tokens:
+            drafter.bind(self)
+        shared_kv = getattr(self, "_omlx_mtp_shared_kv", None)
+        if not shared_kv:
+            raise RuntimeError(
+                "gemma4 mtp_forward called without a prior return_hidden "
+                "backbone forward (no shared K/V stash)"
+            )
+
+        h = hidden_states[:, -1:, :]
+        tok_embed = drafter._input_embed(next_token_ids[:, -1:])
+        tok_embed = tok_embed * drafter._input_embed_scale
+        inputs_embeds = mx.concatenate([tok_embed.astype(h.dtype), h], axis=-1)
+
+        # The stash was taken at the verify forward, so after a rejection it
+        # still carries the rejected rows in its tail; drop them.
+        valid_len = _query_position(self)
+        rejected = getattr(self, "_omlx_mtp_kv_offset", valid_len) - valid_len
+        if rejected > 0:
+            from mlx_vlm.speculative.mtp import (  # noqa: SLF001
+                _slice_shared_kv_after_reject,
+            )
+
+            shared_kv = _slice_shared_kv_after_reject(shared_kv, rejected)
+
+        drafter._kv_valid_len = valid_len
+        position_ids = mx.array([[max(valid_len - 1, 0)]])
+        head_hidden, logits = drafter(inputs_embeds, shared_kv, position_ids)
+        if return_hidden:
+            return logits, head_hidden
+        return logits
+
+    def make_mtp_cache(self):
+        """The assistant head is stateless."""
+        return []
+
+    cls.__init__ = __init__
+    cls.__call__ = __call__
+    cls._omlx_logits = _omlx_logits
+    cls.mtp_forward = mtp_forward
+    cls.make_mtp_cache = make_mtp_cache
+    cls._omlx_mtp_attach_patched = True
+
+
+def _query_position(model: Any) -> int:
+    """Committed length, from the cache stashed at the last verify forward.
+
+    Host-side ints only, never the per-row ``offset`` array, so the chain
+    cycle stays sync-free. Batched rotating caches expose ``_offset``
+    (absolute processed length), batched plain caches ``_idx`` (storage
+    length, equal to committed under the singleton gating MTP requires),
+    and stock caches an int ``offset``.
+    """
+    for c in getattr(model, "_omlx_mtp_cache_ref", None) or []:
+        rotating = getattr(c, "_offset", None)
+        if isinstance(rotating, int):
+            return rotating
+        offset = getattr(c, "offset", None)
+        if isinstance(offset, int):
+            return offset
+        idx = getattr(c, "_idx", None)
+        if isinstance(idx, int):
+            return idx
+    raise RuntimeError("gemma4 mtp_forward: no cache offset available")
+
+
+def _align_head_dtype(weights: dict) -> dict:
+    """Store the assistant head at the backbone's float dtype.
+
+    The head ships bfloat16 and the combine step preserves that, so in a
+    float16 build every head matmul meets float16 activations and MLX
+    promotes the result to float32 — the head then runs at twice the
+    memory traffic it needs, on the decode hot path. bfloat16 -> float16
+    is lossless here (float16 carries 10 mantissa bits against bfloat16's
+    7, and the head's largest weight is 23.1 against a 65504 ceiling).
+    Mirrors the bfloat16 -> float16 normalisation deepseek_v4_model
+    already applies to its own MTP metadata.
+    """
+    import mlx.core as mx
+
+    target = None
+    for key, value in weights.items():
+        if key.startswith(_MTP_KEY_PREFIXES) or ".mtp." in key:
+            continue
+        if value.dtype in (mx.float16, mx.bfloat16):
+            target = value.dtype
+            break
+    if target is None:
+        return weights
+
+    aligned = {}
+    for key, value in weights.items():
+        head = key.startswith(_MTP_KEY_PREFIXES) or ".mtp." in key
+        if head and value.dtype in (mx.float16, mx.bfloat16) and value.dtype != target:
+            value = value.astype(target)
+        aligned[key] = value
+    return aligned
+
+
+def _patch_outer_model(mod: Any) -> None:
+    """Teach ``gemma4.Model``, which is the object the engine holds.
+
+    The engine splits its lookups: ``_model_has_mtp_module`` walks
+    ``language_model`` for ``.mtp``, but ``hasattr(model, "mtp_forward")``
+    and the ``return_hidden`` forward both run against the outer wrapper,
+    whose ``__call__`` lists its parameters and so rejects the kwarg.
+    """
+    cls = mod.Model
+    if getattr(cls, "_omlx_mtp_outer_patched", False):
+        return
+    original = cls.__call__
+
+    def __call__(self, inputs, cache=None, **kwargs):
+        if not (kwargs.get("return_hidden") or kwargs.get("shared_kv_sink")):
+            for key in ("return_hidden", "shared_kv_sink", "n_confirmed"):
+                kwargs.pop(key, None)
+            return original(self, inputs, cache=cache, **kwargs)
+        return self.language_model(inputs, cache=cache, **kwargs)
+
+    def mtp_forward(self, *args, **kwargs):
+        return self.language_model.mtp_forward(*args, **kwargs)
+
+    def make_mtp_cache(self):
+        return self.language_model.make_mtp_cache()
 
     def sanitize(self, weights):
-        weights = {
-            k: v
-            for k, v in weights.items()
-            if not k.removeprefix("model.").startswith(_MTP_KEY_PREFIXES)
-        }
+        """Drop the merged head, or align its dtype to the backbone.
+
+        Attachment already happened in ``__init__``, so the head's own
+        presence is the condition — no second read of the active flag.
+        """
+        if getattr(self.language_model, "mtp", None) is None:
+            weights = {
+                k: v
+                for k, v in weights.items()
+                if not k.removeprefix("model.").startswith(_MTP_KEY_PREFIXES)
+            }
+        else:
+            weights = _align_head_dtype(weights)
         return original_sanitize(self, weights)
 
+    original_sanitize = cls.sanitize
+    cls.__call__ = __call__
+    cls.mtp_forward = mtp_forward
+    cls.make_mtp_cache = make_mtp_cache
     cls.sanitize = sanitize
-    cls._omlx_gemma4_mtp_sanitize_patched = True
-    logger.debug("mlx-lm gemma4 sanitize patched to strip merged mtp.* keys")
+    cls._omlx_mtp_outer_patched = True
+
+
+def apply() -> bool:
+    """Patch mlx-lm's gemma4 pair. False when mlx-lm is not importable."""
+    try:
+        from mlx_lm.models import gemma4 as lm_gemma4
+        from mlx_lm.models import gemma4_text as lm_gemma4_text
+    except ImportError:
+        logger.debug("mlx_lm.models.gemma4 not importable; MTP patch skipped")
+        return False
+
+    _patch_model_args(lm_gemma4_text)
+    _patch_decoder_layer(lm_gemma4_text)
+    _patch_text_model(lm_gemma4_text)
+    _patch_inner_model(lm_gemma4_text)
+    _patch_outer_model(lm_gemma4)
+    logger.debug("mlx-lm gemma4 assistant MTP patch applied")
     return True

--- a/omlx/patches/mlx_lm_mtp/gemma4_text_model.py
+++ b/omlx/patches/mlx_lm_mtp/gemma4_text_model.py
@@ -263,9 +263,16 @@ def _patch_inner_model(mod: Any) -> None:
         state to restore and replay: every layer drops
         ``num_drafts - accepted`` positions. Trimmability is checked across
         all layers before any are trimmed, because a half-rolled-back cache
-        is unrecoverable. A sliding layer whose ring has wrapped reports
-        ``is_trimmable()`` False and the caller takes the standard step.
+        is unrecoverable.
+
+        A sliding layer whose ring has wrapped still trims: ``cache_rollback``
+        arms an undo log around the verify forward, so ``is_trimmable()``
+        answers for that snapshot rather than for the ring. A layer carrying
+        neither returns False and the caller takes the standard step.
         """
+        layers = self.model.layers
+        if len(cache) != len(layers):
+            return False
         trim_n = num_drafts - accepted
         if trim_n <= 0:
             return True
@@ -310,34 +317,56 @@ def _query_position(model: Any) -> int:
     raise RuntimeError("gemma4 mtp_forward: no cache offset available")
 
 
+def _is_head_key(key: str) -> bool:
+    return key.startswith(_MTP_KEY_PREFIXES) or ".mtp." in key
+
+
 def _align_head_dtype(weights: dict) -> dict:
     """Store the assistant head at the backbone's float dtype.
 
     The head ships bfloat16 and the combine step preserves that, so in a
     float16 build every head matmul meets float16 activations and MLX
     promotes the result to float32 — the head then runs at twice the
-    memory traffic it needs, on the decode hot path. bfloat16 -> float16
-    is lossless here (float16 carries 10 mantissa bits against bfloat16's
-    7, and the head's largest weight is 23.1 against a 65504 ceiling).
-    Mirrors the bfloat16 -> float16 normalisation deepseek_v4_model
-    already applies to its own MTP metadata.
+    memory traffic it needs, on the decode hot path. Mirrors the
+    bfloat16 -> float16 normalization deepseek_v4_model already applies to
+    its own MTP metadata.
+
+    Either direction is safe to cast, for a reason specific to drafting:
+    the head only proposes. Every token the engine emits is one the
+    backbone verified, so head precision moves the acceptance rate and can
+    never move the output. bfloat16 -> float16 is in any case lossless
+    here (float16 carries 10 mantissa bits against bfloat16's 7, and the
+    head's largest weight is 23.1 against a 65504 ceiling); float16 ->
+    bfloat16, which needs a checkpoint whose head and backbone were
+    written by different tools, drops 3 mantissa bits and is still worth
+    it against a float32 hot path.
+
+    The target is the dtype most of the backbone is stored in, not the
+    first one seen: in a quantized checkpoint most tensors are packed
+    uint32 with float scales beside them, and dict order would otherwise
+    let one unrepresentative tensor choose for the whole model.
     """
+    from collections import Counter
+
     import mlx.core as mx
 
-    target = None
+    counts: Counter = Counter()
     for key, value in weights.items():
-        if key.startswith(_MTP_KEY_PREFIXES) or ".mtp." in key:
+        if _is_head_key(key):
             continue
         if value.dtype in (mx.float16, mx.bfloat16):
-            target = value.dtype
-            break
-    if target is None:
+            counts[value.dtype] += 1
+    if not counts:
         return weights
+    target = counts.most_common(1)[0][0]
 
     aligned = {}
     for key, value in weights.items():
-        head = key.startswith(_MTP_KEY_PREFIXES) or ".mtp." in key
-        if head and value.dtype in (mx.float16, mx.bfloat16) and value.dtype != target:
+        if (
+            _is_head_key(key)
+            and value.dtype in (mx.float16, mx.bfloat16)
+            and value.dtype != target
+        ):
             value = value.astype(target)
         aligned[key] = value
     return aligned

--- a/omlx/patches/mlx_lm_mtp/gemma4_text_model.py
+++ b/omlx/patches/mlx_lm_mtp/gemma4_text_model.py
@@ -227,9 +227,21 @@ def _patch_inner_model(mod: Any) -> None:
         arms an undo log around the verify forward, so ``is_trimmable()``
         answers for that snapshot rather than for the ring. A layer carrying
         neither returns False and the caller takes the standard step.
+
+        The cache holds one entry per distinct K/V owner, which is not one per
+        layer. E2B and E4B share the last ``num_kv_shared_layers`` layers' K/V
+        with an earlier layer of the same type (20 of 35, 18 of 42), so
+        ``make_cache`` returns ``num_hidden_layers - num_kv_shared_layers``
+        entries and a per-layer count refuses every rollback on those
+        checkpoints -- silently, since the caller just rebuilds and takes a
+        standard step. mlx-lm materializes the mapping as ``previous_kvs``,
+        whose distinct values are exactly the caches that exist; a backbone
+        that does not publish one keeps the per-layer count.
         """
         layers = self.model.layers
-        if len(cache) != len(layers):
+        previous_kvs = getattr(self.model, "previous_kvs", None)
+        expected = len(set(previous_kvs)) if previous_kvs else len(layers)
+        if len(cache) != expected:
             return False
         trim_n = num_drafts - accepted
         if trim_n <= 0:

--- a/omlx/patches/mlx_lm_mtp/gemma4_text_model.py
+++ b/omlx/patches/mlx_lm_mtp/gemma4_text_model.py
@@ -152,12 +152,9 @@ def _patch_inner_model(mod: Any) -> None:
         self._omlx_mtp_decode_enabled = enabled
         if not enabled:
             return
-        from mlx_vlm.speculative.drafters.gemma4_assistant import (
-            Gemma4AssistantDraftModel,
-            ModelConfig as Gemma4AssistantConfig,
-        )
+        from ..mlx_lm_gemma4_assistant import build_draft_model
 
-        self.mtp = Gemma4AssistantDraftModel(Gemma4AssistantConfig.from_dict(assistant))
+        self.mtp = build_draft_model(assistant)
         # Function refs read weights at call time, so binding pre-load is safe.
         self.mtp.bind(self)
         self._omlx_mtp_chain = True
@@ -239,11 +236,9 @@ def _patch_inner_model(mod: Any) -> None:
         valid_len = _query_position(self)
         rejected = getattr(self, "_omlx_mtp_kv_offset", valid_len) - valid_len
         if rejected > 0:
-            from mlx_vlm.speculative.mtp import (  # noqa: SLF001
-                _slice_shared_kv_after_reject,
-            )
+            from ..mlx_lm_gemma4_assistant import slice_shared_kv_after_reject
 
-            shared_kv = _slice_shared_kv_after_reject(shared_kv, rejected)
+            shared_kv = slice_shared_kv_after_reject(shared_kv, rejected)
 
         drafter._kv_valid_len = valid_len
         position_ids = mx.array([[max(valid_len - 1, 0)]])

--- a/omlx/patches/mlx_lm_mtp/gemma4_text_model.py
+++ b/omlx/patches/mlx_lm_mtp/gemma4_text_model.py
@@ -270,12 +270,16 @@ def _align_head_dtype(weights: dict) -> dict:
     Either direction is safe to cast, for a reason specific to drafting:
     the head only proposes. Every token the engine emits is one the
     backbone verified, so head precision moves the acceptance rate and can
-    never move the output. bfloat16 -> float16 is in any case lossless
-    here (float16 carries 10 mantissa bits against bfloat16's 7, and the
-    head's largest weight is 23.1 against a 65504 ceiling); float16 ->
-    bfloat16, which needs a checkpoint whose head and backbone were
-    written by different tools, drops 3 mantissa bits and is still worth
-    it against a float32 hot path.
+    never move the output.
+
+    Measured on the 31B, two loads of one checkpoint over 120 depth-1
+    draft steps: float16 and bfloat16 heads accepted the same 32 drafts,
+    at 76ms against 152ms per step. bfloat16 -> float16 costs nothing
+    here, as expected (float16 carries 10 mantissa bits against
+    bfloat16's 7, and the head's largest weight is 23.1 against a 65504
+    ceiling). float16 -> bfloat16 does drop 3 mantissa bits, and needs a
+    checkpoint whose head and backbone were written by different tools;
+    it is still worth it against a float32 hot path.
 
     The target is the dtype most of the backbone is stored in, not the
     first one seen: in a quantized checkpoint most tensors are packed

--- a/omlx/patches/mlx_vlm_mtp/gemma4_vlm_runtime.py
+++ b/omlx/patches/mlx_vlm_mtp/gemma4_vlm_runtime.py
@@ -137,7 +137,7 @@ def _patch_vlm_language_model(g4_lang: Any) -> None:
         ModelConfig as Gemma4AssistantConfig,
     )
 
-    from ..mlx_lm_gemma4_assistant import query_position
+    from ..mlx_lm_gemma4_assistant import draft_step, query_position
 
     original_init = cls.__init__
     original_call = cls.__call__
@@ -215,8 +215,6 @@ def _patch_vlm_language_model(g4_lang: Any) -> None:
     ):
         """Drive the assistant head; the mlx-lm path drives it the same way."""
         del mtp_cache, logits_keep  # stateless head; output is 1 position
-        from ..mlx_lm_gemma4_assistant import draft_step
-
         return draft_step(self, hidden_states, next_token_ids, return_hidden)
 
     def make_mtp_cache(self):

--- a/omlx/patches/mlx_vlm_mtp/gemma4_vlm_runtime.py
+++ b/omlx/patches/mlx_vlm_mtp/gemma4_vlm_runtime.py
@@ -44,8 +44,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-import mlx.core as mx
-
 logger = logging.getLogger(__name__)
 
 _APPLIED = False
@@ -138,7 +136,8 @@ def _patch_vlm_language_model(g4_lang: Any) -> None:
         Gemma4AssistantDraftModel,
         ModelConfig as Gemma4AssistantConfig,
     )
-    from mlx_vlm.speculative.mtp import _slice_shared_kv_after_reject  # noqa: SLF001
+
+    from ..mlx_lm_gemma4_assistant import query_position
 
     original_init = cls.__init__
     original_call = cls.__call__
@@ -198,39 +197,13 @@ def _patch_vlm_language_model(g4_lang: Any) -> None:
         # Committed length at capture time. A later rollback lowers the
         # live cache counters below this, and mtp_forward slices the
         # rejected tail off the stashed banks by the difference.
-        self._omlx_mtp_kv_offset = _mtp_query_position(self)
+        self._omlx_mtp_kv_offset = query_position(self)
         return LanguageModelOutput(
             logits=out.logits,
             hidden_states=out.hidden_states,
             gdn_states=[],
             shared_kv_states=sink,
         )
-
-    def _mtp_query_position(self) -> int:
-        """Current committed length = the drafter's constant query position.
-
-        Read from the live cache list (stashed at the last verify forward)
-        so post-rollback folds see the committed offset, not the verify
-        length. Uses the caches' host-side int counters — never the
-        per-row ``offset`` mx.array — to keep the chain cycle sync-free:
-        ``BatchRotatingKVCache._offset`` is the absolute processed length
-        (its ``_idx`` is a ring index), ``BatchKVCache._idx`` is the
-        storage length (== committed length; singleton MTP activation
-        guarantees zero left padding), and plain caches keep an int
-        ``offset``. All three are adjusted by ``trim`` / the rollback
-        undo, so post-rollback reads are committed-only.
-        """
-        for c in self._omlx_mtp_cache_ref or []:
-            rotating_offset = getattr(c, "_offset", None)
-            if isinstance(rotating_offset, int):
-                return rotating_offset
-            offset = getattr(c, "offset", None)
-            if isinstance(offset, int):
-                return offset
-            idx = getattr(c, "_idx", None)
-            if isinstance(idx, int):
-                return idx
-        raise RuntimeError("gemma4 mtp_forward: no cache offset available")
 
     def mtp_forward(
         self,
@@ -240,54 +213,11 @@ def _patch_vlm_language_model(g4_lang: Any) -> None:
         return_hidden: bool = False,
         logits_keep: int = 0,
     ):
-        """Assistant-head forward under the Lightning chain contract.
-
-        The head is single-position (no history fold): only the last
-        (hidden, token) pair matters, so multi-row history folds slice to
-        the final position. ``hidden_states`` is either the trunk-normed
-        backbone hidden (first fold call) or the head's own
-        ``post_projection`` output (chain steps) — both 5376-dim, matching
-        ``draft_block``'s ``h_prev`` feedback. ``mtp_cache`` is unused
-        (stateless head).
-        """
+        """Drive the assistant head; the mlx-lm path drives it the same way."""
         del mtp_cache, logits_keep  # stateless head; output is 1 position
-        drafter = self.mtp
-        # Re-bind when the backbone embed module was swapped after the
-        # __init__-time bind — nn.quantize() replaces embed_tokens with a
-        # QuantizedEmbedding AFTER model construction, and a stale binding
-        # keeps a random-init nn.Embedding (garbage drafts, ~10% accept).
-        if drafter._input_embed is not self.model.embed_tokens:
-            drafter.bind(self)
-        shared_kv = getattr(self, "_omlx_mtp_shared_kv", None)
-        if not shared_kv:
-            raise RuntimeError(
-                "gemma4 mtp_forward called without a prior "
-                "return_hidden backbone forward (no shared K/V stash)"
-            )
+        from ..mlx_lm_gemma4_assistant import draft_step
 
-        h = hidden_states[:, -1:, :]
-        ids = next_token_ids[:, -1:]
-        tok_embed = drafter._input_embed(ids) * drafter._input_embed_scale
-        inputs_embeds = mx.concatenate([tok_embed.astype(h.dtype), h], axis=-1)
-
-        # Committed length (post-rollback). The stash was captured at the
-        # verify forward, so on a rejection it still carries the rejected
-        # draft rows in the tail — slice them off (verify captures are
-        # temporal-ordered, mirrors _mtp_rounds' post-reject slicing).
-        valid_len = _mtp_query_position(self)
-        rejected = getattr(self, "_omlx_mtp_kv_offset", valid_len) - valid_len
-        if rejected > 0:
-            shared_kv = _slice_shared_kv_after_reject(shared_kv, rejected)
-
-        # The drafter's constant query position is the position of the
-        # hidden's token — the last committed slot, not the next one
-        # (mirrors _mtp_draft_position).
-        drafter._kv_valid_len = valid_len
-        position_ids = mx.array([[max(valid_len - 1, 0)]])
-        head_hidden, logits = drafter(inputs_embeds, shared_kv, position_ids)
-        if return_hidden:
-            return logits, head_hidden
-        return logits
+        return draft_step(self, hidden_states, next_token_ids, return_hidden)
 
     def make_mtp_cache(self):
         """The assistant head keeps no state — nothing to clone or trim."""

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -1109,9 +1109,9 @@ def _is_mtp_compatible(config: dict, model_type: str | None) -> bool:
 
     Supports Qwen3.5/3.6 (mlx-lm PR 990), DeepSeek-V4-Flash (Blaizzy/mlx-lm
     fork PR 15), GLM-5.2 (glm_moe_dsa), Nemotron-H hybrids (nemotron_h) and
-    Gemma 4 merged-assistant checkpoints (gemma4 and gemma4_unified, VLM path
-    only). The model also has to declare MTP heads in the config; otherwise
-    the patch is a no-op.
+    Gemma 4 merged-assistant checkpoints (gemma4 and gemma4_unified, on both
+    the mlx-vlm and mlx-lm paths). The model also has to declare MTP heads in
+    the config; otherwise the patch is a no-op.
     """
     if not _has_mtp_heads(config):
         return False

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -735,6 +735,18 @@ def maybe_apply_pre_load_patches(
             set_mtp_depth,
         )
 
+        if model_type in ("gemma4", "gemma4_unified"):
+            # Gemma 4 alone ships its draft head as a separate model, and the
+            # only implementation of it is mlx-vlm's. Declaring that here, and
+            # not inside mlx_lm_mtp, is what keeps cluster.autoconfigure from
+            # asking every rank serving any model to install mlx-vlm.
+            from ..patches.mlx_lm_gemma4_assistant import warn_if_unavailable
+
+            # The import stays under the model-type test alone so the derived
+            # requirement keeps its guard; only the call is opt-in.
+            if mtp_enabled:
+                warn_if_unavailable(model_name)
+
         if apply_mlx_lm_mtp_patch():
             set_mtp_active(mtp_enabled)
             # mtp_num_draft_tokens is the MAX draft depth; an adaptive

--- a/tests/test_cluster_autoconfigure.py
+++ b/tests/test_cluster_autoconfigure.py
@@ -1541,6 +1541,26 @@ def test_a_minimax_rank_needs_mlx_vlm_even_though_a_rank_is_an_mlx_lm_server(tmp
     assert "mlx_vlm" in modules
 
 
+def test_a_gemma4_rank_needs_mlx_vlm_for_the_draft_head(tmp_path):
+    """Under-asking is the other half, and it is the one that kills a rank.
+
+    Gemma 4 alone ships its draft head as a separate model that only mlx-vlm
+    implements, so ``omlx.patches.mlx_lm_gemma4_assistant`` holds that import
+    and ``mlx_lm_mtp`` does not — true of gemma4, not of every MTP model.
+    """
+
+    from omlx.cluster.autoconfigure import required_imports
+
+    modules = {
+        requirement.module
+        for requirement in required_imports(
+            _model_dir(tmp_path, model_type="gemma4")
+        )
+    }
+
+    assert "mlx_vlm" in modules
+
+
 def test_a_plain_llama_is_not_asked_to_bring_mlx_vlm(tmp_path):
     """Over-asking blocks a cluster that would have worked."""
 

--- a/tests/test_gemma4_text_mtp_runtime.py
+++ b/tests/test_gemma4_text_mtp_runtime.py
@@ -209,11 +209,26 @@ def test_kv_sink_is_cleared_between_forwards():
     assert getattr(_active, "sink", None) is None
 
 
-def test_trunk_norm_is_restored_when_the_forward_raises():
+class _LayerError(RuntimeError):
+    """A deliberate mid-forward failure, so the test owns the exception."""
+
+
+def test_trunk_norm_is_restored_when_the_forward_raises(monkeypatch):
+    # The recorder stands in for self.norm for the duration of one forward.
+    # If an exception could leave it installed, every later forward would
+    # return the recorder's output and leak the previous request's hidden.
+    from mlx_lm.models.gemma4_text import DecoderLayer
+
+    def explode(self, *args, **kwargs):
+        raise _LayerError("layer failed mid-forward")
+
     model = _inner()
     norm = model.model.norm
-    with pytest.raises(Exception):
-        model(mx.array([[1, 2, 3]]), cache="not-a-cache", return_hidden=True)
+    monkeypatch.setattr(DecoderLayer, "__call__", explode)
+
+    with pytest.raises(_LayerError):
+        model(mx.array([[1, 2, 3]]), cache=model.make_cache(), return_hidden=True)
+
     assert model.model.norm is norm
     from omlx.patches.mlx_lm_mtp.gemma4_text_model import _active
 

--- a/tests/test_gemma4_text_mtp_runtime.py
+++ b/tests/test_gemma4_text_mtp_runtime.py
@@ -398,9 +398,9 @@ def test_align_does_not_read_the_head_when_picking_the_target():
 
 
 def _position(entries):
-    return gemma4_text_model._query_position(
-        SimpleNamespace(_omlx_mtp_cache_ref=entries)
-    )
+    from omlx.patches.mlx_lm_gemma4_assistant import query_position
+
+    return query_position(SimpleNamespace(_omlx_mtp_cache_ref=entries))
 
 
 def test_query_position_prefers_the_rotating_absolute_offset():

--- a/tests/test_gemma4_text_mtp_runtime.py
+++ b/tests/test_gemma4_text_mtp_runtime.py
@@ -1,0 +1,546 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for omlx.patches.mlx_lm_mtp.gemma4_text_model.
+
+Covers assistant-config retention through ``ModelArgs.from_dict``, head
+attach gating, the two outputs the head consumes from a backbone forward
+(per-layer-type K/V sink and the pre-norm hidden), head dtype alignment,
+``sanitize``'s strip-or-keep branch, and depth-k partial rollback across
+gemma4's mixed sliding/full cache classes.
+
+Tiny configs throughout — real modules, no checkpoint.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+
+pytest.importorskip("mlx_lm.models.gemma4_text")
+
+from omlx.patches import mlx_lm_mtp as lm_mtp  # noqa: E402
+from omlx.patches.mlx_lm_mtp import gemma4_text_model  # noqa: E402
+
+TINY_TEXT_CONFIG = {
+    "model_type": "gemma4_text",
+    "hidden_size": 24,
+    "num_hidden_layers": 4,
+    "intermediate_size": 32,
+    "num_attention_heads": 2,
+    "head_dim": 8,
+    "global_head_dim": 8,
+    "num_key_value_heads": 1,
+    "num_global_key_value_heads": 1,
+    "num_kv_shared_layers": 0,
+    "vocab_size": 64,
+    "sliding_window": 8,
+    "sliding_window_pattern": 2,
+    "attention_k_eq_v": True,
+    "hidden_size_per_layer_input": 0,
+    "use_double_wide_mlp": False,
+    "tie_word_embeddings": True,
+}
+
+TINY_ASSISTANT_CONFIG = {
+    "model_type": "gemma4_assistant",
+    "backbone_hidden_size": 24,
+    "tie_word_embeddings": True,
+    "use_ordered_embeddings": False,
+    "block_size": 4,
+    "text_config": {
+        "model_type": "gemma4_text",
+        "hidden_size": 16,
+        "num_hidden_layers": 2,
+        "intermediate_size": 32,
+        "num_attention_heads": 2,
+        "head_dim": 8,
+        "global_head_dim": 8,
+        "num_key_value_heads": 1,
+        "num_global_key_value_heads": 1,
+        "num_kv_shared_layers": 0,
+        "vocab_size": 64,
+        "sliding_window": 8,
+        "sliding_window_pattern": 2,
+        "attention_k_eq_v": True,
+        "hidden_size_per_layer_input": 0,
+        "use_double_wide_mlp": False,
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def _applied_patch():
+    if not gemma4_text_model.apply():
+        pytest.skip("mlx-lm gemma4 not importable")
+    depth = lm_mtp.get_mtp_depth()
+    lm_mtp.set_mtp_active(False)
+    yield
+    lm_mtp.set_mtp_active(False)
+    lm_mtp.set_mtp_depth(depth)
+
+
+def _args(extra: dict | None = None):
+    from mlx_lm.models.gemma4_text import ModelArgs
+
+    params = dict(TINY_TEXT_CONFIG)
+    if extra:
+        params.update(extra)
+    return ModelArgs.from_dict(params)
+
+
+def _inner(extra: dict | None = None):
+    from mlx_lm.models.gemma4_text import Model
+
+    return Model(_args(extra))
+
+
+def _outer(extra: dict | None = None):
+    from mlx_lm.models.gemma4 import Model, ModelArgs
+
+    text = dict(TINY_TEXT_CONFIG)
+    if extra:
+        text.update(extra)
+    return Model(
+        ModelArgs.from_dict(
+            {"model_type": "gemma4", "text_config": text, "vocab_size": 64}
+        )
+    )
+
+
+def _with_assistant():
+    return {"mtp_assistant_config": TINY_ASSISTANT_CONFIG}
+
+
+# ---------------------------------------------------------------------------
+# Patch application and config retention
+# ---------------------------------------------------------------------------
+
+
+def test_apply_is_idempotent():
+    assert gemma4_text_model.apply()
+    assert gemma4_text_model.apply()
+
+
+def test_model_args_retains_assistant_config():
+    # BaseModelArgs.from_dict keeps only dataclass fields, so the merged
+    # assistant config needs carrying past it or the head cannot be sized.
+    assert _args(_with_assistant()).mtp_assistant_config == TINY_ASSISTANT_CONFIG
+
+
+def test_model_args_without_assistant_config_has_no_attribute():
+    assert getattr(_args(), "mtp_assistant_config", None) is None
+
+
+# ---------------------------------------------------------------------------
+# Head attach gating
+# ---------------------------------------------------------------------------
+
+
+def test_no_attach_without_assistant_config():
+    lm_mtp.set_mtp_active(True)
+    model = _inner()
+    assert getattr(model, "mtp", None) is None
+    assert model._omlx_mtp_decode_enabled is False
+
+
+def test_no_attach_when_mtp_inactive():
+    # A merged checkpoint served with mtp_enabled=False keeps the stock
+    # text path, head weights and all.
+    model = _inner(_with_assistant())
+    assert getattr(model, "mtp", None) is None
+    assert model._omlx_mtp_decode_enabled is False
+
+
+def test_attach_and_chain_flags_when_active():
+    pytest.importorskip("mlx_vlm.speculative.drafters.gemma4_assistant")
+    lm_mtp.set_mtp_active(True)
+    lm_mtp.set_mtp_depth(3)
+    model = _inner(_with_assistant())
+    assert model.mtp is not None
+    assert model._omlx_mtp_decode_enabled is True
+    assert model._omlx_mtp_chain is True
+    assert model._omlx_mtp_depth == 3
+    # The head keeps no state of its own.
+    assert model.make_mtp_cache() == []
+
+
+# ---------------------------------------------------------------------------
+# What a backbone forward has to hand the head
+# ---------------------------------------------------------------------------
+
+
+def test_plain_forward_is_unchanged_shape():
+    model = _inner()
+    out = model(mx.array([[1, 2, 3]]), cache=model.make_cache())
+    assert out.shape == (1, 3, 64)
+
+
+def test_forward_populates_kv_sink_per_layer_type():
+    model = _inner()
+    sink: dict = {}
+    model(mx.array([[1, 2, 3]]), cache=model.make_cache(), shared_kv_sink=sink)
+    # sliding_window_pattern=2 over 4 layers gives both types.
+    assert sorted(sink) == ["full_attention", "sliding_attention"]
+    for keys, values in sink.values():
+        assert keys.shape == values.shape == (1, 1, 3, 8)
+
+
+def test_return_hidden_yields_pre_norm_hidden():
+    # batch_generator re-applies the trunk norm for any model that does not
+    # set _omlx_mtp_head_hidden_normed, so capturing post-norm would
+    # double-norm the head's input and show up only as weak acceptance.
+    model = _inner()
+    logits, hidden = model(
+        mx.array([[1, 2, 3]]), cache=model.make_cache(), return_hidden=True
+    )
+    assert logits.shape == (1, 3, 64)
+    assert hidden.shape == (1, 3, 24)
+    assert not mx.allclose(hidden, model.model.norm(hidden)).item()
+
+
+def test_kv_sink_is_cleared_between_forwards():
+    model = _inner()
+    ids = mx.array([[1, 2, 3]])
+    model(ids, cache=model.make_cache(), shared_kv_sink={})
+    # A forward that asks for neither must not write into a stale sink.
+    from omlx.patches.mlx_lm_mtp.gemma4_text_model import _active
+
+    assert getattr(_active, "sink", None) is None
+
+
+def test_trunk_norm_is_restored_when_the_forward_raises():
+    model = _inner()
+    norm = model.model.norm
+    with pytest.raises(Exception):
+        model(mx.array([[1, 2, 3]]), cache="not-a-cache", return_hidden=True)
+    assert model.model.norm is norm
+    from omlx.patches.mlx_lm_mtp.gemma4_text_model import _active
+
+    assert getattr(_active, "sink", None) is None
+
+
+# ---------------------------------------------------------------------------
+# Outer gemma4.Model wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_outer_forward_passes_through_without_mtp_kwargs():
+    model = _outer()
+    out = model(mx.array([[1, 2, 3]]), cache=model.make_cache())
+    assert out.shape == (1, 3, 64)
+
+
+def test_outer_forward_tolerates_falsy_mtp_kwargs():
+    # The engine passes return_hidden=False on ordinary steps; the stock
+    # gemma4.Model signature would reject the kwarg outright.
+    model = _outer()
+    out = model(
+        mx.array([[1, 2, 3]]),
+        cache=model.make_cache(),
+        return_hidden=False,
+        n_confirmed=0,
+    )
+    assert out.shape == (1, 3, 64)
+
+
+def test_outer_forward_reaches_the_inner_hidden_hook():
+    model = _outer()
+    logits, hidden = model(
+        mx.array([[1, 2, 3]]), cache=model.make_cache(), return_hidden=True
+    )
+    assert logits.shape == (1, 3, 64)
+    assert hidden.shape == (1, 3, 24)
+
+
+# ---------------------------------------------------------------------------
+# sanitize: strip the head when it has nowhere to bind, keep it when attached
+# ---------------------------------------------------------------------------
+
+
+def _head_and_backbone_weights():
+    return {
+        "model.language_model.mtp.pre_projection.weight": mx.zeros(
+            (4, 4), dtype=mx.bfloat16
+        ),
+        "model.language_model.model.embed_tokens.weight": mx.zeros(
+            (64, 24), dtype=mx.float16
+        ),
+    }
+
+
+def test_sanitize_strips_the_head_when_it_is_not_attached():
+    # The pre-existing behaviour for every plain gemma4 text quant: no
+    # binding site, so the merged head weights would be unexpected keys.
+    model = _outer()
+    assert getattr(model.language_model, "mtp", None) is None
+    out = model.sanitize(_head_and_backbone_weights())
+    assert not [k for k in out if ".mtp." in k]
+
+
+def test_sanitize_keeps_the_head_when_it_is_attached():
+    pytest.importorskip("mlx_vlm.speculative.drafters.gemma4_assistant")
+    lm_mtp.set_mtp_active(True)
+    model = _outer(_with_assistant())
+    assert model.language_model.mtp is not None
+    out = model.sanitize(_head_and_backbone_weights())
+    assert [k for k in out if ".mtp." in k]
+
+
+# ---------------------------------------------------------------------------
+# Head dtype alignment
+# ---------------------------------------------------------------------------
+
+
+def _align(weights):
+    return gemma4_text_model._align_head_dtype(weights)
+
+
+def test_align_casts_a_bfloat16_head_to_a_float16_backbone():
+    # The head ships bfloat16; against float16 activations MLX promotes to
+    # float32 and the head runs at twice the memory traffic it needs.
+    out = _align(
+        {
+            "model.embed_tokens.weight": mx.zeros((4, 4), dtype=mx.float16),
+            "language_model.mtp.pre_projection.weight": mx.zeros(
+                (4, 4), dtype=mx.bfloat16
+            ),
+        }
+    )
+    assert out["language_model.mtp.pre_projection.weight"].dtype == mx.float16
+
+
+def test_align_casts_a_float16_head_to_a_bfloat16_backbone():
+    out = _align(
+        {
+            "model.embed_tokens.weight": mx.zeros((4, 4), dtype=mx.bfloat16),
+            "language_model.mtp.pre_projection.weight": mx.zeros(
+                (4, 4), dtype=mx.float16
+            ),
+        }
+    )
+    assert out["language_model.mtp.pre_projection.weight"].dtype == mx.bfloat16
+
+
+def test_align_leaves_non_float_head_tensors_alone():
+    # Quantised weights and their packed scales/biases must survive intact.
+    weights = {
+        "model.embed_tokens.weight": mx.zeros((4, 4), dtype=mx.float16),
+        "language_model.mtp.q_proj.weight": mx.zeros((4, 4), dtype=mx.uint32),
+        "language_model.mtp.q_proj.scales": mx.zeros((4, 4), dtype=mx.bfloat16),
+        "language_model.mtp.layer_idx": mx.zeros((1,), dtype=mx.int32),
+    }
+    out = _align(weights)
+    assert out["language_model.mtp.q_proj.weight"].dtype == mx.uint32
+    assert out["language_model.mtp.layer_idx"].dtype == mx.int32
+    assert out["language_model.mtp.q_proj.scales"].dtype == mx.float16
+
+
+def test_align_is_a_noop_when_the_backbone_has_no_float_tensor():
+    weights = {
+        "model.embed_tokens.weight": mx.zeros((4, 4), dtype=mx.uint32),
+        "language_model.mtp.pre_projection.weight": mx.zeros(
+            (4, 4), dtype=mx.bfloat16
+        ),
+    }
+    out = _align(weights)
+    assert out["language_model.mtp.pre_projection.weight"].dtype == mx.bfloat16
+
+
+def test_align_does_not_read_the_head_when_picking_the_target():
+    # A head tensor appearing first must not become the target dtype.
+    out = _align(
+        {
+            "language_model.mtp.pre_projection.weight": mx.zeros(
+                (4, 4), dtype=mx.bfloat16
+            ),
+            "model.embed_tokens.weight": mx.zeros((4, 4), dtype=mx.float16),
+        }
+    )
+    assert out["language_model.mtp.pre_projection.weight"].dtype == mx.float16
+
+
+# ---------------------------------------------------------------------------
+# Query position
+# ---------------------------------------------------------------------------
+
+
+def _position(entries):
+    return gemma4_text_model._query_position(
+        SimpleNamespace(_omlx_mtp_cache_ref=entries)
+    )
+
+
+def test_query_position_prefers_the_rotating_absolute_offset():
+    # BatchRotatingKVCache._offset is the committed length; _idx is a ring
+    # index and offset may be a per-row array.
+    assert _position([SimpleNamespace(_offset=5, _idx=99, offset=mx.array([5]))]) == 5
+
+
+def test_query_position_falls_back_to_a_plain_int_offset():
+    assert _position([SimpleNamespace(offset=6)]) == 6
+
+
+def test_query_position_falls_back_to_the_batch_ring_index():
+    assert _position([SimpleNamespace(offset=mx.array([4]), _idx=4)]) == 4
+
+
+def test_query_position_raises_when_no_cache_carries_one():
+    with pytest.raises(RuntimeError, match="no cache offset"):
+        _position([SimpleNamespace()])
+
+
+# ---------------------------------------------------------------------------
+# mtp_forward preconditions
+# ---------------------------------------------------------------------------
+
+
+def test_mtp_forward_requires_a_prior_return_hidden_forward():
+    pytest.importorskip("mlx_vlm.speculative.drafters.gemma4_assistant")
+    lm_mtp.set_mtp_active(True)
+    model = _inner(_with_assistant())
+    model._omlx_mtp_shared_kv = None
+    with pytest.raises(RuntimeError, match="shared K/V stash"):
+        model.mtp_forward(mx.zeros((1, 1, 24)), mx.zeros((1, 1), dtype=mx.uint32), [])
+
+
+# ---------------------------------------------------------------------------
+# Depth-k partial rollback
+# ---------------------------------------------------------------------------
+
+
+class _FakeTrimmable:
+    def __init__(self, trimmable=True):
+        self._trimmable = trimmable
+        self.trimmed = 0
+
+    def is_trimmable(self):
+        return self._trimmable
+
+    def trim(self, n):
+        self.trimmed += n
+        return n
+
+
+def _rollback(caches, accepted, num_drafts):
+    from mlx_lm.models.gemma4_text import Model
+
+    return Model.mtp_partial_rollback(
+        SimpleNamespace(), caches, accepted, num_drafts
+    )
+
+
+def test_rollback_is_a_noop_when_every_draft_was_accepted():
+    caches = [_FakeTrimmable(), _FakeTrimmable()]
+    assert _rollback(caches, 3, 3) is True
+    assert all(c.trimmed == 0 for c in caches)
+
+
+def test_rollback_trims_the_rejected_tail_from_every_layer():
+    caches = [_FakeTrimmable(), _FakeTrimmable()]
+    assert _rollback(caches, 1, 3) is True
+    assert all(c.trimmed == 2 for c in caches)
+
+
+def test_rollback_refuses_rather_than_trimming_some_layers():
+    # A partial trim desynchronises per-layer KV lengths and is
+    # unrecoverable; the caller falls back to a standard step instead.
+    good_a, bad, good_b = _FakeTrimmable(), _FakeTrimmable(False), _FakeTrimmable()
+    assert _rollback([good_a, bad, good_b], 0, 2) is False
+    assert good_a.trimmed == 0
+    assert good_b.trimmed == 0
+
+
+def test_rollback_skips_none_cache_slots():
+    live = _FakeTrimmable()
+    assert _rollback([None, live, None], 0, 1) is True
+    assert live.trimmed == 1
+
+
+def test_rollback_refuses_an_empty_cache():
+    assert _rollback([None, None], 0, 1) is False
+
+
+class TestPartialRollbackAcrossCacheClasses:
+    """gemma4 interleaves sliding and full attention, so one verify block is
+    rolled back across two cache classes at once. Both must land on the same
+    committed length as a reference cache that only ever saw the confirmed
+    token plus the accepted drafts — otherwise the layers desynchronise by a
+    position and every later forward is quietly wrong."""
+
+    @staticmethod
+    def _fill(cache, n, dim=4):
+        for i in range(n):
+            k = mx.full((1, 1, 1, dim), float(i))
+            cache.update_and_fetch(k, k)
+
+    @pytest.mark.parametrize("accepted", [0, 1, 2, 3])
+    def test_mixed_cache_partial_accept_matches_a_reference(self, accepted):
+        from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+        from omlx.patches.mlx_lm_mtp import cache_rollback
+
+        cache_rollback.apply()
+        num_drafts = 3
+        verify_steps = num_drafts + 1
+
+        def build():
+            # max_size=8 with 12 tokens written: the ring has wrapped, so
+            # stock trim is impossible and the armed undo log is load-bearing.
+            caches = [RotatingKVCache(max_size=8), KVCache()]
+            for c in caches:
+                self._fill(c, 12)
+            return caches
+
+        caches = build()
+        reference = build()
+
+        verify = mx.broadcast_to(
+            mx.arange(100, 100 + verify_steps, dtype=mx.float32).reshape(
+                1, 1, verify_steps, 1
+            ),
+            (1, 1, verify_steps, 4),
+        )
+        cache_rollback.set_undo_armed(True)
+        try:
+            for c in caches:
+                c.update_and_fetch(verify, verify)
+        finally:
+            cache_rollback.set_undo_armed(False)
+
+        assert _rollback(caches, accepted, num_drafts) is True
+
+        # The reference only ever saw the confirmed token plus the accepted
+        # drafts: 1 + accepted of the verify block's verify_steps positions.
+        keep = 1 + accepted
+        for c in reference:
+            c.update_and_fetch(verify[..., :keep, :], verify[..., :keep, :])
+
+        nxt = mx.full((1, 1, 1, 4), 300.0)
+        for actual, wanted in zip(caches, reference):
+            ak, av = actual.update_and_fetch(nxt, nxt)
+            rk, rv = wanted.update_and_fetch(nxt, nxt)
+            mx.eval(ak, av, rk, rv)
+            assert mx.array_equal(ak, rk).item()
+            assert mx.array_equal(av, rv).item()
+            assert actual.offset == wanted.offset
+
+    def test_every_layer_lands_on_the_same_committed_length(self):
+        from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+        from omlx.patches.mlx_lm_mtp import cache_rollback
+
+        cache_rollback.apply()
+        caches = [RotatingKVCache(max_size=8), KVCache(), RotatingKVCache(max_size=8)]
+        for c in caches:
+            self._fill(c, 12)
+        verify = mx.zeros((1, 1, 4, 4))
+        cache_rollback.set_undo_armed(True)
+        try:
+            for c in caches:
+                c.update_and_fetch(verify, verify)
+        finally:
+            cache_rollback.set_undo_armed(False)
+
+        assert _rollback(caches, 1, 3) is True
+        assert len({c.offset for c in caches}) == 1

--- a/tests/test_gemma4_text_mtp_runtime.py
+++ b/tests/test_gemma4_text_mtp_runtime.py
@@ -270,7 +270,7 @@ def _head_and_backbone_weights():
 
 
 def test_sanitize_strips_the_head_when_it_is_not_attached():
-    # The pre-existing behaviour for every plain gemma4 text quant: no
+    # The pre-existing behavior for every plain gemma4 text quant: no
     # binding site, so the merged head weights would be unexpected keys.
     model = _outer()
     assert getattr(model.language_model, "mtp", None) is None
@@ -323,7 +323,7 @@ def test_align_casts_a_float16_head_to_a_bfloat16_backbone():
 
 
 def test_align_leaves_non_float_head_tensors_alone():
-    # Quantised weights and their packed scales/biases must survive intact.
+    # Quantized weights and their packed scales/biases must survive intact.
     weights = {
         "model.embed_tokens.weight": mx.zeros((4, 4), dtype=mx.float16),
         "language_model.mtp.q_proj.weight": mx.zeros((4, 4), dtype=mx.uint32),
@@ -345,6 +345,23 @@ def test_align_is_a_noop_when_the_backbone_has_no_float_tensor():
     }
     out = _align(weights)
     assert out["language_model.mtp.pre_projection.weight"].dtype == mx.bfloat16
+
+
+def test_align_targets_the_dtype_most_of_the_backbone_uses():
+    # A quantized checkpoint is mostly packed uint32 with float scales; one
+    # unrepresentative tensor early in dict order must not choose for the
+    # whole model.
+    weights = {
+        "model.layers.0.self_attn.q_proj.scales": mx.zeros((4, 4), dtype=mx.bfloat16),
+        "model.embed_tokens.weight": mx.zeros((4, 4), dtype=mx.float16),
+        "model.norm.weight": mx.zeros((4,), dtype=mx.float16),
+        "model.layers.0.input_layernorm.weight": mx.zeros((4,), dtype=mx.float16),
+        "language_model.mtp.pre_projection.weight": mx.zeros(
+            (4, 4), dtype=mx.bfloat16
+        ),
+    }
+    out = _align(weights)
+    assert out["language_model.mtp.pre_projection.weight"].dtype == mx.float16
 
 
 def test_align_does_not_read_the_head_when_picking_the_target():
@@ -404,6 +421,99 @@ def test_mtp_forward_requires_a_prior_return_hidden_forward():
         model.mtp_forward(mx.zeros((1, 1, 24)), mx.zeros((1, 1), dtype=mx.uint32), [])
 
 
+def _stubbed_head_model(captured, committed):
+    """Model with a stub drafter, a K/V stash and a cache at ``committed``.
+
+    ``captured`` is how many positions the verify forward put in the stash;
+    ``committed`` is where the cache sits once rollback has trimmed it.
+    """
+    from unittest.mock import MagicMock
+
+    pytest.importorskip("mlx_vlm.speculative.drafters.gemma4_assistant")
+    lm_mtp.set_mtp_active(True)
+    model = _inner(_with_assistant())
+
+    drafter = MagicMock()
+    drafter._input_embed = lambda ids: mx.zeros((1, 1, 24), dtype=mx.float32)
+    drafter._input_embed_scale = 1.0
+    drafter.return_value = (
+        mx.zeros((1, 1, 24), dtype=mx.float32),
+        mx.zeros((1, 1, 64), dtype=mx.float32),
+    )
+    model.mtp = drafter
+    model._omlx_mtp_shared_kv = {
+        "full_attention": (
+            mx.zeros((1, 1, captured, 8)),
+            mx.zeros((1, 1, captured, 8)),
+        ),
+        "sliding_attention": (
+            mx.zeros((1, 1, captured, 8)),
+            mx.zeros((1, 1, captured, 8)),
+        ),
+    }
+    model._omlx_mtp_kv_offset = captured
+    model._omlx_mtp_cache_ref = [SimpleNamespace(offset=committed)]
+    return model, drafter
+
+
+def _draft(model):
+    return model.mtp_forward(
+        mx.zeros((1, 3, 24)), mx.zeros((1, 3), dtype=mx.uint32), []
+    )
+
+
+class TestRejectedTailSlicing:
+    """The stash is taken at the verify forward, so after a rejection it still
+    carries the rejected rows. Rollback trims the backbone cache first, which
+    is what makes the stash longer than the committed length — the difference
+    is exactly what has to come off before the head drafts again. Getting this
+    wrong lets the head attend over K/V for tokens that were thrown away, and
+    shows up only as a weak acceptance rate."""
+
+    def test_the_rejected_tail_is_sliced_off_every_layer_type(self):
+        # Depth-3 verify captured 4 positions; 2 drafts rejected leaves 2.
+        model, drafter = _stubbed_head_model(captured=4, committed=2)
+        _draft(model)
+        _, shared_kv, _ = drafter.call_args.args
+        for keys, values in shared_kv.values():
+            assert keys.shape[-2] == 2
+            assert values.shape[-2] == 2
+
+    def test_a_full_accept_leaves_the_stash_alone(self):
+        model, drafter = _stubbed_head_model(captured=4, committed=4)
+        stash = model._omlx_mtp_shared_kv
+        _draft(model)
+        _, shared_kv, _ = drafter.call_args.args
+        assert shared_kv is stash
+        for keys, _values in shared_kv.values():
+            assert keys.shape[-2] == 4
+
+    def test_the_head_is_told_the_committed_length(self):
+        model, drafter = _stubbed_head_model(captured=4, committed=2)
+        _draft(model)
+        assert drafter._kv_valid_len == 2
+
+    def test_the_query_position_is_the_last_committed_slot(self):
+        model, drafter = _stubbed_head_model(captured=4, committed=2)
+        _draft(model)
+        _, _, position_ids = drafter.call_args.args
+        assert position_ids.tolist() == [[1]]
+
+    def test_only_the_last_hidden_and_token_are_consumed(self):
+        model, drafter = _stubbed_head_model(captured=4, committed=4)
+        _draft(model)
+        inputs_embeds = drafter.call_args.args[0]
+        # Fused input is [token embedding (24) | backbone hidden (24)].
+        assert inputs_embeds.shape == (1, 1, 48)
+
+    def test_a_stale_bind_is_refreshed_before_drafting(self):
+        # nn.quantize() swaps embed_tokens after the __init__-time bind; a
+        # stale bind drafts through a random-init embedding.
+        model, drafter = _stubbed_head_model(captured=2, committed=2)
+        _draft(model)
+        drafter.bind.assert_called_once_with(model)
+
+
 # ---------------------------------------------------------------------------
 # Depth-k partial rollback
 # ---------------------------------------------------------------------------
@@ -422,12 +532,13 @@ class _FakeTrimmable:
         return n
 
 
-def _rollback(caches, accepted, num_drafts):
+def _rollback(caches, accepted, num_drafts, layer_count=None):
     from mlx_lm.models.gemma4_text import Model
 
-    return Model.mtp_partial_rollback(
-        SimpleNamespace(), caches, accepted, num_drafts
-    )
+    if layer_count is None:
+        layer_count = len(caches)
+    host = SimpleNamespace(model=SimpleNamespace(layers=[object()] * layer_count))
+    return Model.mtp_partial_rollback(host, caches, accepted, num_drafts)
 
 
 def test_rollback_is_a_noop_when_every_draft_was_accepted():
@@ -443,7 +554,7 @@ def test_rollback_trims_the_rejected_tail_from_every_layer():
 
 
 def test_rollback_refuses_rather_than_trimming_some_layers():
-    # A partial trim desynchronises per-layer KV lengths and is
+    # A partial trim desynchronizes per-layer KV lengths and is
     # unrecoverable; the caller falls back to a standard step instead.
     good_a, bad, good_b = _FakeTrimmable(), _FakeTrimmable(False), _FakeTrimmable()
     assert _rollback([good_a, bad, good_b], 0, 2) is False
@@ -461,11 +572,19 @@ def test_rollback_refuses_an_empty_cache():
     assert _rollback([None, None], 0, 1) is False
 
 
+def test_rollback_refuses_a_cache_of_the_wrong_length():
+    # A stale cache list would otherwise trim whichever entries happen to be
+    # present and leave the rest a position ahead.
+    caches = [_FakeTrimmable(), _FakeTrimmable()]
+    assert _rollback(caches, 0, 1, layer_count=3) is False
+    assert all(c.trimmed == 0 for c in caches)
+
+
 class TestPartialRollbackAcrossCacheClasses:
     """gemma4 interleaves sliding and full attention, so one verify block is
     rolled back across two cache classes at once. Both must land on the same
     committed length as a reference cache that only ever saw the confirmed
-    token plus the accepted drafts — otherwise the layers desynchronise by a
+    token plus the accepted drafts — otherwise the layers desynchronize by a
     position and every later forward is quietly wrong."""
 
     @staticmethod

--- a/tests/test_gemma4_text_mtp_runtime.py
+++ b/tests/test_gemma4_text_mtp_runtime.py
@@ -547,13 +547,18 @@ class _FakeTrimmable:
         return n
 
 
-def _rollback(caches, accepted, num_drafts, layer_count=None):
+def _rollback(caches, accepted, num_drafts, layer_count=None, previous_kvs=None):
     from mlx_lm.models.gemma4_text import Model
 
+    gemma4_text_model.apply()
     if layer_count is None:
         layer_count = len(caches)
-    host = SimpleNamespace(model=SimpleNamespace(layers=[object()] * layer_count))
-    return Model.mtp_partial_rollback(host, caches, accepted, num_drafts)
+    inner = SimpleNamespace(layers=[object()] * layer_count)
+    if previous_kvs is not None:
+        inner.previous_kvs = previous_kvs
+    return Model.mtp_partial_rollback(
+        SimpleNamespace(model=inner), caches, accepted, num_drafts
+    )
 
 
 def test_rollback_is_a_noop_when_every_draft_was_accepted():
@@ -593,6 +598,39 @@ def test_rollback_refuses_a_cache_of_the_wrong_length():
     caches = [_FakeTrimmable(), _FakeTrimmable()]
     assert _rollback(caches, 0, 1, layer_count=3) is False
     assert all(c.trimmed == 0 for c in caches)
+
+
+def test_rollback_accepts_a_kv_shared_cache_shorter_than_the_layer_count():
+    # E2B shares the last 20 of 35 layers' K/V and E4B the last 18 of 42, so
+    # make_cache returns one entry per distinct owner, not per layer. Counting
+    # per layer refused every rollback on those checkpoints, and refused it
+    # silently: the caller rebuilds the cache and takes a standard step, so
+    # MTP stays switched on and simply stops paying for itself.
+    caches = [_FakeTrimmable(), _FakeTrimmable()]
+    assert _rollback(caches, 1, 3, layer_count=4, previous_kvs=[0, 1, 0, 1]) is True
+    assert all(c.trimmed == 2 for c in caches)
+
+
+def test_rollback_still_refuses_a_stale_cache_under_kv_sharing():
+    # The distinct-owner count is the invariant; "shorter than the layer
+    # count" on its own is not enough to accept.
+    caches = [_FakeTrimmable()]
+    assert _rollback(caches, 0, 1, layer_count=4, previous_kvs=[0, 1, 0, 1]) is False
+    assert caches[0].trimmed == 0
+
+
+def test_rollback_matches_the_backbones_own_cache_under_kv_sharing():
+    # End to end against a real backbone with sharing configured, driven by
+    # the cache its own make_cache builds -- the shape no local checkpoint
+    # has, since 12B/26B/31B all set num_kv_shared_layers = 0 and reduce KV
+    # with within-layer attention_k_eq_v instead.
+    gemma4_text_model.apply()
+    model = _inner({"num_kv_shared_layers": 2})
+    caches = model.make_cache()
+    assert len(caches) < len(model.model.layers)
+    fakes = [_FakeTrimmable() for _ in caches]
+    assert model.mtp_partial_rollback(fakes, 1, 3) is True
+    assert all(c.trimmed == 2 for c in fakes)
 
 
 class TestPartialRollbackAcrossCacheClasses:

--- a/tests/test_gemma4_verify_attention.py
+++ b/tests/test_gemma4_verify_attention.py
@@ -249,3 +249,101 @@ def test_kernel_route_matches_stock_logits(step_len):
 
     assert mx.allclose(got, ref, atol=2e-2, rtol=2e-2)
     assert mx.argmax(got[0, -1]).item() == mx.argmax(ref[0, -1]).item()
+
+
+# ---------------------------------------------------------------------------
+# The same routes on the mlx-lm engine
+# ---------------------------------------------------------------------------
+#
+# mlx-lm's gemma4_text.Attention takes the same (x, mask, cache, shared_kv,
+# offset) signature, carries the same attribute names and returns the same
+# (output, kv, offset) triple, so it is installed from the same code. These
+# repeat the load-bearing checks against that class rather than trusting the
+# shapes to have stayed aligned.
+
+
+def _lm_model(extra: dict | None = None):
+    from mlx_lm.models.gemma4_text import ModelArgs, Model
+
+    params = dict(TINY_TEXT_CONFIG)
+    if extra:
+        params.update(extra)
+    return Model(ModelArgs.from_dict(params))
+
+
+def _lm_run(model, prompt_len: int, step_len: int):
+    """Prefill then one step forward. mlx-lm returns logits directly."""
+    mx.random.seed(7)
+    tokens = mx.random.randint(0, 100, (1, prompt_len + step_len))
+    cache = model.make_cache()
+    mx.eval(model(tokens[:, :prompt_len], cache=cache))
+    result = model(tokens[:, prompt_len:], cache=cache)
+    mx.eval(result)
+    return result
+
+
+def _lm_count_single_token_updates(model, prompt_len: int, step_len: int) -> int:
+    mx.random.seed(7)
+    tokens = mx.random.randint(0, 100, (1, prompt_len + step_len))
+    cache = model.make_cache()
+    mx.eval(model(tokens[:, :prompt_len], cache=cache))
+
+    single = {"n": 0}
+    for c in cache:
+        original = c.update_and_fetch
+
+        def wrapper(k, v, _orig=original):
+            if k.shape[2] == 1:
+                single["n"] += 1
+            return _orig(k, v)
+
+        c.update_and_fetch = wrapper
+
+    mx.eval(model(tokens[:, prompt_len:], cache=cache))
+    return single["n"]
+
+
+def test_mlx_lm_apply_is_idempotent():
+    assert gemma4_verify_attention.apply_mlx_lm()
+    assert gemma4_verify_attention.apply_mlx_lm()
+
+
+@pytest.mark.parametrize("step_len", [2, 3])
+def test_mlx_lm_decomposed_matches_stock_logits(step_len):
+    # The port must not move the numbers. Same weights, same tokens, route
+    # on and route off -- a wrong port would show up here rather than as a
+    # quietly worse acceptance rate in a benchmark.
+    assert gemma4_verify_attention.apply_mlx_lm()
+    model = _lm_model()
+    got = _lm_run(model, prompt_len=24, step_len=step_len)
+
+    old_min = gemma4_verify_attention._MIN_L
+    gemma4_verify_attention._MIN_L = 99
+    try:
+        ref = _lm_run(model, prompt_len=24, step_len=step_len)
+    finally:
+        gemma4_verify_attention._MIN_L = old_min
+
+    assert mx.allclose(got, ref, atol=2e-2, rtol=2e-2)
+    assert mx.argmax(got[0, -1]).item() == mx.argmax(ref[0, -1]).item()
+
+
+def test_mlx_lm_kv_sharing_backbones_stay_on_stock_path():
+    # E2B/E4B again: a decomposed donor would hand downstream shared layers
+    # a final-token KV view they cannot causally slice.
+    assert gemma4_verify_attention.apply_mlx_lm()
+    model = _lm_model({"num_kv_shared_layers": 2})
+    assert _lm_count_single_token_updates(model, prompt_len=12, step_len=2) == 0
+
+
+def test_mlx_lm_l_gate_routes_only_small_steps():
+    assert gemma4_verify_attention.apply_mlx_lm()
+    model = _lm_model()
+    # head_dim 16 is not lane-splittable, so the fused kernel stays out and
+    # L=4 falls past the per-token ceiling to the stock chunked update.
+    assert _lm_count_single_token_updates(model, prompt_len=12, step_len=4) == 0
+    n_layers = len(model.make_cache())
+    assert (
+        _lm_count_single_token_updates(model, prompt_len=12, step_len=2)
+        == 2 * n_layers
+    )

--- a/tests/test_prefix_cache_gdn_split.py
+++ b/tests/test_prefix_cache_gdn_split.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """End-to-end tests for SSD-only GDN sidecars plus normal KV blocks."""
 
+import time
 from unittest.mock import MagicMock
 
 import mlx.core as mx
@@ -14,6 +15,26 @@ from omlx.scheduler import Scheduler, SchedulerConfig, _BoundarySnapshotProvider
 
 BLOCK_SIZE = 4
 LAYER_TYPES = ["KVCache", "ArraysCache"]
+
+
+def _drain_boundary_writes(store: BoundarySnapshotSSDStore) -> None:
+    """Wait for the store's writer thread to stage every queued snapshot.
+
+    ``save`` only enqueues -- a daemon thread performs the write -- so whatever
+    asks for the staged file next races it. That is
+    ``take_staged_file``, and therefore every split-GDN checkpoint commit: a
+    commit that loses the race returns False, the placeholder block is
+    rejected, and the store walks back to an earlier boundary. The symptom is
+    a store or restore that is short by exactly one block, on a machine slow
+    enough to lose. ``test_boundary_snapshot_store`` waits on the same
+    condition around its own saves.
+    """
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        if store.pending_bytes == 0:
+            return
+        time.sleep(0.01)
+    raise AssertionError("boundary snapshot writes did not drain")
 
 
 class _HybridModel:
@@ -121,6 +142,7 @@ def test_split_store_restores_one_sidecar_and_walks_back(tmp_path):
                 [MagicMock()],
                 lambda _snapshot, extracted=extracted: (extracted, None),
             )
+            _drain_boundary_writes(boundary)
 
         provider = _BoundarySnapshotProvider(
             boundary,
@@ -223,6 +245,7 @@ def test_split_store_restores_one_sidecar_and_walks_back(tmp_path):
                 [MagicMock()],
                 lambda _snapshot: (_hybrid_extracted(12, 12.0), None),
             )
+            _drain_boundary_writes(legacy_boundary)
             legacy_staged = legacy_boundary.take_staged_file(
                 "legacy-request", 12
             )
@@ -301,6 +324,7 @@ def test_split_store_commits_single_final_sidecar_outside_provider_index(tmp_pat
             [MagicMock()],
             lambda _snapshot: (extracted, None),
         )
+        _drain_boundary_writes(boundary)
         # Scheduler excludes the latest snapshot from the provider's mapping;
         # it is still staged and must be committed for the final block.
         provider = _BoundarySnapshotProvider(
@@ -369,6 +393,7 @@ def test_split_dedup_recreates_evicted_sidecar(tmp_path):
                 [MagicMock()],
                 lambda _snapshot, extracted=extracted: (extracted, None),
             )
+            _drain_boundary_writes(boundary)
         original_provider = _BoundarySnapshotProvider(
             boundary,
             "dedup-original",
@@ -399,6 +424,7 @@ def test_split_dedup_recreates_evicted_sidecar(tmp_path):
             [MagicMock()],
             lambda _snapshot: (replacement, None),
         )
+        _drain_boundary_writes(boundary)
         repair_provider = _BoundarySnapshotProvider(
             boundary,
             "dedup-repair",
@@ -464,6 +490,7 @@ def test_split_restore_walks_back_from_structurally_invalid_sidecar(tmp_path):
                 [MagicMock()],
                 lambda _snapshot, extracted=extracted: (extracted, None),
             )
+            _drain_boundary_writes(boundary)
 
         provider = _BoundarySnapshotProvider(
             boundary,
@@ -552,6 +579,7 @@ def test_split_store_rejects_placeholder_when_checkpoint_commit_fails(tmp_path):
             [MagicMock()],
             lambda _snapshot: (extracted, None),
         )
+        _drain_boundary_writes(boundary)
         provider = _BoundarySnapshotProvider(
             boundary,
             request_id,
@@ -721,6 +749,7 @@ def test_split_restore_retries_legacy_candidate_at_the_same_endpoint(tmp_path):
                 [MagicMock()],
                 lambda _snapshot, extracted=extracted: (extracted, None),
             )
+            _drain_boundary_writes(boundary)
         provider = _BoundarySnapshotProvider(
             boundary,
             request_id,
@@ -757,6 +786,7 @@ def test_split_restore_retries_legacy_candidate_at_the_same_endpoint(tmp_path):
             [MagicMock()],
             lambda _snapshot: (_hybrid_extracted(12, 12.0), None),
         )
+        _drain_boundary_writes(legacy_boundary)
         legacy_staged = legacy_boundary.take_staged_file("legacy-request", 12)
         assert legacy_staged is not None
         assert (
@@ -862,6 +892,7 @@ def test_split_restore_retry_budget_is_one_per_block(tmp_path):
                 [MagicMock()],
                 lambda _snapshot, extracted=extracted: (extracted, None),
             )
+            _drain_boundary_writes(boundary)
         provider = _BoundarySnapshotProvider(
             boundary,
             request_id,


### PR DESCRIPTION
A Gemma 4 merged-assistant checkpoint served through mlx-lm advertises MTP, accepts `mtp_enabled: true`, logs `Speculative backend selected: Lightning MTP` — and never drafts a token. This attaches the head on that path: **+28% decode** at short context, **+11.6%** at long context on a 31B oQ4 text-only quant.

## What is wrong

Google ships the Gemma 4 draft head as a separate `gemma4_assistant` model, which `oq.combine_gemma4_assistant_mtp` merges under `language_model.mtp.*`. The head only ever had a binding site on the mlx-vlm path.

`detect_model_type` returns `"vlm"` only when it finds a `vision_config`, `vit_config` or `mm_vision_tower`. A checkpoint with no vision tower therefore loads through mlx-lm's `gemma4` / `gemma4_text`, where `mlx_lm_mtp.gemma4_text_model` existed for one purpose: to strip `mtp.*` out of the weights so they would not fail as unexpected keys. Three ordinary things land there — a text-only quant, a DFlash target, and the VLM→LLM fallback.

Nothing reports it. `_is_mtp_compatible` accepts `gemma4`, so the patch is applied and the server logs its backend; then the engine looks for `.mtp`, does not find it, and decodes one token per forward for the life of the model.

## What this does

`gemma4_text.Model.__init__` builds the same `Gemma4AssistantDraftModel` the VLM path uses and binds it to the mlx-lm host. That is cheap because the drafter is not vision-coupled, mlx-lm's `gemma4_text` already implements Gemma 4's cross-layer K/V sharing, and `batch_generator`'s MTP machinery is model-agnostic.

What was missing is the two things the head consumes from a backbone forward, so the patch adds them rather than copying the layer loop:

- **K/V banks per layer type.** Each `DecoderLayer` already returns its `kvs`; wrapping the layer records them into a sink keyed by `layer_type`.
- **The pre-norm hidden.** Swapping the trunk `RMSNorm` for a recorder captures its input. It has to be pre-norm — `_trunk_norm_module` re-applies the trunk norm unless a model sets `_omlx_mtp_head_hidden_normed`, so a post-norm hidden would double-norm the head's input, silently, as a weak acceptance rate.

Then `mtp_partial_rollback` for depth-k. Gemma 4 is attention-only, so unlike the qwen35 sibling there is no recurrent state to restore and replay: every layer drops the rejected count, asked before any is trimmed because a half-rolled-back cache is unrecoverable. And `sanitize` aligns the head's dtype to the backbone's, because a bfloat16 head against float16 activations promotes every head matmul to float32. That is free: over 120 depth-1 steps on one checkpoint loaded twice, float16 and bfloat16 heads accepted the same 32 drafts, at 76ms against 152ms per step.

Gemma 4 alone needs mlx-vlm for the draft head, so that import lives in its own module reached from a gemma4-guarded branch — otherwise `cluster.autoconfigure` asks every rank serving any model to install mlx-vlm.

It is also why `mlx_vlm_mtp/gemma4_vlm_runtime.py` is in the diff: both engines drive the head identically, so `draft_step` is shared rather than copied — 29 fewer lines of code, and one implementation to fix instead of two.

A gemma4 text checkpoint with no merged head, and any checkpoint loaded with MTP off, behaves exactly as before.

## Before and after

M1 Max / 32 GB, mlx 0.32.2, mlx-lm 0.31.3, `gemma-4-31B-it-oQ4-fp16-mtp` (60 layers, hidden 5376, 50 sliding / 10 full, 4-bit g64, float16, 4-layer 1024-wide head).

| | short context | long context (2.7k prompt) |
|---|---|---|
| before | 15.03 tok/s | 14.93 tok/s |
| after, depth 1 | +5.3% | — |
| after, depth 3 | **+28.0%** | **+11.6%** |

Long context accepts 38/41 (92.7%) at 2.67 tokens per cycle with no rollback rejections. The gain is smaller there because a 4-token verify costs more when attention spans 2,700 positions; the head itself is 2.8% of decode (`backbone=3260.8ms mtp=92.6ms`).

Two notes on method: long-context figures difference two token counts on the same prompt, because whole-request timing is mostly prefill and reads only +3.3%; and every figure is a median of within-block ratios from interleaved arms, because on a contended host the unchanged baseline arm moved 15.3 → 12.6 tok/s between blocks.

## Reproducing

Any Gemma 4 checkpoint with the assistant head merged and no vision tower — `text_config.mtp_assistant_config` in `config.json` plus `language_model.mtp.*` in the safetensors index.

```python
from omlx.patches.mlx_lm_mtp import set_mtp_active
from omlx.utils.model_loading import maybe_apply_pre_load_patches

class S: mtp_enabled = True; trust_remote_code = False

set_mtp_active(True)
maybe_apply_pre_load_patches(MODEL, model_settings=S())

from mlx_lm.utils import load
model, _ = load(MODEL)
inner = getattr(model, "language_model", model)
print(getattr(inner, "mtp", None) is not None, hasattr(model, "mtp_forward"))
```

`False False` before, `True True` after — with no warning anywhere in the load. Serving it, the engine's MTP telemetry line is absent before and reports the accept rate after.

## Tests

`tests/test_gemma4_text_mtp_runtime.py` — tiny real modules, no checkpoint, following the VLM-side runtime test. Covers attach gating, both backbone outputs, dtype alignment, `sanitize`'s two branches, and the rejected-tail slicing.

Both engines were also driven live on a merged checkpoint, including a deliberately low-acceptance prompt. At 100% acceptance the rejected-tail slicing never runs at all, so a clean full-accept run proves less than it looks like it does.

The load-bearing one is depth-k rollback across Gemma 4's mixed cache classes: sliding layers get `RotatingKVCache` and full layers `KVCache`, so one verify block rolls back through two mechanisms — a wrapped ring restores its armed undo snapshot and replays, a plain cache moves its offset. Both must land on the same committed length or the layers desynchronize by a position. The parametrized test walks every accept count against a reference cache that only saw the confirmed token plus the accepted drafts.

## One note

`model_loading` sets `set_mtp_depth(8)` for gemma4, citing a 26B code workload. That only ever reached the VLM path; this change makes it reachable for text checkpoints. I could not separate depth 8 from depth 3 here — three interleaved blocks gave 0.995 / 1.188 / 1.043, well inside the noise — so the default stays untouched.
