### PR TITLE
fix(mac): display advertised physical memory capacity

### DIFF
--- a/apps/omlx-mac/Sources/AppView/Screens/StatusScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/StatusScreen.swift
@@ -489,8 +489,8 @@ private struct SystemRamTrailing: View {
         guard let used = metrics.ramUsedBytes,
               let total = metrics.ramTotalBytes
         else { return "—" }
-        let u = SystemMetricsPoller.formatBytesAsGB(used)
-        let t = SystemMetricsPoller.formatBytesAsGB(total)
+        let u = SystemMetricsPoller.formatBytesAsGiB(used)
+        let t = SystemMetricsPoller.formatBytesAsGiB(total)
         return "\(u) / \(t) GB"
     }
 }

--- a/apps/omlx-mac/Sources/AppView/Utils/SystemMetricsPoller.swift
+++ b/apps/omlx-mac/Sources/AppView/Utils/SystemMetricsPoller.swift
@@ -127,4 +127,10 @@ final class SystemMetricsPoller {
         let gb = Double(bytes) / 1_000_000_000.0
         return String(format: "%.1f", gb)
     }
+
+    /// Format binary memory units for the macOS system-memory panel.
+    nonisolated static func formatBytesAsGiB(_ bytes: UInt64) -> String {
+        let gib = Double(bytes) / 1_073_741_824.0
+        return String(format: "%.1f", gib)
+    }
 }

--- a/apps/omlx-mac/Sources/Menubar/SystemStatsPanels.swift
+++ b/apps/omlx-mac/Sources/Menubar/SystemStatsPanels.swift
@@ -156,7 +156,7 @@ struct MemoryStatsPanel: View {
                 comment: "Title of the Memory panel in the System Stats submenu"
             ))
             HStack {
-                Text("\(SystemMetricsPoller.formatBytesAsGB(memory.usedBytes)) / \(StatsFormat.wholeGB(memory.totalBytes)) GB")
+                Text("\(SystemMetricsPoller.formatBytesAsGiB(memory.usedBytes)) / \(StatsFormat.wholeGiB(memory.totalBytes)) GB")
                     .font(.omlxMono(12, weight: .semibold))
                     .foregroundStyle(theme.text)
                 Spacer()
@@ -207,7 +207,7 @@ struct MemoryStatsPanel: View {
                 .font(.omlxText(11.5))
                 .foregroundStyle(theme.textSecondary)
             Spacer()
-            Text(SystemStatsSampler.formatBytes(bytes))
+            Text(SystemMetricsPoller.formatBytesAsGiB(bytes) + " GB")
                 .font(.omlxMono(11.5))
                 .foregroundStyle(theme.text)
         }
@@ -388,9 +388,9 @@ enum StatsFormat {
         return "\(Int((min(1, max(0, fraction)) * 100).rounded()))%"
     }
 
-    /// 512_000_000_000 → "512" (whole decimal GB for machine totals)
-    static func wholeGB(_ bytes: UInt64) -> String {
-        "\(Int((Double(bytes) / 1_000_000_000).rounded()))"
+    /// 51_539_607_552 → "48" (whole binary GiB for physical memory totals)
+    static func wholeGiB(_ bytes: UInt64) -> String {
+        "\(Int((Double(bytes) / 1_073_741_824).rounded()))"
     }
 
     /// History window caption: 60 samples at 1 s → "60s"; at 0.5 s → "30s".

--- a/apps/omlx-mac/Tests/oMLXTests/SystemMetricsTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/SystemMetricsTests.swift
@@ -82,7 +82,7 @@ final class SystemMetricsTests: XCTestCase {
         XCTAssertEqual(vm.gpuUtilizationPercent, 0.0, accuracy: 0.001)
     }
 
-    // MARK: - Bytes → GB formatter
+    // MARK: - Byte formatters
 
     func testFormatBytesAsGbRoundsToOneDecimal() {
         // 34.6 GB in decimal bytes = 34_600_000_000.
@@ -96,6 +96,7 @@ final class SystemMetricsTests: XCTestCase {
 
     func testFormatBytesAsGibUsesBinaryUnits() {
         XCTAssertEqual(SystemMetricsPoller.formatBytesAsGiB(51_539_607_552), "48.0")
+        XCTAssertEqual(SystemMetricsPoller.formatBytesAsGiB(2_684_354_560), "2.5")
     }
 
     func testFormatBytesAsGbRoundsHalfUp() {

--- a/apps/omlx-mac/Tests/oMLXTests/SystemMetricsTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/SystemMetricsTests.swift
@@ -94,6 +94,10 @@ final class SystemMetricsTests: XCTestCase {
         XCTAssertEqual(SystemMetricsPoller.formatBytesAsGB(0), "0.0")
     }
 
+    func testFormatBytesAsGibUsesBinaryUnits() {
+        XCTAssertEqual(SystemMetricsPoller.formatBytesAsGiB(51_539_607_552), "48.0")
+    }
+
     func testFormatBytesAsGbRoundsHalfUp() {
         // 12.55 GB → "12.5" (banker's) or "12.6" (away). printf %.1f on
         // Darwin rounds half to even at the binary level — pin whichever

--- a/apps/omlx-mac/Tests/oMLXTests/SystemStatsTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/SystemStatsTests.swift
@@ -156,7 +156,7 @@ final class SystemStatsTests: XCTestCase {
         XCTAssertEqual(StatsFormat.percent(nil), "–")
         XCTAssertEqual(StatsFormat.percent(0.153), "15%")
         XCTAssertEqual(StatsFormat.percent(1.7), "100%", "fractions clamp to 100%")
-        XCTAssertEqual(StatsFormat.wholeGB(512_000_000_000), "512")
+        XCTAssertEqual(StatsFormat.wholeGiB(51_539_607_552), "48")
         XCTAssertEqual(StatsFormat.window(sampleCount: 60, interval: 1.0), "60s")
         XCTAssertEqual(StatsFormat.window(sampleCount: 60, interval: 0.5), "30s")
         XCTAssertEqual(StatsFormat.window(sampleCount: 0, interval: 1.0), "")

--- a/apps/omlx-mac/Tests/oMLXTests/SystemStatsTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/SystemStatsTests.swift
@@ -157,6 +157,7 @@ final class SystemStatsTests: XCTestCase {
         XCTAssertEqual(StatsFormat.percent(0.153), "15%")
         XCTAssertEqual(StatsFormat.percent(1.7), "100%", "fractions clamp to 100%")
         XCTAssertEqual(StatsFormat.wholeGiB(51_539_607_552), "48")
+        XCTAssertEqual(StatsFormat.wholeGiB(2_684_354_560), "3")
         XCTAssertEqual(StatsFormat.window(sampleCount: 60, interval: 1.0), "60s")
         XCTAssertEqual(StatsFormat.window(sampleCount: 60, interval: 0.5), "30s")
         XCTAssertEqual(StatsFormat.window(sampleCount: 0, interval: 1.0), "")


### PR DESCRIPTION
Fixes #3538.

Use binary units for physical memory and the panel usage rows so advertised capacity and component values use the same scale.

Validation: xcodebuild -project apps/omlx-mac/oMLX.xcodeproj -scheme oMLX -destination platform=macOS test — 310 passed, 1 opt-in integration test skipped.