### PR TITLE
test(engine_pool): rename the shadowing TestEnginePoolStatus class (3 tests never collected)

### DIFF
--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -2666,7 +2666,7 @@ class TestEnginePoolPrefillEviction:
         assert f"phys_footprint={released_gb:.2f}GB" in decisions[1]
 
 
-class TestEnginePoolStatus:
+class TestEnginePoolStatusIsLoading:
     """Tests for get_status is_loading field."""
 
     def test_get_status_includes_is_loading(self, small_mock_model_dir):


### PR DESCRIPTION
### Problem

`tests/test_engine_pool.py` defines `class TestEnginePoolStatus` **twice**:

| line | docstring | tests |
|---|---|---|
| 432 | `"""Tests for EnginePool status reporting."""` | `test_get_status`, `test_get_model_ids`, `test_get_loaded_model_ids_empty` |
| 2669 | `"""Tests for get_status is_loading field."""` | `test_get_status_includes_is_loading` |

The second binding replaces the first in the module namespace, so pytest never sees the class at line 432. **Three tests have silently stopped being collected** — `get_status()`'s ceiling/memory/count/pinned reporting, `get_model_ids()`, and `get_loaded_model_ids()` are currently untested.

Collecting the two class skeletons exactly as they appear in the file:

```
$ pytest --collect-only -q       # as on main
test_dup_demo.py::TestEnginePoolStatus::test_get_status_includes_is_loading
1 test collected

$ pytest --collect-only -q       # with the second class renamed
test_fixed_demo.py::TestEnginePoolStatus::test_get_status
test_fixed_demo.py::TestEnginePoolStatus::test_get_model_ids
test_fixed_demo.py::TestEnginePoolStatus::test_get_loaded_model_ids_empty
test_fixed_demo.py::TestEnginePoolStatusIsLoading::test_get_status_includes_is_loading
4 tests collected
```

`pyflakes` flags it as `redefinition of unused 'TestEnginePoolStatus' from line 432`.

### Fix

Rename the later class to `TestEnginePoolStatusIsLoading`, matching its own docstring. No test body is touched; the three shadowed tests simply become collectable again.

### On the restored tests

I don't have Apple silicon, so I could not execute them — `omlx.engine_pool` imports `mlx.core`. I checked their assertions against `omlx/engine_pool.py` on `main` instead:

- `get_status()` (L3169) returns `final_ceiling`, `current_model_memory`, `model_count`, `loaded_count`, and a `models` list whose entries carry `id`, `loaded` and `pinned` — every key the restored `test_get_status` asserts on.
- `discover_models(dirs, pinned_models=[...])` (L787) sets `is_pinned` from `pinned_set`, which is what `model_a_status["pinned"] is True` checks.
- `get_model_ids` (L899) and `get_loaded_model_ids` (L903) both exist.
- The `small_mock_model_dir` fixture creates exactly `model-a` and `model-b`, matching `model_count == 2`.
- `test_get_status_includes_is_loading` — the test that *is* currently collected — drives the same `_make_pool` → `discover_models` → `get_status` path and passes in CI today.

If CI disagrees on any of the three, I'm happy to adjust them in this PR rather than leave them shadowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
