### PR TITLE
fix(server): reject /v1/embeddings responses that contain non-finite vectors

### DIFF
--- a/omlx/api/embedding_utils.py
+++ b/omlx/api/embedding_utils.py
@@ -11,7 +11,7 @@ Provides:
 import base64
 import math
 import struct
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Sequence, Union
 
 from .embedding_models import EmbeddingInputItem
 
@@ -30,6 +30,31 @@ def encode_embedding_base64(embedding: List[float]) -> str:
     """
     packed = struct.pack(f"<{len(embedding)}f", *embedding)
     return base64.b64encode(packed).decode("ascii")
+
+
+def find_non_finite_embeddings(embeddings: Sequence[Sequence[float]]) -> List[int]:
+    """
+    Return the indices of embeddings that contain NaN or infinite values.
+
+    A model that overflows in its attention mask (see modernbert in
+    mlx-embeddings) can hand back NaN vectors for some items of a padded
+    batch. Those must not be serialized as a successful response: JSON has
+    no NaN, so the client would receive ``null``-filled vectors with a 200.
+
+    Args:
+        embeddings: One vector per input item.
+
+    Returns:
+        Indices of the items whose vector is not entirely finite.
+    """
+    bad: List[int] = []
+    for index, embedding in enumerate(embeddings):
+        try:
+            if not all(math.isfinite(float(value)) for value in embedding):
+                bad.append(index)
+        except (TypeError, ValueError):
+            bad.append(index)
+    return bad
 
 
 def truncate_embedding(embedding: List[float], dimensions: int) -> List[float]:

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -94,6 +94,7 @@ from .api.embedding_models import (
 )
 from .api.embedding_utils import (
     encode_embedding_base64,
+    find_non_finite_embeddings,
     normalize_embedding_items,
     normalize_input,
     truncate_embedding,
@@ -3442,6 +3443,26 @@ async def create_embeddings(
 
         elapsed = time.perf_counter() - start_time
         resolved_model = resolve_model_id(request.model) or request.model
+
+        # A NaN/Inf vector has no JSON representation: FastAPI would ship it
+        # as null-filled arrays inside a 200, and a RAG pipeline stores the
+        # corrupt vectors without noticing. Fail the request instead.
+        non_finite = find_non_finite_embeddings(output.embeddings)
+        if non_finite:
+            logger.error(
+                f"Embedding: model={resolved_model} returned non-finite values "
+                f"for input item(s) {non_finite} of {len(embedding_inputs)}"
+            )
+            raise HTTPException(
+                status_code=500,
+                detail=(
+                    "Embedding model returned non-finite (NaN/Inf) values for "
+                    f"input item(s) {non_finite}. The response was rejected "
+                    "instead of returning null vectors; try sending the affected "
+                    "inputs one per request or batching inputs of equal length."
+                ),
+            )
+
         logger.info(
             f"Embedding: model={resolved_model}, "
             f"{len(embedding_inputs)} inputs, {output.dimensions} dims, "

--- a/tests/test_embeddings_non_finite.py
+++ b/tests/test_embeddings_non_finite.py
@@ -1,0 +1,86 @@
+"""/v1/embeddings must not answer 200 with null-filled vectors (#3507)."""
+
+from __future__ import annotations
+
+import math
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from omlx.api.embedding_utils import find_non_finite_embeddings
+from omlx.models.embedding import EmbeddingOutput
+from omlx.server import ServerState, app
+
+
+def test_find_non_finite_embeddings_reports_bad_items_only():
+    embeddings = [
+        [0.1, 0.2],
+        [math.nan, 0.3],
+        [0.4, math.inf],
+        [-math.inf, 0.0],
+        [0.5, 0.6],
+    ]
+    assert find_non_finite_embeddings(embeddings) == [1, 2, 3]
+    assert find_non_finite_embeddings([[0.1], [0.2]]) == []
+    assert find_non_finite_embeddings([]) == []
+
+
+def test_find_non_finite_embeddings_accepts_array_like_rows():
+    class _Row:
+        def __init__(self, values):
+            self._values = values
+
+        def __iter__(self):
+            return iter(self._values)
+
+    assert find_non_finite_embeddings([_Row([1.0, 2.0]), _Row([math.nan])]) == [1]
+
+
+def _post_embeddings(embeddings: list[list[float]]):
+    engine = MagicMock()
+    engine.embed = AsyncMock(
+        return_value=EmbeddingOutput(
+            embeddings=embeddings,
+            total_tokens=len(embeddings) * 2,
+            dimensions=len(embeddings[0]) if embeddings else 0,
+        )
+    )
+
+    @asynccontextmanager
+    async def _acquire(_model):
+        yield engine
+
+    state = ServerState()
+    with (
+        patch("omlx.server._server_state", state),
+        patch("omlx.server.get_embedding_engine", AsyncMock(return_value=engine)),
+        patch("omlx.server.acquire_embedding_engine", _acquire),
+        patch("omlx.server.get_embedding_max_length", return_value=512),
+        patch("omlx.server.resolve_model_id", return_value="emb"),
+        patch("omlx.server.get_server_metrics", return_value=MagicMock()),
+    ):
+        client = TestClient(app, raise_server_exceptions=False)
+        return client.post(
+            "/v1/embeddings",
+            json={"model": "emb", "input": ["short", "a much longer input"]},
+        )
+
+
+def test_embeddings_endpoint_rejects_non_finite_vectors():
+    response = _post_embeddings([[0.1, 0.2], [math.nan, math.nan]])
+
+    assert response.status_code == 500
+    body = response.json()
+    # API routes answer with the OpenAI-style error envelope.
+    message = body["error"]["message"] if "error" in body else body["detail"]
+    assert "non-finite" in message
+    assert "[1]" in message
+
+
+def test_embeddings_endpoint_returns_finite_vectors():
+    response = _post_embeddings([[0.1, 0.2], [0.3, 0.4]])
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert [item["embedding"] for item in data] == [[0.1, 0.2], [0.3, 0.4]]


### PR DESCRIPTION
Refs #3507 (the first of the two things oMLX can do independently of the upstream mlx-embeddings fix).

## Problem

When the embedding model returns NaN/Inf values (ModernBERT through the pinned `mlx-embeddings` revision on padded batches whose longest item is a multiple of 32 ≥ 128, per the issue), `/v1/embeddings` answered **HTTP 200** with the vectors serialized as `null`-filled arrays. JSON has no NaN, so the client saw a normal-looking response and a RAG pipeline stored corrupt vectors without noticing.

## Change

- `omlx/api/embedding_utils.py`: new `find_non_finite_embeddings(embeddings) -> list[int]` returning the indices of vectors that are not entirely finite (a row that cannot be converted to floats counts as bad).
- `omlx/server.py` (`create_embeddings._build_embeddings`): after `engine.embed(...)`, if any vector is non-finite the request fails with a **500** whose detail names the affected item indices and suggests sending those inputs one per request or batching inputs of equal length. The failure is logged with the model id and the indices. Finite results are unchanged.

Bumping the `mlx-embeddings` pin once Blaizzy/mlx-embeddings#80 lands is left for a separate change.

## Tests

`tests/test_embeddings_non_finite.py`:
- unit tests for `find_non_finite_embeddings` (NaN, +Inf, -Inf rows, array-like rows, empty input);
- endpoint test through `TestClient` with a mocked embedding engine: a batch with one NaN vector returns 500 and the OpenAI-style error message names item `[1]`; an all-finite batch still returns 200 with the vectors. The endpoint test fails on `main` (it gets a 200 with `null` entries) and passes with the change.

`pytest tests/test_embeddings_non_finite.py` (4 passed), `ruff check` on the changed files; `black --diff` reports nothing in the new code (the remaining diff in `embedding_utils.py` / `server.py` is pre-existing formatting).
