### PR TITLE
fix(cli): keep the configured Claude tiers when the launcher picks a model interactively

### DIFF
--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -497,15 +497,12 @@ def launch_command(args, extra_args: list[str] | None = None):
         print(f"Install: {integration.install_hint}")
         sys.exit(1)
 
-    # If the model was chosen interactively (no --model and no explicit tier flags),
-    # use the picked model for all tiers instead of letting settings-based tier
-    # models override the user's selection.
-    if args.model is None and not (
-        cli_opus_model or cli_sonnet_model or cli_haiku_model
-    ):
-        opus_model = None
-        sonnet_model = None
-        haiku_model = None
+    # Tier precedence: explicit tier flag > saved claude_code tier setting >
+    # the model picked (or auto-selected) above. The picker only chooses the
+    # default model; tiers configured on the Claude Code settings page keep
+    # their role, otherwise the three persisted selections would be silently
+    # replaced by one model on every interactive launch (#3543). Roles without
+    # a saved model fall back to the picked model in the integration.
 
     # Enforce Claude Code's model requirements after all interactive,
     # automatic, and explicit model paths have resolved. The picker also marks

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -753,8 +753,8 @@ class TestLaunchCommandFunction:
         assert "Using model: only-32k" in output
         assert "Cannot launch Claude Code with model 'only-32k'" in output
 
-    def test_launch_command_shows_picker_and_clears_saved_tiers(self):
-        """Bare `omlx launch claude` shows the picker and ignores saved tier models."""
+    def test_launch_command_shows_picker_and_keeps_saved_tiers(self):
+        """Bare `omlx launch claude` shows the picker for the default model and keeps the saved tier models (#3543)."""
         from omlx.cli import launch_command
 
         integration = MagicMock()
@@ -813,9 +813,9 @@ class TestLaunchCommandFunction:
         integration.select_model.assert_called_once()
         ctx = integration.launch.call_args.args[0]
         assert ctx.model == "sonnet-local"
-        assert ctx.opus_model is None
-        assert ctx.sonnet_model is None
-        assert ctx.haiku_model is None
+        assert ctx.opus_model == "opus-local"
+        assert ctx.sonnet_model == "sonnet-local"
+        assert ctx.haiku_model == "haiku-local"
         assert ctx.api_key == "saved-key"
 
     def test_launch_command_claude_cli_tiers_override_saved_settings(self):
@@ -1353,3 +1353,114 @@ class TestCLIDocstrings:
         assert (
             "multi-model" in result.stdout.lower() or "server" in result.stdout.lower()
         )
+
+
+class TestLaunchClaudeTierPrecedence:
+    def _run(
+        self, *, args_model, settings_tiers, cli_tiers=None, picked="picked-model"
+    ):
+        from omlx.cli import launch_command
+
+        integration = MagicMock()
+        integration.display_name = "Claude Code"
+        integration.is_installed.return_value = True
+        integration.select_model.return_value = picked
+
+        health_response = MagicMock()
+        health_response.raise_for_status.return_value = None
+        status_response = MagicMock()
+        status_response.ok = True
+        status_response.json.return_value = {
+            "models": [
+                {"id": m, "max_context_window": 131072}
+                for m in (
+                    "picked-model",
+                    "other-model",
+                    "opus-cfg",
+                    "sonnet-cfg",
+                    "haiku-cfg",
+                    "opus-flag",
+                )
+            ]
+        }
+
+        # Third request: the interactive path lists /v1/models before the picker.
+        models_response = MagicMock()
+        models_response.raise_for_status.return_value = None
+        models_response.json.return_value = {
+            "data": [
+                {"id": m["id"], "model_type": "llm"}
+                for m in status_response.json.return_value["models"]
+            ]
+        }
+
+        settings = SimpleNamespace(
+            server=SimpleNamespace(host="127.0.0.1", port=8000),
+            auth=SimpleNamespace(api_key="saved-key"),
+            claude_code=SimpleNamespace(**settings_tiers),
+        )
+        cli_tiers = cli_tiers or {}
+        args = argparse.Namespace(
+            tool="claude",
+            host=None,
+            port=None,
+            api_key=None,
+            model=args_model,
+            tools_profile="coding",
+            opus_model=cli_tiers.get("opus_model"),
+            sonnet_model=cli_tiers.get("sonnet_model"),
+            haiku_model=cli_tiers.get("haiku_model"),
+        )
+        with (
+            patch(
+                "requests.get",
+                side_effect=[health_response, status_response, models_response],
+            ),
+            patch("omlx.integrations.get_integration", return_value=integration),
+            patch("omlx.settings.GlobalSettings.load", return_value=settings),
+        ):
+            launch_command(args)
+        integration.launch.assert_called_once()
+        return integration.launch.call_args.args[0]
+
+    def test_interactive_pick_keeps_saved_tier_models(self):
+        """The picker chooses the default model; the persisted tiers keep their roles (#3543)."""
+        ctx = self._run(
+            args_model=None,
+            settings_tiers={
+                "opus_model": "opus-cfg",
+                "sonnet_model": "sonnet-cfg",
+                "haiku_model": "haiku-cfg",
+            },
+        )
+        assert ctx.model == "picked-model"
+        assert (ctx.opus_model, ctx.sonnet_model, ctx.haiku_model) == (
+            "opus-cfg",
+            "sonnet-cfg",
+            "haiku-cfg",
+        )
+
+    def test_explicit_tier_flag_overrides_saved_setting(self):
+        ctx = self._run(
+            args_model="picked-model",
+            settings_tiers={
+                "opus_model": "opus-cfg",
+                "sonnet_model": "sonnet-cfg",
+                "haiku_model": "haiku-cfg",
+            },
+            cli_tiers={"opus_model": "opus-flag"},
+        )
+        assert ctx.opus_model == "opus-flag"
+        assert (ctx.sonnet_model, ctx.haiku_model) == ("sonnet-cfg", "haiku-cfg")
+
+    def test_without_saved_tiers_the_picked_model_is_used(self):
+        ctx = self._run(
+            args_model=None,
+            settings_tiers={
+                "opus_model": None,
+                "sonnet_model": None,
+                "haiku_model": None,
+            },
+        )
+        assert ctx.model == "picked-model"
+        assert (ctx.opus_model, ctx.sonnet_model, ctx.haiku_model) == (None, None, None)


### PR DESCRIPTION
Fixes #3543

## Problem

With `claude_code.mode = "local"` and three tier models saved on the Claude Code settings page, `omlx launch claude` (no `--model`, no tier flags) shows the picker and then uses the picked model for the Opus, Sonnet and Haiku roles: `launch_command()` read the saved tiers first and then deliberately cleared all three after the interactive selection, so `ClaudeCodeIntegration.launch()` fell back to `ctx.model` for every role. The persisted per-tier selections were never honored on the default interactive launch path, which makes the settings page misleading.

## Change

- `omlx/cli.py`: the tier values are no longer cleared after an interactive pick. Precedence is now `explicit tier flag > saved claude_code tier setting > picked model`; the picker chooses the default model only, and a role without a saved model still falls back to the picked model in the integration (unchanged).
- Tests (`tests/test_cli.py`): new `TestLaunchClaudeTierPrecedence` covers the interactive pick with saved tiers (fails on `main`), an explicit tier flag overriding a saved tier, and the no-saved-tiers case. The existing `test_launch_command_shows_picker_and_clears_saved_tiers` encoded the old behavior; it is renamed to `..._keeps_saved_tiers` with the assertions updated.

## Note for reviewers

That existing test shows the clearing was intentional ("shows the picker and ignores saved tier models"), so this is a behavior change rather than a plain bug fix. The argument from #3543 is that the picker is about the default model, while the three saved tiers are configured explicitly for their roles and should win over an incidental picker choice; explicit flags still override everything. If you would rather keep the old semantics (for example, only when the picked model is not one of the saved tiers), I am happy to adjust.

`pytest tests/test_cli.py`: 72 passed; `black` on the test file; `ruff check` reports only pre-existing findings.
