### PR TITLE
fix(memory): schedule a retry when emergency abort/unload does not drain

### DIFF
--- a/omlx/process_memory_enforcer.py
+++ b/omlx/process_memory_enforcer.py
@@ -1639,9 +1639,17 @@ class ProcessMemoryEnforcer:
                                 "hard memory pressure",
                                 abort_requested=True,
                             )
-                            await self._engine_pool._unload_pending_if_idle_locked(
-                                busy_victim
+                            unloaded = (
+                                await self._engine_pool._unload_pending_if_idle_locked(
+                                    busy_victim
+                                )
                             )
+                            if not unloaded:
+                                # Not drained yet: schedule the poller, mirroring
+                                # request_unload's own fallback, or the latch never clears.
+                                self._engine_pool._schedule_pending_unload_locked(
+                                    busy_victim
+                                )
                         logger.warning(
                             "Hard memory pressure: requested abort/unload for "
                             "'%s' (aborted=%d)",

--- a/tests/test_process_memory_enforcer.py
+++ b/tests/test_process_memory_enforcer.py
@@ -229,6 +229,10 @@ def mock_engine_pool():
     pool._mark_pending_unload_locked = MagicMock(
         side_effect=_mark_pending_unload_locked
     )
+    pool._scheduled_pending_unloads = []
+    pool._schedule_pending_unload_locked = MagicMock(
+        side_effect=pool._scheduled_pending_unloads.append
+    )
     return pool
 
 
@@ -1523,6 +1527,36 @@ class TestSingleModelMemoryPressure:
         entry.in_use = 0
         await enforcer._engine_pool._unload_pending_if_idle_locked("big-model")
         enforcer._engine_pool._unload_engine.assert_awaited_once_with("big-model")
+
+    @pytest.mark.asyncio
+    async def test_single_busy_model_schedules_retry_when_still_busy_after_abort(
+        self, enforcer
+    ):
+        """The pending-unload latch must not depend on a later manual drain check.
+
+        _check_and_enforce()'s while loop is not revisited once pressure recovers
+        to "ok" (an earlier branch returns before reaching it), so if the busy
+        victim has not drained by the time this tick's single inline
+        _unload_pending_if_idle_locked call runs, nothing else will ever retry it.
+        """
+        engine = MagicMock()
+        engine.has_active_requests.return_value = False
+        engine.abort_all_requests = AsyncMock(return_value=3)
+        entry = _make_entry("big-model", engine=engine)
+        entry.in_use = 1
+        enforcer._engine_pool._entries = {"big-model": entry}
+        enforcer._engine_pool._find_lru_victim.return_value = None
+
+        with patch("omlx.process_memory_enforcer.mx") as mock_mx:
+            mock_mx.get_active_memory.side_effect = _cycling(
+                [13 * 1024**3, 13 * 1024**3]
+            )
+            await enforcer._check_and_enforce()
+
+        assert entry.pending_unload_reason == "hard memory pressure"
+        enforcer._engine_pool._schedule_pending_unload_locked.assert_called_once_with(
+            "big-model"
+        )
 
     @pytest.mark.asyncio
     async def test_two_models_one_inferring_evicts_idle(self, enforcer):


### PR DESCRIPTION
When `_check_and_enforce`'s emergency branch aborts the last busy non-pinned model, it marks `pending_unload_reason` and makes one inline `_unload_pending_if_idle_locked` call. If the abort hasn't drained by then, that call returns `False` and nothing retries it: the `while` loop it sits in is never reached again once pressure recovers to "ok" (an earlier branch returns before that point on the next tick). The latch stays set forever, and every later request against that model raises `ModelBusyError`.

The manual unload path (`EnginePool.request_unload`) hits the same "not idle yet" case and falls back to `_schedule_pending_unload_locked`, which spawns `_wait_for_pending_unload` to poll until the entry drains. The emergency path never had that fallback. Added it: schedule the poller when the inline attempt doesn't unload immediately.

Added `test_single_busy_model_schedules_retry_when_still_busy_after_abort`, mirroring the existing `test_single_busy_model_pending_unload_at_emergency_pressure` fixture: it asserts `_schedule_pending_unload_locked` gets called once the busy victim is still busy after the abort. Without the fix it's never called.

Couldn't run the real suite here, `mlx` needs Apple Silicon. Ran `tests/test_process_memory_enforcer.py` (165 passed) against a build with `mlx`/`mlx_lm`/`mlx_vlm` and `omlx.engine` stubbed down to the two symbols this file actually touches (`BaseNonStreamingEngine`, `TTSEngine`), so it's this file's own logic under test, not the neighboring stubs.

Fixes #3363