### PR TITLE
fix(vlm): derive Gemma4 global KV head fields from per_layer_config

### DIFF
--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -766,6 +766,111 @@ def _is_mlx_format_safetensors_dir(model_dir: Path) -> bool:
     return isinstance(metadata, dict) and metadata.get("format") == "mlx"
 
 
+def _gemma4_global_kv_from_per_layer_config(config: dict) -> dict[str, int]:
+    """Derive Gemma4's legacy full-attention head fields from ``per_layer_config``.
+
+    Newer Gemma4 checkpoints (Transformers >= 5.15) record the ``head_dim`` /
+    ``num_key_value_heads`` overrides of the full-attention layers under
+    ``text_config.per_layer_config`` instead of the legacy global
+    ``global_head_dim`` / ``num_global_key_value_heads`` fields. The pinned
+    mlx-vlm Gemma4 loader reads only the legacy fields, so it sizes the
+    full-attention K/V projections with the sliding-window head count and
+    ``load_weights`` fails with a shape mismatch (#3537).
+
+    Returns the legacy fields that are absent from ``text_config`` and can be
+    derived unambiguously (every overridden full-attention layer agrees), or
+    an empty dict.
+    """
+    text_config = config.get("text_config")
+    if not isinstance(text_config, dict):
+        return {}
+    model_type = str(text_config.get("model_type") or config.get("model_type") or "")
+    if not model_type.startswith("gemma4"):
+        return {}
+    per_layer = text_config.get("per_layer_config")
+    if not isinstance(per_layer, dict) or not per_layer:
+        return {}
+    layer_types = text_config.get("layer_types")
+    if not isinstance(layer_types, list):
+        layer_types = None
+
+    derived: dict[str, int] = {}
+    for legacy_key, layer_key in (
+        ("global_head_dim", "head_dim"),
+        ("num_global_key_value_heads", "num_key_value_heads"),
+    ):
+        if text_config.get(legacy_key) is not None:
+            continue
+        values: set[int] = set()
+        for layer_id, overrides in per_layer.items():
+            if not isinstance(overrides, dict) or overrides.get(layer_key) is None:
+                continue
+            if layer_types is not None:
+                try:
+                    layer_idx = int(layer_id)
+                except (TypeError, ValueError):
+                    continue
+                if not 0 <= layer_idx < len(layer_types):
+                    continue
+                if layer_types[layer_idx] != "full_attention":
+                    continue
+            try:
+                values.add(int(overrides[layer_key]))
+            except (TypeError, ValueError):
+                continue
+        if len(values) == 1:
+            derived[legacy_key] = values.pop()
+    return derived
+
+
+@contextlib.contextmanager
+def _derive_gemma4_global_kv_on_load(model_dir: Path):
+    """Feed ``per_layer_config``-only Gemma4 head overrides to the mlx-vlm loader.
+
+    Wraps ``mlx_vlm.utils.load_config`` for one ``vlm_load(...)`` so the
+    config handed to the Gemma4 ``TextConfig`` carries ``global_head_dim`` /
+    ``num_global_key_value_heads`` derived from ``per_layer_config`` when the
+    checkpoint does not spell them out (#3537). Checkpoints that already
+    carry the legacy fields, and non-Gemma4 models, are untouched.
+    """
+    config_path = model_dir / "config.json"
+    try:
+        config = json.loads(config_path.read_text())
+    except Exception:
+        yield
+        return
+    derived = (
+        _gemma4_global_kv_from_per_layer_config(config)
+        if isinstance(config, dict)
+        else {}
+    )
+    if not derived:
+        yield
+        return
+
+    import mlx_vlm.utils as _vu
+
+    original_load_config = _vu.load_config
+
+    def _patched_load_config(model_path, **kwargs):
+        loaded = original_load_config(model_path, **kwargs)
+        text_config = loaded.get("text_config") if isinstance(loaded, dict) else None
+        if isinstance(text_config, dict):
+            for key, value in derived.items():
+                text_config.setdefault(key, value)
+        return loaded
+
+    logger.info(
+        "derive_gemma4_global_kv_on_load: per_layer_config -> %s",
+        ", ".join(f"{k}={v}" for k, v in derived.items()),
+    )
+    _vu.load_config = _patched_load_config
+    try:
+        yield
+    finally:
+        _vu.load_config = original_load_config
+
+
 @contextlib.contextmanager
 def _drop_gemma4_mlx_shared_kv_extras_on_load(model_dir: Path):
     """Drop Gemma4 shared-KV extra weights for MLX-format VLM checkpoints.
@@ -1696,6 +1801,7 @@ class VLMBatchedEngine(BaseEngine):
             with (
                 _strip_audio_config_if_orphaned(Path(self._model_name)),
                 _drop_gemma4_mlx_shared_kv_extras_on_load(Path(self._model_name)),
+                _derive_gemma4_global_kv_on_load(Path(self._model_name)),
                 _force_minimax_m3_moe_sanitize_on_load(Path(self._model_name)),
                 _force_qwen4_exp_sanitize_on_load(Path(self._model_name)),
                 _remap_nested_visual_on_load(Path(self._model_name)),

--- a/tests/test_gemma4_per_layer_config.py
+++ b/tests/test_gemma4_per_layer_config.py
@@ -1,0 +1,171 @@
+"""Gemma4 checkpoints that keep the full-attention head overrides in
+``text_config.per_layer_config`` instead of the legacy global fields (#3537)."""
+
+import copy
+import json
+from pathlib import Path
+
+import mlx_vlm.utils as mlx_vlm_utils
+import pytest
+
+from omlx.engine.vlm import (
+    _derive_gemma4_global_kv_on_load,
+    _gemma4_global_kv_from_per_layer_config,
+)
+
+FULL_ATTENTION_LAYERS = (5, 11, 17, 23, 29)
+
+
+def _config(**text_overrides) -> dict:
+    layer_types = ["sliding_attention"] * 30
+    for idx in FULL_ATTENTION_LAYERS:
+        layer_types[idx] = "full_attention"
+    text_config = {
+        "model_type": "gemma4_text",
+        "num_hidden_layers": 30,
+        "head_dim": 256,
+        "num_key_value_heads": 8,
+        "layer_types": layer_types,
+        "per_layer_config": {
+            f"{idx:02d}": {"head_dim": 512, "num_key_value_heads": 2}
+            for idx in FULL_ATTENTION_LAYERS
+        },
+    }
+    text_config.update(text_overrides)
+    return {"model_type": "gemma4", "text_config": text_config}
+
+
+def _write_model_dir(tmp_path: Path, name: str, config: dict) -> Path:
+    model_dir = tmp_path / name
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text(json.dumps(config))
+    return model_dir
+
+
+def test_derives_legacy_global_fields_from_per_layer_config():
+    assert _gemma4_global_kv_from_per_layer_config(_config()) == {
+        "global_head_dim": 512,
+        "num_global_key_value_heads": 2,
+    }
+
+
+def test_explicit_legacy_fields_win():
+    assert _gemma4_global_kv_from_per_layer_config(_config(global_head_dim=512)) == {
+        "num_global_key_value_heads": 2,
+    }
+    assert (
+        _gemma4_global_kv_from_per_layer_config(
+            _config(global_head_dim=512, num_global_key_value_heads=2)
+        )
+        == {}
+    )
+
+
+def test_only_full_attention_overrides_count():
+    config = _config()
+    config["text_config"]["per_layer_config"]["00"] = {
+        "head_dim": 128,
+        "num_key_value_heads": 4,
+    }
+    assert _gemma4_global_kv_from_per_layer_config(config) == {
+        "global_head_dim": 512,
+        "num_global_key_value_heads": 2,
+    }
+
+
+def test_without_layer_types_every_override_counts():
+    config = _config()
+    del config["text_config"]["layer_types"]
+    assert _gemma4_global_kv_from_per_layer_config(config) == {
+        "global_head_dim": 512,
+        "num_global_key_value_heads": 2,
+    }
+
+
+def test_disagreeing_overrides_are_not_derived():
+    config = _config()
+    config["text_config"]["per_layer_config"]["11"]["num_key_value_heads"] = 4
+    assert _gemma4_global_kv_from_per_layer_config(config) == {"global_head_dim": 512}
+
+
+def test_non_gemma4_and_missing_per_layer_config_are_ignored():
+    config = _config()
+    config["model_type"] = "qwen3_vl"
+    config["text_config"]["model_type"] = "qwen3_vl_text"
+    assert _gemma4_global_kv_from_per_layer_config(config) == {}
+
+    config = _config()
+    del config["text_config"]["per_layer_config"]
+    assert _gemma4_global_kv_from_per_layer_config(config) == {}
+
+    assert _gemma4_global_kv_from_per_layer_config({"model_type": "gemma4"}) == {}
+
+
+def test_on_load_hands_derived_fields_to_the_loader(tmp_path, monkeypatch):
+    config = _config()
+    model_dir = _write_model_dir(tmp_path, "model", config)
+    seen = []
+
+    def fake_load_config(model_path, **kwargs):
+        seen.append((model_path, kwargs))
+        return copy.deepcopy(config)
+
+    monkeypatch.setattr(mlx_vlm_utils, "load_config", fake_load_config)
+
+    with _derive_gemma4_global_kv_on_load(model_dir):
+        assert mlx_vlm_utils.load_config is not fake_load_config
+        loaded = mlx_vlm_utils.load_config(model_dir, trust_remote_code=True)
+
+    text_config = loaded["text_config"]
+    assert text_config["global_head_dim"] == 512
+    assert text_config["num_global_key_value_heads"] == 2
+    # The source layout stays in place; only the missing legacy fields are added.
+    assert text_config["per_layer_config"] == config["text_config"]["per_layer_config"]
+    assert text_config["head_dim"] == 256
+    assert text_config["num_key_value_heads"] == 8
+    assert seen == [(model_dir, {"trust_remote_code": True})]
+    # The wrapper is removed again once loading is over.
+    assert mlx_vlm_utils.load_config is fake_load_config
+
+
+def test_on_load_keeps_explicit_legacy_fields(tmp_path, monkeypatch):
+    config = _config(global_head_dim=512, num_global_key_value_heads=4)
+    model_dir = _write_model_dir(tmp_path, "model", config)
+    monkeypatch.setattr(
+        mlx_vlm_utils, "load_config", lambda model_path, **kw: copy.deepcopy(config)
+    )
+
+    with _derive_gemma4_global_kv_on_load(model_dir):
+        loaded = mlx_vlm_utils.load_config(model_dir)
+
+    assert loaded["text_config"]["num_global_key_value_heads"] == 4
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        _config(global_head_dim=512, num_global_key_value_heads=2),
+        {"model_type": "qwen3_vl", "text_config": {"per_layer_config": {"0": {}}}},
+        {"model_type": "gemma4", "text_config": {"head_dim": 256}},
+    ],
+)
+def test_on_load_is_a_noop_without_anything_to_derive(tmp_path, monkeypatch, config):
+    model_dir = _write_model_dir(tmp_path, "model", config)
+
+    def fake_load_config(model_path, **kwargs):
+        return {"text_config": {}}
+
+    monkeypatch.setattr(mlx_vlm_utils, "load_config", fake_load_config)
+
+    with _derive_gemma4_global_kv_on_load(model_dir):
+        assert mlx_vlm_utils.load_config is fake_load_config
+
+
+def test_on_load_tolerates_a_missing_config(tmp_path, monkeypatch):
+    def fake_load_config(model_path, **kwargs):
+        return {"text_config": {}}
+
+    monkeypatch.setattr(mlx_vlm_utils, "load_config", fake_load_config)
+
+    with _derive_gemma4_global_kv_on_load(tmp_path / "missing"):
+        assert mlx_vlm_utils.load_config is fake_load_config


### PR DESCRIPTION
## Summary

Fixes #3537.

Gemma4 checkpoints written by Transformers ≥ 5.15 record the `head_dim` / `num_key_value_heads` overrides of the full-attention layers under `text_config.per_layer_config` instead of the legacy `global_head_dim` / `num_global_key_value_heads` fields. The pinned mlx-vlm Gemma4 loader reads only the legacy fields, so it sizes the full-attention K/V projections with the sliding-window head count and `load_weights` fails with `Expected (4096, 440) received (1024, 440)`.

## Change

`omlx/engine/vlm.py`

- `_gemma4_global_kv_from_per_layer_config(config)` derives the legacy fields that are missing from `text_config` when every overridden full-attention layer agrees (`layer_types` decides which layers count; without it every override counts). Explicit legacy fields always win; non-Gemma4 configs, missing `per_layer_config` and disagreeing overrides yield nothing.
- `_derive_gemma4_global_kv_on_load(model_dir)` follows the existing `*_on_load` pattern: for one `vlm_load(...)` it wraps `mlx_vlm.utils.load_config` and `setdefault`s the derived fields into `text_config`, so the pinned loader's `TextConfig` sees `global_head_dim=512` / `num_global_key_value_heads=2` for the checkpoint from the issue. The source layout (`per_layer_config`) stays in place; checkpoints that already carry the legacy fields are untouched.
- Added to the VLM load context stack next to `_drop_gemma4_mlx_shared_kv_extras_on_load`.

This mirrors the workaround confirmed in the issue (adding the two fields to `text_config`) without editing the checkpoint.

## Tests

`tests/test_gemma4_per_layer_config.py` (12 tests): derivation from the issue's config, explicit fields win, only full-attention layers count, no `layer_types`, disagreeing overrides, non-Gemma4 / missing `per_layer_config`; the `_on_load` wrapper hands the derived fields to a stubbed `mlx_vlm.utils.load_config`, keeps explicit fields, is a no-op when there is nothing to derive, tolerates a missing `config.json`, and restores the original function afterwards.

`ruff check` / `ruff format --check` are clean for the added code (the pre-existing findings in `vlm.py` are unchanged).
