### PR TITLE
fix(grammar): size the VLM grammar bitmask from text_config.vocab_size

### DIFF
--- a/omlx/utils/tokenizer.py
+++ b/omlx/utils/tokenizer.py
@@ -44,11 +44,24 @@ def unwrap_tokenizer(tokenizer):
     return tokenizer
 
 
+def _positive_int(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return None
+    return value
+
+
 def resolve_vocab_size(model: Any) -> int | None:
     """Extract vocab_size from a model's config/args, handling nested configs.
 
-    Tries ``model.config.vocab_size``, then ``model.args.vocab_size``,
-    then ``text_config.vocab_size`` for VLM composite models (e.g. Qwen3.5).
+    For a composite (VLM) config the nested ``text_config.vocab_size`` wins
+    over the top-level ``vocab_size``: the language model's embedding and
+    ``lm_head`` are sized from the text config, while the top-level field
+    is often a dataclass placeholder that the checkpoint's ``config.json``
+    never sets (mlx-vlm's Qwen3-VL ``ModelConfig`` defaults it to 32000
+    against a 151936-token text vocabulary). Sizing the grammar bitmask
+    from that placeholder misaligns the mask with the logits, and every
+    sampled token is rejected until ``max_tokens`` (#3550). Falls back to
+    ``model.config.vocab_size`` / ``model.args.vocab_size`` for plain LLMs.
 
     Args:
         model: An MLX model object (LLM, VLM, or any object with config/args).
@@ -62,15 +75,17 @@ def resolve_vocab_size(model: Any) -> int | None:
         config = getattr(model, attr, None)
         if config is None:
             continue
-        vs = getattr(config, "vocab_size", None)
-        if isinstance(vs, int):
-            return vs
         text_cfg = getattr(config, "text_config", None)
         if isinstance(text_cfg, dict):
-            vs = text_cfg.get("vocab_size")
+            nested = _positive_int(text_cfg.get("vocab_size"))
         elif text_cfg is not None:
-            vs = getattr(text_cfg, "vocab_size", None)
-        if isinstance(vs, int):
+            nested = _positive_int(getattr(text_cfg, "vocab_size", None))
+        else:
+            nested = None
+        if nested is not None:
+            return nested
+        vs = _positive_int(getattr(config, "vocab_size", None))
+        if vs is not None:
             return vs
     return None
 

--- a/tests/test_resolve_vocab_size.py
+++ b/tests/test_resolve_vocab_size.py
@@ -1,0 +1,65 @@
+"""resolve_vocab_size must size the grammar bitmask from the language model's
+vocabulary. A composite (VLM) config's top-level ``vocab_size`` is often a
+dataclass placeholder the checkpoint never sets (mlx-vlm's Qwen3-VL
+``ModelConfig`` defaults it to 32000 while ``text_config.vocab_size`` is
+151936); sizing the mask from it misaligned mask and logits, so structured
+output on the VLM engine rejected every sampled token until max_tokens
+(#3550)."""
+
+from types import SimpleNamespace
+
+from omlx.utils.tokenizer import resolve_vocab_size
+
+
+def test_nested_text_config_wins_over_top_level_placeholder():
+    config = SimpleNamespace(
+        vocab_size=32000,  # mlx-vlm ModelConfig default, not from config.json
+        text_config=SimpleNamespace(vocab_size=151936),
+    )
+    assert resolve_vocab_size(SimpleNamespace(config=config)) == 151936
+
+
+def test_nested_text_config_as_dict():
+    config = SimpleNamespace(vocab_size=32000, text_config={"vocab_size": 151936})
+    assert resolve_vocab_size(SimpleNamespace(config=config)) == 151936
+
+
+def test_top_level_vocab_size_for_plain_llm():
+    assert (
+        resolve_vocab_size(SimpleNamespace(config=SimpleNamespace(vocab_size=151936)))
+        == 151936
+    )
+
+
+def test_top_level_vocab_size_when_text_config_has_none():
+    config = SimpleNamespace(
+        vocab_size=257152, text_config=SimpleNamespace(hidden_size=16)
+    )
+    assert resolve_vocab_size(SimpleNamespace(config=config)) == 257152
+
+
+def test_args_fallback_when_config_is_missing():
+    model = SimpleNamespace(args=SimpleNamespace(vocab_size=32064))
+    assert resolve_vocab_size(model) == 32064
+
+
+def test_config_takes_precedence_over_args():
+    model = SimpleNamespace(
+        config=SimpleNamespace(text_config={"vocab_size": 151936}),
+        args=SimpleNamespace(vocab_size=32000),
+    )
+    assert resolve_vocab_size(model) == 151936
+
+
+def test_unusable_values_are_skipped():
+    assert resolve_vocab_size(None) is None
+    assert resolve_vocab_size(SimpleNamespace()) is None
+    assert (
+        resolve_vocab_size(SimpleNamespace(config=SimpleNamespace(vocab_size=None)))
+        is None
+    )
+    # zero, negative and bool placeholders are not vocabulary sizes
+    config = SimpleNamespace(vocab_size=0, text_config={"vocab_size": True})
+    assert resolve_vocab_size(SimpleNamespace(config=config)) is None
+    config = SimpleNamespace(vocab_size=-1, text_config={"vocab_size": 0})
+    assert resolve_vocab_size(SimpleNamespace(config=config)) is None


### PR DESCRIPTION
## Summary

Fixes #3550.

Structured output (`response_format: json_schema`) on `VLMBatchedEngine` looped to `max_tokens` with `GrammarMatcher rejected token 0` on every step, while the same request on `BatchedEngine` worked.

## Root cause

`resolve_vocab_size` (used by `create_grammar_compiler` for the xgrammar `TokenizerInfo` and by the scheduler for the `GrammarConstraintProcessor` bitmask width) read the top-level `config.vocab_size` first and only fell back to `text_config.vocab_size`. For a composite VLM config the top-level field is frequently a dataclass placeholder the checkpoint never sets: mlx-vlm's Qwen3-VL `ModelConfig` (and Qwen2.5-VL, LLaVA) defaults it to **32000**, and `Qwen/Qwen3-VL-8B-Instruct`'s `config.json` only carries `text_config.vocab_size = 151936`. So on the VLM path the tokenizer info and the bitmask were sized for 32000 tokens against 151936 logits, the mask and the logits were misaligned, and the matcher rejected every sampled token, which is exactly the reporter's hypothesis.

## Change

`omlx/utils/tokenizer.py`: `resolve_vocab_size` prefers the nested `text_config.vocab_size` (dict or object) when present and falls back to the top-level `config.vocab_size` / `args.vocab_size` otherwise; non-positive and bool placeholders are skipped. The text engine path is unchanged (plain LLM configs have no `text_config`).

## Tests

`tests/test_resolve_vocab_size.py`: nested wins over the 32000 placeholder (object and dict forms), plain LLM top-level, top-level when `text_config` has no `vocab_size` (e.g. Gemma 3), `args` fallback, `config` over `args`, and unusable values. Three cases fail on `main`.

`pytest tests/test_resolve_vocab_size.py tests/test_utils_tokenizer.py tests/test_grammar.py` → all green; `ruff check` / `ruff format --check` clean.

I could not run a VLM checkpoint end to end here, so the reproduction is the config-level one (mlx-vlm `ModelConfig.vocab_size` default vs the checkpoint's `text_config.vocab_size`).
