### PR TITLE
perf(qwen4): batch warmed native QSA prefill queries

### DIFF
--- a/benchmarks/bench_qwen4_qsa_prefill_tiles.py
+++ b/benchmarks/bench_qwen4_qsa_prefill_tiles.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Compare complete QSA prefill at 256-query and automatic native tile widths.
+
+Run from the repository root with PYTHONPATH=. and the native glm_moe_dsa
+extension built against the installed MLX version; no model weights are needed.
+This measures one attention call, not whole-model prompt processing or decode.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import statistics
+import time
+
+import mlx.core as mx
+
+from omlx.custom_kernels.glm_moe_dsa import fast
+from omlx.patches import mlx_vlm_qwen4_exp_compat as compat
+
+compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+from mlx_vlm.models.qwen4_exp import qsa_fast  # noqa: E402
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--key-tokens", type=int, default=65536)
+    parser.add_argument("--query-tokens", type=int, default=2048)
+    parser.add_argument("--repetitions", type=int, default=12)
+    args = parser.parse_args()
+    if args.query_tokens < 1024 or args.key_tokens <= args.query_tokens + 2048:
+        parser.error(
+            "use at least 1024 queries and more than 2048 cached prefix tokens"
+        )
+    if args.repetitions < 2:
+        parser.error("at least two repetitions are required")
+    if not fast.is_native_available() or not all(
+        fast.has_symbol(name)
+        for name in (
+            "qwen4_qsa_indexer_scores",
+            "qwen4_qsa_topk_indices",
+            "qwen4_qsa_sparse_gqa_attention",
+        )
+    ):
+        parser.error("build the native glm_moe_dsa extension first")
+    mx.random.seed(81)
+    rows, tokens = args.query_tokens, args.key_tokens
+    inputs = (
+        (mx.random.normal((1, 24, rows, 256)) * 0.1).astype(mx.bfloat16),
+        (mx.random.normal((1, 2, tokens, 256)) * 0.1).astype(mx.bfloat16),
+        (mx.random.normal((1, 2, tokens, 256)) * 0.1).astype(mx.bfloat16),
+        (mx.random.normal((1, rows, 4, 128)) * 0.1).astype(mx.bfloat16),
+        (mx.random.normal((1, tokens, 128)) * 0.1).astype(mx.bfloat16),
+        mx.arange(tokens)[None],
+    )
+    kwargs = dict(
+        num_query_heads=24,
+        num_key_value_heads=2,
+        head_dim=256,
+        indexer_head_dim=128,
+        compress_ratio=4,
+        token_budget=2048,
+        index_key_norm=lambda x: x,
+        apply_index_rope=lambda x, p: x,
+    )
+    kwargs["pooled_index_keys"] = qsa_fast.pool_completed_index_keys(
+        inputs[4],
+        inputs[5],
+        compress_ratio=4,
+        index_key_norm=kwargs["index_key_norm"],
+        apply_index_rope=kwargs["apply_index_rope"],
+    )
+    mx.eval(inputs, kwargs["pooled_index_keys"])
+
+    def call(mode):
+        return qsa_fast.contiguous_causal_gathered_qsa(
+            *inputs, query_chunk=256 if mode == "control" else None, **kwargs
+        )
+
+    expected = call("control")
+    mx.eval(expected)
+    assert all(
+        getattr(qsa_fast, f"_NATIVE_QSA_{stage}_PROVEN")
+        for stage in ("MAIN", "SCORE", "TOPK")
+    )
+    widths = []
+    original = qsa_fast._native_sparse_gqa_attention
+
+    def record(q, *a, **kw):
+        widths.append(q.shape[2])
+        return original(q, *a, **kw)
+
+    try:
+        qsa_fast._native_sparse_gqa_attention = record
+        actual = call("candidate")
+        mx.eval(actual)
+    finally:
+        qsa_fast._native_sparse_gqa_attention = original
+    assert max(widths) > 256, "automatic wider tiles did not engage"
+    assert mx.array_equal(expected.view(mx.uint8), actual.view(mx.uint8)).item()
+    for _ in range(3):
+        mx.eval(call("control"), call("candidate"))
+    samples = {"control": [], "candidate": []}
+    for index in range(args.repetitions):
+        order = ("control", "candidate") if index % 2 == 0 else ("candidate", "control")
+        for mode in order:
+            mx.synchronize()
+            start = time.perf_counter()
+            mx.eval(call(mode))
+            samples[mode].append((time.perf_counter() - start) * 1000)
+    medians = {mode: statistics.median(times) for mode, times in samples.items()}
+    print(
+        json.dumps(
+            {
+                "device": mx.device_info()["device_name"],
+                "mlx": importlib.metadata.version("mlx"),
+                "key_tokens": tokens,
+                "query_tokens": rows,
+                "repetitions_per_arm": args.repetitions,
+                "candidate_tiles": widths,
+                "byte_identical": True,
+                "median_ms": medians,
+                "samples_ms": samples,
+                "latency_reduction_percent": 100
+                * (1 - medians["candidate"] / medians["control"]),
+                "scope": "Synthetic QSA attention component with precomputed pooled keys; not whole-model PP or decode",
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qsa_fast.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qsa_fast.py
@@ -562,6 +562,7 @@ def contiguous_causal_gathered_qsa(
     if num_query_heads % num_key_value_heads:
         raise ValueError("QSA query heads must divide evenly over K/V heads")
 
+    native_prefill_retry_chunk = None
     if query_chunk is None:
         query_chunk = contiguous_causal_query_chunk(key_tokens)
         # The direct-index main-attention kernel carries no per-query gathered
@@ -581,6 +582,50 @@ def contiguous_causal_gathered_qsa(
                     "qwen4_qsa_sparse_gqa_attention"
                 ):
                     query_chunk = max(query_chunk, 256)
+                    # Once all three native stages have executed successfully,
+                    # batch more independent prefill queries per dispatch.
+                    # A single FP32 score sheet is capped at 128 MiB; this is
+                    # not a cap on all attention intermediates or model memory.
+                    # Decode/verify and first-use ABI probes keep their tiles.
+                    if (
+                        query_tokens >= 1024
+                        and keys.dtype == values.dtype == queries.dtype
+                        and index_queries.shape[2:] == (4, 128)
+                        and index_queries.dtype == queries.dtype
+                        and index_keys.dtype == queries.dtype
+                        and (
+                            pooled_index_keys is None
+                            or pooled_index_keys.dtype == queries.dtype
+                        )
+                        and indexer_head_dim == 128
+                        and compress_ratio == 4
+                        and token_budget == 2048
+                        and key_tokens > token_budget
+                        and _NATIVE_QSA_MAIN_PROVEN
+                        and _NATIVE_QSA_SCORE_PROVEN
+                        and _NATIVE_QSA_TOPK_PROVEN
+                        and not _NATIVE_QSA_SCORE_DISABLED
+                        and not _NATIVE_QSA_TOPK_DISABLED
+                        and max(
+                            _native_score_min_rows(),
+                            _native_topk_min_rows(),
+                            _native_main_min_rows(),
+                        ) <= 256
+                    ):
+                        score_rows = (128 * 1024 * 1024) // (
+                            4 * (key_tokens // compress_ratio)
+                        )
+                        if score_rows >= 256:
+                            query_chunk = min(1024, (score_rows // 256) * 256)
+                        else:
+                            query_chunk = max(
+                                1,
+                                min(contiguous_causal_query_chunk(key_tokens), score_rows),
+                            )
+                        if query_chunk > 256:
+                            native_prefill_retry_chunk = contiguous_causal_query_chunk(
+                                key_tokens
+                            )
             except Exception:
                 pass
     if query_chunk <= 0:
@@ -690,6 +735,32 @@ def contiguous_causal_gathered_qsa(
             if native_output is not None:
                 outputs.append(native_output)
                 continue
+            if (
+                native_prefill_retry_chunk is not None
+                and chunk_tokens > native_prefill_retry_chunk
+            ):
+                # A native rejection must not turn a wide direct-index tile
+                # into a much larger portable per-query K/V gather. Retry
+                # with an explicit portable width, which cannot re-enter this
+                # automatic widening branch; native failure latches remain.
+                return contiguous_causal_gathered_qsa(
+                    queries,
+                    keys,
+                    values,
+                    index_queries,
+                    index_keys,
+                    index_position_ids,
+                    num_query_heads=num_query_heads,
+                    num_key_value_heads=num_key_value_heads,
+                    head_dim=head_dim,
+                    indexer_head_dim=indexer_head_dim,
+                    compress_ratio=compress_ratio,
+                    token_budget=token_budget,
+                    index_key_norm=index_key_norm,
+                    apply_index_rope=apply_index_rope,
+                    pooled_index_keys=pooled_index_keys,
+                    query_chunk=native_prefill_retry_chunk,
+                )
 
             selected_indices = (
                 selected_block_rows[..., None] * ratio

--- a/tests/test_qwen4_qsa_prefill_tiles.py
+++ b/tests/test_qwen4_qsa_prefill_tiles.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exercise prefill tile selection through the gathered QSA entry point."""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import pytest
+
+from omlx.custom_kernels.glm_moe_dsa import fast
+from omlx.patches import mlx_vlm_qwen4_exp_compat as compat
+
+compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+from mlx_vlm.models.qwen4_exp import qsa_fast  # noqa: E402
+
+
+@pytest.fixture
+def native_calls(monkeypatch):
+    """Record dispatch geometry without allocating gathered K/V per query."""
+    calls = []
+    monkeypatch.setattr(fast, "is_native_available", lambda: True)
+    monkeypatch.setattr(fast, "has_symbol", lambda name: True)
+    for stage in ("MAIN", "SCORE", "TOPK"):
+        monkeypatch.setattr(qsa_fast, f"_NATIVE_QSA_{stage}_PROVEN", True)
+        monkeypatch.setattr(qsa_fast, f"_NATIVE_QSA_{stage}_DISABLED", False)
+
+    def scores(q, pooled, **kwargs):
+        return mx.zeros((1, q.shape[1], pooled.shape[1]), dtype=mx.float32)
+
+    def topk(scores, k):
+        return mx.broadcast_to(mx.arange(k), (*scores.shape[:-1], k))
+
+    def attention(q, k, v, selected, *, q_offset):
+        calls.append((q.shape[2], q_offset))
+        return q.transpose(0, 2, 1, 3)
+
+    monkeypatch.setattr(qsa_fast, "_native_indexer_scores", scores)
+    monkeypatch.setattr(qsa_fast, "_native_topk_indices", topk)
+    monkeypatch.setattr(qsa_fast, "_native_sparse_gqa_attention", attention)
+    return calls
+
+
+def _run(*, rows=2049, tokens=4096, dtype=mx.bfloat16, **overrides):
+    kwargs = dict(
+        num_query_heads=24,
+        num_key_value_heads=2,
+        head_dim=256,
+        indexer_head_dim=128,
+        compress_ratio=4,
+        token_budget=2048,
+        index_key_norm=lambda x: x,
+        apply_index_rope=lambda x, p: x,
+    )
+    kwargs.update(overrides)
+    queries = mx.zeros((1, 24, rows, 256), dtype=dtype)
+    keys = mx.zeros((1, 2, tokens, 256), dtype=dtype)
+    output = qsa_fast.contiguous_causal_gathered_qsa(
+        queries,
+        keys,
+        keys,
+        mx.zeros((1, rows, 4, 128), dtype=dtype),
+        mx.zeros((1, tokens, 128), dtype=dtype),
+        mx.arange(tokens)[None],
+        **kwargs,
+    )
+    mx.eval(output)
+    assert output.shape == (1, rows, 24, 256)
+
+
+def test_warm_native_prefill_uses_wider_tiles_and_exact_tail(native_calls):
+    _run()
+    assert native_calls == [(1024, 2047), (1024, 3071), (1, 4095)]
+
+
+@pytest.mark.parametrize("rows", [2, 6, 1023])
+def test_decode_verify_and_short_prefill_keep_existing_tiles(native_calls, rows):
+    _run(rows=rows)
+    assert max(width for width, _ in native_calls) <= 256
+
+
+@pytest.mark.parametrize("stage", ["MAIN", "SCORE", "TOPK"])
+@pytest.mark.parametrize("state", ["unproven", "disabled"])
+def test_unproven_or_disabled_kernel_keeps_existing_tiles(
+    monkeypatch, native_calls, stage, state
+):
+    suffix, value = ("PROVEN", False) if state == "unproven" else ("DISABLED", True)
+    monkeypatch.setattr(qsa_fast, f"_NATIVE_QSA_{stage}_{suffix}", value)
+    _run()
+    assert max(width for width, _ in native_calls) <= 256
+
+
+@pytest.mark.parametrize("missing", ["extension", "symbol"])
+def test_missing_native_abi_keeps_portable_tile_size(
+    monkeypatch, native_calls, missing
+):
+    if missing == "extension":
+        monkeypatch.setattr(fast, "is_native_available", lambda: False)
+    else:
+        monkeypatch.setattr(fast, "has_symbol", lambda name: False)
+    _run()
+    assert max(width for width, _ in native_calls) == 32
+
+
+def test_explicit_query_chunk_is_respected(native_calls):
+    _run(query_chunk=37)
+    assert max(width for width, _ in native_calls) == 37
+    assert sum(width for width, _ in native_calls) == 2049
+
+
+@pytest.mark.parametrize(
+    "kwargs", [{"dtype": mx.float32}, {"compress_ratio": 2}, {"token_budget": 1024}]
+)
+def test_other_dtypes_and_sparse_geometry_keep_existing_tiles(native_calls, kwargs):
+    _run(**kwargs)
+    assert max(width for width, _ in native_calls) <= 256
+
+
+@pytest.mark.parametrize(
+    "tokens,expected", [(65536, 1024), (262144, 512), (524288, 256), (524292, 128)]
+)
+def test_score_sheet_cap_shrinks_tiles_at_long_context(native_calls, tokens, expected):
+    # Broadcast K/V are lazy and the fake attention never evaluates them.
+    _run(rows=1024, tokens=tokens)
+    assert max(width for width, _ in native_calls) == expected
+    assert expected * (tokens // 4) * 4 <= 128 * 1024 * 1024
+
+
+@pytest.mark.parametrize("stage", ["score", "topk", "main"])
+def test_native_minimum_rows_override_keeps_existing_tiles(
+    monkeypatch, native_calls, stage
+):
+    monkeypatch.setattr(qsa_fast, f"_native_{stage}_min_rows", lambda: 2048)
+    _run()
+    assert max(width for width, _ in native_calls) == 256
+
+
+def test_native_rejection_retries_before_a_wide_portable_gather(
+    monkeypatch, native_calls
+):
+    monkeypatch.setattr(qsa_fast, "_native_sparse_gqa_attention", lambda *a, **k: None)
+
+    class ReachedPortableGatherError(Exception):
+        pass
+
+    widths = []
+
+    def gather(kv, indices):
+        widths.append(indices.shape[1])
+        raise ReachedPortableGatherError
+
+    monkeypatch.setattr(qsa_fast, "_gather_kv_rows", gather)
+    with pytest.raises(ReachedPortableGatherError):
+        _run()
+    assert widths == [32]
+
+
+_NATIVE = fast.is_native_available() and all(
+    fast.has_symbol(name)
+    for name in (
+        "qwen4_qsa_indexer_scores",
+        "qwen4_qsa_topk_indices",
+        "qwen4_qsa_sparse_gqa_attention",
+    )
+)
+
+
+@pytest.mark.skipif(not _NATIVE, reason="native Qwen4 QSA kernels not built")
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+@pytest.mark.parametrize("tokens", [4096, 65536])
+def test_native_wide_prefill_preserves_attention_bytes(monkeypatch, dtype, tokens):
+    # Exercise actual score, top-k and attention kernels, including an uneven
+    # final tile, against the existing explicit 256-query schedule.
+    for stage in ("MAIN", "SCORE", "TOPK"):
+        monkeypatch.setattr(qsa_fast, f"_NATIVE_QSA_{stage}_PROVEN", False)
+        monkeypatch.setattr(qsa_fast, f"_NATIVE_QSA_{stage}_DISABLED", False)
+    mx.random.seed(81)
+    rows = 1025
+    inputs = (
+        (mx.random.normal((1, 24, rows, 256)) * 0.1).astype(dtype),
+        (mx.random.normal((1, 2, tokens, 256)) * 0.1).astype(dtype),
+        (mx.random.normal((1, 2, tokens, 256)) * 0.1).astype(dtype),
+        (mx.random.normal((1, rows, 4, 128)) * 0.1).astype(dtype),
+        (mx.random.normal((1, tokens, 128)) * 0.1).astype(dtype),
+        mx.arange(tokens)[None],
+    )
+    mx.eval(inputs)
+    kwargs = dict(
+        num_query_heads=24,
+        num_key_value_heads=2,
+        head_dim=256,
+        indexer_head_dim=128,
+        compress_ratio=4,
+        token_budget=2048,
+        index_key_norm=lambda x: x,
+        apply_index_rope=lambda x, p: x,
+    )
+    expected = qsa_fast.contiguous_causal_gathered_qsa(
+        *inputs, query_chunk=256, **kwargs
+    )
+    mx.eval(expected)
+    assert all(
+        getattr(qsa_fast, f"_NATIVE_QSA_{stage}_PROVEN")
+        for stage in ("MAIN", "SCORE", "TOPK")
+    )
+    widths = []
+    original = qsa_fast._native_sparse_gqa_attention
+
+    def record(q, *args, **kw):
+        widths.append(q.shape[2])
+        return original(q, *args, **kw)
+
+    monkeypatch.setattr(qsa_fast, "_native_sparse_gqa_attention", record)
+    actual = qsa_fast.contiguous_causal_gathered_qsa(*inputs, **kwargs)
+    mx.eval(actual)
+    assert widths == [1024, 1]
+    assert mx.array_equal(expected.view(mx.uint8), actual.view(mx.uint8)).item()


### PR DESCRIPTION
Warm native Qwen4 QSA prefill currently dispatches at most 256 query rows at a time, even after the score, top-k and direct-index attention kernels have all run successfully. This change batches up to 1,024 independent prefill queries per call, reducing dispatch overhead while preserving the existing token selection and native attention reductions.

The wider path requires at least 1,024 queries, the supported 24-query/2-KV-head geometry with head dimension 256, four indexer heads of dimension 128, FP16/BF16, compression ratio 4, and a 2,048-token budget. All three native stages must already be proven and enabled, and their minimum-row overrides must permit the path. Explicit query widths, first-use probes, and short decode/verification calls retain their existing behavior. A single FP32 indexer score sheet is limited to 128 MiB by reducing the width as context grows; this is not a bound on total attention or model memory. If native attention rejects a widened call, execution retries at the existing portable width before allocating per-query gathered K/V.

## Reproducible component measurements

Apple M5 Max, MLX 0.32.2, native `glm_moe_dsa` extension rebuilt against the pinned nanobind 2.15.0 ABI, BF16, 2,048 query tokens, synthetic seeded inputs and precomputed pooled keys. Each arm has three warmups and 12 measured calls; control/candidate order alternates each repetition, and outputs are synchronized. The control explicitly selects 256-query tiles; the candidate uses the automatic path, with actual 1,024-query dispatches checked before timing.

| Cached K/V tokens | 256-query median | Automatic median | Latency reduction |
|---|---:|---:|---:|
| 16,384 | 16.886 ms | 16.095 ms | 4.7% |
| 65,536 | 22.170 ms | 20.882 ms | 5.8% |

These numbers measure one complete QSA attention call, including indexer scoring and selection, rather than whole-model PP or decode. Full-model throughput and peak-memory confirmation on current upstream, including M3 hardware, remain outstanding; this PR is a draft for that reason.

```sh
# From the repository root, after building the native extension:
PYTHONPATH=. MLX_ENABLE_TF32=0 python benchmarks/bench_qwen4_qsa_prefill_tiles.py --key-tokens 16384
PYTHONPATH=. MLX_ENABLE_TF32=0 python benchmarks/bench_qwen4_qsa_prefill_tiles.py --key-tokens 65536
```

## Validation

The new dispatch regression failed on unmodified main because the entry point produced 256-row calls instead of the expected 1,024-row calls. Native numerical checks compare every output byte against explicit 256-query tiling at 4,096 and 65,536 K/V tokens in both FP16 and BF16, including an uneven final query tile, and assert that the widened branch actually executes. Additional cases cover unavailable/unproven/disabled kernels, row-threshold overrides, short requests, explicit widths, score-sheet bounds, and native rejection before a large portable gather.

```sh
python -m pytest -q -o addopts= -p no:cacheprovider \
  tests/test_qwen4_qsa_*.py \
  tests/test_mlx_vlm_qwen4_exp_compat.py \
  tests/test_qwen4_eager_dispatch.py
# 228 passed with the native extension enabled
```

Ruff passes for the new benchmark and tests, and `git diff --check` passes. The three existing UP033 findings on `functools.lru_cache(maxsize=None)` in `qsa_fast.py` are unchanged.
