### PR TITLE
perf(qwen4_exp): Qwen3.8-Flash-Next decode: gathered attention kernel, NAX indexer scores, fused verify rows, primed re-entry, narrow gathered windows

### DIFF
--- a/docs/superpowers/plans/profiling/gdn_dual_probe.py
+++ b/docs/superpowers/plans/profiling/gdn_dual_probe.py
@@ -1,0 +1,77 @@
+"""Shim: for 2-row gdn_sink calls, run the stock GDN forward on a shadow cache next to the patched
+one and log any numeric difference (out, conv, recurrent, q/k/v, intermediate states)."""
+import logging, os
+import mlx.core as mx
+import omlx.patches.qwen35_gdn_prework as pm
+from mlx_vlm.models.qwen3_5 import language as q35
+
+log = logging.getLogger("omlx.patches.qwen35_gdn_prework")
+ROWS = int(os.environ.get("OMLX_DUAL_ROWS", "2"))
+LIMIT = int(os.environ.get("OMLX_DUAL_LIMIT", "3600"))
+_apply = pm.apply_qwen35_gdn_prework_patch
+_orig_call = q35.Qwen3_5GatedDeltaNet.__call__
+state = {"n": 0, "layer": 0, "diff_calls": 0}
+
+
+class Shadow:
+    def __init__(self, cache):
+        self._s = {0: cache[0], 1: cache[1]}
+        self.lengths = getattr(cache, "lengths", None)
+        self.left_padding = getattr(cache, "left_padding", None)
+
+    def __getitem__(self, i):
+        return self._s[i]
+
+    def __setitem__(self, i, v):
+        self._s[i] = v
+
+    def advance(self, n):
+        pass
+
+
+def apply_and_wrap():
+    ok = _apply()
+    cls = q35.Qwen3_5GatedDeltaNet
+    patched = cls.__call__
+
+    def dual(self, inputs, mask=None, cache=None, gdn_sink=None, target_verify=False):
+        if gdn_sink is None or cache is None or inputs.shape[1] != ROWS or state["n"] >= LIMIT:
+            return patched(self, inputs, mask=mask, cache=cache, gdn_sink=gdn_sink, target_verify=target_verify)
+        state["n"] += 1
+        shadow = Shadow(cache)
+        sink2 = []
+        ref = _orig_call(self, inputs, mask=mask, cache=shadow, gdn_sink=sink2, target_verify=True)
+        out = patched(self, inputs, mask=mask, cache=cache, gdn_sink=gdn_sink, target_verify=target_verify)
+        pairs = [("out", out, ref), ("conv", cache[0], shadow[0]), ("rec", cache[1], shadow[1]),
+                 ("q", gdn_sink[-1][0], sink2[0][0]), ("k", gdn_sink[-1][1], sink2[0][1]),
+                 ("v", gdn_sink[-1][2], sink2[0][2]), ("a", gdn_sink[-1][3], sink2[0][3]),
+                 ("b", gdn_sink[-1][4], sink2[0][4]), ("conv_in", gdn_sink[-1][9], sink2[0][9]),
+                 ("inter", gdn_sink[-1][11], sink2[0][11])]
+        diffs = {}
+        for name, x, y in pairs:
+            if x is None or y is None:
+                if x is not y:
+                    diffs[name] = "None-mismatch"
+                continue
+            if x.shape != y.shape:
+                diffs[name] = f"shape {x.shape} vs {y.shape}"
+                continue
+            d = mx.abs(x.astype(mx.float32) - y.astype(mx.float32)).max().item()
+            if d > 0:
+                diffs[name] = d
+        if diffs:
+            state["diff_calls"] += 1
+            if state["diff_calls"] <= 40:
+                log.info("DUALPROBE call=%d layer=%d S=%d bits=%s diffs=%s", state["n"], (state["n"] - 1) % 36, inputs.shape[1],
+                         (self.in_proj_qkv.bits, self.in_proj_z.bits), diffs)
+        elif state["n"] % 360 == 0:
+            log.info("DUALPROBE call=%d no diffs so far (diff_calls=%d)", state["n"], state["diff_calls"])
+        return out
+
+    cls.__call__ = dual
+    log.info("DUALPROBE installed (rows=%d)", ROWS)
+    return ok
+
+
+pm.apply_qwen35_gdn_prework_patch = apply_and_wrap
+print("[gdn_dual_probe] installed", flush=True)

--- a/docs/superpowers/plans/profiling/gdn_g_sweep.py
+++ b/docs/superpowers/plans/profiling/gdn_g_sweep.py
@@ -1,0 +1,49 @@
+"""Sweep every finite bf16 value of the GDN gate input `a` through the fused kernel's g/beta and
+compare with mlx-vlm's _compute_g_beta on a real layer's A_log/dt_bias. usage: gdn_g_sweep.py [layer]"""
+import json, os, sys
+import mlx.core as mx
+from mlx_vlm.models.qwen3_5.gated_delta import _compute_g_beta
+from omlx.patches import qwen35_gdn_prework as pm
+
+M = os.path.expanduser("~/.omlx-bench/models/Jundot/Qwen3.8-Flash-Next-oQ4e-mtp")
+GDN_IDX = int(sys.argv[1]) if len(sys.argv) > 1 else 11  # index among the GDN layers
+cfg = json.load(open(f"{M}/config.json")); tcfg = cfg.get("text_config", cfg)
+idx = json.load(open(f"{M}/model.safetensors.index.json"))["weight_map"]
+gdn_layers = sorted({int(k.split(".layers.")[1].split(".")[0]) for k in idx if ".linear_attn.A_log" in k})
+LAYER = gdn_layers[GDN_IDX]
+p = f"language_model.model.layers.{LAYER}.linear_attn."
+d = mx.load(f"{M}/{idx[p + 'A_log']}")
+A_log, dt_bias = d[p + "A_log"], d[p + "dt_bias"]
+HK, HV, DK, DV, C = 16, 48, 128, 128, 10240
+S = 8
+# every bf16 bit pattern with |a| finite and < 2^7 (the model's a range is a few units)
+bits = mx.arange(0, 65536, dtype=mx.uint32).astype(mx.uint16)
+vals = bits.view(mx.bfloat16)
+import numpy as np
+keep = np.asarray(mx.isfinite(vals) & (mx.abs(vals) < 128))
+vals = mx.array(np.asarray(vals.astype(mx.float32))[keep]).astype(mx.bfloat16)
+n = int(vals.size)
+per = S  # each row carries one value replicated across all heads
+vals = mx.concatenate([vals, mx.zeros((per - n % per,), dtype=mx.bfloat16)]) if n % per else vals
+calls = int(vals.size) // per
+print(f"layer {LAYER}: sweeping {n} bf16 values of a in {calls} kernel calls")
+inv = DK**-0.5
+q_scale = mx.array(inv * inv, dtype=mx.bfloat16); k_scale = mx.array(inv, dtype=mx.bfloat16)
+qkv = mx.zeros((1, S, C), dtype=mx.bfloat16); conv_state = mx.zeros((1, 3, C), dtype=mx.bfloat16)
+conv_w = mx.zeros((C, 4, 1), dtype=mx.bfloat16)
+g_mis = b_mis = 0; examples = []
+for c in range(calls):
+    a = mx.broadcast_to(vals[c * per:(c + 1) * per].reshape(1, S, 1), (1, S, HV))
+    a = mx.contiguous(a)
+    b = a  # sweep beta on the same values
+    out = pm.qwen4_verify_prework_fused(qkv, conv_state, conv_w, q_scale, k_scale, b, a, A_log, dt_bias, HK, HV, DK, DV)
+    g_k, beta_k = out[4], out[5]
+    g_r, beta_r = _compute_g_beta(A_log, a, b, dt_bias)
+    mx.eval(g_k, beta_k, g_r, beta_r)
+    gm = (g_k != g_r); bm = (beta_k != beta_r)
+    g_mis += int(gm.sum().item()); b_mis += int(bm.sum().item())
+    if gm.any().item() and len(examples) < 6:
+        i = int(mx.argmax(gm.reshape(-1)).item())
+        examples.append((float(a.reshape(-1)[i].item()), i % HV, float(g_k.reshape(-1)[i].item()), float(g_r.reshape(-1)[i].item())))
+print(f"g mismatches {g_mis}/{n * HV}  beta mismatches {b_mis}/{n * HV}")
+for e in examples: print("  a=%g head=%d kernel=%.9g ref=%.9g" % e)

--- a/docs/superpowers/plans/profiling/gdn_gate_probe.py
+++ b/docs/superpowers/plans/profiling/gdn_gate_probe.py
@@ -1,0 +1,29 @@
+"""Shim: log the first evaluations of the Qwen4 fused GDN verify gate per (rows, result) with call site."""
+import logging, traceback
+import omlx.patches.qwen35_gdn_prework as pm
+log = logging.getLogger("omlx.patches.qwen35_gdn_prework")
+_orig = pm._qwen4_verify_dynamic_eligible
+_seen = {}
+
+
+def probe(module, inputs, mask, cache, gdn_sink):
+    r = _orig(module, inputs, mask, cache, gdn_sink)
+    S = inputs.shape[1] if getattr(inputs, "ndim", 0) == 3 else None
+    key = (S, r)
+    if _seen.get(key, 0) < 2:
+        _seen[key] = _seen.get(key, 0) + 1
+        c0 = cache[0] if cache is not None else None
+        c1 = cache[1] if cache is not None else None
+        stack = [f"{f.name}:{f.lineno}" for f in traceback.extract_stack()[-9:-1]]
+        log.info(
+            "GATEPROBE S=%s result=%s sink=%s mask=%s lengths=%s leftpad=%s conv=%s/%s rec=%s/%s static=%s in=%s/%s stack=%s",
+            S, r, gdn_sink is not None, type(mask).__name__ if mask is not None else None,
+            getattr(cache, "lengths", None) is not None, getattr(cache, "left_padding", None) is not None,
+            getattr(c0, "shape", None), getattr(c0, "dtype", None), getattr(c1, "shape", None), getattr(c1, "dtype", None),
+            pm._qwen4_decode_static_eligible(module), getattr(inputs, "dtype", None), getattr(inputs, "shape", None), stack,
+        )
+    return r
+
+
+pm._qwen4_verify_dynamic_eligible = probe
+print("[gdn_gate_probe] installed", flush=True)

--- a/docs/superpowers/plans/profiling/gdn_layer_parity.py
+++ b/docs/superpowers/plans/profiling/gdn_layer_parity.py
@@ -1,0 +1,96 @@
+"""Numeric delta of the fused Qwen4 GDN verify arm vs the stock forward on real layer weights.
+usage: .venv/bin/python gdn_layer_parity.py [model dir] [layer]  (default: bench oQ4e pack, layer 0)"""
+import json, os, sys
+import mlx.core as mx
+import mlx.nn as nn
+
+M = sys.argv[1] if len(sys.argv) > 1 else os.path.expanduser("~/.omlx-bench/models/Jundot/Qwen3.8-Flash-Next-oQ4e-mtp")
+LAYER = int(sys.argv[2]) if len(sys.argv) > 2 else 0
+from omlx.patches.mlx_vlm_qwen4_exp_compat import apply_mlx_vlm_qwen4_exp_compat_patch
+apply_mlx_vlm_qwen4_exp_compat_patch()
+from mlx_vlm.models.qwen4_exp.config import TextConfig
+from mlx_vlm.models.qwen4_exp.language import Qwen4ExpGatedDeltaNet
+from mlx_vlm.models.qwen3_5 import language as q35
+from omlx.patches import qwen35_gdn_prework as pm
+
+cfg = json.load(open(f"{M}/config.json"))
+tc = TextConfig.from_dict(cfg.get("text_config", cfg))
+idx = json.load(open(f"{M}/model.safetensors.index.json"))["weight_map"]
+prefix = f"language_model.model.layers.{LAYER}.linear_attn."
+keys = [k for k in idx if k.startswith(prefix)]
+shards = {idx[k] for k in keys}
+w = {}
+for s in shards:
+    d = mx.load(f"{M}/{s}")
+    w.update({k[len(prefix):]: d[k] for k in keys if idx[k] == s})
+
+mod = Qwen4ExpGatedDeltaNet(tc)
+for name in ("in_proj_qkv", "in_proj_z", "in_proj_b", "in_proj_a", "out_proj"):
+    wq, sc, bi = w[name + ".weight"], w[name + ".scales"], w[name + ".biases"]
+    rows, packed = wq.shape
+    K = sc.shape[1] * (2560 // sc.shape[1]) if name != "out_proj" else 6144
+    K = getattr(mod, name).weight.shape[1] if hasattr(getattr(mod, name), "weight") else K
+    K = {"out_proj": 6144}.get(name, 2560)
+    bits = packed * 32 // K
+    group = K // sc.shape[1]
+    ql = nn.QuantizedLinear(K, rows, bias=False, group_size=group, bits=bits)
+    ql.weight, ql.scales, ql.biases = wq, sc, bi
+    setattr(mod, name, ql)
+mod.conv1d.weight = w["conv1d.weight"]
+mod.A_log, mod.dt_bias, mod.norm.weight = w["A_log"], w["dt_bias"], w["norm.weight"]
+mod.eval()
+print("static eligible:", pm._qwen4_decode_static_eligible(mod), "bits:", {n: (getattr(mod, n).bits, getattr(mod, n).group_size) for n in ("in_proj_qkv", "in_proj_z", "in_proj_b", "in_proj_a", "out_proj")})
+
+cls = q35.Qwen3_5GatedDeltaNet
+orig = cls.__call__ if not getattr(cls, "_omlx_gdn_prework_patched", False) else None
+assert orig is not None, "patch already applied; run in a fresh process"
+assert pm.apply_qwen35_gdn_prework_patch()
+
+
+class Cache:
+    def __init__(self, c, r):
+        self._s = {0: c, 1: r}; self.lengths = None; self.left_padding = None; self.n = 0
+    def __getitem__(self, i): return self._s[i]
+    def __setitem__(self, i, v): self._s[i] = v
+    def advance(self, n): self.n += n
+
+
+def run(fn, S, seed, fused):
+    ks = mx.random.split(mx.random.key(seed), 3)
+    x = mx.random.normal((1, S, 2560), key=ks[0]).astype(mx.bfloat16)
+    conv = (mx.random.normal((1, 3, 10240), key=ks[1]) * 0.5).astype(mx.bfloat16)
+    rec = (mx.random.normal((1, 48, 128, 128), key=ks[2]) * 0.05).astype(mx.float32)
+    cache = Cache(conv, rec); sink = []
+    if fused:
+        out = fn(mod, x, cache=cache, gdn_sink=sink)
+    else:
+        out = fn(mod, x, mask=None, cache=cache, gdn_sink=sink, target_verify=True)
+    mx.eval(out, cache[0], cache[1], *[t for t in sink[0] if isinstance(t, mx.array)])
+    return out, cache, sink[0]
+
+
+def cmp(name, a, b):
+    a32, b32 = a.astype(mx.float32), b.astype(mx.float32)
+    d = mx.abs(a32 - b32); n = int((d > 0).sum().item())
+    rel = (d.max() / (mx.abs(b32).max() + 1e-30)).item()
+    print(f"    {name:20s} differing={n}/{a.size}  max|d|={d.max().item():.3g}  max|d|/max|ref|={rel:.3g}")
+    return n
+
+
+NSEEDS = int(os.environ.get("NSEEDS", "1"))
+for S in (1, 2, 3, 4, 8):
+    total = 0; elems = 0
+    for seed in range(NSEEDS):
+        pm._QWEN4_VERIFY_ENGAGED_LOGGED = False
+        o1, c1, s1 = run(cls.__call__, S, 100 + S + 1000 * seed, True)
+        assert pm._QWEN4_VERIFY_ENGAGED_LOGGED, "fused arm did not engage"
+        o0, c0, s0 = run(orig, S, 100 + S + 1000 * seed, False)
+        pairs = [("out", o1, o0), ("conv_state", c1[0], c0[0]), ("recurrent", c1[1], c0[1]),
+                 ("q", s1[0], s0[0]), ("k", s1[1], s0[1]), ("v", s1[2], s0[2]), ("inter_states", s1[11], s0[11])]
+        if NSEEDS == 1:
+            print(f"S={S}")
+            for name, a, b in pairs: total += cmp(name, a, b)
+        else:
+            for name, a, b in pairs:
+                d = (a.astype(mx.float32) != b.astype(mx.float32)).sum().item(); total += int(d); elems += a.size
+    print(f"S={S}: {'BIT-EXACT' if total == 0 else 'differs'} over {NSEEDS} seeds, {elems} elements, {total} differing")

--- a/docs/superpowers/plans/profiling/gdn_rows_filter.py
+++ b/docs/superpowers/plans/profiling/gdn_rows_filter.py
@@ -1,0 +1,15 @@
+"""Shim: restrict the fused Qwen4 GDN verify arm to the row counts in OMLX_GVF_ROWS (comma list)."""
+import os
+import omlx.patches.qwen35_gdn_prework as pm
+ROWS = {int(x) for x in os.environ.get("OMLX_GVF_ROWS", "1").split(",") if x}
+_orig = pm._qwen4_verify_dynamic_eligible
+
+
+def gate(module, inputs, mask, cache, gdn_sink):
+    if getattr(inputs, "ndim", 0) == 3 and inputs.shape[1] not in ROWS:
+        return False
+    return _orig(module, inputs, mask, cache, gdn_sink)
+
+
+pm._qwen4_verify_dynamic_eligible = gate
+print(f"[gdn_rows_filter] fused verify arm limited to rows {sorted(ROWS)}", flush=True)

--- a/omlx/custom_kernels/decode_fast/csrc/bindings.cpp
+++ b/omlx/custom_kernels/decode_fast/csrc/bindings.cpp
@@ -32,4 +32,21 @@ NB_MODULE(_ext, m) {
       "mask"_a = nb::none(),
       "sinks"_a = nb::none(),
       "stream"_a = nb::none());
+  m.def(
+      "sdpa_decode_gathered_supported",
+      &omlx::decode_fast_kernels::sdpa_decode_gathered_supported,
+      "q"_a,
+      "k"_a,
+      "v"_a,
+      "indices"_a,
+      "stream"_a = nb::none());
+  m.def(
+      "sdpa_decode_gathered",
+      &omlx::decode_fast_kernels::sdpa_decode_gathered,
+      "q"_a,
+      "k"_a,
+      "v"_a,
+      "indices"_a,
+      "scale"_a,
+      "stream"_a = nb::none());
 }

--- a/omlx/custom_kernels/decode_fast/csrc/sdpa_decode.cpp
+++ b/omlx/custom_kernels/decode_fast/csrc/sdpa_decode.cpp
@@ -337,6 +337,171 @@ void sdpa_decode_2pass(
   compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
 }
 
+
+int sdpa_decode_blocks(char devc, int N, int n_simds) {
+  int blocks;
+  if (devc == 's') {
+    blocks = 64;
+    if (N > 1024 && n_simds > 4) {
+      if (N <= 8192) {
+        blocks = 128;
+      } else if (N <= 32768) {
+        blocks = 256;
+      } else if (N <= 65536) {
+        blocks = 512;
+      } else {
+        blocks = 1024;
+      }
+    }
+  } else if (devc == 'd') {
+    int b = (((N + 255) / 256 + 31) / 32) * 32;
+    blocks = std::min(256, std::max(N >= 4096 ? 64 : 32, b));
+  } else {
+    blocks = n_simds >= 4 ? 64 : 32;
+  }
+  return blocks;
+}
+
+void sdpa_decode_gathered_2pass(
+    const Stream& s,
+    metal::Device& d,
+    MTL::Library* lib,
+    const array& q,
+    const array& k,
+    const array& v,
+    const array& indices,
+    array& out,
+    float scale) {
+  std::string kname;
+  kname.reserve(64);
+  concatenate(
+      kname,
+      "omlx_sdpa_decode_gathered_2pass_1_",
+      sdpa_type_name(q.dtype()),
+      "_",
+      q.shape(-1));
+
+  const int gqa_factor = q.shape(1) / k.shape(1);
+  const int q_seq_len = q.shape(2);
+  const int N = indices.shape(-1);
+  char devc = d.get_architecture().back();
+  int blocks = sdpa_decode_blocks(devc, N, gqa_factor);
+
+  size_t k_head_stride = k.shape(1) == 1 ? k.strides(0) : k.strides(1);
+  size_t k_seq_stride = k.strides()[2];
+  size_t v_head_stride = v.shape(1) == 1 ? v.strides(0) : v.strides(1);
+  size_t v_seq_stride = v.strides()[2];
+  MTL::Size group_dims(32, gqa_factor, 1);
+  MTL::Size grid_dims(k.shape(1), q.shape(0) * q_seq_len, blocks);
+
+  Shape intermediate_shape;
+  intermediate_shape.reserve(out.ndim() + 1);
+  intermediate_shape.insert(
+      intermediate_shape.end(), out.shape().begin(), out.shape().end() - 1);
+  intermediate_shape.push_back(blocks);
+  intermediate_shape.push_back(out.shape().back());
+  array intermediate(intermediate_shape, float32, nullptr, {});
+  intermediate_shape.pop_back();
+  array sums(intermediate_shape, float32, nullptr, {});
+  array maxs(std::move(intermediate_shape), float32, nullptr, {});
+  intermediate.set_data(allocator::malloc(intermediate.nbytes()));
+  sums.set_data(allocator::malloc(sums.nbytes()));
+  maxs.set_data(allocator::malloc(maxs.nbytes()));
+  auto& compute_encoder = metal::get_command_encoder(s);
+  compute_encoder.add_temporary(intermediate);
+  compute_encoder.add_temporary(sums);
+  compute_encoder.add_temporary(maxs);
+
+  metal::MTLFCList func_consts = {
+      {&blocks, MTL::DataType::DataTypeInt, 26},
+  };
+  std::string hash_name = kname;
+  hash_name += "_";
+  hash_name += std::to_string(blocks);
+
+  auto kernel = d.get_kernel(kname, lib, hash_name, func_consts);
+  compute_encoder.set_compute_pipeline_state(kernel);
+
+  compute_encoder.set_input_array(q, 0);
+  compute_encoder.set_input_array(k, 1);
+  compute_encoder.set_input_array(v, 2);
+  compute_encoder.set_output_array(intermediate, 3);
+  compute_encoder.set_output_array(sums, 4);
+  compute_encoder.set_output_array(maxs, 5);
+  compute_encoder.set_input_array(indices, 6);
+  compute_encoder.set_bytes(N, 7);
+  compute_encoder.set_bytes(k_head_stride, 8);
+  compute_encoder.set_bytes(k_seq_stride, 9);
+  compute_encoder.set_bytes(v_head_stride, 10);
+  compute_encoder.set_bytes(v_seq_stride, 11);
+  compute_encoder.set_bytes(scale, 12);
+  compute_encoder.set_bytes(q_seq_len, 13);
+  compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+
+  kname.clear();
+  concatenate(
+      kname,
+      "omlx_sdpa_decode_2pass_2_",
+      sdpa_type_name(q.dtype()),
+      "_",
+      v.shape(-1));
+  kernel = d.get_kernel(kname, lib);
+  compute_encoder.set_compute_pipeline_state(kernel);
+  compute_encoder.set_input_array(intermediate, 0);
+  compute_encoder.set_input_array(sums, 1);
+  compute_encoder.set_input_array(maxs, 2);
+  compute_encoder.set_output_array(out, 3);
+  compute_encoder.set_bytes(blocks, 4);
+  group_dims = MTL::Size(1024, 1, 1);
+  grid_dims = MTL::Size(q.shape(0) * q.shape(1), q_seq_len, 1);
+  compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+}
+
+class SdpaDecodeGatheredPrimitive : public Primitive {
+ public:
+  SdpaDecodeGatheredPrimitive(Stream stream, float scale)
+      : Primitive(stream), scale_(scale) {}
+
+  void eval_cpu(
+      const std::vector<array>& /* inputs */,
+      std::vector<array>& /* outputs */) override {
+    throw std::runtime_error("SdpaDecodeGatheredPrimitive has no CPU path.");
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    auto& s = stream();
+    auto& d = metal::device(s.device);
+    auto& q = inputs[0];
+    auto& k = inputs[1];
+    auto& v = inputs[2];
+    auto& indices = inputs[3];
+    auto& o = outputs[0];
+    if (!q.flags().row_contiguous || !kv_layout_ok(k) || !kv_layout_ok(v) ||
+        !indices.flags().row_contiguous) {
+      throw std::runtime_error(
+          "[omlx_decode_fast.sdpa_decode_gathered] realized input layout is "
+          "not compatible with the gathered decode kernel; pass contiguous "
+          "queries/indices and a cache-layout K/V.");
+    }
+    o.set_data(allocator::malloc(o.nbytes()));
+    auto lib = d.get_library(
+        "omlx_decode_fast_kernels", current_binary_dir_sdpa());
+    sdpa_decode_gathered_2pass(s, d, lib, q, k, v, indices, o, scale_);
+  }
+
+  DEFINE_NAME(OMLXSdpaDecodeGathered)
+
+  bool is_equivalent(const Primitive& other) const override {
+    const auto& rhs = static_cast<const SdpaDecodeGatheredPrimitive&>(other);
+    return scale_ == rhs.scale_;
+  }
+
+ private:
+  float scale_;
+};
+
 class SdpaDecodePrimitive : public Primitive {
  public:
   SdpaDecodePrimitive(Stream stream, float scale, bool do_causal)
@@ -489,6 +654,69 @@ mx::array sdpa_decode(
   if (mask.has_value()) {
     inputs.push_back(*mask);
   }
+  Shape out_shape{q.shape(0), q.shape(1), q.shape(2), v.shape(-1)};
+  return array(
+      std::move(out_shape), q.dtype(), std::move(primitive), std::move(inputs));
+}
+
+bool sdpa_decode_gathered_supported(
+    const mx::array& q,
+    const mx::array& k,
+    const mx::array& v,
+    const mx::array& indices,
+    mx::StreamOrDevice s_) {
+  auto s = to_stream(s_);
+  if (s.device == Device::cpu) {
+    return false;
+  }
+  if (q.ndim() != 4 || k.ndim() != 4 || v.ndim() != 4 || indices.ndim() != 3) {
+    return false;
+  }
+  auto t = q.dtype();
+  if (t != float32 && t != float16 && t != bfloat16) {
+    return false;
+  }
+  if (k.dtype() != t || v.dtype() != t || indices.dtype() != int32) {
+    return false;
+  }
+  const int dim = q.shape(-1);
+  if ((dim != 64 && dim != 96 && dim != 128 && dim != 256) ||
+      k.shape(-1) != dim || v.shape(-1) != dim) {
+    return false;
+  }
+  const int B = q.shape(0);
+  const int qL = q.shape(2);
+  if (qL < 1 || qL > 32 || indices.shape(0) != B || indices.shape(1) != qL ||
+      indices.shape(2) < 1) {
+    return false;
+  }
+  if (k.shape(0) != B || v.shape(0) != B || v.shape(1) != k.shape(1) ||
+      v.shape(2) != k.shape(2) || k.shape(2) < 1) {
+    return false;
+  }
+  const int gqa_factor = q.shape(1) / k.shape(1);
+  if (q.shape(1) % k.shape(1) != 0 || gqa_factor > 32) {
+    return false;
+  }
+  // Layouts are checked at eval time (flags of lazy inputs are not final).
+  return true;
+}
+
+mx::array sdpa_decode_gathered(
+    const mx::array& q,
+    const mx::array& k,
+    const mx::array& v,
+    const mx::array& indices,
+    float scale,
+    mx::StreamOrDevice s_) {
+  if (!sdpa_decode_gathered_supported(q, k, v, indices, s_)) {
+    throw std::invalid_argument(
+        "[omlx_decode_fast.sdpa_decode_gathered] unsupported shapes/dtypes/"
+        "layout for the gathered decode kernel.");
+  }
+  auto s = to_stream(s_);
+  std::vector<array> inputs = {q, k, v, indices};
+  auto primitive = std::make_shared<SdpaDecodeGatheredPrimitive>(s, scale);
   Shape out_shape{q.shape(0), q.shape(1), q.shape(2), v.shape(-1)};
   return array(
       std::move(out_shape), q.dtype(), std::move(primitive), std::move(inputs));

--- a/omlx/custom_kernels/decode_fast/csrc/sdpa_decode.h
+++ b/omlx/custom_kernels/decode_fast/csrc/sdpa_decode.h
@@ -32,4 +32,25 @@ mx::array sdpa_decode(
     const std::optional<mx::array>& sinks = std::nullopt,
     mx::StreamOrDevice s = {});
 
+// True when the gathered decode kernel applies: Metal stream, 4-D fp32/fp16/
+// bf16 q/k/v with equal square head dims (64/96/128/256), int32 indices of
+// shape (B, qL, S) naming cache rows per query row (-1 = empty slot), GQA
+// fan-out <= 32.
+bool sdpa_decode_gathered_supported(
+    const mx::array& q,
+    const mx::array& k,
+    const mx::array& v,
+    const mx::array& indices,
+    mx::StreamOrDevice s = {});
+
+// Decode attention over per-query-row index sets read straight from the
+// cache. Returns (B, H, qL, D).
+mx::array sdpa_decode_gathered(
+    const mx::array& q,
+    const mx::array& k,
+    const mx::array& v,
+    const mx::array& indices,
+    float scale,
+    mx::StreamOrDevice s = {});
+
 } // namespace omlx::decode_fast_kernels

--- a/omlx/custom_kernels/decode_fast/csrc/sdpa_decode.metal
+++ b/omlx/custom_kernels/decode_fast/csrc/sdpa_decode.metal
@@ -34,7 +34,19 @@ using namespace metal;
       qk_dim,                                                       \
       value_dim)
 
+#define instantiate_omlx_sdpa_decode_gathered(type, dim)          \
+  instantiate_kernel(                                             \
+      "omlx_sdpa_decode_gathered_2pass_1_" #type "_" #dim,        \
+      omlx_sdpa_decode_gathered_2pass_1,                          \
+      type,                                                       \
+      dim,                                                        \
+      dim)
+
 #define instantiate_omlx_sdpa_decode_heads(type)      \
+  instantiate_omlx_sdpa_decode_gathered(type, 64)     \
+  instantiate_omlx_sdpa_decode_gathered(type, 96)     \
+  instantiate_omlx_sdpa_decode_gathered(type, 128)    \
+  instantiate_omlx_sdpa_decode_gathered(type, 256)    \
   instantiate_omlx_sdpa_decode(type, 64, 64)          \
   instantiate_omlx_sdpa_decode(type, 96, 96)          \
   instantiate_omlx_sdpa_decode(type, 128, 128)        \

--- a/omlx/custom_kernels/decode_fast/csrc/sdpa_decode_kernels.h
+++ b/omlx/custom_kernels/decode_fast/csrc/sdpa_decode_kernels.h
@@ -600,3 +600,169 @@ template <typename T, int D>
     }
   }
 }
+
+// Gathered variant of omlx_sdpa_decode_2pass_1: every query row attends to its
+// own set of N cache rows named by `indices` (int32 [B, qL, N], -1 = empty
+// slot). Query rows live on the grid (tid.y = batch * qL + row) since their
+// index sets differ, so the threadgroup is (32, gqa_factor, 1) and the
+// qL * gqa <= 32 limit of the contiguous kernel does not apply.
+template <typename T, int D, int V = D>
+[[kernel]] void omlx_sdpa_decode_gathered_2pass_1(
+    const device T* queries [[buffer(0)]],
+    const device T* keys [[buffer(1)]],
+    const device T* values [[buffer(2)]],
+    device float* out [[buffer(3)]],
+    device float* sums [[buffer(4)]],
+    device float* maxs [[buffer(5)]],
+    const device int* indices [[buffer(6)]],
+    const constant int& N [[buffer(7)]],
+    const constant size_t& k_head_stride [[buffer(8)]],
+    const constant size_t& k_seq_stride [[buffer(9)]],
+    const constant size_t& v_head_stride [[buffer(10)]],
+    const constant size_t& v_seq_stride [[buffer(11)]],
+    const constant float& scale [[buffer(12)]],
+    const constant int& q_seq_len [[buffer(13)]],
+    uint3 tptg [[threads_per_threadgroup]],
+    uint3 tidtg [[thread_position_in_threadgroup]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint3 tpg [[threadgroups_per_grid]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  constexpr int BD = 32;
+  constexpr int TK = 4;
+  constexpr int qk_per_thread = D / BD;
+  constexpr int v_per_thread = V / BD;
+
+  typedef float U;
+
+  thread U q[qk_per_thread];
+  thread U o[v_per_thread] = {0};
+
+  const int kv_head_idx = tid.x;
+  const int batch_idx = int(tid.y) / q_seq_len;
+  const int q_seq_idx = int(tid.y) % q_seq_len;
+  const int block_idx = tid.z;
+  const int gqa_factor = tptg.y;
+  const int q_head_idx = gqa_factor * kv_head_idx + tidtg.y;
+  const int num_kv_heads = tpg.x;
+  const int num_q_heads = num_kv_heads * gqa_factor;
+  const int q_batch_head_idx = batch_idx * num_q_heads + q_head_idx;
+  const int o_offset = q_batch_head_idx * q_seq_len + q_seq_idx;
+
+  queries += o_offset * D + simd_lid * qk_per_thread;
+  indices += (batch_idx * q_seq_len + q_seq_idx) * N;
+
+  const int chunk = (N + blocks - 1) / blocks;
+  const int k_start = block_idx * chunk;
+  const int k_end = min(N, k_start + chunk);
+
+  const int kv_batch_head_idx = batch_idx * num_kv_heads + kv_head_idx;
+  keys += kv_batch_head_idx * k_head_stride + simd_lid * qk_per_thread;
+  values += kv_batch_head_idx * v_head_stride + simd_lid * v_per_thread;
+  out += o_offset * blocks * V + block_idx * V + simd_lid * v_per_thread;
+  sums += o_offset * blocks + block_idx;
+  maxs += o_offset * blocks + block_idx;
+
+  {
+    thread T qt[qk_per_thread];
+    load_vec<T, qk_per_thread>(qt, queries);
+    for (int i = 0; i < qk_per_thread; i++) {
+      q[i] = static_cast<U>(scale) * static_cast<U>(qt[i]);
+    }
+  }
+
+  U max_score = Limits<U>::finite_min;
+  U sum_exp_score = 0;
+
+  int i = k_start;
+  for (; i + TK <= k_end; i += TK) {
+    thread T ks[TK][qk_per_thread];
+    U scores[TK];
+    bool use_key[TK];
+    int rows[TK];
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      rows[t] = indices[i + t];
+      use_key[t] = rows[t] >= 0;
+      // An empty slot reads row 0 (always present) and is masked below.
+      load_vec<T, qk_per_thread>(
+          ks[t], keys + size_t(max(rows[t], 0)) * k_seq_stride);
+    }
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      U score = 0;
+      for (int j = 0; j < qk_per_thread; j++) {
+        score += q[j] * static_cast<U>(ks[t][j]);
+      }
+      score = simd_sum(score);
+      scores[t] = use_key[t] ? score : Limits<U>::finite_min;
+    }
+
+    U tile_max = scores[0];
+#pragma unroll
+    for (int t = 1; t < TK; t++) {
+      tile_max = max(tile_max, scores[t]);
+    }
+    U new_max = max(max_score, tile_max);
+
+    thread T vs[TK][v_per_thread];
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      load_vec<T, v_per_thread>(
+          vs[t], values + size_t(max(rows[t], 0)) * v_seq_stride);
+    }
+
+    if (new_max > max_score) {
+      U factor = fast::exp(max_score - new_max);
+      sum_exp_score *= factor;
+      for (int j = 0; j < v_per_thread; j++) {
+        o[j] *= factor;
+      }
+      max_score = new_max;
+    }
+
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      U p = use_key[t] ? fast::exp(scores[t] - max_score) : U(0);
+      sum_exp_score += p;
+#pragma unroll
+      for (int j = 0; j < v_per_thread; j++) {
+        o[j] += p * static_cast<U>(vs[t][j]);
+      }
+    }
+  }
+
+  for (; i < k_end; i++) {
+    const int row = indices[i];
+    if (row >= 0) {
+      thread T k[qk_per_thread];
+      load_vec<T, qk_per_thread>(k, keys + size_t(row) * k_seq_stride);
+      U score = 0;
+      for (int j = 0; j < qk_per_thread; j++) {
+        score += q[j] * static_cast<U>(k[j]);
+      }
+      score = simd_sum(score);
+
+      U new_max = max(max_score, score);
+      U factor = fast::exp(max_score - new_max);
+      U exp_score = fast::exp(score - new_max);
+
+      max_score = new_max;
+      sum_exp_score = sum_exp_score * factor + exp_score;
+
+      thread T vt[v_per_thread];
+      load_vec<T, v_per_thread>(vt, values + size_t(row) * v_seq_stride);
+      for (int j = 0; j < v_per_thread; j++) {
+        o[j] = o[j] * factor + exp_score * static_cast<U>(vt[j]);
+      }
+    }
+  }
+
+  if (simd_lid == 0) {
+    sums[0] = sum_exp_score;
+    maxs[0] = max_score;
+  }
+
+  for (int j = 0; j < v_per_thread; j++) {
+    out[j] = o[j];
+  }
+}

--- a/omlx/custom_kernels/decode_fast/fast.py
+++ b/omlx/custom_kernels/decode_fast/fast.py
@@ -93,4 +93,54 @@ def sdpa_decode(
     )
 
 
-__all__ = ["NATIVE_AVAILABLE", "is_native_available", "import_error", "sdpa_decode"]
+def _gathered_fallback(q, k, v, indices, scale):
+    """Gather the rows per query row and run MLX SDPA with a validity mask."""
+    B, H, qL, D = q.shape
+    Hk, L = k.shape[1], k.shape[2]
+    valid = indices >= 0
+    flat = (mx.where(valid, indices, 0) + (mx.arange(B) * L)[:, None, None]).reshape(-1)
+    rows_k = k.transpose(0, 2, 1, 3).reshape(B * L, Hk, D)[flat]
+    rows_v = v.transpose(0, 2, 1, 3).reshape(B * L, Hk, D)[flat]
+    S = indices.shape[-1]
+    ks = rows_k.reshape(B * qL, S, Hk, D).transpose(0, 2, 1, 3)
+    vs = rows_v.reshape(B * qL, S, Hk, D).transpose(0, 2, 1, 3)
+    qs = q.transpose(0, 2, 1, 3).reshape(B * qL, H, 1, D)
+    out = mx.fast.scaled_dot_product_attention(
+        qs, ks, vs, scale=scale, mask=valid.reshape(B * qL, 1, 1, S)
+    )
+    return out.reshape(B, qL, H, D).transpose(0, 2, 1, 3)
+
+
+def sdpa_decode_gathered(
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+    indices: mx.array,
+    scale: float,
+    *,
+    stream: Optional[mx.Stream] = None,
+    force_fallback: bool = False,
+) -> mx.array:
+    """Decode attention over per-query-row cache row sets (int32 [B, qL, S], -1 = empty),
+    read in place by the native kernel when its ABI accepts the inputs."""
+    if (
+        not force_fallback
+        and _ext is not None
+        and hasattr(_ext, "sdpa_decode_gathered_supported")
+        and _ext.sdpa_decode_gathered_supported(q, k, v, indices, stream)
+    ):
+        # Verify-window slices arrive strided; contiguous() is free on realized
+        # row-major inputs and the kernel requires it.
+        return _ext.sdpa_decode_gathered(
+            mx.contiguous(q), k, v, mx.contiguous(indices), scale, stream
+        )
+    return _gathered_fallback(q, k, v, indices, scale)
+
+
+__all__ = [
+    "NATIVE_AVAILABLE",
+    "is_native_available",
+    "import_error",
+    "sdpa_decode",
+    "sdpa_decode_gathered",
+]

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/CMakeLists.txt
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(
   ${CMAKE_CURRENT_LIST_DIR}/exact_block_attention.cpp
   ${CMAKE_CURRENT_LIST_DIR}/fused_moe.cpp
   ${CMAKE_CURRENT_LIST_DIR}/qwen4_qsa_sparse_gqa.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/qwen4_qsa_nax_indexer.cpp
   ${CMAKE_CURRENT_LIST_DIR}/sparse_mla.cpp)
 target_include_directories(
   omlx_glm_kernel_ops
@@ -114,6 +115,46 @@ if(MLX_BUILD_METAL)
   add_custom_target(omlx_glm_kernels_metallib DEPENDS ${OMLX_GLM_METALLIB})
 
   add_dependencies(omlx_glm_kernel_ops omlx_glm_kernels_metallib)
+
+  # Tensor-unit (NAX) kernels live in a second metallib built with
+  # -mmacosx-version-min=26.2 (MetalPerformancePrimitives tensor ops); the host
+  # checks for the file and the GPU generation and keeps the classic kernels
+  # otherwise.
+  execute_process(
+    COMMAND xcrun -sdk macosx --show-sdk-version
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE OMLX_GLM_MACOS_SDK_VERSION
+    ERROR_QUIET)
+  if(OMLX_GLM_MACOS_SDK_VERSION VERSION_GREATER_EQUAL 26.2)
+    set(OMLX_GLM_NAX_METAL_FLAGS
+        -x metal -Wall -Wextra -fno-fast-math -Wno-c++17-extensions
+        -Wno-c++20-extensions -mmacosx-version-min=26.2)
+    if(MLX_METAL_DEBUG)
+      set(OMLX_GLM_NAX_METAL_FLAGS ${OMLX_GLM_NAX_METAL_FLAGS} -gline-tables-only -frecord-sources)
+    endif()
+    set(OMLX_GLM_NAX_AIR ${CMAKE_CURRENT_BINARY_DIR}/qwen4_qsa_nax_indexer_score.air)
+    add_custom_command(
+      OUTPUT ${OMLX_GLM_NAX_AIR}
+      COMMAND xcrun -sdk macosx metal ${OMLX_GLM_NAX_METAL_FLAGS} -c
+              ${CMAKE_CURRENT_LIST_DIR}/qwen4_qsa_nax_indexer_score.metal
+              ${OMLX_GLM_METAL_INCLUDE_ARGS} -o ${OMLX_GLM_NAX_AIR}
+      DEPENDS ${CMAKE_CURRENT_LIST_DIR}/qwen4_qsa_nax_indexer_score.metal
+              ${OMLX_GLM_METAL_HEADERS}
+      COMMENT "Building qwen4_qsa_nax_indexer_score.air"
+      VERBATIM)
+    set(OMLX_GLM_NAX_METALLIB ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/omlx_glm_kernels_nax.metallib)
+    add_custom_command(
+      OUTPUT ${OMLX_GLM_NAX_METALLIB}
+      COMMAND xcrun -sdk macosx metal -mmacosx-version-min=26.2 ${OMLX_GLM_NAX_AIR}
+              -o ${OMLX_GLM_NAX_METALLIB}
+      DEPENDS ${OMLX_GLM_NAX_AIR}
+      COMMENT "Building omlx_glm_kernels_nax.metallib"
+      VERBATIM)
+    add_custom_target(omlx_glm_kernels_nax_metallib DEPENDS ${OMLX_GLM_NAX_METALLIB})
+    add_dependencies(omlx_glm_kernel_ops omlx_glm_kernels_nax_metallib)
+  else()
+    message(STATUS "omlx: macOS SDK ${OMLX_GLM_MACOS_SDK_VERSION} < 26.2, skipping glm NAX kernels")
+  endif()
 
 endif()
 

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/bindings.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/bindings.cpp
@@ -9,6 +9,7 @@
 #include "dspark_qmv.h"
 #include "exact_block_attention.h"
 #include "fused_moe.h"
+#include "qwen4_qsa_nax_indexer.h"
 #include "qwen4_qsa_sparse_gqa.h"
 #include "sparse_mla.h"
 
@@ -59,6 +60,19 @@ NB_MODULE(_ext, m) {
       "pooled_keys"_a,
       "mask_ratio"_a = 4,
       "mask_q_offset"_a = 0,
+      "stream"_a = nb::none());
+  m.def(
+      "qwen4_qsa_nax_indexer_available",
+      &omlx::glm_kernels::qwen4_qsa_nax_indexer_available);
+  m.def(
+      "qwen4_qsa_nax_indexer_scores",
+      &omlx::glm_kernels::qwen4_qsa_nax_indexer_scores,
+      "queries"_a,
+      "pooled_keys"_a,
+      "mask_ratio"_a = 4,
+      "mask_q_offset"_a = 0,
+      "block_rows"_a = 64,
+      "block_cols"_a = 64,
       "stream"_a = nb::none());
   m.def(
       "qwen4_qsa_topk_indices",

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/kernels/nax_qwen4_qsa_indexer_score.h
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/kernels/nax_qwen4_qsa_indexer_score.h
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Qwen4 QSA indexer scores on the tensor units: per head, a bf16 GEMM with fp32
+// accumulate (mlx steel NAX tiles) followed by ReLU and the head-sum in
+// registers, then 1/sqrt(D) and the pooled causal sentinel in the epilogue.
+// Same contract as qwen4_qsa_indexer_score (steel_dsa_indexer_score.h); the
+// fp32 sums differ from it only by accumulation order.
+#pragma once
+
+using namespace mlx::steel;
+
+template <typename T, int BM, int BN, int BK, int WM, int WN>
+[[kernel, max_total_threads_per_threadgroup(WM * WN * 32)]] void
+qwen4_qsa_nax_indexer_score(
+    const device T* Q [[buffer(0)]],
+    const device T* K [[buffer(1)]],
+    device float* O [[buffer(2)]],
+    const constant GEMMParams* params [[buffer(3)]],
+    const constant int& mask_ratio [[buffer(4)]],
+    const constant int& mask_q_offset [[buffer(5)]],
+    const constant float& score_divisor [[buffer(6)]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint3 tid [[threadgroup_position_in_grid]]) {
+  constexpr int H = 4;
+  constexpr short SM = BM / WM;
+  constexpr short SN = BN / WN;
+  constexpr short SK = 32;
+  constexpr short TM = SM / 16;
+  constexpr short TN = SN / 16;
+  static_assert(SM % 16 == 0 && SN % 16 == 0 && BK % SK == 0, "NAX tiles are 16 wide");
+
+  const int tid_x = int(tid.x);
+  const int tid_y = int(tid.y);
+  if (params->tiles_n <= tid_x || params->tiles_m <= tid_y) {
+    return;
+  }
+  const int M = params->M;
+  const int N = params->N;
+  const int D = params->K;
+  Q += size_t(tid.z) * H * M * D;
+  K += size_t(tid.z) * N * D;
+  O += size_t(tid.z) * M * N;
+
+  const short tm = SM * (simd_group_id / WN);
+  const short tn = SN * (simd_group_id % WN);
+  const int row0 = tid_y * BM + tm;
+  const int col0 = tid_x * BN + tn;
+  const short sgp_sm = short(metal::min(int(SM), M - row0));
+  const short sgp_sn = short(metal::min(int(SN), N - col0));
+  const bool aligned_m = sgp_sm == SM;
+  const bool aligned_n = sgp_sn == SN;
+
+  using Tile = NAXTile<float, TM, TN>;
+  const device T* Bp = K + size_t(metal::max(col0, 0)) * params->ldb;
+  float acc[Tile::kElemsPerTile];
+  STEEL_PRAGMA_UNROLL
+  for (short i = 0; i < Tile::kElemsPerTile; ++i) {
+    acc[i] = 0.0f;
+  }
+
+  STEEL_PRAGMA_UNROLL
+  for (short h = 0; h < H; ++h) {
+    const device T* Ap = Q + size_t(h) * M * D + size_t(metal::max(row0, 0)) * params->lda;
+    Tile Dtile;
+    dispatch_bool(aligned_m, [&](auto kAlignedM) {
+      dispatch_bool(aligned_n, [&](auto kAlignedN) {
+        Dtile = gemm_loop<
+            T, SM, SN, SK, BK, false, true, kAlignedM.value, kAlignedN.value, true, float>(
+            Ap, Bp, params->lda, params->ldb, params->K,
+            params->gemm_k_iterations_aligned, sgp_sm, sgp_sn);
+      });
+    });
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < Tile::kNumFrags; ++i) {
+      STEEL_PRAGMA_UNROLL
+      for (short e = 0; e < Tile::kElemsPerFrag; ++e) {
+        acc[i * Tile::kElemsPerFrag + e] += metal::max(Dtile.val_frags[i][e], 0.0f);
+      }
+    }
+  }
+
+  if (sgp_sm <= 0 || sgp_sn <= 0) {
+    return;
+  }
+  const float sentinel = as_type<float>(uint(0xFF7FFFFF));
+  STEEL_PRAGMA_UNROLL
+  for (short mm = 0; mm < TM; ++mm) {
+    STEEL_PRAGMA_UNROLL
+    for (short nn = 0; nn < TN; ++nn) {
+      STEEL_PRAGMA_UNROLL
+      for (short e = 0; e < Tile::kElemsPerFrag; ++e) {
+        const short2 c = Tile::NAXFrag_t::get_coord(e);
+        const int row = row0 + mm * 16 + c.y;
+        const int col = col0 + nn * 16 + c.x;
+        if (row < M && col < N) {
+          const bool masked = col >= (mask_q_offset + row + 1) / mask_ratio;
+          O[size_t(row) * params->ldd + col] =
+              masked ? sentinel : acc[(mm * TN + nn) * Tile::kElemsPerFrag + e] / score_divisor;
+        }
+      }
+    }
+  }
+}

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/qwen4_qsa_nax_indexer.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/qwen4_qsa_nax_indexer.cpp
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "qwen4_qsa_nax_indexer.h"
+
+#include <dlfcn.h>
+#include <cmath>
+#include <filesystem>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "mlx/allocator.h"
+#include "mlx/backend/common/utils.h"
+#include "mlx/backend/metal/device.h"
+#include "mlx/backend/metal/kernels/steel/gemm/params.h"
+#include "mlx/backend/metal/metal.h"
+#include "mlx/backend/metal/utils.h"
+#include "mlx/ops.h"
+#include "mlx/primitives.h"
+#include "mlx/utils.h"
+
+namespace omlx::glm_kernels {
+namespace {
+using namespace mlx::core;
+
+constexpr const char* kNaxMetallibName = "omlx_glm_kernels_nax";
+
+std::string current_binary_dir() {
+  static std::string binary_dir = []() {
+    Dl_info info;
+    if (!dladdr(reinterpret_cast<void*>(&current_binary_dir), &info)) {
+      throw std::runtime_error("Unable to get omlx_glm_kernels binary dir.");
+    }
+    return std::filesystem::path(info.dli_fname).parent_path().string();
+  }();
+  return binary_dir;
+}
+
+bool row_contiguous(const array& a) {
+  return a.flags().row_contiguous;
+}
+
+// Mirror of mlx::core::metal::is_nax_available() (not exported by libmlx).
+bool nax_gpu() {
+  static bool available = []() {
+    if (!metal::is_available()) {
+      return false;
+    }
+    bool os_ok = false;
+    if (__builtin_available(macOS 26.2, iOS 26.2, tvOS 26.2, visionOS 26.2, *)) {
+      os_ok = true;
+    }
+    if (!os_ok) {
+      return false;
+    }
+    auto& d = metal::device(Device::gpu);
+    const auto& arch = d.get_architecture();
+    if (arch.empty()) {
+      return false;
+    }
+    const char suffix = arch.back();
+    const int gen = d.get_architecture_gen();
+    return gen >= (suffix == 'p' ? 18 : 17);
+  }();
+  return available;
+}
+
+bool nax_lib_built() {
+  static bool built = std::filesystem::exists(
+      std::filesystem::path(current_binary_dir()) /
+      (std::string(kNaxMetallibName) + ".metallib"));
+  return built;
+}
+
+class Qwen4QSANaxIndexerScoresPrimitive : public Primitive {
+ public:
+  Qwen4QSANaxIndexerScoresPrimitive(
+      Stream stream, int mask_ratio, int mask_q_offset, int block_rows, int block_cols)
+      : Primitive(stream),
+        mask_ratio_(mask_ratio),
+        mask_q_offset_(mask_q_offset),
+        block_rows_(block_rows),
+        block_cols_(block_cols) {}
+
+  static bool unsupported(const array& q, const array& k, int block_rows, int block_cols, Stream s) {
+    if (s.device == Device::cpu || q.dtype() != k.dtype()) {
+      return true;
+    }
+    if (q.dtype() != float16 && q.dtype() != bfloat16) {
+      return true;
+    }
+    if (q.ndim() != 4 || k.ndim() != 4) {
+      return true;
+    }
+    if (block_rows != 64 || (block_cols != 64 && block_cols != 128)) {
+      return true;
+    }
+    return q.shape(0) != 1 || k.shape(0) != 1 || q.shape(1) != 4 ||
+        k.shape(1) != 1 || q.shape(2) <= 0 || k.shape(2) <= 0 ||
+        q.shape(3) != 128 || k.shape(3) != 128;
+  }
+
+  void eval_cpu(const std::vector<array>&, std::vector<array>&) override {
+    throw std::runtime_error("Qwen4QSANaxIndexerScoresPrimitive has no CPU path.");
+  }
+
+  void eval_gpu(const std::vector<array>& inputs, std::vector<array>& outputs) override {
+    auto& s = stream();
+    auto& d = metal::device(s.device);
+    auto& out = outputs[0];
+    const auto& q = inputs[0];
+    const auto& k = inputs[1];
+    if (!row_contiguous(q) || !row_contiguous(k)) {
+      throw std::runtime_error(
+          "[omlx_glm_kernels.qwen4_qsa_nax_indexer_scores] inputs must be row-contiguous");
+    }
+    out.set_data(allocator::malloc(out.nbytes()));
+    const int bm = block_rows_;
+    const int bn = block_cols_;
+    constexpr int bk = 64;
+    constexpr int wm = 2;
+    constexpr int wn = 2;
+    const int B = q.shape(0);
+    const int H = q.shape(1);
+    const int M = q.shape(2);
+    const int N = k.shape(2);
+    const int D = q.shape(3);
+    const int tiles_m = (M + bm - 1) / bm;
+    const int tiles_n = (N + bn - 1) / bn;
+    mlx::steel::GEMMParams params{
+        /* M = */ M,
+        /* N = */ N,
+        /* K = */ D,
+        /* lda = */ D,
+        /* ldb = */ D,
+        /* ldd = */ N,
+        /* tiles_n = */ tiles_n,
+        /* tiles_m = */ tiles_m,
+        /* batch_stride_a = */ int64_t(H) * M * D,
+        /* batch_stride_b = */ int64_t(N) * D,
+        /* batch_stride_d = */ int64_t(M) * N,
+        /* swizzle_log = */ 0,
+        /* gemm_k_iterations_aligned = */ D / bk,
+        /* batch_ndim = */ 1};
+    std::string name;
+    concatenate(name, "qwen4_qsa_nax_indexer_score_", type_to_name(q), "_bm", bm,
+                "_bn", bn, "_bk", bk, "_wm", wm, "_wn", wn);
+    auto lib = d.get_library(kNaxMetallibName, current_binary_dir());
+    auto kernel = d.get_kernel(name, lib);
+    auto& encoder = metal::get_command_encoder(s);
+    encoder.set_compute_pipeline_state(kernel);
+    encoder.set_input_array(q, 0);
+    encoder.set_input_array(k, 1);
+    encoder.set_output_array(out, 2);
+    encoder.set_bytes(params, 3);
+    encoder.set_bytes(mask_ratio_, 4);
+    encoder.set_bytes(mask_q_offset_, 5);
+    const float score_divisor = std::sqrt(static_cast<float>(D));
+    encoder.set_bytes(score_divisor, 6);
+    encoder.dispatch_threadgroups(MTL::Size(tiles_n, tiles_m, B), MTL::Size(wm * wn * 32, 1, 1));
+  }
+
+  DEFINE_NAME(OMLXQwen4QSANaxIndexerScores)
+
+  bool is_equivalent(const Primitive& other) const override {
+    const auto& rhs = static_cast<const Qwen4QSANaxIndexerScoresPrimitive&>(other);
+    return mask_ratio_ == rhs.mask_ratio_ && mask_q_offset_ == rhs.mask_q_offset_ &&
+        block_rows_ == rhs.block_rows_ && block_cols_ == rhs.block_cols_;
+  }
+
+ private:
+  int mask_ratio_;
+  int mask_q_offset_;
+  int block_rows_;
+  int block_cols_;
+};
+} // namespace
+
+bool qwen4_qsa_nax_indexer_available() {
+  return nax_gpu() && nax_lib_built();
+}
+
+array qwen4_qsa_nax_indexer_scores(
+    const array& queries, const array& pooled_keys, int mask_ratio, int mask_q_offset,
+    int block_rows, int block_cols, StreamOrDevice s) {
+  auto stream = to_stream(s);
+  if (Qwen4QSANaxIndexerScoresPrimitive::unsupported(queries, pooled_keys, block_rows, block_cols, stream) ||
+      mask_ratio <= 0 || mask_q_offset < 0 || !qwen4_qsa_nax_indexer_available()) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.qwen4_qsa_nax_indexer_scores] expected q=[1,4,M,128], "
+        << "k=[1,1,N,128] bf16/fp16, mask_ratio>0, block_rows == 64, block_cols in {64,128}, a NAX GPU and "
+        << kNaxMetallibName << ".metallib; got " << queries.shape() << ", "
+        << pooled_keys.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  // Lazy views carry no final flags; contiguous() is elided on realized row-major inputs.
+  array q = contiguous(queries, false, s);
+  array k = contiguous(pooled_keys, false, s);
+  Shape out_shape{q.shape(0), q.shape(2), k.shape(2)};
+  return array(
+      std::move(out_shape), float32,
+      std::make_shared<Qwen4QSANaxIndexerScoresPrimitive>(stream, mask_ratio, mask_q_offset, block_rows, block_cols),
+      std::vector<array>{q, k});
+}
+} // namespace omlx::glm_kernels

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/qwen4_qsa_nax_indexer.h
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/qwen4_qsa_nax_indexer.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+#include "mlx/array.h"
+#include "mlx/stream.h"
+#include "mlx/utils.h"
+namespace mx = mlx::core;
+namespace omlx::glm_kernels {
+// True when the GPU has tensor units (macOS >= 26.2, applegpu gen >= 17) and
+// omlx_glm_kernels_nax.metallib was built next to the extension.
+bool qwen4_qsa_nax_indexer_available();
+// Tensor-unit form of qwen4_qsa_indexer_scores: same inputs ([1,4,M,128] and
+// [1,1,N,128] bf16/fp16), same fp32 [1,M,N] output with the pooled causal
+// sentinel; fp32 sums differ from the steel kernel only by accumulation order.
+mx::array qwen4_qsa_nax_indexer_scores(
+    const mx::array& queries,
+    const mx::array& pooled_keys,
+    int mask_ratio = 4,
+    int mask_q_offset = 0,
+    int block_rows = 64,
+    int block_cols = 64,
+    mx::StreamOrDevice s = {});
+} // namespace omlx::glm_kernels

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/qwen4_qsa_nax_indexer_score.metal
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/qwen4_qsa_nax_indexer_score.metal
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Compiled into omlx_glm_kernels_nax.metallib (-mmacosx-version-min=26.2).
+// clang-format off
+#include "mlx/backend/metal/kernels/utils.h"
+#include "mlx/backend/metal/kernels/steel/gemm/gemm_nax.h"
+#include "kernels/nax_qwen4_qsa_indexer_score.h"
+// clang-format on
+using namespace mlx::steel;
+#define instantiate_qwen4_nax_score(tname, dtype, bm, bn, bk, wm, wn)          \
+  instantiate_kernel("qwen4_qsa_nax_indexer_score_" #tname "_bm" #bm "_bn" #bn \
+                     "_bk" #bk "_wm" #wm "_wn" #wn,                            \
+                     qwen4_qsa_nax_indexer_score, dtype, bm, bn, bk, wm, wn)
+// 64x64 is the measured best on the M5 Max (3.1 ms per 2048x32768 vs 4.8 steel); 64x128 kept as the alternate.
+instantiate_qwen4_nax_score(bfloat16, bfloat16_t, 64, 64, 64, 2, 2);
+instantiate_qwen4_nax_score(float16, half, 64, 64, 64, 2, 2);
+instantiate_qwen4_nax_score(bfloat16, bfloat16_t, 64, 128, 64, 2, 2);
+instantiate_qwen4_nax_score(float16, half, 64, 128, 64, 2, 2);

--- a/omlx/custom_kernels/glm_moe_dsa/fast.py
+++ b/omlx/custom_kernels/glm_moe_dsa/fast.py
@@ -102,6 +102,7 @@ NATIVE_SYMBOLS = (
     "dsa_decode_scores",
     "dsa_indexer_scores",
     "qwen4_qsa_indexer_scores",
+    "qwen4_qsa_nax_indexer_scores",
     "qwen4_qsa_topk_indices",
     "qwen4_qsa_sparse_gqa_attention",
     "dsa_topk_indices",
@@ -286,6 +287,40 @@ def qwen4_qsa_indexer_scores(
         pooled_keys,
         mask_ratio=mask_ratio,
         mask_q_offset=mask_q_offset,
+        **_native_stream_kwargs(stream),
+    )
+
+
+def qwen4_qsa_nax_indexer_available() -> bool:
+    """True on a tensor-unit GPU with the NAX metallib built next to the extension."""
+    fn = getattr(_ext, "qwen4_qsa_nax_indexer_available", None) if _ext is not None else None
+    try:
+        return bool(fn()) if fn is not None else False
+    except Exception:
+        return False
+
+
+def qwen4_qsa_nax_indexer_scores(
+    queries: mx.array,
+    pooled_keys: mx.array,
+    mask_ratio: int = 4,
+    mask_q_offset: int = 0,
+    *,
+    block_rows: int = 64,
+    block_cols: int = 64,
+    stream=None,
+) -> mx.array:
+    """Tensor-unit form of :func:`qwen4_qsa_indexer_scores` (same inputs, fp32
+    ``[1, M, N]`` output, sums differ only by accumulation order)."""
+    if _ext is None or not hasattr(_ext, "qwen4_qsa_nax_indexer_scores"):
+        raise RuntimeError("qwen4_qsa_nax_indexer_scores requires a local extension build")
+    return _ext.qwen4_qsa_nax_indexer_scores(
+        queries,
+        pooled_keys,
+        mask_ratio=mask_ratio,
+        mask_q_offset=mask_q_offset,
+        block_rows=block_rows,
+        block_cols=block_cols,
         **_native_stream_kwargs(stream),
     )
 

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1951,6 +1951,16 @@ class VLMBatchedEngine(BaseEngine):
         except Exception:
             logger.debug("Qwen GDN prework patch not applied", exc_info=True)
 
+        # Small-row projections: one qmm per quantisation signature.
+        try:
+            from ..patches.qwen35_grouped_linears import (
+                apply_qwen35_grouped_linears_patch,
+            )
+
+            apply_qwen35_grouped_linears_patch()
+        except Exception:
+            logger.debug("Qwen grouped linears patch not applied", exc_info=True)
+
         # Qwen3.5/3.6 verify-width (MTP target-verify) attention -> chunked
         # causal vector-kernel calls instead of the per-row SDPA loop.
         try:

--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -758,6 +758,8 @@ class _MtpState:
     # True while this state is a bounded re-entry probe after a performance
     # handoff. Correctness fallbacks and late-join handoffs do not set it.
     reentry_probe: bool = False
+    # Head-input hidden of next_main, kept at park time for the parked fold.
+    park_hidden: Optional[Any] = None
 
     # Accept-rate / throughput counters. Surfaced via logger.info on finish.
     stats: _MtpStats = field(default_factory=_MtpStats)
@@ -2300,6 +2302,17 @@ def _dspark_next_drafts(
     mx.async_eval(state.drafts)
 
 
+def _head_input_hidden(model: Any, hidden_rows: Any) -> Any:
+    """Trunk hidden as the MTP head consumes it: post-norm unless the head
+    normalizes internally (inkling, Qwen4 mark ``_omlx_mtp_head_prenorm``)."""
+    head_prenorm = getattr(model, "_omlx_mtp_head_prenorm", False) or getattr(
+        getattr(model, "_language_model", None), "_omlx_mtp_head_prenorm", False
+    )
+    if _HEAD_HIDDEN_POST_NORM and not head_prenorm and hidden_rows.ndim == 3:
+        return _trunk_norm_module(model)(hidden_rows)
+    return hidden_rows
+
+
 def _chain_next_drafts(
     gen_batch: Any,
     state: _MtpState,
@@ -2353,14 +2366,7 @@ def _chain_next_drafts(
         state.draft_accept_lps = []
         return
 
-    # Models whose MTP head normalizes its hidden input internally
-    # (inkling: per-block hidden_norm, chain_hidden_post_norm=False) mark
-    # themselves and receive the raw pre-norm trunk hidden.
-    head_prenorm = getattr(model, "_omlx_mtp_head_prenorm", False) or getattr(
-        getattr(model, "_language_model", None), "_omlx_mtp_head_prenorm", False
-    )
-    if _HEAD_HIDDEN_POST_NORM and not head_prenorm and hidden_rows.ndim == 3:
-        hidden_rows = _trunk_norm_module(model)(hidden_rows)
+    hidden_rows = _head_input_hidden(model, hidden_rows)
 
     # Multi-block heads (inkling) route fold/chain by a per-cycle pass
     # counter on the cache list; reset it before the fold. Single-block
@@ -2713,9 +2719,10 @@ def _feed_next_main_to_standard(gen_batch: Any, state: _MtpState) -> bool:
         prev_buf = None
         if procs is not None:
             prev_buf = gen_batch._token_context[0].update_and_fetch(state.next_main)
-        logits, _, _ = _call_backbone(
+        logits, hidden, _ = _call_backbone(
             gen_batch.model, state.next_main[:, None], gen_batch.prompt_cache
         )
+        state.park_hidden = _park_hidden_or_none(gen_batch.model, hidden)
         last = _apply_processors(procs, prev_buf, logits[:, -1, :])
         lp_2d = _logprobs(last)
         next_tok = _ensure_uint32(_resolve_sampler(gen_batch)(lp_2d))
@@ -2727,6 +2734,49 @@ def _feed_next_main_to_standard(gen_batch: Any, state: _MtpState) -> bool:
         return False
     _clear_rollback(gen_batch.prompt_cache)
     return True
+
+
+def _park_hidden_or_none(model: Any, hidden: Any):
+    """Head-input hidden of the fed token; None (no parked fold) when unavailable."""
+    if hidden is None:
+        return None
+    try:
+        return _head_input_hidden(model, hidden[:, -1:])
+    except Exception:
+        return None
+
+
+def _arm_parked_fold(gen_batch: Any, state: _MtpState) -> None:
+    """Hand the committed head cache to the priming context so standard decode
+    keeps folding pairs and the re-entry probe starts primed."""
+    if not _parked_fold_enabled():
+        return
+    try:
+        if not state.mtp_cache or state.park_hidden is None:
+            return
+        if not state.head_clone:
+            _mtp_head_trim_to(state.mtp_cache, state.hist_offset)
+        anchor_offset = _prompt_priming._activation_offset(gen_batch.prompt_cache)
+        if anchor_offset is None:
+            return
+        _prompt_priming.begin_parked_ctx(
+            gen_batch.model,
+            state.mtp_cache,
+            state.park_hidden,
+            folded=int(state.hist_offset),
+            expected_offset=int(anchor_offset),
+        )
+    except Exception:
+        logger.debug("parked head fold not armed", exc_info=True)
+
+
+def _parked_fold_enabled() -> bool:
+    return os.environ.get("OMLX_MTP_PARKED_FOLD", "1").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
 
 
 def _park_mtp_to_standard(gen_batch: Any, state: _MtpState) -> bool:
@@ -2742,6 +2792,7 @@ def _park_mtp_to_standard(gen_batch: Any, state: _MtpState) -> bool:
     """
     if not _feed_next_main_to_standard(gen_batch, state):
         return False
+    _arm_parked_fold(gen_batch, state)
     park_state = _mtp_park_state_for_batch(gen_batch)
     if state.reentry_probe and park_state is not None:
         park_state.restart_after_failed_probe()

--- a/omlx/patches/mlx_lm_mtp/prompt_priming.py
+++ b/omlx/patches/mlx_lm_mtp/prompt_priming.py
@@ -148,6 +148,9 @@ class _PrimeCtx:
     extra_key_token_start: Optional[int] = None
     extra_key_ranges: Optional[list[tuple[int, tuple[Any, ...]]]] = None
     snapshot_candidate: Any = None
+    # Parked-decode timeline: pairs are buffered and folded in blocks.
+    parked: bool = False
+    pending_pairs: list = field(default_factory=list)
 
 
 @dataclass
@@ -398,6 +401,53 @@ def _snapshot_arrays(snapshot: _MtpPrefixSnapshot) -> list[Any]:
             if isinstance(value, mx.array):
                 arrays.append(value)
     return arrays
+
+
+def park_fold_block() -> int:
+    try:
+        return max(1, int(os.environ.get("OMLX_MTP_PARK_FOLD_BLOCK", "32")))
+    except ValueError:
+        return 32
+
+
+def begin_parked_ctx(model, mtp_cache, pending_hidden, *, folded: int, expected_offset: int):
+    """Adopt a parked MTP head cache as the priming timeline (see _park_mtp_to_standard).
+
+    ``folded`` is the head cache's committed offset; ``take_primed`` returns
+    ``folded + 1`` as the new ``hist_offset``."""
+    host = _eligible_host(model)
+    if host is None or not mtp_cache or folded < 0:
+        return None
+    drop_ctx(host)
+    ctx = _PrimeCtx(
+        mtp_cache=mtp_cache,
+        pending_hidden=pending_hidden,
+        folded=int(folded),
+        expected_offset=int(expected_offset),
+        parked=True,
+    )
+    setattr(host, _CTX_ATTR, ctx)
+    return ctx
+
+
+def _flush_parked(host, ctx) -> None:
+    if not ctx.pending_pairs:
+        return
+    import mlx.core as mx
+
+    hidden = mx.concatenate([h for h, _ in ctx.pending_pairs], axis=1)
+    tokens = mx.concatenate([t for _, t in ctx.pending_pairs], axis=1)
+    host.mtp_forward(hidden, tokens, ctx.mtp_cache, logits_keep=1)
+    ctx.folded += int(tokens.shape[1])
+    ctx.pending_pairs = []
+    evals = []
+    for c in ctx.mtp_cache:
+        for name in ("keys", "values"):
+            arr = getattr(c, name, None)
+            if arr is not None:
+                evals.append(arr)
+    if evals:
+        mx.async_eval(evals)
 
 
 def capture_eligible(host: Any, cache: Optional[List[Any]]) -> bool:
@@ -673,6 +723,19 @@ def maybe_capture(
     if ctx is not None and ctx.window_exceeded:
         ctx.expected_offset = offset_after
         return
+    if ctx is not None and ctx.parked:
+        # Standard decode while MTP is parked: buffer (hidden, next token)
+        # pairs and fold them in blocks; the prime window does not apply.
+        if seq_len != 1:
+            drop_ctx(host)
+            return
+        if ctx.pending_hidden is not None:
+            ctx.pending_pairs.append((ctx.pending_hidden, inputs))
+            if len(ctx.pending_pairs) >= park_fold_block():
+                _flush_parked(host, ctx)
+        ctx.pending_hidden = normed[:, -1:]
+        ctx.expected_offset = offset_after
+        return
     window = prime_window()
     if window:
         # Cap by the primed span (the head-KV the window exists to bound),
@@ -795,6 +858,8 @@ def take_primed(
         # hook declined without popping it — not ours to consume.
         return None
     drop_ctx(model)
+    if ctx.parked:
+        _flush_parked(model, ctx)
     if not (ctx.valid and ctx.folded > 0 and ctx.pending_hidden is not None):
         return None
     offset = _activation_offset(cache)

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -92,6 +92,19 @@ def _rank_two_text_position_ids(
     )
 
 
+def _gathered_narrow_min_context() -> int:
+    """Context (cache offset) from which narrow 2..15-row windows take the gathered
+    arm: the masked-dense path reads the whole prefix per window (4.9 ms at 82k
+    for the MTP head's 3-4 row fold) while gathered rows stay context-flat."""
+    raw = os.environ.get("OMLX_QWEN4_GATHERED_NARROW_MIN_CONTEXT", "").strip()
+    if raw:
+        try:
+            return max(0, int(raw))
+        except ValueError:
+            pass
+    return 16384
+
+
 def _gathered_min_query_tokens() -> int:
     """Keep narrow Lightning MTP windows on masked SDPA (M5 crossover)."""
     raw = os.environ.get("OMLX_QWEN4_GATHERED_MIN_QUERY", "").strip()
@@ -1284,16 +1297,20 @@ class Qwen4ExpAttention(Qwen3_5Attention):
         if not (
             x.ndim == 3
             and x.shape[0] == 1
-            # Narrow multi-row windows (Lightning MTP history/verify passes)
-            # are cheaper on the official masked path; see
-            # _gathered_min_query_tokens.
-            and x.shape[1] >= _gathered_min_query_tokens()
+            and x.shape[1] > 1
             and causal_mask
             and type(cache) is QSAKVCache
             and isinstance(cache.offset, int)
             and position_embeddings is None
             and not target_verify
             and self._batch_one_text_position_ids(position_ids, x.shape[1])
+        ):
+            return False
+        # Narrow windows (Lightning MTP head folds, prefill tails) are cheaper
+        # on the masked path at short context and on the gathered arm once the
+        # prefix is long; see _gathered_min_query_tokens / _gathered_narrow_min_context.
+        if x.shape[1] < _gathered_min_query_tokens() and (
+            cache.offset < _gathered_narrow_min_context()
         ):
             return False
         return bool(

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qsa_fast.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qsa_fast.py
@@ -22,6 +22,7 @@ IndexRoPE = Callable[[mx.array, mx.array], mx.array]
 
 _NATIVE_QSA_SCORE_DISABLED = False
 _NATIVE_QSA_SCORE_PROVEN = False
+_NATIVE_QSA_NAX_SCORES_DISABLED = False
 _NATIVE_QSA_TOPK_DISABLED = False
 _NATIVE_QSA_TOPK_PROVEN = False
 _NATIVE_QSA_MAIN_DISABLED = False
@@ -191,6 +192,24 @@ def pool_completed_index_keys(
     return apply_index_rope(pooled[:, None], pooled_positions)[:, 0]
 
 
+def _native_scores_kernel(fast):
+    """The tensor-unit score kernel on NAX GPUs (OMLX_QWEN4_QSA_NAX_SCORES=0 keeps
+    the steel kernel), else the steel kernel."""
+    global _NATIVE_QSA_NAX_SCORES_DISABLED
+    if (
+        not _NATIVE_QSA_NAX_SCORES_DISABLED
+        and os.environ.get("OMLX_QWEN4_QSA_NAX_SCORES", "").strip() != "0"
+        and fast.has_symbol("qwen4_qsa_nax_indexer_scores")
+    ):
+        try:
+            if fast.qwen4_qsa_nax_indexer_available():
+                return fast.qwen4_qsa_nax_indexer_scores
+        except Exception:
+            pass
+        _NATIVE_QSA_NAX_SCORES_DISABLED = True
+    return fast.qwen4_qsa_indexer_scores
+
+
 def _native_indexer_scores(
     queries: mx.array,
     pooled_keys: mx.array,
@@ -232,7 +251,7 @@ def _native_indexer_scores(
         # The caller's [B,M,H,D] view transposes back to the GEMM-friendly
         # [B,H,M,D] ABI. The native wrapper only copies when the resulting
         # view is not row-contiguous (for example an offset query chunk).
-        scores = fast.qwen4_qsa_indexer_scores(
+        scores = _native_scores_kernel(fast)(
             queries.transpose(0, 2, 1, 3),
             pooled_keys[:, None],
             mask_ratio=compress_ratio,

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qsa_fast.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qsa_fast.py
@@ -26,6 +26,8 @@ _NATIVE_QSA_TOPK_DISABLED = False
 _NATIVE_QSA_TOPK_PROVEN = False
 _NATIVE_QSA_MAIN_DISABLED = False
 _NATIVE_QSA_MAIN_PROVEN = False
+_NATIVE_QSA_GATHERED_DISABLED = False
+_NATIVE_QSA_GATHERED_PROVEN = False
 
 
 def _nax_gpu() -> bool:
@@ -350,6 +352,61 @@ def _native_sparse_gqa_attention(
         return None
 
 
+def _native_gathered_decode_attention(
+    queries: mx.array,
+    keys: mx.array,
+    values: mx.array,
+    selected_indices: mx.array,
+    selected_valid: mx.array,
+) -> mx.array | None:
+    """Attend the selected cache rows in place through the gathered decode kernel.
+
+    Covers the verify widths below the steel kernel's row gate, where the MLX
+    path copies every row set out of the cache before fp32 SDPA. ``queries``
+    is ``[B, H, T, D]``; ``selected_indices``/``selected_valid`` are
+    ``[B, T, S]``. Returns ``[B, T, H, D]`` or None to keep the MLX path.
+    """
+
+    global _NATIVE_QSA_GATHERED_DISABLED, _NATIVE_QSA_GATHERED_PROVEN
+    if _NATIVE_QSA_GATHERED_DISABLED:
+        return None
+    if os.environ.get("OMLX_QWEN4_QSA_GATHERED_DECODE", "").strip() == "0":
+        return None
+    if (
+        queries.ndim != 4
+        or keys.ndim != 4
+        or values.shape != keys.shape
+        or queries.dtype != keys.dtype
+        or queries.dtype != values.dtype
+        or queries.dtype not in {mx.float16, mx.bfloat16, mx.float32}
+        or queries.shape[-1] not in {64, 96, 128, 256}
+        or queries.shape[2] >= _native_main_min_rows()
+        or selected_indices.shape != selected_valid.shape
+        or selected_indices.shape[:2] != (queries.shape[0], queries.shape[2])
+    ):
+        return None
+    try:
+        from omlx.custom_kernels.decode_fast import fast
+
+        extension = getattr(fast, "_ext", None)
+        if not getattr(fast, "NATIVE_AVAILABLE", False) or not hasattr(
+            extension, "sdpa_decode_gathered"
+        ):
+            _NATIVE_QSA_GATHERED_DISABLED = True
+            return None
+        indices = mx.where(selected_valid, selected_indices, -1).astype(mx.int32)
+        output = fast.sdpa_decode_gathered(
+            queries, keys, values, indices, queries.shape[-1] ** -0.5
+        )
+        if not _NATIVE_QSA_GATHERED_PROVEN:
+            mx.eval(output)
+            _NATIVE_QSA_GATHERED_PROVEN = True
+        return output.transpose(0, 2, 1, 3)
+    except Exception:
+        _NATIVE_QSA_GATHERED_DISABLED = True
+        return None
+
+
 def _decode_qsa_sdpa(
     queries: mx.array,
     keys: mx.array,
@@ -486,6 +543,16 @@ def contiguous_causal_gathered_qsa_decode(
     if complete_key_len < key_tokens:
         tail = mx.arange(complete_key_len, key_tokens, dtype=mx.int32)[None]
         selected_tokens = mx.concatenate((selected_tokens, tail), axis=-1)
+
+    native_output = _native_gathered_decode_attention(
+        queries,
+        keys,
+        values,
+        selected_tokens[:, None, :],
+        mx.ones(selected_tokens.shape, dtype=mx.bool_)[:, None, :],
+    )
+    if native_output is not None:
+        return native_output
 
     selected_keys = _gather_kv_rows(keys, selected_tokens)
     selected_values = _gather_kv_rows(values, selected_tokens)
@@ -717,6 +784,13 @@ def contiguous_causal_gathered_qsa(
         tail_valid = tail < visible_counts[..., None]
         selected_indices = mx.concatenate((selected_indices, tail), axis=-1)
         selected_valid = mx.concatenate((selected_valid, tail_valid), axis=-1)
+
+        native_output = _native_gathered_decode_attention(
+            queries[:, :, start:stop], keys, values, selected_indices, selected_valid
+        )
+        if native_output is not None:
+            outputs.append(native_output)
+            continue
 
         safe_selected = mx.where(selected_valid, selected_indices, 0).astype(mx.int32)
 

--- a/omlx/patches/qwen35_gdn_prework.py
+++ b/omlx/patches/qwen35_gdn_prework.py
@@ -26,6 +26,7 @@ stock path.
 from __future__ import annotations
 
 import logging
+import os
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -208,7 +209,8 @@ _QWEN4_DECODE_SOURCE = """
         }
         if (lane == 0) {
             const T bv = b_in[head];
-            T by = T(1) / (T(1) + metal::exp(metal::abs(bv)));
+            // mx.sigmoid is a prebuilt (precise-exp) op; nn.silu above is compiled (fast exp).
+            T by = T(1) / (T(1) + T(metal::precise::exp(float(metal::abs(bv)))));
             beta_out[head] = (bv < T(0)) ? by : T(1) - by;
 
             // compute_g casts A_log to FP32 but keeps softplus(a+dt_bias)
@@ -248,6 +250,119 @@ _QWEN4_NORM_GATE_SOURCE = """
         out[base + i] = T(float(normed) * sig);
     }
 """
+
+
+_QWEN4_VERIFY_SOURCE = """
+    uint lane = thread_position_in_threadgroup.x;
+    uint t = threadgroup_position_in_grid.y;
+    uint logical_head = threadgroup_position_in_grid.z;
+    constexpr uint q_heads = uint(HK);
+    constexpr uint k_head_base = uint(HK);
+    constexpr uint v_head_base = 2 * uint(HK);
+    bool is_q = logical_head < q_heads;
+    bool is_k = logical_head >= k_head_base && logical_head < v_head_base;
+    uint head = is_q ? logical_head
+               : (is_k ? logical_head - k_head_base
+                       : logical_head - v_head_base);
+    uint channel_base = is_q ? head * uint(DK)
+                       : (is_k ? uint(HK) * uint(DK) + head * uint(DK)
+                               : 2 * uint(HK) * uint(DK) + head * uint(DV));
+
+    T activated[4];
+    float sumsq = 0.0f;
+    for (uint i = 0; i < 4; ++i) {
+        uint channel = channel_base + lane * 4 + i;
+        float acc = 0.0f;
+        // Window rows t..t+3 of [state(3) | qkv(S)]: index < 3 reads the
+        // old state, otherwise qkv row (index - 3).
+        for (uint tap = 0; tap < 4; ++tap) {
+            uint idx = t + tap;
+            float xv = (idx < 3)
+                ? float(conv_state[idx * uint(C) + channel])
+                : float(qkv[(idx - 3) * uint(C) + channel]);
+            acc += xv * float(conv_w[channel * 4 + tap]);
+        }
+        const T conv = T(acc);
+        T sy = T(1) / (T(1) + metal::exp(metal::abs(conv)));
+        const T act = conv * ((conv < T(0)) ? sy : T(1) - sy);
+        activated[i] = act;
+        float value = float(act);
+        sumsq += value * value;
+        if (t == 0) {
+            // Next state = concat rows S..S+2; only row-0 threads write it.
+            for (uint j = 0; j < 3; ++j) {
+                uint idx = uint(S) + j;
+                conv_out[j * uint(C) + channel] = (idx < 3)
+                    ? conv_state[idx * uint(C) + channel]
+                    : qkv[(idx - 3) * uint(C) + channel];
+            }
+        }
+    }
+
+    if (is_q || is_k) {
+        sumsq = simd_sum(sumsq);
+        float inv = metal::precise::rsqrt(sumsq / float(DK) + 1e-6f);
+        float scale = is_q ? float(q_scale) : float(k_scale);
+        uint out_base = (t * uint(HK) + head) * uint(DK) + lane * 4;
+        for (uint i = 0; i < 4; ++i) {
+            const T rms = T(float(activated[i]) * inv);
+            const T value = T(float(rms) * scale);
+            if (is_q) {
+                q_out[out_base + i] = value;
+            } else {
+                k_out[out_base + i] = value;
+            }
+        }
+    } else {
+        uint out_base = (t * uint(HV) + head) * uint(DV) + lane * 4;
+        for (uint i = 0; i < 4; ++i) {
+            v_out[out_base + i] = activated[i];
+        }
+        if (lane == 0) {
+            const uint hb = t * uint(HV) + head;
+            const T bv = b_in[hb];
+            // mx.sigmoid is a prebuilt (precise-exp) op; nn.silu above is compiled (fast exp).
+            T by = T(1) / (T(1) + T(metal::precise::exp(float(metal::abs(bv)))));
+            beta_out[hb] = (bv < T(0)) ? by : T(1) - by;
+            const T apd = T(float(a_in[hb]) + float(dt_bias[head]));
+            const T neg_abs = -metal::abs(apd);
+            const T exp_term = T(metal::precise::exp(float(neg_abs)));
+            const T log_term = T(omlx_log1p(float(exp_term)));
+            const T positive = metal::max(apd, T(0));
+            const T sp = T(float(positive) + float(log_term));
+            float ea = metal::precise::exp(float(A_log[head]));
+            g_out[hb] = metal::precise::exp(-(ea * float(sp)));
+        }
+    }
+"""
+
+
+_QWEN4_VERIFY_NORM_GATE_SOURCE = """
+    uint lane = thread_position_in_threadgroup.x;
+    uint t = threadgroup_position_in_grid.y;
+    uint head = threadgroup_position_in_grid.z;
+    uint base = (t * uint(HV) + head) * uint(DV) + lane * 4;
+    float xs[4];
+    float sumsq = 0.0f;
+    for (uint i = 0; i < 4; ++i) {
+        xs[i] = float(y[base + i]);
+        sumsq += xs[i] * xs[i];
+    }
+    sumsq = simd_sum(sumsq);
+    float inv = metal::precise::rsqrt(sumsq / float(DV) + float(eps));
+    for (uint i = 0; i < 4; ++i) {
+        const T normed = norm_w[lane * 4 + i] * T(xs[i] * inv);
+        float zv = float(z[base + i]);
+        float sy = 1.0f / (1.0f + metal::precise::exp(metal::abs(zv)));
+        float sig = zv < 0.0f ? sy : 1.0f - sy;
+        out[base + i] = T(float(normed) * sig);
+    }
+"""
+
+_QWEN4_VERIFY_KERNEL = None
+_QWEN4_VERIFY_NORM_GATE_KERNEL = None
+_QWEN4_VERIFY_MAX_ROWS = 8
+_QWEN4_VERIFY_ENGAGED_LOGGED = False
 
 
 def _kernel():
@@ -409,6 +524,154 @@ def qwen4_decode_norm_gate_fused(y, z, norm_w, *, hv, dv, eps):
     )[0]
 
 
+def _qwen4_verify_enabled() -> bool:
+    return os.environ.get("OMLX_QWEN4_GDN_VERIFY_FUSED", "1").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+
+
+def qwen4_verify_rows_supported(s_len: int) -> bool:
+    return 1 <= int(s_len) <= _QWEN4_VERIFY_MAX_ROWS
+
+
+def _qwen4_scales(module):
+    """Cached bf16 (q_scale, k_scale) arrays for the fused Qwen4 arms."""
+    q_scale = getattr(module, "_omlx_qwen4_decode_q_scale", None)
+    k_scale = getattr(module, "_omlx_qwen4_decode_k_scale", None)
+    if q_scale is None or k_scale is None:
+        inv_scale = module.head_k_dim**-0.5
+        q_scale = mx.array(inv_scale * inv_scale, dtype=mx.bfloat16)
+        k_scale = mx.array(inv_scale, dtype=mx.bfloat16)
+        module._omlx_qwen4_decode_q_scale = q_scale
+        module._omlx_qwen4_decode_k_scale = k_scale
+    return q_scale, k_scale
+
+
+def _qwen4_verify_kernel():
+    global _QWEN4_VERIFY_KERNEL
+    if _QWEN4_VERIFY_KERNEL is None:
+        _QWEN4_VERIFY_KERNEL = mx.fast.metal_kernel(
+            name="omlx_qwen4_gdn_verify_prework",
+            input_names=[
+                "qkv",
+                "conv_state",
+                "conv_w",
+                "q_scale",
+                "k_scale",
+                "b_in",
+                "a_in",
+                "A_log",
+                "dt_bias",
+            ],
+            output_names=[
+                "q_out",
+                "k_out",
+                "v_out",
+                "conv_out",
+                "g_out",
+                "beta_out",
+            ],
+            header=_QWEN4_DECODE_HEADER,
+            source=_QWEN4_VERIFY_SOURCE,
+        )
+    return _QWEN4_VERIFY_KERNEL
+
+
+def qwen4_verify_prework_fused(
+    qkv, conv_state, conv_w, q_scale, k_scale, b, a, A_log, dt_bias, hk, hv, dk, dv
+):
+    """Row-batched Qwen4 GDN prework for 1..8 rows: qkv [1,S,C], conv_state [1,3,C]."""
+    s_len = int(qkv.shape[1])
+    c_dim = int(qkv.shape[-1])
+    return _qwen4_verify_kernel()(
+        inputs=[qkv, conv_state, conv_w, q_scale, k_scale, b, a, A_log, dt_bias],
+        template=[
+            ("T", qkv.dtype),
+            ("HK", hk),
+            ("HV", hv),
+            ("DK", dk),
+            ("DV", dv),
+            ("C", c_dim),
+            ("S", s_len),
+        ],
+        grid=(32, s_len, 2 * hk + hv),
+        threadgroup=(32, 1, 1),
+        output_shapes=[
+            (1, s_len, hk, dk),
+            (1, s_len, hk, dk),
+            (1, s_len, hv, dv),
+            (1, 3, c_dim),
+            (1, s_len, hv),
+            (1, s_len, hv),
+        ],
+        output_dtypes=[
+            qkv.dtype,
+            qkv.dtype,
+            qkv.dtype,
+            qkv.dtype,
+            mx.float32,
+            qkv.dtype,
+        ],
+    )
+
+
+def _qwen4_verify_norm_gate_kernel():
+    global _QWEN4_VERIFY_NORM_GATE_KERNEL
+    if _QWEN4_VERIFY_NORM_GATE_KERNEL is None:
+        _QWEN4_VERIFY_NORM_GATE_KERNEL = mx.fast.metal_kernel(
+            name="omlx_qwen4_gdn_verify_norm_gate",
+            input_names=["y", "z", "norm_w", "eps"],
+            output_names=["out"],
+            source=_QWEN4_VERIFY_NORM_GATE_SOURCE,
+        )
+    return _QWEN4_VERIFY_NORM_GATE_KERNEL
+
+
+def qwen4_verify_norm_gate_fused(y, z, norm_w, *, hv, dv, eps):
+    s_len = int(y.shape[1])
+    return _qwen4_verify_norm_gate_kernel()(
+        inputs=[y, z, norm_w, mx.array(eps, dtype=mx.float32)],
+        template=[("T", y.dtype), ("HV", hv), ("DV", dv)],
+        grid=(32, s_len, hv),
+        threadgroup=(32, 1, 1),
+        output_shapes=[(1, s_len, hv * dv)],
+        output_dtypes=[y.dtype],
+    )[0]
+
+
+def _qwen4_verify_recurrence_with_states(q, k, v, g, beta, state):
+    """States-returning recurrence from precomputed g/beta: the tail of
+    gated_delta_update_with_states after its _compute_g_beta."""
+    from mlx_vlm.models.qwen3_5 import gated_delta as gd
+
+    kernel = getattr(gd, "_gated_delta_with_states_kernel", None)
+    if kernel is None or mx.default_device() != mx.gpu:
+        raise RuntimeError("gated delta states kernel unavailable")
+    B, T, Hk, Dk = k.shape
+    Hv, Dv = v.shape[2:]
+    if state is None:
+        state = mx.zeros((B, Hv, Dv, Dk), dtype=mx.float32)
+    return kernel(
+        inputs=[q, k, v, g, beta, state, T],
+        template=[
+            ("InT", q.dtype),
+            ("StT", state.dtype),
+            ("Dk", Dk),
+            ("Dv", Dv),
+            ("Hk", Hk),
+            ("Hv", Hv),
+            ("StateT", T),
+        ],
+        grid=(32, Dv, B * Hv),
+        threadgroup=(32, 4, 1),
+        output_shapes=[(B, T, Hv, Dv), state.shape, (B, T, Hv, Dv, Dk)],
+        output_dtypes=[q.dtype, state.dtype, state.dtype],
+    )
+
+
 def _qwen4_decode_recurrence(q, k, v, g, beta, state):
     from mlx_lm.models.gated_delta import gated_delta_kernel
 
@@ -537,6 +800,39 @@ def _qwen4_decode_dynamic_eligible(
     )
 
 
+def _qwen4_verify_dynamic_eligible(module, inputs, mask, cache, gdn_sink) -> bool:
+    if (
+        gdn_sink is None
+        or mask is not None
+        or cache is None
+        or not isinstance(inputs, mx.array)
+        or inputs.ndim != 3
+        or inputs.shape[0] != 1
+        or inputs.shape[2] != 2560
+        or not qwen4_verify_rows_supported(inputs.shape[1])
+        or inputs.dtype != mx.bfloat16
+        or getattr(cache, "lengths", None) is not None
+        or getattr(cache, "left_padding", None) is not None
+    ):
+        return False
+    conv_state = cache[0]
+    recurrent_state = cache[1]
+    return (
+        isinstance(conv_state, mx.array)
+        and conv_state.shape == (1, 3, 10240)
+        and conv_state.dtype == mx.bfloat16
+        and (
+            recurrent_state is None
+            or (
+                isinstance(recurrent_state, mx.array)
+                and recurrent_state.shape == (1, 48, 128, 128)
+                and recurrent_state.dtype == mx.float32
+            )
+        )
+        and _qwen4_decode_static_eligible(module)
+    )
+
+
 def apply_qwen35_gdn_prework_patch() -> bool:
     """Route the batch-1 target-verify GDN prework through the fused kernel.
 
@@ -577,6 +873,7 @@ def apply_qwen35_gdn_prework_patch() -> bool:
     orig_call = cls.__call__
     disabled = {"flag": False}
     qwen4_decode_disabled = {"flag": False}
+    qwen4_verify_disabled = {"flag": not _qwen4_verify_enabled()}
 
     def _eligible(self, inputs, mask, cache, gdn_sink, s_len):
         if gdn_sink is None or cache is None:
@@ -629,17 +926,7 @@ def apply_qwen35_gdn_prework_patch() -> bool:
                     inputs,
                     False,
                 )
-                inv_scale = self.head_k_dim**-0.5
-                q_scale = getattr(self, "_omlx_qwen4_decode_q_scale", None)
-                k_scale = getattr(self, "_omlx_qwen4_decode_k_scale", None)
-                if q_scale is None or k_scale is None:
-                    q_scale = mx.array(
-                        inv_scale * inv_scale,
-                        dtype=mx.bfloat16,
-                    )
-                    k_scale = mx.array(inv_scale, dtype=mx.bfloat16)
-                    self._omlx_qwen4_decode_q_scale = q_scale
-                    self._omlx_qwen4_decode_k_scale = k_scale
+                q_scale, k_scale = _qwen4_scales(self)
 
                 q, k, v, next_conv_state, g, beta = (
                     qwen4_decode_prework_fused(
@@ -705,6 +992,89 @@ def apply_qwen35_gdn_prework_patch() -> bool:
                 qwen4_decode_disabled["flag"] = True
                 logger.warning(
                     "Qwen4 fused GDN decode arm failed; reverting to stock "
+                    "for the rest of the process",
+                    exc_info=True,
+                )
+
+        if (
+            not qwen4_verify_disabled["flag"]
+            and _qwen4_verify_dynamic_eligible(self, inputs, mask, cache, gdn_sink)
+        ):
+            conv_state = cache[0]
+            recurrent_state = cache[1]
+            sink_len = len(gdn_sink)
+            try:
+                mixed_qkv, z, b, a = q35._target_verify_linears(
+                    (
+                        self.in_proj_qkv,
+                        self.in_proj_z,
+                        self.in_proj_b,
+                        self.in_proj_a,
+                    ),
+                    inputs,
+                    True,
+                )
+                z = z.reshape(1, S, self.num_v_heads, self.head_v_dim)
+                q_scale, k_scale = _qwen4_scales(self)
+                q, k, v, new_conv_state, g, beta = qwen4_verify_prework_fused(
+                    mixed_qkv,
+                    conv_state,
+                    self.conv1d.weight,
+                    q_scale,
+                    k_scale,
+                    b,
+                    a,
+                    self.A_log,
+                    self.dt_bias,
+                    self.num_k_heads,
+                    self.num_v_heads,
+                    self.head_k_dim,
+                    self.head_v_dim,
+                )
+                state = recurrent_state
+                if state is not None and state.shape[0] != 1:
+                    state = None
+                initial_state = state
+                out, state, intermediate_states = (
+                    _qwen4_verify_recurrence_with_states(q, k, v, g, beta, state)
+                )
+                conv_input = mx.concatenate([conv_state, mixed_qkv], axis=1)
+                gdn_sink.append(
+                    (
+                        q, k, v, a, b, self.A_log, self.dt_bias, initial_state,
+                        None, conv_input, self.conv_kernel_size, intermediate_states,
+                    )
+                )
+                flat = qwen4_verify_norm_gate_fused(
+                    out,
+                    z,
+                    self.norm.weight,
+                    hv=self.num_v_heads,
+                    dv=self.head_v_dim,
+                    eps=self.norm.eps,
+                )
+                result = q35._target_verify_linear(self.out_proj, flat, True)
+                # Commit cache ownership only after every fallible step succeeded.
+                cache[0] = new_conv_state
+                cache[1] = state
+                if hasattr(cache, "advance"):
+                    cache.advance(S)
+                    q35._qwen3_5_advance_left_padding_info(cache, S)
+                    q35._qwen3_5_advance_lengths_info(cache, S)
+                global _QWEN4_VERIFY_ENGAGED_LOGGED
+                if not _QWEN4_VERIFY_ENGAGED_LOGGED:
+                    _QWEN4_VERIFY_ENGAGED_LOGGED = True
+                    logger.info(
+                        "[gdn-prework] fused Qwen4 verify arm engaged (S=%d)", S
+                    )
+                return result
+            except Exception:
+                cache[0] = conv_state
+                cache[1] = recurrent_state
+                del gdn_sink[sink_len:]
+                qwen4_verify_disabled["flag"] = True
+                logger.warning(
+                    "Qwen4 fused GDN verify arm failed; reverting to stock "
                     "for the rest of the process",
                     exc_info=True,
                 )

--- a/omlx/patches/qwen35_grouped_linears.py
+++ b/omlx/patches/qwen35_grouped_linears.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+"""One quantized matmul per quantisation signature for small-row projections.
+
+``_target_verify_linears`` in mlx-vlm's Qwen3.5 family issues one qmm per
+projection for B=1 rows (its fused helper needs exactly four identically
+quantised linears and T == 1). Concatenating weights along the output axis is
+bit-exact per output row, so grouping by (bits, group_size, mode) removes 1-3
+dispatches per call site on MTP verify rows (2..8; single-row decode measured
+slower grouped). Each group is a cached ``nn.QuantizedLinear`` so the
+verify-qmm routing patch sees the same call shape it sees for single linears;
+a group whose routing would differ from its members' falls back to separate
+calls. Disable with OMLX_QWEN35_GROUPED_LINEARS=0.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+import mlx.core as mx
+import mlx.nn as nn
+
+logger = logging.getLogger(__name__)
+
+MIN_ROWS = 2  # T=1 measured -2% serial (grouping costs more than the saved dispatches)
+MAX_ROWS = 8  # verify rows; MLX switches qmm kernels above this and rows stop matching per output row
+_PATCHED = False
+_CACHE_ATTR = "_omlx_grouped_linears"
+
+
+def enabled() -> bool:
+    return os.environ.get("OMLX_QWEN35_GROUPED_LINEARS", "1").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+
+
+def _signature(linear):
+    return (int(linear.bits), int(linear.group_size), str(linear.mode))
+
+
+def _eligible(linears, x) -> bool:
+    if not (
+        isinstance(x, mx.array)
+        and x.ndim == 3
+        and x.shape[0] == 1
+        and MIN_ROWS <= x.shape[1] <= MAX_ROWS
+        and len(linears) >= 2
+    ):
+        return False
+    for lin in linears:
+        if (
+            not isinstance(lin, nn.QuantizedLinear)
+            or "bias" in lin
+            or getattr(lin, "mode", "affine") != "affine"
+            or lin.biases is None
+            or lin.scales.dtype != x.dtype
+            or lin.biases.dtype != x.dtype
+        ):
+            return False
+    return True
+
+
+class _GroupLinear(nn.QuantizedLinear):
+    """A QuantizedLinear over concatenated member weights, built without the random init."""
+
+    def __init__(self, weight, scales, biases, *, bits, group_size, mode):
+        nn.Module.__init__(self)
+        self.group_size = group_size
+        self.bits = bits
+        self.mode = mode
+        self.weight, self.scales, self.biases = weight, scales, biases
+        self.freeze()
+
+
+def _make_group_linear(members):
+    bits, group_size, mode = _signature(members[0])
+    weight = mx.concatenate([m.weight for m in members], axis=0)
+    scales = mx.concatenate([m.scales for m in members], axis=0)
+    biases = mx.concatenate([m.biases for m in members], axis=0)
+    mx.eval(weight, scales, biases)
+    lin = _GroupLinear(weight, scales, biases, bits=bits, group_size=group_size, mode=mode)
+    splits, off = [], 0
+    for m in members[:-1]:
+        off += int(m.weight.shape[0])
+        splits.append(off)
+    return lin, splits
+
+
+def _groups(linears):
+    """Cache the group linears on the first member (weights change identity on reload)."""
+    first = linears[0]
+    key = tuple((id(l.weight), id(l.scales), id(l.biases)) for l in linears)
+    cached = getattr(first, _CACHE_ATTR, None)
+    if cached is not None and cached[0] == key:
+        return cached[1]
+    by_sig: dict = {}
+    for idx, lin in enumerate(linears):
+        by_sig.setdefault(_signature(lin), []).append(idx)
+    groups = []
+    for sig, idxs in by_sig.items():
+        members = [linears[i] for i in idxs]
+        if len(members) == 1:
+            groups.append((idxs, None, None, members))
+            continue
+        lin, splits = _make_group_linear(members)
+        groups.append((idxs, lin, splits, members))
+    # Plain attribute assignment would register the group as a parameter.
+    object.__setattr__(first, _CACHE_ATTR, (key, groups))
+    return groups
+
+
+def _routing_matches(group_linear, members, x) -> bool:
+    """True unless the verify-qmm patch would route the group differently from a member."""
+    try:
+        from omlx.patches import qwen35_verify_qmm as vk
+    except ImportError:
+        return True
+    if not (vk._is_armed() and 2 <= x.shape[1] <= 6):
+        return True
+    args = (x.shape[1], x.shape[-1])
+    grouped = vk.vk_eligible(*args, group_linear.scales.shape[0], group_linear.bits,
+                             group_linear.group_size, x.dtype)
+    return all(
+        vk.vk_eligible(*args, m.scales.shape[0], m.bits, m.group_size, x.dtype) == grouped
+        for m in members
+    )
+
+
+def grouped_quantized_linears(linears, x):
+    """Outputs in the order of ``linears``; None when the call is not eligible."""
+    if not _eligible(linears, x):
+        return None
+    outs = [None] * len(linears)
+    for idxs, group_linear, splits, members in _groups(linears):
+        if group_linear is None or not _routing_matches(group_linear, members, x):
+            for idx, m in zip(idxs, members):
+                outs[idx] = m(x)
+            continue
+        y = group_linear(x)
+        for idx, part in zip(idxs, mx.split(y, splits, axis=-1)):
+            outs[idx] = part
+    return tuple(outs)
+
+
+def _rebind_everywhere(orig, patched) -> None:
+    """Modules that imported the helper by name hold their own binding (vendored Qwen4)."""
+    for name, module in list(sys.modules.items()):
+        if module is None or not name.startswith(("mlx_vlm.", "omlx.")):
+            continue
+        # __dict__ lookup: getattr on lazy modules would import their backends.
+        if vars(module).get("_target_verify_linears") is orig:
+            module._target_verify_linears = patched
+
+
+def apply_qwen35_grouped_linears_patch() -> bool:
+    global _PATCHED
+    if _PATCHED:
+        return True
+    if not enabled() or not mx.metal.is_available():
+        return False
+    try:
+        from mlx_vlm.models.qwen3_5 import language as q35
+    except ImportError:
+        return False
+    orig = q35._target_verify_linears
+    state = {"failed": False}
+
+    def patched(linears, x, target_verify):
+        if not state["failed"]:
+            try:
+                out = grouped_quantized_linears(linears, x)
+            except Exception:  # noqa: BLE001 - optional path
+                state["failed"] = True
+                logger.warning("grouped linears failed closed", exc_info=True)
+                out = None
+            if out is not None:
+                return out
+        return orig(linears, x, target_verify)
+
+    patched.__name__ = "patched"
+    _rebind_everywhere(orig, patched)
+    _PATCHED = True
+    logger.info("Qwen3.5-family grouped small-row linears engaged")
+    return True

--- a/tests/test_decode_fast_sdpa_gathered.py
+++ b/tests/test_decode_fast_sdpa_gathered.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Gathered decode SDPA (decode_fast): K/V rows read through per-query index sets."""
+
+import mlx.core as mx
+import pytest
+
+fast = pytest.importorskip("omlx.custom_kernels.decode_fast.fast")
+
+pytestmark = pytest.mark.skipif(
+    not fast.NATIVE_AVAILABLE, reason="native extension not built"
+)
+
+
+def _reference(q, k, v, indices, scale):
+    """Gather the selected rows per query row and run MLX SDPA with a validity mask."""
+    B, H, qL, D = q.shape
+    outs = []
+    for b in range(B):
+        rows = []
+        for r in range(qL):
+            idx = indices[b, r]
+            valid = idx >= 0
+            safe = mx.where(valid, idx, 0)
+            ks = mx.take(k[b], safe, axis=1)[None]
+            vs = mx.take(v[b], safe, axis=1)[None]
+            out = mx.fast.scaled_dot_product_attention(
+                q[b : b + 1, :, r : r + 1], ks, vs, scale=scale, mask=valid[None, None, None]
+            )
+            rows.append(out[:, :, 0])
+        outs.append(mx.stack(rows, axis=2))
+    return mx.concatenate(outs, axis=0)
+
+
+def _inputs(dtype, B, H, Hkv, qL, kL, D, S, holes):
+    mx.random.seed(0)
+    q = mx.random.normal((B, H, qL, D)).astype(dtype)
+    k = mx.random.normal((B, Hkv, kL, D)).astype(dtype)
+    v = mx.random.normal((B, Hkv, kL, D)).astype(dtype)
+    indices = mx.sort(mx.random.randint(0, kL, (B, qL, S)), axis=-1).astype(mx.int32)
+    if holes:
+        # Invalidate a ragged tail per query row, like QSA's incomplete last block.
+        keep = mx.arange(S)[None, None] < (S - 1 - mx.arange(qL)[None, :, None])
+        indices = mx.where(keep, indices, -1)
+    return q, k, v, indices
+
+
+@pytest.mark.parametrize("dtype", [mx.float32, mx.bfloat16, mx.float16])
+@pytest.mark.parametrize(
+    "B,H,Hkv,qL,kL,D,S,holes",
+    [
+        (1, 24, 2, 1, 4096, 256, 2051, False),   # Qwen4 QSA decode: top-2048 + 3 tail rows
+        (1, 24, 2, 4, 65536, 256, 2051, True),   # MTP verify width, ragged tails, gqa*qL > 32
+        (1, 24, 2, 8, 8192, 256, 2051, True),
+        (1, 8, 1, 1, 512, 128, 100, False),      # S not a multiple of the key tile
+        (2, 8, 2, 3, 1500, 128, 257, True),      # batch > 1
+        (1, 4, 4, 1, 1024, 64, 33, False),       # MHA, small head
+    ],
+)
+def test_gathered_matches_reference(dtype, B, H, Hkv, qL, kL, D, S, holes):
+    q, k, v, indices = _inputs(dtype, B, H, Hkv, qL, kL, D, S, holes)
+    scale = D**-0.5
+    assert fast._ext.sdpa_decode_gathered_supported(q, k, v, indices)
+    out = fast._ext.sdpa_decode_gathered(q, k, v, indices, scale)
+    ref = _reference(q, k, v, indices, scale)
+    mx.eval(out, ref)
+    assert out.shape == (B, H, qL, D)
+    tol = 1e-5 if dtype == mx.float32 else 5e-3
+    assert mx.allclose(out, ref, atol=tol, rtol=tol).item()
+
+
+def test_gathered_reads_the_cache_in_place():
+    """A strided K/V view of a larger cache must be read without a copy: rows past the
+    view's length are never touched, so out-of-range rows in the backing store do not matter."""
+    q, k, v, indices = _inputs(mx.bfloat16, 1, 24, 2, 4, 2048, 256, 300, True)
+    backing_k = mx.concatenate([k, mx.full(k.shape, float("nan"), dtype=k.dtype)], axis=2)
+    backing_v = mx.concatenate([v, mx.full(v.shape, float("nan"), dtype=v.dtype)], axis=2)
+    kv_view = backing_k[:, :, :2048], backing_v[:, :, :2048]
+    mx.eval(*kv_view)
+    assert fast._ext.sdpa_decode_gathered_supported(q, *kv_view, indices)
+    out = fast._ext.sdpa_decode_gathered(q, *kv_view, indices, 1 / 16)
+    ref = _reference(q, k, v, indices, 1 / 16)
+    mx.eval(out, ref)
+    assert mx.allclose(out, ref, atol=5e-3, rtol=5e-3).item()
+
+
+def test_gathered_supported_rejects_wrong_inputs():
+    q, k, v, indices = _inputs(mx.bfloat16, 1, 8, 1, 1, 512, 128, 100, False)
+    ok = fast._ext.sdpa_decode_gathered_supported
+    assert ok(q, k, v, indices)
+    assert not ok(q, k, v, indices.astype(mx.uint32))                # index dtype
+    assert not ok(q, k, v, indices[0])                               # rank
+    assert not ok(q, k.astype(mx.float32), v, indices)               # dtype mismatch
+    assert not ok(q, k, v, mx.zeros((1, 2, 100), dtype=mx.int32))    # qL mismatch
+    assert not ok(mx.zeros((1, 8, 1, 32), dtype=mx.bfloat16), k, v, indices)  # head dim
+
+
+def test_wrapper_accepts_strided_queries_and_indices():
+    """Slices of the verify window arrive non-contiguous; the wrapper must not hand them to the kernel raw."""
+    q, k, v, indices = _inputs(mx.bfloat16, 1, 24, 2, 8, 4096, 256, 512, True)
+    q_view, idx_view = q[:, :, ::2], indices[:, ::2, ::2]
+    out = fast.sdpa_decode_gathered(q_view, k, v, idx_view, 1 / 16)
+    ref = _reference(mx.contiguous(q_view), k, v, mx.contiguous(idx_view), 1 / 16)
+    mx.eval(out, ref)
+    assert mx.allclose(out, ref, atol=5e-3, rtol=5e-3).item()
+
+
+def test_wrapper_falls_back_when_unsupported():
+    q, k, v, indices = _inputs(mx.float32, 1, 4, 4, 1, 256, 32, 20, True)  # D=32: no kernel
+    out = fast.sdpa_decode_gathered(q, k, v, indices, 32**-0.5)
+    ref = _reference(q, k, v, indices, 32**-0.5)
+    mx.eval(out, ref)
+    assert mx.allclose(out, ref, atol=1e-5, rtol=1e-5).item()

--- a/tests/test_mtp_parked_fold.py
+++ b/tests/test_mtp_parked_fold.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Parked-decode head folds: the MTP head cache stays warm while the controller
+parks speculation, so the re-entry probe starts primed."""
+
+from __future__ import annotations
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from omlx.patches.mlx_lm_mtp import prompt_priming as pp
+from tests.test_mtp_prompt_priming import (  # noqa: F401 - autouse fixture
+    TINY_CONFIG,
+    _apply_patch,
+    _make_tiny_model,
+)
+
+H = TINY_CONFIG["hidden_size"]
+
+
+class _Anchor:
+    def __init__(self, offset):
+        self.offset = offset
+
+
+def _cache_at(n):
+    return [_Anchor(n)]
+
+
+def _head_offset(cache):
+    return int(cache[0].offset)
+
+
+def _fold_hidden(model, h):
+    from omlx.patches.mlx_lm_mtp import batch_generator as bg
+
+    return bg._head_input_hidden(model, h)
+
+
+def _hidden(value, rows=1):
+    return (mx.ones((1, rows, H)) * value).astype(mx.bfloat16)
+
+
+def test_parked_ctx_folds_in_blocks_and_flushes_at_probe(monkeypatch):
+    monkeypatch.setenv("OMLX_MTP_PARK_FOLD_BLOCK", "8")
+    model = _make_tiny_model()
+    pre = 5  # pairs already in the head cache when parking
+    seed_h = _fold_hidden(model, _hidden(0.03, pre))
+    seed_t = mx.arange(pre, dtype=mx.uint32).reshape(1, pre)
+    head_cache = model.make_mtp_cache()
+    model.mtp_forward(seed_h, seed_t, head_cache, logits_keep=1)
+    ref_cache = model.make_mtp_cache()
+    model.mtp_forward(seed_h, seed_t, ref_cache, logits_keep=1)
+
+    hidden0 = _fold_hidden(model, _hidden(0.02))
+    ctx = pp.begin_parked_ctx(model, head_cache, hidden0, folded=pre, expected_offset=10)
+    assert ctx is not None and ctx.parked and pp._find_ctx(model) is ctx
+
+    pairs_h, pairs_t = [hidden0], []
+    for step in range(20):
+        tok = mx.array([[step % 7]], dtype=mx.uint32)
+        h = _fold_hidden(model, _hidden((step + 1) * 0.01))
+        pairs_t.append(tok)
+        pp.maybe_capture(model, tok, h, _cache_at(11 + step))
+        pairs_h.append(h)
+    assert pp._find_ctx(model) is ctx
+    assert len(ctx.pending_pairs) < 8  # folded in blocks of 8
+    assert ctx.folded >= pre + 16
+
+    main_tok = mx.array([[3]], dtype=mx.uint32)
+    primed = pp.take_primed(model, _cache_at(31), main_tok)
+    assert primed is not None
+    cache, hist = primed
+    assert hist == pre + 20 + 1
+    assert pp._find_ctx(model) is None
+
+    model.mtp_forward(
+        mx.concatenate(pairs_h[:-1], axis=1), mx.concatenate(pairs_t, axis=1), ref_cache, logits_keep=1
+    )
+    model.mtp_forward(pairs_h[-1], main_tok, ref_cache, logits_keep=1)
+    mx.eval(cache[0].keys, cache[0].values, ref_cache[0].keys, ref_cache[0].values)
+    assert _head_offset(cache) == _head_offset(ref_cache) == pre + 20 + 1
+    assert mx.allclose(cache[0].keys, ref_cache[0].keys, atol=1e-5).item()
+    assert mx.allclose(cache[0].values, ref_cache[0].values, atol=1e-5).item()
+
+
+def test_parked_ctx_drops_on_discontiguous_step():
+    model = _make_tiny_model()
+    head_cache = model.make_mtp_cache()
+    ctx = pp.begin_parked_ctx(model, head_cache, _hidden(0.02), folded=0, expected_offset=10)
+    assert ctx is not None
+    pp.maybe_capture(model, mx.array([[1]], dtype=mx.uint32), _hidden(0.01), _cache_at(11))
+    assert pp._find_ctx(model) is ctx
+    # A rewind (offset going backwards) must invalidate the parked timeline.
+    pp.maybe_capture(model, mx.array([[2]], dtype=mx.uint32), _hidden(0.01), _cache_at(9))
+    assert pp._find_ctx(model) is None
+
+
+def test_parked_ctx_ignores_prime_window(monkeypatch):
+    monkeypatch.setenv("OMLX_MTP_PRIME_WINDOW", "4")
+    model = _make_tiny_model()
+    head_cache = model.make_mtp_cache()
+    ctx = pp.begin_parked_ctx(model, head_cache, _hidden(0.02), folded=0, expected_offset=10)
+    for step in range(10):
+        pp.maybe_capture(model, mx.array([[step]], dtype=mx.uint32), _hidden(0.01), _cache_at(11 + step))
+    assert pp._find_ctx(model) is ctx and not ctx.window_exceeded
+
+
+def test_feed_to_standard_survives_a_backbone_without_hidden(monkeypatch):
+    """The parked fold is optional: a backbone that yields no hidden must not fail the park."""
+    from types import SimpleNamespace
+
+    from omlx.patches.mlx_lm_mtp import batch_generator as bg
+    from omlx.patches.mlx_lm_mtp.batch_generator import _MtpState
+
+    logits = mx.zeros((1, 1, 8))
+    monkeypatch.setattr(bg, "_call_backbone", lambda model, x, cache: (logits, None, None))
+    monkeypatch.setattr(bg, "_proc_list", lambda gb: None)
+    monkeypatch.setattr(bg, "_set_singleton_mrope_delta", lambda gb: None)
+    monkeypatch.setattr(bg, "_resolve_sampler", lambda gb: (lambda lp: mx.argmax(lp, axis=-1)))
+    monkeypatch.setattr(bg, "_clear_rollback", lambda cache: None)
+    state = _MtpState(uid=7, next_main=mx.array([3], dtype=mx.uint32))
+    gen_batch = SimpleNamespace(model=object(), prompt_cache=[], _next_tokens=None, _next_logprobs=None)
+    assert bg._feed_next_main_to_standard(gen_batch, state) is True
+    assert state.park_hidden is None
+    assert gen_batch._next_tokens is not None

--- a/tests/test_qwen35_grouped_linears.py
+++ b/tests/test_qwen35_grouped_linears.py
@@ -1,0 +1,118 @@
+"""Grouped small-row quantized linears: bit-exact per row, one dispatch per signature."""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+
+from omlx.patches import qwen35_grouped_linears as grouped
+
+K = 2560
+
+
+def _qlinear(rows, bits, group_size, seed):
+    lin = nn.Linear(K, rows, bias=False)
+    lin.weight = (mx.random.normal((rows, K), key=mx.random.key(seed)) * 0.05).astype(
+        mx.bfloat16
+    )
+    return nn.QuantizedLinear.from_linear(lin, group_size=group_size, bits=bits)
+
+
+@pytest.mark.parametrize("T", [2, 3, 4, 8])
+@pytest.mark.parametrize(
+    "sigs",
+    [
+        [(10240, 4, 64), (6144, 5, 128), (48, 5, 128), (48, 5, 128)],
+        [(12288, 8, 32), (512, 8, 32), (512, 8, 32)],
+        [(640, 8, 128), (640, 8, 128)],
+        [(4096, 6, 64), (512, 6, 64), (512, 6, 64), (48, 6, 64)],
+    ],
+)
+def test_grouped_matches_separate(T, sigs):
+    linears = [_qlinear(r, b, g, i) for i, (r, b, g) in enumerate(sigs)]
+    x = mx.random.normal((1, T, K), key=mx.random.key(99)).astype(mx.bfloat16)
+    got = grouped.grouped_quantized_linears(linears, x)
+    exp = tuple(lin(x) for lin in linears)
+    mx.eval(*got, *exp)
+    assert len(got) == len(exp)
+    for a, b in zip(got, exp):
+        assert a.shape == b.shape
+        assert mx.array_equal(a, b).item()
+
+
+def test_one_dispatch_per_signature(monkeypatch):
+    linears = [
+        _qlinear(10240, 4, 64, 0),
+        _qlinear(6144, 5, 128, 1),
+        _qlinear(48, 5, 128, 2),
+        _qlinear(48, 5, 128, 3),
+    ]
+    x = mx.random.normal((1, 4, K)).astype(mx.bfloat16)
+    grouped.grouped_quantized_linears(linears, x)  # build the group cache first
+    calls = []
+    orig = mx.quantized_matmul
+
+    def counting(*a, **kw):
+        calls.append(kw.get("bits"))
+        return orig(*a, **kw)
+
+    monkeypatch.setattr(mx, "quantized_matmul", counting)
+    out = grouped.grouped_quantized_linears(linears, x)
+    mx.eval(*out)
+    assert sorted(calls) == [4, 5]
+
+
+def test_group_cache_is_not_a_module_parameter():
+    linears = [_qlinear(64, 4, 64, 0), _qlinear(64, 4, 64, 1)]
+    x = mx.zeros((1, 2, K), dtype=mx.bfloat16)
+    grouped.grouped_quantized_linears(linears, x)
+    from mlx.utils import tree_flatten
+
+    names = [name for name, _ in tree_flatten(linears[0].parameters())]
+    assert not any(grouped._CACHE_ATTR in name for name in names)
+
+
+def test_declines_batch_wide_rows_and_non_quantized():
+    linears = [_qlinear(64, 4, 64, 0), _qlinear(64, 4, 64, 1)]
+    assert grouped.grouped_quantized_linears(linears, mx.zeros((2, 1, K), dtype=mx.bfloat16)) is None
+    assert grouped.grouped_quantized_linears(linears, mx.zeros((1, 1, K), dtype=mx.bfloat16)) is None
+    assert grouped.grouped_quantized_linears(linears, mx.zeros((1, 9, K), dtype=mx.bfloat16)) is None
+    mixed = [linears[0], nn.Linear(K, 64, bias=False)]
+    assert grouped.grouped_quantized_linears(mixed, mx.zeros((1, 2, K), dtype=mx.bfloat16)) is None
+
+
+def test_routing_mismatch_falls_back_to_members(monkeypatch):
+    from omlx.patches import qwen35_verify_qmm as vk
+
+    linears = [_qlinear(12288, 8, 32, 0), _qlinear(512, 8, 32, 1), _qlinear(512, 8, 32, 2)]
+    x = mx.random.normal((1, 4, K)).astype(mx.bfloat16)
+    monkeypatch.setattr(vk, "_is_armed", lambda: True)
+    monkeypatch.setattr(vk, "_MIN_ROUTE_N", 13000)  # group N=13312 routes, members do not
+    grouped.grouped_quantized_linears(linears, x)
+    calls = []
+    orig = mx.quantized_matmul
+
+    def counting(*a, **kw):
+        calls.append(a[1].shape[0])
+        return orig(*a, **kw)
+
+    monkeypatch.setattr(mx, "quantized_matmul", counting)
+    out = grouped.grouped_quantized_linears(linears, x)
+    mx.eval(*out)
+    assert calls == [12288, 512, 512]
+
+
+def test_patch_rebinds_vendored_qwen4_module(monkeypatch):
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+    import mlx_vlm.models.qwen3_5.language as q35
+    import mlx_vlm.models.qwen4_exp.language as q4
+
+    monkeypatch.setattr(grouped, "_PATCHED", False)
+    assert grouped.apply_qwen35_grouped_linears_patch()
+    assert q4._target_verify_linears is q35._target_verify_linears
+    assert q35._target_verify_linears.__name__ == "patched"

--- a/tests/test_qwen4_gdn_verify_fused.py
+++ b/tests/test_qwen4_gdn_verify_fused.py
@@ -1,0 +1,262 @@
+"""Row-batched Qwen4 GDN verify kernels vs the composed stock ops."""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+
+from omlx.patches import qwen35_gdn_prework as prework_mod
+
+HK, HV, DK, DV, KS = 16, 48, 128, 128, 4
+C = 2 * HK * DK + HV * DV  # 10240
+
+
+def _stock_prework(qkv, conv_state, conv_w, b, a, A_log, dt_bias):
+    from mlx_vlm.models.qwen3_5.gated_delta import _compute_g_beta
+
+    conv_input = mx.concatenate([conv_state, qkv], axis=1)
+    next_state = mx.contiguous(conv_input[:, -(KS - 1) :, :])
+    conv = nn.Conv1d(C, C, kernel_size=KS, groups=C, padding=0, bias=False)
+    conv.weight = conv_w
+    conv_out = nn.silu(conv(conv_input))
+    q, k, v = mx.split(conv_out, [HK * DK, 2 * HK * DK], -1)
+    T = qkv.shape[1]
+    q = q.reshape(1, T, HK, DK)
+    k = k.reshape(1, T, HK, DK)
+    v = v.reshape(1, T, HV, DV)
+    inv = DK**-0.5
+    q = (inv * inv) * mx.fast.rms_norm(q, None, 1e-6)
+    k = inv * mx.fast.rms_norm(k, None, 1e-6)
+    g, beta = _compute_g_beta(A_log, a, b, dt_bias)
+    return q, k, v, next_state, g, beta
+
+
+def _inputs(T, seed=0):
+    ks = mx.random.split(mx.random.key(seed), 7)
+    qkv = (mx.random.normal((1, T, C), key=ks[0]) * 0.5).astype(mx.bfloat16)
+    conv_state = (mx.random.normal((1, KS - 1, C), key=ks[1]) * 0.5).astype(
+        mx.bfloat16
+    )
+    conv_w = (mx.random.normal((C, KS, 1), key=ks[2]) * 0.3).astype(mx.bfloat16)
+    b = mx.random.normal((1, T, HV), key=ks[3]).astype(mx.bfloat16)
+    a = mx.random.normal((1, T, HV), key=ks[4]).astype(mx.bfloat16)
+    A_log = (mx.random.normal((HV,), key=ks[5]) * 0.2).astype(mx.bfloat16)
+    dt_bias = (mx.random.normal((HV,), key=ks[6]) * 0.2).astype(mx.bfloat16)
+    return qkv, conv_state, conv_w, b, a, A_log, dt_bias
+
+
+@pytest.mark.parametrize("T", [1, 2, 3, 4, 8])
+def test_verify_prework_matches_stock(T):
+    qkv, conv_state, conv_w, b, a, A_log, dt_bias = _inputs(T)
+    inv = DK**-0.5
+    q_scale = mx.array(inv * inv, dtype=mx.bfloat16)
+    k_scale = mx.array(inv, dtype=mx.bfloat16)
+    got = prework_mod.qwen4_verify_prework_fused(
+        qkv, conv_state, conv_w, q_scale, k_scale, b, a, A_log, dt_bias, HK, HV, DK, DV
+    )
+    exp = _stock_prework(qkv, conv_state, conv_w, b, a, A_log, dt_bias)
+    mx.eval(*got, *exp)
+    names = ["q", "k", "v", "conv_state", "g", "beta"]
+    for name, x, y in zip(names, got, exp):
+        assert x.shape == y.shape, name
+        assert x.dtype == y.dtype, name
+        assert mx.array_equal(x, y).item(), name
+
+
+@pytest.mark.parametrize("T", [1, 2, 4, 8])
+def test_verify_norm_gate_matches_module(T):
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models.qwen4_exp.language import Qwen4ExpRMSNormGated
+
+    ks = mx.random.split(mx.random.key(1), 3)
+    y = mx.random.normal((1, T, HV, DV), key=ks[0]).astype(mx.bfloat16)
+    z = mx.random.normal((1, T, HV, DV), key=ks[1]).astype(mx.bfloat16)
+    norm = Qwen4ExpRMSNormGated(DV, eps=1e-6, activation="sigmoid")
+    norm.weight = (mx.random.normal((DV,), key=ks[2]) * 0.1).astype(mx.bfloat16)
+    exp = norm(y, z).reshape(1, T, HV * DV)
+    got = prework_mod.qwen4_verify_norm_gate_fused(
+        y, z, norm.weight, hv=HV, dv=DV, eps=1e-6
+    )
+    mx.eval(exp, got)
+    assert got.shape == exp.shape
+    assert mx.array_equal(exp, got).item()
+
+
+def test_verify_rows_supported_is_one_to_eight():
+    assert prework_mod.qwen4_verify_rows_supported(1)
+    assert prework_mod.qwen4_verify_rows_supported(2)
+    assert prework_mod.qwen4_verify_rows_supported(8)
+    assert not prework_mod.qwen4_verify_rows_supported(0)
+    assert not prework_mod.qwen4_verify_rows_supported(9)
+
+
+def test_verify_recurrence_with_states_matches_public_helper():
+    """Precomputed g/beta through the states kernel == gated_delta_update_with_states."""
+    from mlx_vlm.models.qwen3_5.gated_delta import (
+        _compute_g_beta,
+        gated_delta_update_with_states,
+    )
+
+    T = 4
+    qkv, conv_state, conv_w, b, a, A_log, dt_bias = _inputs(T, seed=3)
+    q, k, v, _, g, beta = _stock_prework(qkv, conv_state, conv_w, b, a, A_log, dt_bias)
+    state = (mx.random.normal((1, HV, DV, DK), key=mx.random.key(9)) * 0.01).astype(
+        mx.float32
+    )
+    exp = gated_delta_update_with_states(
+        q, k, v, a, b, A_log, dt_bias, state, None, use_kernel=True
+    )
+    got = prework_mod._qwen4_verify_recurrence_with_states(q, k, v, g, beta, state)
+    mx.eval(*exp, *got)
+    assert len(got) == 3
+    for x, y in zip(got, exp):
+        assert x.shape == y.shape
+        assert mx.array_equal(x, y).item()
+
+
+class _FakeCache:
+    def __init__(self, conv_state, recurrent_state=None):
+        self._store = {0: conv_state, 1: recurrent_state}
+        self.lengths = None
+        self.left_padding = None
+        self.advance_calls = []
+
+    def __getitem__(self, i):
+        return self._store[i]
+
+    def __setitem__(self, i, v):
+        self._store[i] = v
+
+    def advance(self, n):
+        self.advance_calls.append(n)
+
+
+def _fake_module():
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        in_proj_qkv=None,
+        in_proj_z=None,
+        in_proj_b=None,
+        in_proj_a=None,
+        conv1d=SimpleNamespace(weight=None),
+        head_k_dim=DK,
+        head_v_dim=DV,
+        num_k_heads=HK,
+        num_v_heads=HV,
+        A_log=None,
+        dt_bias=None,
+        norm=SimpleNamespace(weight=None, eps=1e-6),
+        out_proj=None,
+        conv_kernel_size=KS,
+        training=False,
+    )
+
+
+def _arm_route(monkeypatch, q35, S, prework):
+    monkeypatch.setattr(prework_mod, "_PATCHED", False)
+    monkeypatch.setattr(prework_mod, "_QWEN4_VERIFY_ENGAGED_LOGGED", False)
+    monkeypatch.setattr(q35.Qwen3_5GatedDeltaNet, "_omlx_gdn_prework_patched", False, raising=False)
+    monkeypatch.setattr(prework_mod, "_qwen4_decode_dynamic_eligible", lambda *a, **k: False)
+    monkeypatch.setattr(prework_mod, "_qwen4_verify_dynamic_eligible", lambda *a, **k: True)
+    monkeypatch.setattr(
+        q35,
+        "_target_verify_linears",
+        lambda *a, **k: (
+            mx.zeros((1, S, C), dtype=mx.bfloat16),
+            mx.zeros((1, S, HV * DV), dtype=mx.bfloat16),
+            mx.zeros((1, S, HV), dtype=mx.bfloat16),
+            mx.zeros((1, S, HV), dtype=mx.bfloat16),
+        ),
+    )
+    monkeypatch.setattr(prework_mod, "qwen4_verify_prework_fused", prework)
+
+
+@pytest.mark.parametrize("S", [2, 4])
+def test_verify_route_commits_states_sink_and_advances_once(monkeypatch, S):
+    q35 = pytest.importorskip("mlx_vlm.models.qwen3_5.language")
+    cls = q35.Qwen3_5GatedDeltaNet
+    old_conv = mx.zeros((1, 3, C), dtype=mx.bfloat16)
+    old_recurrent = mx.zeros((1, HV, DV, DK), dtype=mx.float32)
+    next_conv = mx.ones_like(old_conv)
+    next_recurrent = mx.ones_like(old_recurrent)
+    fused = mx.ones((1, S, 2560), dtype=mx.bfloat16)
+
+    def stock(*args, **kwargs):
+        raise AssertionError("eligible Qwen4 verify unexpectedly fell back")
+
+    monkeypatch.setattr(cls, "__call__", stock, raising=False)
+    _arm_route(
+        monkeypatch, q35, S,
+        lambda *a, **k: (None, None, None, next_conv, None, None),
+    )
+    monkeypatch.setattr(
+        prework_mod,
+        "_qwen4_verify_recurrence_with_states",
+        lambda *a, **k: (None, next_recurrent, "states"),
+    )
+    monkeypatch.setattr(prework_mod, "qwen4_verify_norm_gate_fused", lambda *a, **k: fused)
+    monkeypatch.setattr(q35, "_target_verify_linear", lambda *a: fused)
+    assert prework_mod.apply_qwen35_gdn_prework_patch()
+
+    cache = _FakeCache(old_conv, old_recurrent)
+    sink = []
+    result = cls.__call__(
+        _fake_module(), mx.zeros((1, S, 2560), dtype=mx.bfloat16), cache=cache, gdn_sink=sink
+    )
+    assert result is fused
+    assert cache[0] is next_conv
+    assert cache[1] is next_recurrent
+    assert cache.advance_calls == [S]
+    assert len(sink) == 1 and len(sink[0]) == 12
+    assert sink[0][7] is old_recurrent and sink[0][11] == "states"
+
+
+def test_verify_route_restores_states_and_sink_before_stock_fallback(monkeypatch):
+    q35 = pytest.importorskip("mlx_vlm.models.qwen3_5.language")
+    cls = q35.Qwen3_5GatedDeltaNet
+    S = 2
+    old_conv = mx.zeros((1, 3, C), dtype=mx.bfloat16)
+    old_recurrent = mx.zeros((1, HV, DV, DK), dtype=mx.float32)
+    calls = []
+
+    def stock(self, inputs, mask=None, cache=None, gdn_sink=None, target_verify=False):
+        calls.append((cache[0], cache[1], len(gdn_sink)))
+        return "stock"
+
+    def boom(*a, **k):
+        raise RuntimeError("kernel failed")
+
+    monkeypatch.setattr(cls, "__call__", stock, raising=False)
+    _arm_route(monkeypatch, q35, S, boom)
+    assert prework_mod.apply_qwen35_gdn_prework_patch()
+
+    cache = _FakeCache(old_conv, old_recurrent)
+    sink = ["earlier-layer"]
+    module = _fake_module()
+    x = mx.zeros((1, S, 2560), dtype=mx.bfloat16)
+    assert cls.__call__(module, x, cache=cache, gdn_sink=sink) == "stock"
+    assert cls.__call__(module, x, cache=cache, gdn_sink=sink) == "stock"
+    assert calls == [(old_conv, old_recurrent, 1), (old_conv, old_recurrent, 1)]
+    assert cache.advance_calls == []
+
+
+def test_verify_beta_matches_prebuilt_sigmoid_at_fast_math_outlier():
+    """mx.sigmoid is a prebuilt precise-exp op; the JIT fast exp disagrees at b=-6.84375."""
+    T = 2
+    qkv, conv_state, conv_w, b, a, A_log, dt_bias = _inputs(T, seed=5)
+    b = mx.full((1, T, HV), -6.84375, dtype=mx.bfloat16)
+    inv = DK**-0.5
+    got = prework_mod.qwen4_verify_prework_fused(
+        qkv, conv_state, conv_w, mx.array(inv * inv, dtype=mx.bfloat16),
+        mx.array(inv, dtype=mx.bfloat16), b, a, A_log, dt_bias, HK, HV, DK, DV,
+    )
+    beta = got[5]
+    exp = mx.sigmoid(b)
+    mx.eval(beta, exp)
+    assert mx.array_equal(beta, exp).item()

--- a/tests/test_qwen4_qsa_gathered_decode_attn.py
+++ b/tests/test_qwen4_qsa_gathered_decode_attn.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Verify-width and single-row QSA attention read selected rows in place through the
+gathered decode kernel, matching the portable gather + SDPA math on the same selection."""
+from __future__ import annotations
+
+import mlx.core as mx
+import pytest
+
+from omlx.patches import mlx_vlm_qwen4_exp_compat as compat
+from tests.test_qwen4_qsa_decode_gather import _tiny_text_config
+
+fast = pytest.importorskip("omlx.custom_kernels.decode_fast.fast")
+
+pytestmark = pytest.mark.skipif(
+    not fast.NATIVE_AVAILABLE or not hasattr(fast._ext, "sdpa_decode_gathered"),
+    reason="gathered decode kernel not built",
+)
+
+
+@pytest.fixture(autouse=True)
+def _vendored_qwen4(monkeypatch):
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    import mlx_vlm.models.qwen4_exp.qsa_fast as qsa_fast
+
+    monkeypatch.delenv("OMLX_QWEN4_QSA_GATHERED_DECODE", raising=False)
+    monkeypatch.setattr(qsa_fast, "_NATIVE_QSA_GATHERED_DISABLED", False, raising=False)
+    monkeypatch.setattr(qsa_fast, "_NATIVE_QSA_GATHERED_PROVEN", False, raising=False)
+
+
+def _layer_and_prefix(seed: int = 23, prefix_tokens: int = 10):
+    import mlx_vlm.models.qwen4_exp.language as language
+
+    config = _tiny_text_config()
+    config.head_dim = 64  # smallest head dim the decode kernels support
+    mx.random.seed(seed)  # layer weights and inputs are then independent of test order
+    attention = language.Qwen4ExpAttention(config)
+    mx.eval(attention.parameters())
+    prefix = mx.random.normal((1, prefix_tokens, config.hidden_size))
+    caches = []
+    for _ in range(2):
+        cache = language.QSAKVCache()
+        mx.eval(attention(prefix, mask="causal", cache=cache))
+        caches.append(cache)
+    return config, attention, caches
+
+
+def _spy(monkeypatch):
+    calls = []
+    original = fast.sdpa_decode_gathered
+
+    def tracked(q, k, v, indices, scale, **kwargs):
+        out = original(q, k, v, indices, scale, **kwargs)
+        # Portable gather + SDPA on the kernel's own inputs: the two caches select
+        # blocks independently and a near-tie in the tiny prefix can flip a row.
+        reference = original(q, k, v, indices, scale, force_fallback=True)
+        calls.append((tuple(q.shape), tuple(indices.shape), out, reference))
+        return out
+
+    monkeypatch.setattr(fast, "sdpa_decode_gathered", tracked)
+    return calls
+
+
+@pytest.mark.parametrize("rows", [2, 4])
+def test_verify_rows_use_gathered_decode_kernel_and_match_portable(monkeypatch, rows):
+    config, attention, (native_cache, portable_cache) = _layer_and_prefix()
+    verify = mx.random.normal((1, rows, config.hidden_size))
+    calls = _spy(monkeypatch)
+    actual = attention(verify, mask="causal", cache=native_cache, target_verify=True)
+    mx.eval(actual)
+    assert [c[0][2] for c in calls] == [rows]          # one kernel call covering every verify row
+    assert calls[0][1][:2] == (1, rows)                 # one index set per row
+    kernel_out, portable_out = calls[0][2], calls[0][3]
+    mx.eval(kernel_out, portable_out)
+    assert mx.allclose(kernel_out, portable_out, rtol=1e-4, atol=1e-4).item()
+    monkeypatch.setenv("OMLX_QWEN4_QSA_GATHERED_DECODE", "0")
+    expected = attention(verify, mask="causal", cache=portable_cache, target_verify=True)
+    mx.eval(expected)
+    assert len(calls) == 1                              # kill switch keeps the portable path
+    assert expected.shape == actual.shape and mx.isfinite(expected).all().item()
+
+
+def test_single_row_decode_uses_gathered_decode_kernel(monkeypatch):
+    config, attention, (native_cache, portable_cache) = _layer_and_prefix()
+    token = mx.random.normal((1, 1, config.hidden_size))
+    calls = _spy(monkeypatch)
+    actual = attention(token, mask=None, cache=native_cache)
+    mx.eval(actual)
+    assert [c[0][2] for c in calls] == [1]
+    kernel_out, portable_out = calls[0][2], calls[0][3]
+    mx.eval(kernel_out, portable_out)
+    assert mx.allclose(kernel_out, portable_out, rtol=1e-4, atol=1e-4).item()
+    monkeypatch.setenv("OMLX_QWEN4_QSA_GATHERED_DECODE", "0")
+    expected = attention(token, mask=None, cache=portable_cache)
+    mx.eval(expected)
+    assert len(calls) == 1
+    assert expected.shape == actual.shape and mx.isfinite(expected).all().item()

--- a/tests/test_qwen4_qsa_narrow_gathered.py
+++ b/tests/test_qwen4_qsa_narrow_gathered.py
@@ -1,0 +1,70 @@
+"""Narrow (2..15-row) batch-one text windows take the gathered prefill arm above a context threshold."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from omlx.patches.mlx_vlm_qwen4_exp_compat import apply_mlx_vlm_qwen4_exp_compat_patch
+
+apply_mlx_vlm_qwen4_exp_compat_patch()
+
+from mlx_vlm.models.qwen4_exp import language as L  # noqa: E402
+QSAKVCache = L.QSAKVCache
+
+BUDGET = 2048
+
+
+def _self():
+    return SimpleNamespace(
+        indexer=SimpleNamespace(token_budget=BUDGET),
+        _batch_one_text_position_ids=L.Qwen4ExpAttention._batch_one_text_position_ids,
+    )
+
+
+def _cache(offset):
+    cache = QSAKVCache()
+    cache.offset = offset
+    return cache
+
+
+def _eligible(rows, offset, target_verify=False):
+    x = mx.zeros((1, rows, 64), dtype=mx.bfloat16)
+    return L.Qwen4ExpAttention._gathered_text_prefill_eligible(
+        _self(), x, None, _cache(offset), None, None, target_verify
+    )
+
+
+def test_narrow_windows_gather_above_the_context_threshold(monkeypatch):
+    monkeypatch.delenv("OMLX_QWEN4_GATHERED_NARROW_MIN_CONTEXT", raising=False)
+    threshold = L._gathered_narrow_min_context()
+    assert threshold == 16384
+    for rows in (2, 4, 8, 15):
+        assert _eligible(rows, threshold)
+        assert _eligible(rows, 82_000)
+        assert not _eligible(rows, threshold - 1)
+        assert not _eligible(rows, BUDGET)  # below the threshold: masked path
+
+
+def test_wide_windows_keep_the_budget_rule():
+    assert _eligible(16, BUDGET)  # offset + rows > budget
+    assert _eligible(BUDGET + 1, 0)
+    assert not _eligible(BUDGET, 0)  # whole prefix fits the budget (strictly greater)
+    assert not _eligible(16, 0)
+    assert not _eligible(1, 82_000)  # single rows belong to the decode arm
+
+
+def test_threshold_env_override(monkeypatch):
+    monkeypatch.setenv("OMLX_QWEN4_GATHERED_NARROW_MIN_CONTEXT", "4096")
+    assert L._gathered_narrow_min_context() == 4096
+    assert _eligible(4, 4096)
+    assert not _eligible(4, 4095)
+    monkeypatch.setenv("OMLX_QWEN4_GATHERED_NARROW_MIN_CONTEXT", "bogus")
+    assert L._gathered_narrow_min_context() == 16384
+
+
+def test_verify_rows_still_excluded_from_the_prefill_arm():
+    assert not _eligible(4, 82_000, target_verify=True)

--- a/tests/test_qwen4_qsa_native_indexer.py
+++ b/tests/test_qwen4_qsa_native_indexer.py
@@ -40,6 +40,12 @@ def _topk_sets(scores, topk):
     return mx.sort(indices.astype(mx.int32), axis=-1)
 
 
+@pytest.fixture(autouse=True)
+def _steel_score_kernel(monkeypatch):
+    """These tests exercise the steel score ABI; the tensor-unit kernel has its own file."""
+    monkeypatch.setenv("OMLX_QWEN4_QSA_NAX_SCORES", "0")
+
+
 def test_qwen4_qsa_symbol_is_part_of_the_extension_abi():
     assert "qwen4_qsa_indexer_scores" in fast.NATIVE_SYMBOLS
 

--- a/tests/test_qwen4_qsa_nax_indexer.py
+++ b/tests/test_qwen4_qsa_nax_indexer.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qwen4 QSA indexer scores on the M5 tensor units (NAX): fused bf16 GEMM with fp32 accumulate,
+ReLU, head-sum, 1/sqrt(D) and the pooled causal sentinel, matching the exact fp32 path up to
+accumulation order and selecting the same top-k blocks."""
+from __future__ import annotations
+
+import mlx.core as mx
+import pytest
+
+from omlx.custom_kernels.glm_moe_dsa import fast
+from omlx.patches import mlx_vlm_qwen4_exp_compat as compat
+
+compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+from mlx_vlm.models.qwen4_exp import qsa_fast  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    not (fast.is_native_available() and fast.has_symbol("qwen4_qsa_nax_indexer_scores")),
+    reason="native Qwen4 NAX indexer scores not built",
+)
+
+
+def _reference(q, k, offset):
+    """Exact fp32 path with the same pooled causal sentinel the kernels write."""
+    scores = qsa_fast._portable_indexer_scores(q, k, 128)
+    valid = mx.arange(k.shape[1])[None, None, :] < (offset + mx.arange(q.shape[1])[None, :, None] + 1) // 4
+    return mx.where(valid, scores, mx.finfo(mx.float32).min)
+
+
+def _topk_sets(scores, k):
+    picks = mx.argpartition(scores, kth=-k, axis=-1)[..., -k:]
+    return mx.sort(picks, axis=-1)
+
+
+@pytest.mark.parametrize("dtype", [mx.bfloat16, mx.float16])
+@pytest.mark.parametrize(
+    "rows,blocks,offset",
+    [
+        (67, 521, 2048),        # ragged M and N (boundary tiles), mask inside the tile
+        (256, 4096, 16384),     # aligned prefill chunk
+        (2048, 32770, 131072 - 2048),  # 134k geometry, N two past a tile edge
+        (32, 40, 100),          # every column masked for early rows
+    ],
+)
+def test_nax_scores_match_exact_path_and_topk(dtype, rows, blocks, offset):
+    mx.random.seed(rows)
+    q = (mx.random.normal((1, rows, 4, 128)) * 0.3).astype(dtype)
+    k = (mx.random.normal((1, blocks, 128)) * 0.3).astype(dtype)
+    actual = fast.qwen4_qsa_nax_indexer_scores(
+        q.transpose(0, 2, 1, 3), k[:, None], mask_ratio=4, mask_q_offset=offset
+    )
+    expected = _reference(q, k, offset)
+    mx.eval(actual, expected)
+    assert actual.shape == (1, rows, blocks) and actual.dtype == mx.float32
+    sentinel = mx.finfo(mx.float32).min
+    masked = expected == sentinel
+    assert mx.array_equal(actual == sentinel, masked).item()          # sentinel bit-exact
+    visible = mx.where(masked, 0.0, mx.abs(actual - expected))
+    scale = float(mx.max(mx.where(masked, 0.0, mx.abs(expected))).item()) or 1.0
+    assert float(mx.max(visible).item()) <= 2e-5 * scale               # accumulation-order noise only
+    top = min(512, blocks)
+    assert mx.array_equal(_topk_sets(actual, top), _topk_sets(expected, top)).item()
+
+
+def test_nax_scores_symbol_is_part_of_extension_abi():
+    assert "qwen4_qsa_nax_indexer_scores" in fast.NATIVE_SYMBOLS
+
+
+def test_native_score_route_prefers_nax_and_kill_switch_restores_steel(monkeypatch):
+    monkeypatch.setenv("OMLX_QWEN4_QSA_NATIVE_SCORE_MIN_ROWS", "0")
+    monkeypatch.setattr(qsa_fast, "_NATIVE_QSA_SCORE_DISABLED", False)
+    monkeypatch.setattr(qsa_fast, "_NATIVE_QSA_SCORE_PROVEN", True)
+    q = mx.zeros((1, 40, 4, 128), dtype=mx.bfloat16)
+    k = mx.zeros((1, 600, 128), dtype=mx.bfloat16)
+    calls = []
+    monkeypatch.setattr(fast, "qwen4_qsa_nax_indexer_scores", lambda *a, **kw: calls.append("nax") or mx.zeros((1, 40, 600)))
+    monkeypatch.setattr(fast, "qwen4_qsa_indexer_scores", lambda *a, **kw: calls.append("steel") or mx.zeros((1, 40, 600)))
+    qsa_fast._native_indexer_scores(q, k, head_dim=128, compress_ratio=4, mask_q_offset=4000)
+    monkeypatch.setenv("OMLX_QWEN4_QSA_NAX_SCORES", "0")
+    qsa_fast._native_indexer_scores(q, k, head_dim=128, compress_ratio=4, mask_q_offset=4000)
+    assert calls == ["nax", "steel"]


### PR DESCRIPTION
### TLDR
Accelerating the MTP decoding speed(and little bit prefill) for the Qwen3.8-Flash-Next model.

This PR is essentially a collection of small optimizations here and there; if combining them all into a single PR was a mistake, just let me know and I'll split them into separate PRs.

### Summary
Six commits—improvements on top of `main` d7c63c2. Every commit is independent in files, exact by construction or bit-exact against the composed stock ops, kill-switched, and measured with interleaved A/B runs (A B B A, or A B C C B A) on an M5 Max 128 GB with `Qwen3.8-Flash-Next-oQ4e-mtp`, SSD PLE, 512 generated tokens, greedy unless noted. Base numbers are the state of `main` at the time of each measurement; the whole-branch table at the end is against current main.
The three bit-exact ones (3, 4, 6) are the safe core, ~70% of total performance gain; 1 and 2 are the tolerance-level kernels and both have kill switches.
Commit 2 is both about prefill and decode, because it sits in the same QSA indexer code.

### Benchmarks
`main` d7c63c27 vs this branch a04d2408


### Per-cycle cost at pinned depth 3
main → branch (text-independent: backbone and draft-head milliseconds per verify cycle from the MTP stats, Python code, four passes per cell averaged over mirrored arms):

| context | backbone ms | draft head ms | wall ms / cycle | tokens / cycle | accept | client tok/s |
|---|---|---|---|---|---|---|
| 16k | 34.41 → 34.46 (+0.1%) | 3.37 → 2.89 (−14.2%) | 37.87 → 37.43 (−1.2%) | 2.78 → 2.68 (−3.6%) | 74.9 → 74.2% (−0.7 pt) | 70.7 → 68.9 (−2.5%) |
| 65k | 34.92 → 33.29 (−4.7%) | 5.67 → 3.80 (−33.0%) | 40.70 → 37.18 (−8.6%) | 2.61 → 2.88 (+10.3%) | 71.7 → 78.3% (+6.6 pt) | 61.7 → 74.0 (+19.9%) |
| 136k | 36.75 → 35.01 (−4.7%) | 9.57 → 5.39 (−43.7%) | 46.43 → 40.50 (−12.8%) | 2.68 → 3.03 (+13.1%) | 74.2 → 81.7% (+7.4 pt) | 55.8 → 71.9 (+28.9%) |
| 210k | 37.55 → 35.44 (−5.6%) | 11.22 → 5.41 (−51.8%) | 48.89 → 40.96 (−16.2%) | 2.43 → 2.53 (+4.1%) | 66.5 → 70.0% (+3.5 pt) | 48.0 → 59.5 (+24.0%) |
<img width="935" height="384" alt="mtp_verify_cycle" src="https://github.com/user-attachments/assets/4fa6fa5e-a4a7-49f0-9802-c07d38463698" />

The wall-time-per-cycle column is the kernel work: −1.2% at 16k, −8.6% at 65k, −12.8% at 136k, −16.2% at 210k. The backbone share (−5% from 65k up) is the gathered decode kernel plus the fused verify rows; the head share (−14.2% to −51.8%) is the narrow-window gate, whose saving grows with the prefix. Tokens per cycle and acceptance are shown separately on purpose: the NAX indexer scores are exact only to 2e-5, which flips near-tie block selections, so the greedy continuation forks early and each tree then verifies a different text. On these prompts the fork favoured the branch (+4 to +13% tokens per cycle); that part is continuation luck, not kernel speed, and the NAX kill switch returns tokens per cycle to the base's value exactly.

**Where the cycle saving comes from aka bit-exact commits vs all** (pinned depth 3, Python code, three arms A X C C X A: main; the branch with the two tolerance-level kernels switched off, i.e. the three bit-exact commits 3, 4 and 6 plus commit 5, which changes only when the controller re-enters after a park and never engages at pinned depth; the branch with all six):

| context | main ms / cycle | bit-exact commits only | all six commits | bit-exact share of the saving | throughput at equal acceptance: bit-exact / tolerance on top |
|---|---|---|---|---|---|
| 16k | 37.54 | 37.11 (−1.1%) | 37.11 (−1.1%) | 100% | +1.2% / +0.0% |
| 65k | 40.88 | 38.58 (−5.6%) | 36.84 (−9.9%) | 57% | +6.0% / +4.7% |
| 136k | 46.26 | 42.05 (−9.1%) | 40.76 (−11.9%) | 77% | +10.0% / +3.2% |
| 210k | 48.74 | 42.73 (−12.3%) | 40.76 (−16.4%) | 75% | +14.1% / +4.8% |
<img width="952" height="393" alt="bit-exact-vs-all" src="https://github.com/user-attachments/assets/61d332aa-b952-410c-93bd-db5e70b32283" />

<img width="944" height="392" alt="bit-exact-vs-all_mtp" src="https://github.com/user-attachments/assets/07b63609-8447-46a7-a6fe-f21883c79563" />

The bit-exact set (fused GDN verify rows, grouped verify projections, narrow gate) reproduces main's text, with tokens per cycle within 3% of main's in every cell, and takes the whole draft-head saving. The gathered decode kernel adds a flat 1.3–2.2 ms of backbone from 65k up; the NAX indexer scores add nothing at decode. A reviewer who wanted a strictly bit-exact PR could drop commits 1 and 2 and keep 57–100% of the cycle saving, at the cost of the serial gain and the prefill gain; commit 5 is control flow only and does not touch the numerics of any kernel.

### Adaptive MPT
(greedy, 512 tokens; three prompt families, four passes each, thinking on):

| context | Python code | English prose | mixed-language code | mean of the three |
|---|---|---|---|---|
| 4k | 70.4 → 80.8 (+14.7%) | 73.3 → 74.9 (+2.2%) | 77.6 → 79.1 (+1.9%) | +6.3% |
| 16k | 71.5 → 76.8 (+7.5%) | 70.8 → 71.0 (+0.4%) | 77.1 → 77.1 (+0.0%) | +2.6% |
| 65k | 72.8 → 69.7 (−4.2%) | 66.2 → 76.1 (+14.8%) | 72.2 → 85.4 (+18.2%) | +9.6% |
| 136k | 63.8 → 73.2 (+14.7%) | 57.7 → 67.0 (+16.1%) | 61.6 → 67.1 (+9.0%) | +13.3% |
| 210k | 59.9 → 65.5 (+9.4%) | 63.0 → 67.9 (+7.8%) | 62.4 → 70.1 (+12.4%) | +9.9% |
<img width="907" height="417" alt="mtp_decode" src="https://github.com/user-attachments/assets/8cc0a7f2-7265-43d3-88f0-78ec8b7801bc" />

<img width="947" height="390" alt="mtp_decode_prompts" src="https://github.com/user-attachments/assets/012e5b8d-141f-4002-84ff-e3ef2ae81db3" />

Across the 15 cells the mean is +8.3% with 14 positive. The one negative, Python code at 65k, is a continuation fork rather than slower code: the base's text runs at 85% acceptance (91–94% at the third draft position) and the branch's at 72%, with no parks on either side. The same prompt at pinned depth 3 is +20% on the branch, main itself at pinned depth 3 produces a 72%-acceptance text, and with the two tolerance-level kernels switched off (`OMLX_QWEN4_QSA_GATHERED_DECODE=0 OMLX_QWEN4_QSA_NAX_SCORES=0`) the branch reproduces main's text byte for byte and runs it 6.5% faster. Per-cycle cost favours the branch in every family and context, so the spread between families is the text, not the code.

### Serial decode and cold prefill
(Python code prompts, serial is MTP off; prefill is the pass-1 time to first token, serial and MTP boots pooled):

| context | serial main → branch | cold prefill main → branch |
|---|---|---|
| 4k | 61.6 → 62.4 (+1.4%) | 10.9 → 10.2 s (−6.1%) (first request after each server start, includes warm-up) |
| 16k | 59.0 → 59.4 (+0.8%) | 19.0 → 18.4 s (−2.9%) |
| 65k | 57.1 → 58.9 (+3.1%) | 47.2 → 46.7 s (−1.1%) |
| 136k | 55.7 → 57.0 (+2.3%) | 66.9 → 65.2 s (−2.4%) |
| 210k | 54.2 → 55.7 (+2.8%) | 70.8 → 68.5 s (−3.3%) |
<img width="904" height="414" alt="serial_decode" src="https://github.com/user-attachments/assets/811c5a7f-82a0-4689-bb08-61d82d0cbdca" />

<img width="918" height="413" alt="cold_prefill" src="https://github.com/user-attachments/assets/7d87debe-8f43-4e91-954c-de6544cc452b" />

Serial decode is +1 to +3% from the gathered decode kernel; cold prefill is 1–3% shorter from the NAX indexer scores.


### Commit 1 — indexed-KV attention kernel for gathered QSA decode rows (`omlx/custom_kernels/decode_fast`)

**What.** A two-pass decode SDPA kernel that reads only the selected K/V rows through an int32 index list (masked entries finite-min), so the gathered decode arm and MTP verify rows attend the top-k blocks without materialising the gather and without the masked dense read of the whole prefix. Portable fallback (`take` + masked `mx.fast` SDPA) stays; wrapper always passes contiguous inputs and checks layouts at eval.

**Gain.** MTP +0.3 / +4.8 / +6.8 / +1.0% at 16k / 63k / 134k / 229k, serial +0 / +1.6 / +1.7 / +2.3%, prefill flat. Per verify cycle at 63k the gather + portable attention it replaces was ~2.8 ms of a 34 ms backbone.

**Parity and tests.** `tests/test_decode_fast_sdpa_gathered.py` (22 shape/dtype cases vs the portable path), `tests/test_qwen4_qsa_gathered_decode_attn.py` (verify rows and single rows go through the kernel; the kernel matches the portable gather + SDPA math on its own inputs at 1e-4; the kill switch keeps the portable arm). The layer test deliberately does not compare two separately prefilled caches: with a tiny prefix a near-tie can make them select different blocks for a row, which is a property of top-k selection, not of either attention path. Kill switch `OMLX_QWEN4_QSA_GATHERED_DECODE=0`.

### Commit 2 — QSA indexer scores on the M5 tensor units (`omlx/custom_kernels/glm_moe_dsa`)

**What.** A second metallib (`omlx_glm_kernels_nax.metallib`, compiled with `-mmacosx-version-min=26.2`, SDK-gated in CMake) runs the indexer score matmul on NAX with 64×64 tiles, a ReLU-accumulate epilogue and the masked sentinel; the host mirrors `is_nax_available()` and keeps the steel kernel as the fallback, so machines without NAX (M3 Ultra) are unaffected.

**Gain.** 1.5× per layer-chunk against the steel kernel; cold prefill −1 to −3% at 16k–229k; decode flat.

**Parity and tests.** `tests/test_qwen4_qsa_nax_indexer.py`: sentinel bit-exact, scores within 2e-5 relative, top-512 sets identical, route and kill switch (`OMLX_QWEN4_QSA_NAX_SCORES=0`). Note for reviewers: the existing native-indexer tests pin the kill switch so they keep exercising the steel path.

### Commit 3 — fused GDN prework and norm-gate for MTP verify rows, precise sigmoid in the fused kernels (`omlx/patches/qwen35_gdn_prework.py`)

**What.** Under MTP the 36 GDN layers run with 2..4 verify rows; the existing fusion covered single-row decode and only the conv for 3..9 rows. A row-batched verify arm (1..8 rows) fuses conv, SiLU, q/k RMS norm and scales, `g`, `beta` and the next conv state into one dispatch, feeds precomputed `g`/`beta` to the states-returning recurrence, and fuses the gated RMS norm; depth-1 verify (2 rows) was fully stock before.

**Fix.** `mx.sigmoid` is a prebuilt op compiled with the precise `exp`, while `metal_kernel` sources and compiled functions use the fast one; the two differ at exactly one bf16 input (`b = -6.84375`). Both the new verify kernel and the existing single-row decode kernel computed `beta` with the fast exp, which shifted the GDN recurrent state by an fp32 ulp on rare cycles and forked greedy output about 160 tokens into a completion. Both now use `metal::precise::exp` for `beta` (SiLU keeps the fast exp because `nn.silu` is compiled). Verified with an exhaustive sweep of every finite bf16 gate input on real layer weights (0 mismatches in 1.6M); greedy completions are byte-identical with the arm on and off at pinned depths 1 and 3.

**Gain.** Pinned depth 1 at 5k +3.4%; adaptive: code +0.5 / +1.1%, prose +0.1 / +1.9% (5k / 40k). With per-layer `async_eval` the GPU queue already hides most small dispatch gaps, so this is the honest size of a dispatch-count fusion on this model.

**Parity and tests.** Bit-exact against the composed stock ops for 1, 2, 3, 4 and 8 rows and against the stock forward on real layer-0 weights over 220M elements (out, both cache states, q/k/v, intermediate states). Route tests commit cache states and the rollback sink only after every fallible step. Kill switch `OMLX_QWEN4_GDN_VERIFY_FUSED=0`. Tests: `tests/test_qwen4_gdn_verify_fused.py`, existing `tests/test_qwen35_gdn_prework.py`.

### Commit 4 — grouped verify-row quantized projections (`omlx/patches/qwen35_grouped_linears.py`)

**What.** `_target_verify_linears` issues one quantized matmul per projection for batch-one rows. Concatenating weights along the output axis is bit-exact per output row, so GDN in-projections, attention q/k/v and MLP gate/up now dispatch once per (bits, group_size) signature for 2..8 verify rows. Groups are cached `QuantizedLinear` subclasses so the verify-qmm routing patch sees the usual call shape; a group whose routing would differ from a member's falls back to member calls.

**Gain.** Measured together with commit 3 against their base: MTP code +0.4 / −0.4%, prose +2.3 / +2.6% (5k / 34k); serial flat. Grouping single-row decode projections measured −1.6 to −2.4% serial in all sixteen passes, so it is restricted to verify rows.

**Parity and tests.** `mx.array_equal` to separate linears for mixed signatures {4/64, 5/128, 6/64, 8/32, 8/128}, 2..8 rows; one dispatch per signature; patch rebinds the vendored Qwen4 module's own import of the helper. Kill switch `OMLX_QWEN35_GROUPED_LINEARS=0`. Tests: `tests/test_qwen35_grouped_linears.py`.

### Commit 5 — keep the draft head primed during parked standard decode (`omlx/patches/mlx_lm_mtp/`)

**What.** When the depth controller parks speculation, `_park_mtp_to_standard` dropped the head cache, so every re-entry probe 128/256/…/4096 tokens later started cold (`primed=0`) and, at long context, usually failed, doubling the cooldown. The committed head cache now becomes a parked priming context: standard decode buffers (hidden, next token) pairs and folds them through one batched `mtp_forward` every 32 tokens; `take_primed` flushes the remainder at the probe and returns the exact head offset. The hidden capture is best-effort so a backbone that yields no hidden cannot fail the park handoff.

**Effect.** 68k prose prompt, production sampling: the controller parked after 154 tokens, the probe activated with `primed=68600` and succeeded, decode stayed on MTP for the remaining 742 tokens. Parking is rare at 68..82k on this branch, so the throughput effect is bounded by park frequency; zero cost while the controller never parks.

**Tests.** `tests/test_mtp_parked_fold.py` (tiny mlx-lm model: block folds and the probe flush reproduce a direct fold of the same pairs to 1e-5 with equal head offsets; discontiguous steps drop the context; prime window ignored; park survives a backbone without hidden) plus the existing priming, controller and MTP patch suites. Kill switch `OMLX_MTP_PARKED_FOLD=0`, block size `OMLX_MTP_PARK_FOLD_BLOCK`.

### Commit 6 — narrow text windows take the gathered QSA arm at long context (`qwen4_exp/language.py`)

**What.** The MTP head's committed fold runs the head's QSA layer with 2..8 rows. None of the gathered arms accepted that shape (decode: one row; prefill: ≥ 16 rows; verify: `target_verify` only), so the fold attended the whole prefix through the masked-dense path: 4.9 ms per 3–4-row fold at 82k against 1.0 ms gathered, and 90 of 148 folds have 4 rows. `_gathered_text_prefill_eligible` keeps its 16-row floor at short context and adds one clause: batch-one text windows of 2..15 rows take the gathered arm once `cache.offset >= OMLX_QWEN4_GATHERED_NARROW_MIN_CONTEXT` (default 16384). The arm itself is unchanged; verify rows keep their own gate; drafts are verified exactly.

**Gain.** Adaptive MTP: code 41k +2.3%, code 82k +4.6% (all four passes above base), prose 34k −1.3%, prose 68k −0.1%; head time per cycle at 82k 3.4 → 1.8 ms. The gain is context-proportional.

**Tests.** `tests/test_qwen4_qsa_narrow_gathered.py` (gate above/below the threshold, strict budget rule, single rows on the decode arm, verify rows excluded, env override) plus the existing gathered-arm suites.

### Server-level greedy parity on this branch (pinned depth 3, code 5k and 41k, 512 tokens)

Each kill switch was toggled against the all-on run and the completions compared byte for byte. Fused verify rows off, grouped projections off, narrow gate off: identical, as their bit-exact construction requires (the narrow gate changes only drafts, never verified tokens). Gathered kernel off: the 5k completion identical with identical cycle and acceptance counts, the 41k completion forks at token 24. NAX indexer scores off: the 41k completion forks at token 8. Both are tolerance-level kernels (1e-4 attention, 2e-5 indexer scores), and a long prefix turns any such difference into a flipped near-tie block selection or an argmax flip within a few tokens; a separately measured control showed the same divergence from an unrelated one-ulp perturbation of a prefill norm, with no change in teacher-forced NLL. Acceptance rates on the diverged continuations stay in the usual 70–76% band.

### Method notes

- Every kernel's parity is measured against the composed stock ops on real weights, never kernel-vs-kernel; anything on the MTP verify path was also checked for byte-identical greedy completions with the change on and off.
- Two lessons from this work that apply to future kernels: JIT Metal kernels must match the reference op's compile path (prebuilt ops use the precise exp/log, compiled functions and `metal_kernel` sources the fast ones), and synchronous micro-benchmarks sit at the ~250 µs eval floor on this model, so only in-situ A/B runs can resolve dispatch-level effects.
- Parked as measured-negative and not included: prompt-lookup n-gram drafts (−10 to −20%: wide speculative windows lose on this MoE model whatever the draft source), a block-sparse row-group prefill kernel (3.6× slower), and an MMA rewrite of the GDN prefill recurrence (recurrence is 6.5% of a prefill chunk).
