### PR TITLE
feat(cache): allow overriding resolved paged cache block size

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1806,6 +1806,9 @@ class Scheduler:
         # For ArraysCache-only models (no RotatingKVCache), use a larger block
         # size to reduce boundary snapshot overhead during prefill.
         self._enlarge_block_size_for_arrays_cache()
+        # Escape hatch for workloads the two heuristics above size badly.
+        # Must run last: it is the final say on block size.
+        self._apply_block_size_env_override()
 
         # TurboQuant KV cache (set by engine if model_settings has it enabled)
         self._turboquant_kv_bits: float | None = None
@@ -2781,6 +2784,54 @@ class Scheduler:
     # e.g. a 4096-token block cannot serve a 3k-token prefix. A geometry change
     # also leaves old SSD blocks cold until normal eviction removes them.
     _ARRAYS_CACHE_BLOCK_SIZE = 2048
+
+    def _apply_block_size_env_override(self) -> None:
+        """Honor OMLX_PAGED_CACHE_BLOCK_SIZE, overriding the resolved value.
+
+        The rotating-window and ArraysCache heuristics above pick a block size
+        from model geometry alone. Geometry does not describe the request
+        shape, so a workload whose turns are shorter than the resolved block
+        can end up storing no whole blocks at all — a prefix is only reusable
+        in whole blocks — and re-prefilling every turn. This is the escape
+        hatch for that case, and for A/B measuring block size on a fixed
+        model.
+
+        Runs last so it wins over both heuristics. Defaults are unchanged when
+        the variable is unset. Applies only when the paged cache is enabled,
+        matching the gate on _enlarge_block_size_for_arrays_cache. Invalid
+        values are ignored with a warning rather than raising, so a bad export
+        cannot take the server down.
+        """
+        if not self.config.paged_ssd_cache_dir:
+            return
+        raw = os.environ.get("OMLX_PAGED_CACHE_BLOCK_SIZE", "").strip()
+        if not raw:
+            return
+        try:
+            requested = int(raw)
+        except ValueError:
+            logger.warning(
+                "Ignoring OMLX_PAGED_CACHE_BLOCK_SIZE=%r (not an integer)", raw
+            )
+            return
+        if requested <= 0 or requested & (requested - 1):
+            logger.warning(
+                "Ignoring OMLX_PAGED_CACHE_BLOCK_SIZE=%d "
+                "(must be a positive power of two)",
+                requested,
+            )
+            return
+        current = self.config.paged_cache_block_size
+        if requested == current:
+            return
+        logger.info(
+            "OMLX_PAGED_CACHE_BLOCK_SIZE override: paged cache block_size "
+            "%s -> %s (smaller blocks raise prefix reuse on short turns but "
+            "add boundary snapshot overhead on ArraysCache hybrids)",
+            current,
+            requested,
+        )
+        self.config.paged_cache_block_size = requested
 
     def _enlarge_block_size_for_arrays_cache(self) -> None:
         """Enlarge block size for ArraysCache-only hybrid models.

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -153,6 +153,74 @@ class TestSchedulerConfig:
         assert config.mlx_cache_cleanup_interval == 20
 
 
+class TestPagedCacheBlockSizeEnvOverride:
+    """Tests for the OMLX_PAGED_CACHE_BLOCK_SIZE escape hatch."""
+
+    ENV_VAR = "OMLX_PAGED_CACHE_BLOCK_SIZE"
+
+    @staticmethod
+    def _scheduler(block_size: int = 4096, ssd_dir: str | None = "/tmp/cache"):
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.config = SchedulerConfig(
+            paged_cache_block_size=block_size,
+            paged_ssd_cache_dir=ssd_dir,
+        )
+        return scheduler
+
+    def test_unset_leaves_resolved_block_size_untouched(self, monkeypatch):
+        """Absent the variable, the heuristics' choice must stand."""
+        monkeypatch.delenv(self.ENV_VAR, raising=False)
+        scheduler = self._scheduler()
+
+        scheduler._apply_block_size_env_override()
+
+        assert scheduler.config.paged_cache_block_size == 4096
+
+    def test_empty_value_is_ignored(self, monkeypatch):
+        monkeypatch.setenv(self.ENV_VAR, "   ")
+        scheduler = self._scheduler()
+
+        scheduler._apply_block_size_env_override()
+
+        assert scheduler.config.paged_cache_block_size == 4096
+
+    def test_override_replaces_resolved_block_size(self, monkeypatch):
+        monkeypatch.setenv(self.ENV_VAR, "512")
+        scheduler = self._scheduler()
+
+        scheduler._apply_block_size_env_override()
+
+        assert scheduler.config.paged_cache_block_size == 512
+
+    def test_override_can_raise_block_size(self, monkeypatch):
+        """The hatch is not one-directional."""
+        monkeypatch.setenv(self.ENV_VAR, "2048")
+        scheduler = self._scheduler(block_size=256)
+
+        scheduler._apply_block_size_env_override()
+
+        assert scheduler.config.paged_cache_block_size == 2048
+
+    @pytest.mark.parametrize("raw", ["abc", "512.5", "0", "-512", "768"])
+    def test_invalid_values_are_ignored(self, monkeypatch, raw):
+        """Non-integer, non-positive and non-power-of-two values are refused."""
+        monkeypatch.setenv(self.ENV_VAR, raw)
+        scheduler = self._scheduler()
+
+        scheduler._apply_block_size_env_override()
+
+        assert scheduler.config.paged_cache_block_size == 4096
+
+    def test_ignored_when_paged_cache_disabled(self, monkeypatch):
+        """Matches the gate on _enlarge_block_size_for_arrays_cache."""
+        monkeypatch.setenv(self.ENV_VAR, "512")
+        scheduler = self._scheduler(ssd_dir=None)
+
+        scheduler._apply_block_size_env_override()
+
+        assert scheduler.config.paged_cache_block_size == 4096
+
+
 class TestVLMExtraSlicing:
     """Tests for VLM prompt-aligned extra kwargs used during external prefill."""
 


### PR DESCRIPTION
## Problem

`_align_block_size_with_rotating_window()` and `_enlarge_block_size_for_arrays_cache()` size the paged cache block from model geometry alone. Geometry doesn't describe request shape, so a workload whose turns are shorter than the resolved block stores no whole blocks at all — a prefix is only reusable in whole blocks — and re-prefills every turn.

Concretely, on Qwen3.8-27B-oQ4e-mtp (`model_type: qwen3_5`, 48 `linear_attention` layers), `_enlarge_block_size_for_arrays_cache()` resolves to 4096 through `_detect_qwen35_prefill_floor()`. The Pi coding agent's system prompt is ~3.6k tokens and early agentic turns run 3.9–4.1k prompt tokens total — so the stable prefix sits just under one block and never fills one. The scheduler logs `boundary_snapshot_unavailable` and re-prefills the system prompt on essentially every turn. There is currently no way to opt out.

## Measurement

Measured on `94530d8d`, M3 Max 64GB, Qwen3.8-27B-oQ4e-mtp, native MTP depth 3, fp16 KV, 20 agentic coding tasks (4 tasks × 5 reps), both arms on that commit with block size the only variable:

| metric (median, n=20) | 4096 (resolved) | 512 (override) | Δ |
|---|---:|---:|---:|
| prefix cache hit rate | 59.8% | 88.7% | +28.9pp |
| tokens re-prefilled per attempt | 13,892 | 4,957 | −64.3% |
| TTFT | 18.35s | 5.92s | −67.7% |
| decode | 45.65 tok/s | 44.02 tok/s | −3.6% |
| end-to-end wall (suite total) | 2512.6s | 1546.2s | **−38.5%** |

Per-task medians improve 36–52%, so the gain is broad rather than one outlier task. This build already includes `df4e77ab` (#3102, preserve reusable prefixes at request completion).

**On the prefill-overhead tradeoff.** `_enlarge_block_size_for_arrays_cache()`'s rationale is that larger blocks reduce boundary snapshot stops during prefill, so a smaller block should cost per-token prefill throughput. I can't measure that directly — `prefill_tokens_per_second` is unavailable from the oMLX log (no prompt-eval duration emitted). But TTFT fell −67.7% while the tokens actually needing prefill fell −64.3%; if per-token prefill cost had materially worsened at 512, TTFT would have improved *less* than the token count, not more. Decode is flat, confirming the effect is prefill-side. At this scale the snapshot overhead does not appear to offset the reuse gain — though that balance is certainly model- and workload-dependent, which is the argument for a knob rather than a new default.

## Change

`OMLX_PAGED_CACHE_BLOCK_SIZE` overrides the resolved block size.

- Runs last in `__init__`, so it wins over both heuristics
- Gated on the paged cache being enabled, matching `_enlarge_block_size_for_arrays_cache()`'s own gate
- Warns and ignores invalid values (non-integer, non-positive, non-power-of-two) rather than raising, so a bad export can't take the server down
- Defaults unchanged when unset

## Tests

10 cases in `tests/test_scheduler.py::TestPagedCacheBlockSizeEnvOverride` — unset and empty (defaults preserved), override down and up, four invalid-value classes, and the disabled-cache gate. Full `tests/test_scheduler.py` passes (284 tests).

## Note on approach

Happy to reshape this. An env var is the minimal backward-compatible option, but if you'd prefer a `SchedulerConfig` field plus a CLI flag — or think the real fix is that `_qwen35_prefill_floor`, a prefill-width concept, shouldn't feed the cache block-size target at all — I'll gladly redo it that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)