### PR TITLE
fix(mac): reject custom kernels with the wrong bundled Python ABI

### DIFF
--- a/apps/omlx-mac/Scripts/build.sh
+++ b/apps/omlx-mac/Scripts/build.sh
@@ -114,6 +114,7 @@ CUSTOM_KERNEL_DIRS=(
     "$REPO_ROOT/omlx/custom_kernels/minimax_m3"
     "$REPO_ROOT/omlx/custom_kernels/qwen35_prefill"
 )
+CUSTOM_KERNEL_ABI_CHECKER="$SCRIPT_DIR/check_custom_kernel_python_abi.py"
 # OMLX_EXPORT_DIR overrides the venvstacks export tree we copy Python
 # layers from. Release builds use this to point at a per-target export
 # copy with platform-specific mlx-metal wheels swapped in.
@@ -225,6 +226,40 @@ _custom_kernel_pythonpath() {
     else
         printf "%s\n" "$mlx_site"
     fi
+}
+
+_custom_kernel_donor_python() {
+    [ -n "${DONOR_LAYERS:-}" ] || die "custom kernel build requires resolved donor layers."
+    local donor_python="$DONOR_LAYERS/cpython-3.11/bin/python3"
+    [ -x "$donor_python" ] \
+        || die "donor missing executable bundled Python: $donor_python"
+    printf "%s\n" "$donor_python"
+}
+
+_validate_custom_kernel_python_abi() {
+    # The build-time ABI probe below runs under PYTHON_BIN. That can be a
+    # different CPython than the donor app's embedded interpreter, which
+    # would let a cpython-313 _ext pass the probe before it is bundled into a
+    # cpython-311 app. Compare the actual interpreters before compiling.
+    local donor_python
+    donor_python="$(_custom_kernel_donor_python)"
+    [ -f "$CUSTOM_KERNEL_ABI_CHECKER" ] \
+        || die "custom kernel Python ABI checker missing: $CUSTOM_KERNEL_ABI_CHECKER"
+    "$PYTHON_BIN" "$CUSTOM_KERNEL_ABI_CHECKER" \
+        --build-python "$PYTHON_BIN" \
+        --donor-python "$donor_python" \
+        || die "custom kernel build Python ABI must match the donor app; see output above."
+}
+
+_validate_packaged_custom_kernel_extensions() {
+    # Check the files actually copied into the staged app as well. This
+    # catches stale _ext files that a source-tree build did not replace.
+    local donor_python="$1"
+    local packaged_kernels="$2"
+    "$PYTHON_BIN" "$CUSTOM_KERNEL_ABI_CHECKER" \
+        --donor-python "$donor_python" \
+        --extension-directory "$packaged_kernels" \
+        || die "staged custom kernel extension suffixes do not match the donor app; see output above."
 }
 
 _clean_custom_kernel_build_artifacts() {
@@ -359,6 +394,7 @@ _build_custom_kernels() {
     cmake_args="${CMAKE_ARGS:-}"
     custom_kernel_pythonpath="$(_custom_kernel_pythonpath)"
 
+    _validate_custom_kernel_python_abi
     _check_custom_kernel_nanobind "$custom_kernel_pythonpath"
     log "Building optional native custom kernels (macOS deployment target $deployment_target)…"
     _clean_custom_kernel_build_artifacts
@@ -574,6 +610,11 @@ rsync -a \
     "${RSYNC_EXCLUDES[@]}" \
     "$REPO_ROOT/omlx/" "$RESOURCES_DIR/omlx/"
 ok "  + omlx package"
+
+if [ "$WITH_CUSTOM_KERNEL" = "1" ]; then
+    _validate_packaged_custom_kernel_extensions \
+        "$(_custom_kernel_donor_python)" "$RESOURCES_DIR/omlx/custom_kernels"
+fi
 
 log "Writing engine commit metadata..."
 "$PYTHON_BIN" "$PACKAGING_DIR/build.py" --write-engine-commits "$RESOURCES_DIR/omlx" \

--- a/apps/omlx-mac/Scripts/check_custom_kernel_python_abi.py
+++ b/apps/omlx-mac/Scripts/check_custom_kernel_python_abi.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Fail closed when app-bundled native kernels use the wrong CPython ABI.
+
+The macOS app build can use a donor application's embedded Python runtime
+while ``PYTHON_BIN`` selects the interpreter that compiles native extensions.
+Those interpreters must have the same CPython extension ABI: a successful
+build-time import under ``PYTHON_BIN`` does not prove that the bundled app can
+load the resulting ``_ext`` module.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_DESCRIPTOR_PROGRAM = r"""
+import json
+import sys
+import sysconfig
+
+print(json.dumps({
+    "implementation": sys.implementation.name,
+    "cache_tag": sys.implementation.cache_tag,
+    "version": list(sys.version_info[:2]),
+    "extension_suffix": sysconfig.get_config_var("EXT_SUFFIX"),
+}))
+"""
+
+
+class ABIQueryError(RuntimeError):
+    """An interpreter could not report its extension ABI."""
+
+
+def python_abi_descriptor(interpreter: Path, role: str) -> dict[str, object]:
+    """Query an interpreter without importing the app package or MLX."""
+    try:
+        result = subprocess.run(
+            [str(interpreter), "-c", _DESCRIPTOR_PROGRAM],
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+    except OSError as exc:
+        raise ABIQueryError(
+            f"could not run {role} Python {interpreter}: {exc}"
+        ) from exc
+
+    if result.returncode:
+        detail = (
+            result.stderr.strip()
+            or result.stdout.strip()
+            or f"exit {result.returncode}"
+        )
+        raise ABIQueryError(
+            f"could not query {role} Python ABI at {interpreter}: {detail}"
+        )
+
+    try:
+        descriptor = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise ABIQueryError(
+            f"could not query {role} Python ABI at {interpreter}: invalid JSON output"
+        ) from exc
+
+    required = ("implementation", "cache_tag", "version", "extension_suffix")
+    if not isinstance(descriptor, dict) or not all(
+        descriptor.get(field) for field in required
+    ):
+        raise ABIQueryError(
+            f"could not query {role} Python ABI at {interpreter}: incomplete descriptor"
+        )
+    if not isinstance(descriptor["version"], list) or len(descriptor["version"]) != 2:
+        raise ABIQueryError(
+            f"could not query {role} Python ABI at {interpreter}: invalid version"
+        )
+    return descriptor
+
+
+def _format_descriptor(descriptor: dict[str, object]) -> str:
+    version = descriptor["version"]
+    assert isinstance(version, list)
+    return (
+        f"{descriptor['implementation']} {version[0]}.{version[1]} "
+        f"({descriptor['cache_tag']}, {descriptor['extension_suffix']})"
+    )
+
+
+def validate_build_python(build: dict[str, object], donor: dict[str, object]) -> None:
+    """Require every extension-ABI field needed by this package to match."""
+    fields = ("implementation", "cache_tag", "version", "extension_suffix")
+    if any(build[field] != donor[field] for field in fields):
+        raise ValueError(
+            "custom kernel build Python ABI does not match the donor app: "
+            f"build={_format_descriptor(build)}; donor={_format_descriptor(donor)}. "
+            "Set PYTHON_BIN to a Python with the donor app's exact CPython ABI."
+        )
+
+
+def validate_extension_directory(directory: Path, donor: dict[str, object]) -> None:
+    """Reject a staged bundle unless every native extension has donor's suffix."""
+    if not directory.is_dir():
+        raise ValueError(f"custom kernel extension directory is missing: {directory}")
+
+    extensions = sorted(directory.rglob("_ext*.so"))
+    if not extensions:
+        raise ValueError(f"no native _ext modules found under {directory}")
+
+    extension_suffix = donor["extension_suffix"]
+    assert isinstance(extension_suffix, str)
+    expected_name = f"_ext{extension_suffix}"
+    mismatched = [path for path in extensions if path.name != expected_name]
+    if mismatched:
+        found = ", ".join(str(path) for path in mismatched)
+        raise ValueError(
+            "staged custom kernel extension suffix does not match the donor app "
+            f"ABI ({expected_name} expected): {found}"
+        )
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--donor-python", required=True, type=Path, help="bundled donor interpreter"
+    )
+    parser.add_argument(
+        "--build-python", type=Path, help="interpreter compiling native extensions"
+    )
+    parser.add_argument(
+        "--extension-directory",
+        type=Path,
+        help="staged omlx/custom_kernels directory to validate",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    try:
+        donor = python_abi_descriptor(args.donor_python, "donor app")
+        if args.build_python is not None:
+            build = python_abi_descriptor(args.build_python, "build")
+            validate_build_python(build, donor)
+        if args.extension_directory is not None:
+            validate_extension_directory(args.extension_directory, donor)
+    except (ABIQueryError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_app_bundle_custom_kernel_python_abi.py
+++ b/tests/test_app_bundle_custom_kernel_python_abi.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression coverage for the app bundle's custom-kernel CPython ABI guard."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+CHECKER = (
+    Path(__file__).resolve().parents[1]
+    / "apps/omlx-mac/Scripts/check_custom_kernel_python_abi.py"
+)
+BUILD_SCRIPT = Path(__file__).resolve().parents[1] / "apps/omlx-mac/Scripts/build.sh"
+
+
+def _write_fake_python(path: Path, *, descriptor: str | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if descriptor is None:
+        body = "#!/bin/sh\necho 'query intentionally failed' >&2\nexit 42\n"
+    else:
+        body = f"#!/bin/sh\nprintf '%s\\n' '{descriptor}'\n"
+    path.write_text(body)
+    path.chmod(0o755)
+
+
+def _run_checker(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECKER), *args],
+        check=False,
+        text=True,
+        capture_output=True,
+        env={**os.environ, "PYTHONPATH": ""},
+    )
+
+
+def test_matching_build_and_donor_python_abis_pass(tmp_path):
+    descriptor = (
+        '{"implementation":"cpython","cache_tag":"cpython-311",'
+        '"version":[3,11],"extension_suffix":".cpython-311-darwin.so"}'
+    )
+    build = tmp_path / "build-python"
+    donor = tmp_path / "donor-python"
+    _write_fake_python(build, descriptor=descriptor)
+    _write_fake_python(donor, descriptor=descriptor)
+
+    result = _run_checker("--build-python", str(build), "--donor-python", str(donor))
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_mismatched_build_and_donor_python_abis_fail_closed(tmp_path):
+    build = tmp_path / "build-python"
+    donor = tmp_path / "donor-python"
+    _write_fake_python(
+        build,
+        descriptor=(
+            '{"implementation":"cpython","cache_tag":"cpython-313",'
+            '"version":[3,13],"extension_suffix":".cpython-313-darwin.so"}'
+        ),
+    )
+    _write_fake_python(
+        donor,
+        descriptor=(
+            '{"implementation":"cpython","cache_tag":"cpython-311",'
+            '"version":[3,11],"extension_suffix":".cpython-311-darwin.so"}'
+        ),
+    )
+
+    result = _run_checker("--build-python", str(build), "--donor-python", str(donor))
+
+    assert result.returncode == 1
+    assert "does not match the donor app" in result.stderr
+    assert "cpython-313" in result.stderr
+    assert "cpython-311" in result.stderr
+
+
+def test_donor_abi_query_failure_fails_closed(tmp_path):
+    build = tmp_path / "build-python"
+    donor = tmp_path / "donor-python"
+    _write_fake_python(
+        build,
+        descriptor=(
+            '{"implementation":"cpython","cache_tag":"cpython-311",'
+            '"version":[3,11],"extension_suffix":".cpython-311-darwin.so"}'
+        ),
+    )
+    _write_fake_python(donor)
+
+    result = _run_checker("--build-python", str(build), "--donor-python", str(donor))
+
+    assert result.returncode == 1
+    assert "could not query donor app Python ABI" in result.stderr
+
+
+def test_staged_extension_suffix_mismatch_fails_closed(tmp_path):
+    donor = tmp_path / "donor-python"
+    _write_fake_python(
+        donor,
+        descriptor=(
+            '{"implementation":"cpython","cache_tag":"cpython-311",'
+            '"version":[3,11],"extension_suffix":".cpython-311-darwin.so"}'
+        ),
+    )
+    extension = tmp_path / "custom_kernels/glm_moe_dsa/_ext.cpython-313-darwin.so"
+    extension.parent.mkdir(parents=True)
+    extension.touch()
+
+    result = _run_checker(
+        "--donor-python",
+        str(donor),
+        "--extension-directory",
+        str(extension.parents[1]),
+    )
+
+    assert result.returncode == 1
+    assert "extension suffix does not match the donor app ABI" in result.stderr
+
+
+def test_app_build_wires_the_guard_before_build_and_after_staging():
+    script = BUILD_SCRIPT.read_text()
+
+    build_function = script.index("_build_custom_kernels()")
+    prebuild_guard = script.index(
+        "    _validate_custom_kernel_python_abi", build_function
+    )
+    build = script.index("    _check_custom_kernel_nanobind", build_function)
+    copy = script.index('"$REPO_ROOT/omlx/" "$RESOURCES_DIR/omlx/"')
+    post_staging_guard = script.index(
+        "    _validate_packaged_custom_kernel_extensions", copy
+    )
+
+    assert prebuild_guard < build
+    assert post_staging_guard > copy
+
+
+def test_current_interpreter_and_matching_staged_extension_pass(tmp_path):
+    import sysconfig
+
+    directory = tmp_path / "custom_kernels"
+    directory.mkdir()
+    (directory / ("_ext" + sysconfig.get_config_var("EXT_SUFFIX"))).touch()
+    result = _run_checker(
+        "--build-python", sys.executable, "--donor-python", sys.executable,
+        "--extension-directory", str(directory),
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_empty_extension_directory_is_rejected(tmp_path):
+    result = _run_checker(
+        "--donor-python", sys.executable, "--extension-directory", str(tmp_path)
+    )
+    assert result.returncode == 1
+    assert "no native _ext modules" in result.stderr
+
+
+def test_non_object_descriptor_is_rejected(tmp_path):
+    donor = tmp_path / "donor-python"
+    _write_fake_python(donor, descriptor="[]")
+    result = _run_checker("--donor-python", str(donor))
+    assert result.returncode == 1
+    assert "incomplete descriptor" in result.stderr


### PR DESCRIPTION
The app build can compile custom kernels with a different CPython ABI from the donor app's embedded interpreter, even when the build-time import succeeds. Compare the two interpreters before compilation, then validate the native `_ext` suffixes actually staged into the bundle. Existing MLX and nanobind checks remain in place.

This is the focused app ABI follow-up requested in #2640. Validation at `ccea85b75758e5f1bd1d459c4726f847e3c0f04b`: 8 regression tests passed, covering matching and mismatched ABIs, failed interpreter queries, staged suffix mismatches and missing extensions. Full app building and signing were not run.

Please review the donor-runtime selection and the fail-closed packaging behavior.

