### PR TITLE
fix(api): preserve and normalize thinking controls

### DIFF
--- a/omlx/api/openai_models.py
+++ b/omlx/api/openai_models.py
@@ -13,7 +13,7 @@ These models define the request and response schemas for:
 import json
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import AliasChoices, BaseModel, Field, field_validator
+from pydantic import AliasChoices, BaseModel, Field, field_validator, model_validator
 
 from omlx.api.shared_models import (
     BaseUsage,
@@ -314,6 +314,8 @@ class ChatCompletionRequest(BaseModel):
     guided_grammar: Optional[str] = None
     # Chat template kwargs (e.g. enable_thinking, reasoning_effort)
     chat_template_kwargs: Optional[Dict[str, Any]] = None
+    # Top-level alias used by OpenAI-compatible clients.
+    enable_thinking: Optional[bool] = None
     # OpenAI-compatible reasoning depth; forwarded to the chat template.
     # Numbers stay numbers: models like Inkling take a numeric effort
     # (0.1-0.99) while Qwen3.8 uses strings ("low".."xhigh") — each chat
@@ -337,6 +339,22 @@ class ChatCompletionRequest(BaseModel):
         if isinstance(v, str):
             return [v]
         return v
+
+    @model_validator(mode="after")
+    def normalize_top_level_enable_thinking(self) -> "ChatCompletionRequest":
+        """Preserve the alias and reject contradictory request controls."""
+        if self.enable_thinking is None:
+            return self
+        template_kwargs = dict(self.chat_template_kwargs or {})
+        if "enable_thinking" in template_kwargs and (
+            template_kwargs["enable_thinking"] is not self.enable_thinking
+        ):
+            raise ValueError(
+                "enable_thinking conflicts with chat_template_kwargs.enable_thinking"
+            )
+        template_kwargs["enable_thinking"] = self.enable_thinking
+        self.chat_template_kwargs = template_kwargs
+        return self
 
 
 class AssistantMessage(BaseModel):

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -1473,7 +1473,7 @@ def merge_chat_template_kwargs(
       1. ``settings.chat_template_kwargs``
       2. the dedicated ``enable_thinking`` / ``preserve_thinking`` toggles
       3. per-request kwargs, except keys listed in ``forced_ct_kwargs``
-      4. thinking budget activation when ``enable_thinking`` is still unset
+      4. positive thinking budget activation when ``enable_thinking`` is still unset
       5. the model's preserve-thinking default when it is supported and unset
     """
     merged = merge_chat_template_request_kwargs(settings, request_ct_kwargs)
@@ -1485,7 +1485,11 @@ def merge_chat_template_kwargs(
         and settings.thinking_budget_tokens
     ):
         thinking_budget = settings.thinking_budget_tokens
-    if thinking_budget is not None and "enable_thinking" not in merged:
+    if (
+        thinking_budget is not None
+        and thinking_budget > 0
+        and "enable_thinking" not in merged
+    ):
         merged["enable_thinking"] = True
 
     if (

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -4155,11 +4155,15 @@ async def create_chat_completion(
         if thinking_budget is not None:
             chat_kwargs["thinking_budget"] = thinking_budget
 
-        # Auto-set enable_thinking in chat template kwargs when a thinking
+        # Auto-set enable_thinking in chat template kwargs when a positive thinking
         # budget is active (from request or model settings).  Some chat
         # templates (e.g. Gemma 4) explicitly suppress thinking unless this
         # kwarg is True.
-        if thinking_budget is not None and "enable_thinking" not in merged_ct_kwargs:
+        if (
+            thinking_budget is not None
+            and thinking_budget > 0
+            and "enable_thinking" not in merged_ct_kwargs
+        ):
             merged_ct_kwargs["enable_thinking"] = True
 
         # Auto-set preserve_thinking only when the template advertises support
@@ -6420,10 +6424,14 @@ async def create_anthropic_message(
         if thinking_budget is not None:
             chat_kwargs["thinking_budget"] = thinking_budget
 
-        # Auto-set enable_thinking in chat template kwargs when a thinking
+        # Auto-set enable_thinking in chat template kwargs when a positive thinking
         # budget is active but enable_thinking was not already set (e.g. via
         # the Anthropic thinking.type field above or model settings).
-        if thinking_budget is not None and "enable_thinking" not in merged_ct_kwargs:
+        if (
+            thinking_budget is not None
+            and thinking_budget > 0
+            and "enable_thinking" not in merged_ct_kwargs
+        ):
             merged_ct_kwargs["enable_thinking"] = True
 
         # Auto-set preserve_thinking only when the template advertises support
@@ -7005,8 +7013,12 @@ async def create_response(
         if thinking_budget is not None:
             chat_kwargs["thinking_budget"] = thinking_budget
 
-        # Auto-set enable_thinking when thinking budget is active.
-        if thinking_budget is not None and "enable_thinking" not in merged_ct_kwargs:
+        # Auto-set enable_thinking when a positive thinking budget is active.
+        if (
+            thinking_budget is not None
+            and thinking_budget > 0
+            and "enable_thinking" not in merged_ct_kwargs
+        ):
             merged_ct_kwargs["enable_thinking"] = True
 
         # Auto-set preserve_thinking only when the template advertises support

--- a/tests/integration/test_server_endpoints.py
+++ b/tests/integration/test_server_endpoints.py
@@ -1174,6 +1174,32 @@ class TestChatCompletionEndpoint:
 
         assert response.status_code == 200
 
+    def test_zero_thinking_budget_does_not_enable_template_thinking(
+        self, client, mock_llm_engine
+    ):
+        """Zero is forwarded as a clamp, not as a request to turn thinking on."""
+        recorded_chat_kwargs = []
+
+        async def chat(messages, **kwargs):
+            recorded_chat_kwargs.append(kwargs)
+            return MockGenerationOutput(text="Chat response.")
+
+        mock_llm_engine.chat = chat
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "thinking_budget": 0,
+            },
+        )
+
+        assert response.status_code == 200
+        assert recorded_chat_kwargs[0]["thinking_budget"] == 0
+        assert "enable_thinking" not in recorded_chat_kwargs[0].get(
+            "chat_template_kwargs", {}
+        )
+
     def test_chat_completion_includes_cached_tokens_on_cache_hit(
         self, client, mock_llm_engine
     ):

--- a/tests/test_model_settings.py
+++ b/tests/test_model_settings.py
@@ -641,6 +641,21 @@ class TestModelSettingsManager:
 
         assert merged == {"enable_thinking": True, "custom_flag": "request"}
 
+    @pytest.mark.parametrize("budget", [None, 0, 1])
+    @pytest.mark.parametrize("enabled", [None, True, False])
+    def test_budget_respects_explicit_thinking_mode(self, budget, enabled):
+        from omlx.model_settings import merge_chat_template_kwargs
+
+        kwargs = {} if enabled is None else {"enable_thinking": enabled}
+        expected = {"enable_thinking": True} if not kwargs and budget == 1 else kwargs
+        assert merge_chat_template_kwargs(None, kwargs, thinking_budget=budget) == expected
+
+    def test_zero_thinking_budget_does_not_enable_thinking(self):
+        """Zero means no thinking budget activation at template-render time."""
+        from omlx.model_settings import merge_chat_template_kwargs
+
+        assert merge_chat_template_kwargs(None, thinking_budget=0) == {}
+
     def test_thread_safety(self):
         """Test thread-safe access."""
         import threading

--- a/tests/test_openai_models.py
+++ b/tests/test_openai_models.py
@@ -501,6 +501,50 @@ class TestChatCompletionRequest:
         assert data["model"] == "gpt-4"
         assert data["messages"][0]["role"] == "user"
 
+    def test_top_level_enable_thinking_normalizes_to_template_kwargs(self):
+        """Top-level compatibility input must reach the template renderer."""
+        req = ChatCompletionRequest(
+            model="reasoning-model",
+            messages=[Message(role="user", content="Hello")],
+            enable_thinking=False,
+            thinking_budget=0,
+            chat_template_kwargs={"reasoning_effort": "low"},
+        )
+
+        assert req.enable_thinking is False
+        assert req.thinking_budget == 0
+        assert req.chat_template_kwargs == {
+            "enable_thinking": False,
+            "reasoning_effort": "low",
+        }
+
+    @pytest.mark.parametrize("enabled", [True, False])
+    def test_matching_thinking_alias_preserves_input(self, enabled):
+        template_kwargs = {"enable_thinking": enabled, "custom": "value"}
+        request = ChatCompletionRequest(
+            model="test", messages=[], enable_thinking=enabled,
+            chat_template_kwargs=template_kwargs,
+        )
+        assert request.chat_template_kwargs == template_kwargs
+        assert template_kwargs == {"enable_thinking": enabled, "custom": "value"}
+
+    def test_nested_thinking_without_alias_is_unchanged(self):
+        request = ChatCompletionRequest(
+            model="test", messages=[], chat_template_kwargs={"enable_thinking": False}
+        )
+        assert request.enable_thinking is None
+        assert request.chat_template_kwargs == {"enable_thinking": False}
+
+    def test_top_level_enable_thinking_rejects_nested_conflict(self):
+        """Conflicting control paths must fail instead of choosing silently."""
+        with pytest.raises(ValidationError, match="enable_thinking conflicts"):
+            ChatCompletionRequest(
+                model="reasoning-model",
+                messages=[Message(role="user", content="Hello")],
+                enable_thinking=False,
+                chat_template_kwargs={"enable_thinking": True},
+            )
+
     def test_xtc_defaults_to_none(self):
         """Test XTC params default to None (not sent by client)."""
         req = ChatCompletionRequest(


### PR DESCRIPTION
Top-level `enable_thinking` was silently dropped by OpenAI-compatible chat requests, and a zero thinking budget could implicitly enable thinking. Normalize the top-level value into chat-template kwargs, reject contradictory controls, and only infer thinking activation from a positive budget across settings, chat completions, Anthropic messages and Responses.

This is the focused thinking-controls follow-up requested in #2640. Explicit per-request and forced model settings retain their precedence.

Validation at `a4894ff36e0e8057e262668ef28a09e752f7eeb3`: 242 API, model-settings and endpoint tests passed; three new cases failed against the unchanged base. No model-quality or performance claim is made by these routing tests.

Please review API compatibility, zero-budget behavior and the existing settings precedence.

