### PR TITLE
fix(deepseek): detect nested low-bit attention overrides

### DIFF
--- a/omlx/patches/deepseek_v4/utils_patch.py
+++ b/omlx/patches/deepseek_v4/utils_patch.py
@@ -50,9 +50,13 @@ def _native_ratio128_attention_enabled(config: dict[str, Any]) -> bool:
     quantizations = [config.get("quantization"), config.get("quantization_config")]
     text_config = config.get("text_config")
     if isinstance(text_config, dict):
-        quantizations.append(text_config.get("quantization_config"))
+        quantizations.extend(
+            [text_config.get("quantization"), text_config.get("quantization_config")]
+        )
 
-    for quantization in quantizations:
+    # Per-layer overrides can be nested below a four-bit default.
+    while quantizations:
+        quantization = quantizations.pop()
         bits = quantization.get("bits") if isinstance(quantization, dict) else None
         if (
             isinstance(bits, (int, float))
@@ -60,6 +64,10 @@ def _native_ratio128_attention_enabled(config: dict[str, Any]) -> bool:
             and float(bits) < 4
         ):
             return False
+        if isinstance(quantization, dict):
+            quantizations.extend(quantization.values())
+        elif isinstance(quantization, list):
+            quantizations.extend(quantization)
     return True
 
 

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -162,6 +162,32 @@ class TestUtilsPatch:
             is True
         )
 
+    @pytest.mark.parametrize("location", ["quantization", "quantization_config", "text_quantization", "text_quantization_config"])
+    @pytest.mark.parametrize("bits", [2, 3, 3.5])
+    def test_nested_sub4_override_disables_native_attention(self, location, bits):
+        from omlx.patches.deepseek_v4.utils_patch import (
+            _native_ratio128_attention_enabled,
+        )
+
+        quantization = {"bits": 4, "overrides": [{"layers.0.mlp": {"bits": bits}}]}
+        config = {"model_type": "deepseek_v4"}
+        if location.startswith("text_"):
+            config["text_config"] = {location[5:]: quantization}
+        else:
+            config[location] = quantization
+        assert _native_ratio128_attention_enabled(config) is False
+
+    @pytest.mark.parametrize("bits", [4, 8, True, False, None, "3"])
+    def test_nested_non_sub4_values_keep_existing_dispatch(self, bits):
+        from omlx.patches.deepseek_v4.utils_patch import (
+            _native_ratio128_attention_enabled,
+        )
+
+        config = {"model_type": "deepseek_v4", "quantization": {"layers": {"bits": bits}}}
+        assert _native_ratio128_attention_enabled(config) is True
+        config = {"model_type": "qwen3", "quantization": {"bits": 2}}
+        assert _native_ratio128_attention_enabled(config) is True
+
     @pytest.mark.parametrize(
         ("bits", "expected_enabled"),
         ((4, True), (2, False)),


### PR DESCRIPTION
DeepSeek V4 could select native ratio-128 attention when a four-bit default contained nested two-bit or three-bit quantization overrides. Traverse nested mappings and lists under both quantization keys, including `text_config`, so sub-four-bit overrides select the existing reference path. Four-bit and higher configurations retain their current selection.

This is the focused nested-quantization follow-up requested in #2640. The scope is configuration policy; it adds no artifact-specific loader or model rewrite.

Validation at `289eb2d1e811705d9124607fef09ba4d6bad787b`: 24 policy/load tests passed (120 unrelated cases deselected); twelve nested-configuration cases failed against the unchanged base. No model timing or numerical campaign was run for this patch.

Please review override traversal and fallback policy.

