### PR TITLE
feat(vlm): serve text-only Gemma 4 with a merged MTP head through mlx-vlm

### DIFF
--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -565,6 +565,18 @@ _AUDIO_CONFIG_KEYS = (
 )
 
 
+# Model types whose Gemma 4 weight prefixes are known well enough to conclude
+# a modality is absent. Other families keep the audio-only behavior, because a
+# prefix this list does not know would read as "no vision" and disable it.
+_GEMMA4_FAMILY_TYPES = ("gemma4", "gemma4_unified")
+
+# Prefixes that carry Gemma 4 vision weights. "unified" checkpoints have no
+# vision tower at all -- the single transformer does the work, and vision needs
+# only a patch embedder and a projection -- so the embedder prefixes are as
+# load-bearing as the tower one.
+_GEMMA4_VISION_PREFIXES = ("vision_tower.", "embed_vision.", "vision_embedder.")
+
+
 def _resolve_optiq_vision_sidecar(model_dir: Path) -> Path | None:
     """Resolve the OptiQ multimodal sidecar declared by ``config.json``."""
     config_path = model_dir / "config.json"
@@ -596,8 +608,23 @@ def _resolve_optiq_vision_sidecar(model_dir: Path) -> Path | None:
     return sidecar
 
 
+def _is_gemma4_family(config: dict) -> bool:
+    model_type = str(config.get("model_type") or "").lower().replace("-", "_")
+    return model_type in _GEMMA4_FAMILY_TYPES
+
+
+def _has_vision_weights(model_dir: Path) -> bool:
+    """Return True iff any shard carries Gemma 4 vision tower/embedder keys."""
+    return _has_prefixed_weights(model_dir, _GEMMA4_VISION_PREFIXES)
+
+
 def _has_audio_weights(model_dir: Path) -> bool:
     """Return True iff any safetensors shard contains audio_tower / embed_audio keys."""
+    return _has_prefixed_weights(model_dir, ("audio_tower.", "embed_audio."))
+
+
+def _has_prefixed_weights(model_dir: Path, prefixes: tuple[str, ...]) -> bool:
+    """Return True iff any safetensors shard carries a key with one of ``prefixes``."""
     import safetensors
 
     weight_files = list(model_dir.glob("*.safetensors"))
@@ -609,12 +636,13 @@ def _has_audio_weights(model_dir: Path) -> bool:
         try:
             with safetensors.safe_open(str(sf), framework="np") as f:
                 for k in f.keys():
-                    if k.startswith(("audio_tower.", "embed_audio.")):
+                    if k.startswith(prefixes):
                         return True
         except Exception:
-            # Corrupt or unreadable shard — treat as no audio info, let
-            # downstream loader produce its own error.
-            return False
+                # Skip the shard rather than answer for the whole checkpoint:
+                # one unreadable shard would otherwise drop a real modality.
+            logger.debug("could not scan %s for %s", sf.name, prefixes)
+            continue
     return False
 
 
@@ -645,15 +673,55 @@ def _strip_audio_config_if_orphaned(model_dir: Path):
 
         expand_per_layer_quant_keys(cfg)
 
-        if cfg.get("audio_config") is None:
-            return cfg
         try:
             p = Path(path) if not isinstance(path, Path) else path
             if not p.is_dir():
                 return cfg
-            if _has_audio_weights(p):
-                return cfg
         except Exception:
+            return cfg
+
+            # An absent key is the case `setdefault` fabricates, which makes
+            # mlx-vlm's own text-only branch unreachable. Decide from weights.
+        if _is_gemma4_family(cfg):
+            cfg = dict(cfg)
+
+                # Audio is nulled outright, the long-standing behavior:
+                # nothing dereferences audio_config as a dict.
+            if not _has_audio_weights(p):
+                cfg["audio_config"] = None
+                for k in _AUDIO_CONFIG_KEYS:
+                    if k != "audio_config":
+                        cfg.pop(k, None)
+                if str(p) not in warned:
+                    warned.add(str(p))
+                    logger.warning(
+                        "audio_tower weights missing for %s; loading without "
+                        "audio support",
+                        p.name,
+                    )
+
+            # Vision cannot be nulled the same way: load_model reads
+            # `config.get("vision_config", {}).get("skip_vision", False)`, so
+            # the key has to keep its dict shape. Mark it instead, and let the
+            # two config-inflation points consult the marker.
+            if not _has_vision_weights(p):
+                from ..patches import mlx_vlm_gemma4_text_only as text_only
+
+                text_only.mark_absent(cfg, "vision")
+                if str(cfg.get("model_type") or "").lower() == "gemma4":
+                        # Only `gemma4_unified` carries mlx-vlm's text-only
+                        # branch; the two share the language_model layout.
+                    cfg["model_type"] = "gemma4_unified"
+                text_only.apply()
+                logger.info(
+                    "%s carries no vision weights; loading it as text-only",
+                    p.name,
+                )
+            return cfg
+
+        if cfg.get("audio_config") is None:
+            return cfg
+        if _has_audio_weights(p):
             return cfg
         cfg = dict(cfg)
         # Explicit None instead of pop: mlx-vlm's load_model runs

--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -1554,10 +1554,18 @@ def _register_model(
         # and flag speculative-decoding drafters (dFlash/Assistant/MTP).
         config_model_type = ""
         is_helper = False
+        # Defaulted alongside the other two, because the routing below reads it
+        # outside this block: an unparseable config.json must leave a config
+        # the predicates can answer False for, not an unbound name. Raising
+        # here would be caught as a failed discovery and drop the model, which
+        # is how a malformed config used to reach the repo-name heuristic.
+        _config: dict = {}
         try:
             import json
             with open(model_dir / "config.json") as f:
-                _config = json.load(f)
+                loaded = json.load(f)
+            if isinstance(loaded, dict):
+                _config = loaded
             config_model_type = _config.get("model_type", "")
             is_helper = is_helper_model_config(_config)
         except Exception:
@@ -1573,8 +1581,8 @@ def _register_model(
                 model_id,
             )
         elif engine_type == "vlm" and _gemma4_text_only_prefers_llm_engine(_config):
-                # `supports_images` is `model_type == "vlm"`, so moving only the
-                # engine would leave a text-only checkpoint advertising images.
+            # `supports_images` is `model_type == "vlm"`, so moving only the
+            # engine would leave a text-only checkpoint advertising images.
             engine_type = "batched"
             model_type = "llm"
             text_only_size = 0

--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -1452,6 +1452,52 @@ def _is_hf_cache_mlx_compatible(model_dir: Path, source_repo_id: str) -> bool:
     return False
 
 
+def _gemma4_text_only_wants_vlm_engine(config: dict) -> bool:
+    """True for a text-only Gemma 4 checkpoint carrying a merged MTP head.
+
+    ``gemma4_unified`` already routes to mlx-vlm whatever its vision state,
+    but a plain ``gemma4`` checkpoint with no vision sub-config is classed
+    text-only and served by mlx-lm -- where the merged assistant head has no
+    binding site, so MTP is advertised and never drafts.
+
+    mlx-vlm drives that head today (#2683). The condition is deliberately
+    narrow: reaching the VLM engine costs memory, measurably, so a text-only
+    Gemma 4 checkpoint with no head has nothing to gain and stays where it is.
+    """
+    model_type = str(config.get("model_type") or "").lower().replace("-", "_")
+    if model_type != "gemma4":
+        return False
+    if _has_vision_subconfig(config):
+        return False
+    return _has_merged_mtp_head(config)
+
+
+def _has_merged_mtp_head(config: dict) -> bool:
+    text_config = config.get("text_config")
+    if not isinstance(text_config, dict):
+        return False
+    return isinstance(text_config.get("mtp_assistant_config"), dict)
+
+
+def _gemma4_text_only_prefers_llm_engine(config: dict) -> bool:
+    """True for a text-only Gemma 4 checkpoint with no head to drive.
+
+    ``gemma4_unified`` is routed to mlx-vlm on its model_type alone, so a
+    text-only export of one lands on the VLM engine. Until the text-only load
+    was fixed it failed there and fell back to mlx-lm; fixing the load means
+    it now stays, and pays the VLM engine's overhead -- measured at +0.31 GB
+    on the 12B -- for a head it does not have.
+
+    Keep those on mlx-lm deliberately, rather than by way of a failed load.
+    """
+    model_type = str(config.get("model_type") or "").lower().replace("-", "_")
+    if model_type not in ("gemma4", "gemma4_unified"):
+        return False
+    if _has_vision_subconfig(config):
+        return False
+    return not _has_merged_mtp_head(config)
+
+
 def _register_model(
     models: dict[str, DiscoveredModel],
     model_dir: Path,
@@ -1516,6 +1562,27 @@ def _register_model(
             is_helper = is_helper_model_config(_config)
         except Exception:
             pass
+
+        # Engine, not identity: the model is still text-only and is reported
+        # that way, it is only served by the engine that can drive its head.
+        if model_type == "llm" and _gemma4_text_only_wants_vlm_engine(_config):
+            engine_type = "vlm"
+            logger.info(
+                "%s is text-only Gemma 4 with a merged MTP head; serving it "
+                "on the VLM engine, which can drive that head",
+                model_id,
+            )
+        elif engine_type == "vlm" and _gemma4_text_only_prefers_llm_engine(_config):
+                # `supports_images` is `model_type == "vlm"`, so moving only the
+                # engine would leave a text-only checkpoint advertising images.
+            engine_type = "batched"
+            model_type = "llm"
+            text_only_size = 0
+            logger.info(
+                "%s is text-only Gemma 4 with no merged MTP head; serving it "
+                "on the LLM engine, which carries less overhead",
+                model_id,
+            )
 
         thinking_default = detect_thinking_default(model_dir)
         preserve_thinking_default = detect_preserve_thinking(model_dir)

--- a/omlx/patches/mlx_vlm_gemma4_text_only.py
+++ b/omlx/patches/mlx_vlm_gemma4_text_only.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Let mlx-vlm load a text-only Gemma 4 checkpoint.
+
+mlx-vlm's ``gemma4_unified`` model is written to run without vision or audio::
+
+    if config.vision_config is not None:
+        self.vision_embedder = VisionEmbedder(config.vision_config)
+        ...
+    else:
+        self.vision_embedder = None
+
+and its forward path guards on the same attributes. That branch is
+unreachable from a checkpoint, for three separate reasons in three places:
+
+1. ``load_model`` runs ``config.setdefault("vision_config", {})`` (and the
+   same for audio), so a checkpoint that omits the section still gets one.
+2. ``ModelConfig.from_dict`` converts that ``{}`` into a fully-defaulted
+   ``VisionConfig``, because the field's default is a factory rather than
+   ``None`` despite being typed ``Optional``.
+3. ``update_module_configs`` then re-applies it from the raw dict, so
+   correcting the dataclass afterwards is not enough.
+
+The result is that a text-only Gemma 4 checkpoint builds a patch embedder and
+two projections it has no weights for, and ``load_weights(strict=True)`` fails
+on those tensors. oMLX then drops the VLM engine and serves the model through
+mlx-lm instead.
+
+Simply setting the sections to ``None`` does not work either: ``load_model``
+reads ``config.get("vision_config", {}).get("skip_vision", False)``, which
+assumes a dict.
+
+So this marks the absent modalities in the config and intercepts both
+inflation points, leaving the dict shape mlx-vlm's own plumbing expects. The
+marker is set by the loader that inspected the shards -- see
+``omlx.engine.vlm``, which decides from weight prefixes rather than from the
+config, so an orphaned section and a missing one are handled the same way.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Key the shard inspection writes into the raw config dict. Unknown keys are
+# dropped by ``BaseModelConfig.from_dict``, so carrying it there is harmless.
+ABSENT_MARKER = "_omlx_absent_modalities"
+
+_applied = False
+
+
+def mark_absent(config: dict, modality: str) -> None:
+    """Record that ``modality`` has no weights in this checkpoint."""
+    absent = set(config.get(ABSENT_MARKER) or ())
+    absent.add(modality)
+    config[ABSENT_MARKER] = sorted(absent)
+
+
+def _absent(config: Any) -> set[str]:
+    if isinstance(config, dict):
+        return set(config.get(ABSENT_MARKER) or ())
+    return set()
+
+
+def apply() -> bool:
+    """Patch the two config-inflation points. Idempotent."""
+    global _applied
+    if _applied:
+        return True
+
+    try:
+        import mlx_vlm.utils as vlm_utils
+        from mlx_vlm.models.gemma4_unified import config as unified_config
+    except Exception as exc:  # pragma: no cover - depends on mlx-vlm layout
+        logger.debug("mlx-vlm gemma4 text-only patch unavailable: %s", exc)
+        return False
+
+    original_update = vlm_utils.update_module_configs
+
+    def update_module_configs(model_config, model_class, config, modules):
+        """Skip the modules whose weights the checkpoint does not carry."""
+        absent = _absent(config)
+        if absent:
+            modules = [m for m in modules if m not in absent]
+        return original_update(model_config, model_class, config, modules)
+
+    vlm_utils.update_module_configs = update_module_configs
+
+    original_from_dict = unified_config.ModelConfig.from_dict
+
+    @classmethod
+    def from_dict(cls, params):
+        built = original_from_dict.__func__(cls, params)
+        for modality in _absent(params):
+            attr = f"{modality}_config"
+            if hasattr(built, attr):
+                setattr(built, attr, None)
+        return built
+
+    unified_config.ModelConfig.from_dict = from_dict
+
+    _applied = True
+    logger.info("mlx-vlm Gemma 4 text-only load patch applied")
+    return True

--- a/omlx/patches/mlx_vlm_mtp/gemma4_vlm_runtime.py
+++ b/omlx/patches/mlx_vlm_mtp/gemma4_vlm_runtime.py
@@ -128,6 +128,28 @@ def _patch_text_config(g4_config: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _align_drafter_dtype(drafter: Any, dtype: Any) -> None:
+    """Store the assistant head at the dtype its activations arrive in.
+
+    The head ships bfloat16, so on a float16 checkpoint every head matmul
+    promotes to float32. Safe in either direction: the head only proposes,
+    and every token emitted is one the backbone verified.
+    """
+    from mlx.utils import tree_map
+
+    def _cast(value: Any) -> Any:
+        if (
+            isinstance(value, mx.array)
+            and value.dtype in (mx.float16, mx.bfloat16)
+            and value.dtype != dtype
+        ):
+            return value.astype(dtype)
+        return value
+
+    drafter.update(tree_map(_cast, drafter.parameters()))
+    logger.info("gemma4 vlm assistant head aligned to %s", dtype)
+
+
 def _patch_vlm_language_model(g4_lang: Any) -> None:
     cls = g4_lang.LanguageModel
     if "_omlx_mtp_runtime_patched" in cls.__dict__:
@@ -266,6 +288,12 @@ def _patch_vlm_language_model(g4_lang: Any) -> None:
             )
 
         h = hidden_states[:, -1:, :]
+        # Compared as a string: `mx.array.dtype` builds a fresh Dtype per
+        # access, and `None != a_dtype` raises out of nanobind.
+        want_dtype = str(h.dtype)
+        if getattr(drafter, "_omlx_head_dtype", None) != want_dtype:
+            _align_drafter_dtype(drafter, h.dtype)
+            drafter._omlx_head_dtype = want_dtype
         ids = next_token_ids[:, -1:]
         tok_embed = drafter._input_embed(ids) * drafter._input_embed_scale
         inputs_embeds = mx.concatenate([tok_embed.astype(h.dtype), h], axis=-1)

--- a/tests/test_gemma4_text_only_vlm.py
+++ b/tests/test_gemma4_text_only_vlm.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for serving text-only Gemma 4 checkpoints on the VLM engine.
+
+Two decisions are covered. Which engine a checkpoint is routed to, which is
+made from the config at discovery time; and what the mlx-vlm loader is handed,
+which is decided from the weights so that an absent sub-config and an orphaned
+one behave the same way.
+
+Tiny fixtures throughout — configs and one-tensor shards, no checkpoint.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mlx_vlm.utils")
+
+import mlx_vlm.utils as _vu  # noqa: E402
+
+from omlx.engine.vlm import (  # noqa: E402
+    _has_vision_weights,
+    _strip_audio_config_if_orphaned,
+)
+from omlx.model_discovery import (  # noqa: E402
+    _gemma4_text_only_prefers_llm_engine,
+    _gemma4_text_only_wants_vlm_engine,
+)
+
+MERGED_HEAD = {"mtp_assistant_config": {"num_hidden_layers": 4}}
+
+
+def _write_safetensors(path: Path, keys: list[str]) -> None:
+    """A shard with the given key names and one f32 scalar each."""
+    header: dict = {}
+    offset = 0
+    for key in keys:
+        header[key] = {
+            "dtype": "F32",
+            "shape": [1],
+            "data_offsets": [offset, offset + 4],
+        }
+        offset += 4
+    blob = json.dumps(header).encode()
+    path.write_bytes(
+        struct.pack("<Q", len(blob)) + blob + b"\x00\x00\x80?" * len(keys)
+    )
+
+
+def _model_dir(
+    tmp_path: Path,
+    *,
+    name: str,
+    model_type: str = "gemma4",
+    vision_config: bool = False,
+    audio_config: bool = False,
+    merged_head: bool = False,
+    vision_weights: bool = False,
+) -> Path:
+    model_dir = tmp_path / name
+    model_dir.mkdir()
+    text_config: dict = {"hidden_size": 32, "num_hidden_layers": 1}
+    if merged_head:
+        text_config.update(MERGED_HEAD)
+    config: dict = {
+        "architectures": ["Gemma4ForConditionalGeneration"],
+        "model_type": model_type,
+        "text_config": text_config,
+    }
+    if vision_config:
+        config["vision_config"] = {"hidden_size": 16}
+    if audio_config:
+        config["audio_config"] = {"hidden_size": 16}
+    (model_dir / "config.json").write_text(json.dumps(config))
+
+    keys = ["language_model.model.layers.0.self_attn.q_proj.weight"]
+    if vision_weights:
+        keys.append("vision_embedder.patch_dense.weight")
+    _write_safetensors(model_dir / "model.safetensors", keys)
+    return model_dir
+
+
+def _config(model_dir: Path) -> dict:
+    return json.loads((model_dir / "config.json").read_text())
+
+
+# ---------------------------------------------------------------------------
+# Which engine
+# ---------------------------------------------------------------------------
+
+
+def test_text_only_gemma4_with_a_head_wants_the_vlm_engine(tmp_path: Path):
+    # The case #3536 is about: no vision sub-config, so it is classed
+    # text-only and served by mlx-lm, where the merged head has no binding
+    # site and MTP is advertised without ever drafting.
+    d = _model_dir(tmp_path, name="textonly_head", merged_head=True)
+    assert _gemma4_text_only_wants_vlm_engine(_config(d)) is True
+
+
+def test_a_vision_checkpoint_is_left_alone(tmp_path: Path):
+    d = _model_dir(tmp_path, name="vision", vision_config=True, merged_head=True)
+    assert _gemma4_text_only_wants_vlm_engine(_config(d)) is False
+
+
+def test_text_only_gemma4_without_a_head_is_left_on_mlx_lm(tmp_path: Path):
+    # Reaching the VLM engine costs memory, so a checkpoint with no head to
+    # drive has nothing to gain by moving.
+    d = _model_dir(tmp_path, name="textonly_bare")
+    assert _gemma4_text_only_wants_vlm_engine(_config(d)) is False
+
+
+def test_unified_needs_no_rerouting(tmp_path: Path):
+    # gemma4_unified already routes to mlx-vlm on its model_type alone.
+    d = _model_dir(
+        tmp_path, name="unified_head", model_type="gemma4_unified", merged_head=True
+    )
+    assert _gemma4_text_only_wants_vlm_engine(_config(d)) is False
+
+
+def test_text_only_unified_without_a_head_prefers_mlx_lm(tmp_path: Path):
+    # It is routed to mlx-vlm by model_type, and used to fail there and fall
+    # back. Now that the load succeeds it would stay and pay the overhead, so
+    # send it to mlx-lm deliberately instead of by way of a failed load.
+    d = _model_dir(tmp_path, name="unified_bare", model_type="gemma4_unified")
+    assert _gemma4_text_only_prefers_llm_engine(_config(d)) is True
+
+
+def test_a_unified_vision_checkpoint_stays_on_the_vlm_engine(tmp_path: Path):
+    d = _model_dir(
+        tmp_path, name="unified_vision", model_type="gemma4_unified",
+        vision_config=True,
+    )
+    assert _gemma4_text_only_prefers_llm_engine(_config(d)) is False
+
+
+# ---------------------------------------------------------------------------
+# What the loader is handed
+# ---------------------------------------------------------------------------
+
+
+def test_vision_weights_are_detected_by_embedder_prefix(tmp_path: Path):
+    # A unified checkpoint has no vision tower at all -- the single
+    # transformer does the work -- so the embedder prefixes are what decide it.
+    present = _model_dir(tmp_path, name="has_vision", vision_weights=True)
+    absent = _model_dir(tmp_path, name="no_vision")
+    assert _has_vision_weights(present) is True
+    assert _has_vision_weights(absent) is False
+
+
+def test_loader_is_pointed_at_the_text_capable_module(tmp_path: Path):
+    # mlx-vlm resolves the model class from model_type, and its `gemma4`
+    # module builds a vision tower unconditionally; only `gemma4_unified`
+    # carries the text-only branch.
+    d = _model_dir(tmp_path, name="textonly_head2", merged_head=True)
+    with _strip_audio_config_if_orphaned(d):
+        cfg = _vu.load_config(d)
+    assert cfg["model_type"] == "gemma4_unified"
+    assert cfg["_omlx_absent_modalities"] == ["vision"]
+
+
+def test_a_vision_checkpoint_keeps_its_model_type(tmp_path: Path):
+    d = _model_dir(
+        tmp_path, name="vision2", vision_config=True, vision_weights=True
+    )
+    with _strip_audio_config_if_orphaned(d):
+        cfg = _vu.load_config(d)
+    assert cfg["model_type"] == "gemma4"
+    assert "_omlx_absent_modalities" not in cfg
+
+
+def test_absent_vision_config_is_marked_rather_than_nulled(tmp_path: Path):
+    # load_model reads `config.get("vision_config", {}).get("skip_vision")`,
+    # so the key has to keep a dict shape; nulling it raises AttributeError.
+    d = _model_dir(tmp_path, name="textonly_head3", merged_head=True)
+    with _strip_audio_config_if_orphaned(d):
+        cfg = _vu.load_config(d)
+    # A None here is an AttributeError inside load_model, which is exactly how
+    # the first attempt at this failed.
+    assert cfg.get("vision_config", {}) is not None
+    assert isinstance(cfg.get("vision_config", {}), dict)
+    assert "vision" in cfg["_omlx_absent_modalities"]
+
+# ---------------------------------------------------------------------------
+# The two fields have to move together
+# ---------------------------------------------------------------------------
+
+
+def test_rerouting_to_the_llm_engine_also_reports_it_as_an_llm(tmp_path: Path):
+    """`model_type` is what advertises capability, so it moves with the engine.
+
+    `supports_images` is `model_type == "vlm"`, and `detect_model_type` classes
+    every gemma4_unified checkpoint as a VLM whether or not it carries vision.
+    Moving only `engine_type` left a text-only checkpoint on the LLM engine
+    still telling clients it accepts images -- they would send one, and the
+    engine that received it cannot process image content at all.
+    """
+    from omlx.model_discovery import discover_models
+
+    root = tmp_path / "models"
+    root.mkdir()
+    _model_dir(root, name="unified_textonly", model_type="gemma4_unified")
+
+    found = discover_models(root)["unified_textonly"]
+    assert found.engine_type == "batched"
+    assert found.model_type == "llm"
+    assert found.text_only_size == 0
+
+
+def test_rerouting_to_the_vlm_engine_keeps_reporting_it_as_an_llm(tmp_path: Path):
+    # The other direction: served by the VLM engine so its head can be driven,
+    # but still a text-only model, so it must not advertise images.
+    from omlx.model_discovery import discover_models
+
+    root = tmp_path / "models"
+    root.mkdir()
+    _model_dir(root, name="gemma4_textonly_head", merged_head=True)
+
+    found = discover_models(root)["gemma4_textonly_head"]
+    assert found.engine_type == "vlm"
+    assert found.model_type == "llm"
+
+
+def test_a_vision_checkpoint_keeps_both_fields(tmp_path: Path):
+    from omlx.model_discovery import discover_models
+
+    root = tmp_path / "models"
+    root.mkdir()
+    _model_dir(
+        root, name="gemma4_vision", vision_config=True, vision_weights=True
+    )
+
+    found = discover_models(root)["gemma4_vision"]
+    assert found.engine_type == "vlm"
+    assert found.model_type == "vlm"
+
+
+def test_one_unreadable_shard_does_not_decide_the_modality(tmp_path: Path):
+    # A per-shard read error used to answer for the whole checkpoint, which
+    # for a real multimodal model drops the modality and turns a transient
+    # error into a strict-load failure on its unclaimed tensors.
+    model_dir = _model_dir(tmp_path, name="torn", vision_config=True)
+    _write_safetensors(
+        model_dir / "model-00002.safetensors",
+        ["vision_embedder.patch_dense.weight"],
+    )
+    (model_dir / "model-00003.safetensors").write_bytes(b"not safetensors")
+
+    assert _has_vision_weights(model_dir) is True

--- a/tests/test_vlm_audio_fallback.py
+++ b/tests/test_vlm_audio_fallback.py
@@ -139,15 +139,21 @@ class TestHasAudioWeights:
 
 
 class TestStripAudioConfigIfOrphaned:
-    def test_passthrough_when_config_has_no_audio(self, tmp_path: Path):
-        # Config with no audio_config — patch must leave the dict untouched.
+    def test_absent_audio_config_is_pinned_to_none(self, tmp_path: Path):
+        # An absent audio_config is not the same as a harmless one. mlx-vlm's
+        # load_model runs `config.setdefault("audio_config", {})`, and
+        # gemma4_unified builds embed_audio for any audio_config that is not
+        # None -- so leaving the key absent is what causes a module the
+        # checkpoint has no weights for, and a strict load that fails on
+        # embed_audio.embedding_projection.weight. Pin it to None instead.
         model_dir = _build_model_dir(
             tmp_path, name="vision_only",
             has_audio_config=False, has_audio_weights=False,
         )
         with _strip_audio_config_if_orphaned(model_dir):
             cfg = _vu.load_config(model_dir)
-        assert "audio_config" not in cfg
+        assert "audio_config" in cfg
+        assert cfg["audio_config"] is None
 
     def test_passthrough_when_audio_weights_present(self, tmp_path: Path):
         # Healthy multimodal model — audio_config must remain in the dict.


### PR DESCRIPTION
> **This is an alternative to #3536, not an addition to it.** Both make a text-only Gemma 4 checkpoint with a merged MTP head actually draft; this one does it by teaching the existing mlx-vlm path to load such a checkpoint, in 536 lines instead of 1356 -- 276 against 519 counting only `omlx/` -- rather than adding a second MTP runtime on mlx-lm. Benchmarks for both are below. Draft because only one of the two should land.

A Gemma 4 checkpoint with the assistant head merged under `language_model.mtp.*` and no vision tower advertises MTP, accepts `mtp_enabled: true`, logs `Speculative backend selected: Lightning MTP` — and never drafts a token.

## What is wrong

`detect_model_type` returns `"vlm"` only when it finds a `vision_config`, `vit_config` or `mm_vision_tower`. A checkpoint with no vision tower is therefore classed text-only and served through mlx-lm, where the merged head has no binding site. Three ordinary things land there: a text-only quant, a DFlash target, and the VLM→LLM fallback.

Nothing reports it. `_is_mtp_compatible` accepts `gemma4`, so the patch is applied and the server logs its backend; then the engine looks for `.mtp`, does not find it, and decodes one token per forward for the life of the model.

mlx-vlm already drives this head (#2683). What stopped a text-only checkpoint from reaching it is the loader, and two separate things have to go right.

The Gemma 4 family ships under two model types — `gemma4` and `gemma4_unified` — and mlx-vlm picks the model class from that. A `gemma4` checkpoint gets `gemma4/gemma4.py`, which builds `VisionModel(config.vision_config)` unconditionally: that class has no text-only path at all. Only `gemma4_unified` has one, at `if config.vision_config is not None`.

That branch is then unreachable anyway, even for a `gemma4_unified` checkpoint carrying no vision, because its config declares `vision_config: Optional[VisionConfig] = field(default_factory=VisionConfig)`. An absent key still becomes a real `VisionConfig`, so the check is always true. The model builds vision embedders the shards cannot fill, and the strict `load_weights` that follows fails on the tensors nothing claims. oMLX falls back to mlx-lm — by design, since it refuses `strict=False` — which is why this never looked like a load bug.

## What this does

Two things, matching the two failures. Mark the absent modalities rather than nulling them, so the config chain leaves `vision_config` alone and `gemma4_unified`'s text-only branch becomes reachable. And point a `gemma4` checkpoint at `gemma4_unified`, the implementation that carries that branch — the two share the `language_model` layout, so this is choosing the class that can run the checkpoint rather than asking anyone to relabel it on disk. Audio keeps its existing treatment: nothing dereferences `audio_config` as a dict, so `None` is enough there.

Then route a text-only `gemma4` carrying a merged head to the VLM engine, which can drive it. The reverse rule keeps a text-only checkpoint with *no* head on mlx-lm, which carries less overhead — measured at +0.31 GB on the 12B — rather than letting it arrive there by way of a failed load.

`model_type` moves with `engine_type` in both directions, because `supports_images` is `model_type == "vlm"`: moving only the engine would leave a text-only checkpoint on the LLM engine still telling clients it accepts images. `engine_pool`'s runtime VLM→LLM fallback sets the pair together for the same reason.

The second commit is independent of all of this and worth taking either way — see below.

## Benchmarks

`gemma-4-31B-it-oQ4-fp16-mtp` — 19.0 GB, `model_type` gemma4, no vision sub-config, merged head present. M1 Max / 32 GB, mlx 0.32.2. Driven through the admin benchmark so the numbers reproduce from the UI: bundled `code_python` corpus, `temperature=0.0`, `warmup_mode=quick`.

Four arm types, since "which implementation" and "does the feature pay at all" are different questions. Arms are interleaved rather than blocked, because this host throttles under sustained load; each arm is a fresh server on a freshly checked-out tree; medians are `statistics.median`. An arm counts only if `completion_tokens` matches the request, discovery reports the intended engine, and — with MTP on — the log shows drafting.

**1024-token prompt, 512 generated, n=4 per arm:**

| arm | median tok/s | mean | range |
|---|---|---|---|
| mlx-vlm, MTP on (this PR) | 17.65 | 17.50 | 14.5–20.2 |
| mlx-vlm, MTP off | 14.30 | 14.22 | 13.2–15.1 |
| mlx-lm, MTP on (#3536) | 19.90 | 19.72 | 18.9–20.2 |
| mlx-lm, MTP off | 15.00 | 14.80 | 14.1–15.1 |

MTP pays **+23.4%** here on this path (mean +23.0%), and +32.7% on #3536's. Between the two implementations, mlx-vlm/mlx-lm is **0.887** — this path is ~13% slower with drafting on, and level with it off (1.007 over six arms per side, and 1.000 at a second prompt size). So the difference is in how the head is driven, not in engine overhead. Peak memory is identical: 21.07 GB with MTP on either path, 19.65 GB with it off.

## `perf(mtp)`: the head runs in float32 today

The second commit is a fix to code that already ships and is independent of everything above.

The head is bfloat16 and `oq.combine_gemma4_assistant_mtp` preserves that, so on a float16 checkpoint every head matmul meets float16 activations and MLX promotes the result to float32. The 31B oQ4 quant is that shape — 1243 float16 backbone tensors against 48 bfloat16 head tensors — and it is visible only in the safetensors headers, since the config reports bfloat16 for the whole file.

Measured on that checkpoint, the head forward cost 2355–2744 ms per request before, against 509–787 ms for the same head driven from mlx-lm, which aligns the dtype at load. Casting is safe in either direction because the head only proposes: every token the engine emits is one the backbone verified, so head precision moves the acceptance rate and can never move the output.

It is done at the first draft rather than in `sanitize`, because mlx-vlm skips model sanitizers when safetensors metadata says `format=mlx` — which is exactly these checkpoints.

Happy to split this into its own PR if you'd rather take it independently of the routing change.

## Reproducing

Any Gemma 4 checkpoint with the assistant head merged and no vision tower — `text_config.mtp_assistant_config` in `config.json` plus `language_model.mtp.*` in the safetensors index.

Before this change the model is discovered as `type: llm, engine: batched` and never drafts. After it, discovery reports `type: vlm, engine: vlm` and the engine's MTP telemetry line reports an accept rate.

## Tests

`tests/test_gemma4_text_only_vlm.py` — the routing predicates in both directions, the loader behavior on a marked-absent modality, and four field-pair invariants driven through `discover_models`, so a future change that moves `engine_type` without `model_type` fails rather than quietly advertising images.

`tests/test_vlm_audio_fallback.py` gains coverage that the existing orphaned-audio path still nulls rather than marking, which the first draft of this broke.
