### PR TITLE
fix(cache): keep the snapshot request dir while a queued write stages into it

### DIFF
--- a/omlx/cache/boundary_snapshot_store.py
+++ b/omlx/cache/boundary_snapshot_store.py
@@ -536,8 +536,13 @@ class BoundarySnapshotSSDStore:
             if not self._is_safe_snapshot_path(detached_path):
                 return None
             os.replace(file_path, detached_path)
-            with suppress(OSError):
-                file_path.parent.rmdir()
+            # Do not tidy the (possibly empty) request directory here. The
+            # writer thread creates it with ``mkdir(exist_ok=True)`` and only
+            # then writes the staging file for a later boundary; an ``rmdir``
+            # slipping between those two steps made that write fail with
+            # ENOENT, so the later checkpoint could never be promoted and
+            # the split-GDN store stopped one block short. ``cleanup_request``
+            # removes the directory once the request is done.
             return detached_path
         except Exception as e:
             logger.debug(

--- a/tests/test_boundary_snapshot_store.py
+++ b/tests/test_boundary_snapshot_store.py
@@ -302,6 +302,45 @@ class TestBoundarySnapshotSSDStore:
         # Session directory still exists (recreated).
         assert self.store._snapshot_dir.exists()
 
+    def test_take_staged_file_leaves_request_dir_for_queued_writes(self):
+        """Promoting one boundary must not remove the directory a queued write stages into."""
+        from unittest.mock import patch
+
+        from omlx.cache import boundary_snapshot_store as mod
+
+        request_id = "req-staging"
+        last_tmp = self.store._file_path(request_id, 3072)
+        last_tmp = last_tmp.with_name(last_tmp.stem + "_tmp.safetensors")
+        original_write = mod._write_safetensors_no_mx
+        promoted: list[Path | None] = []
+
+        def promote_earlier_boundaries_first(path, tensors_raw, metadata):
+            # The writer has just created the request directory and is about
+            # to stage the last boundary; the store thread promotes the two
+            # earlier boundaries at exactly that moment.
+            if Path(path) == last_tmp and not promoted:
+                promoted.append(
+                    self.store.take_staged_file(request_id, 1024, timeout_s=5.0)
+                )
+                promoted.append(
+                    self.store.take_staged_file(request_id, 2048, timeout_s=5.0)
+                )
+            return original_write(path, tensors_raw, metadata)
+
+        with patch.object(
+            mod,
+            "_write_safetensors_no_mx",
+            side_effect=promote_earlier_boundaries_first,
+        ):
+            for token_count in (1024, 2048, 3072):
+                assert self.store.save(
+                    request_id, token_count, [MagicMock()], _mock_extract_cache_states
+                )
+            staged = self.store.take_staged_file(request_id, 3072, timeout_s=5.0)
+
+        assert promoted and all(path is not None for path in promoted)
+        assert staged is not None and staged.is_file()
+
     def test_take_staged_file_survives_concurrent_cleanup_all(self):
         """Caller-owned promotion files must outlive session cleanup."""
         import threading


### PR DESCRIPTION
## Summary

Intermittent CI failures in `tests/test_prefix_cache_gdn_split.py` (for example `test_split_restore_walks_back_from_structurally_invalid_sidecar` on #3551, and `test_split_store_restores_one_sidecar_and_walks_back` / `test_split_restore_retries_legacy_candidate_at_the_same_endpoint` on run 34496226504) all show the same captured log line:

```
WARNING omlx.cache.prefix_cache:prefix_cache.py:1293 Rejecting split-GDN placeholder block 3 because its recurrent checkpoint was not committed
```

and a stored block table one block short of the expected length.

## Root cause

`BoundarySnapshotSSDStore.take_staged_file` moved the promoted snapshot out of the request directory and then tried `file_path.parent.rmdir()` as a tidy-up. The writer thread stages each boundary by `mkdir(parents=True, exist_ok=True)` on that same directory and *then* writing the temp file. When the store thread promoted an earlier boundary between those two steps, the directory was empty at that instant, the `rmdir` succeeded, and the writer's `_write_safetensors_no_mx` failed with `ENOENT`. That failure is logged at debug level only, the pending marker is released with no file behind it, `take_staged_file` for that boundary returns `None`, `commit_gdn_checkpoint` returns `False`, and the split-GDN store rejects the placeholder block. Whether the interleaving happens depends on scheduling, hence the flake (25 local runs never hit it; the CI runners do).

## Change

`omlx/cache/boundary_snapshot_store.py`: `take_staged_file` no longer removes the request directory. `cleanup_request` already `rmtree`s it when the request ends, so nothing is leaked; only an empty directory lives a little longer.

## Test

`tests/test_boundary_snapshot_store.py::test_take_staged_file_leaves_request_dir_for_queued_writes` wraps `_write_safetensors_no_mx` so that, right before the writer stages the last boundary (after its `mkdir`), the two earlier boundaries are promoted. Without the fix the directory disappears, the write fails and the last promotion returns `None`; with the fix all three promotions succeed. Fails on `main`, passes with the change.

```
pytest tests/test_boundary_snapshot_store.py tests/test_prefix_cache_gdn_split.py tests/test_gdn_sidecar_quantization.py → 154 passed
```

`ruff check` reports the same pre-existing findings as on `main` for both files; nothing new.
