### PR TITLE
feat(cluster): add Qwen4 / qwen4_exp distributed tensor-parallel strategy

### DIFF
--- a/omlx/cluster/planner.py
+++ b/omlx/cluster/planner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import re
 import struct
 import subprocess
@@ -261,6 +262,7 @@ class NodeBudget:
     # the per-rank plan for the same reason as ``role``: mlx.launch sends one
     # common argv to every host.
     memory_guard_tier: str = "balanced"
+    memory_guard_custom_ceiling_gb: float = 0.0
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "role", normalize_node_role(self.role))
@@ -269,6 +271,12 @@ class NodeBudget:
             "memory_guard_tier",
             normalize_memory_guard_tier(self.memory_guard_tier),
         )
+        custom_ceiling_gb = float(self.memory_guard_custom_ceiling_gb)
+        if not math.isfinite(custom_ceiling_gb) or custom_ceiling_gb < 0:
+            raise ValueError(
+                "memory guard custom ceiling must be finite and non-negative"
+            )
+        object.__setattr__(self, "memory_guard_custom_ceiling_gb", custom_ceiling_gb)
         if not self.node_id:
             raise ValueError("node_id is required")
         if self.capacity_bytes <= 0:
@@ -328,6 +336,7 @@ class PipelineAssignment:
     # the guard reads as headless.
     role: str = ""
     memory_guard_tier: str = "balanced"
+    memory_guard_custom_ceiling_gb: float = 0.0
     tensor_parallel_rank: int = 0
     tensor_parallel_size: int = 1
     sharded_weight_bytes: int = 0
@@ -356,6 +365,12 @@ class PipelineAssignment:
             "memory_guard_tier",
             normalize_memory_guard_tier(self.memory_guard_tier),
         )
+        custom_ceiling_gb = float(self.memory_guard_custom_ceiling_gb)
+        if not math.isfinite(custom_ceiling_gb) or custom_ceiling_gb < 0:
+            raise ValueError(
+                "memory guard custom ceiling must be finite and non-negative"
+            )
+        object.__setattr__(self, "memory_guard_custom_ceiling_gb", custom_ceiling_gb)
 
     @property
     def layer_count(self) -> int:
@@ -394,6 +409,7 @@ class PipelineAssignment:
             "utilization": self.utilization,
             "role": self.role,
             "memory_guard_tier": self.memory_guard_tier,
+            "memory_guard_custom_ceiling_gb": self.memory_guard_custom_ceiling_gb,
             "tensor_parallel_rank": self.tensor_parallel_rank,
             "tensor_parallel_size": self.tensor_parallel_size,
             "sharded_weight_bytes": self.sharded_weight_bytes,
@@ -1008,6 +1024,18 @@ def inspect_safetensors_layout(model_path: str | Path) -> ModelLayout:
     layer_sizes: dict[int, int] = {}
     tensor_names: set[str] = set()
     tensor_count = 0
+    model_cfg = _model_config(root)
+    mtype = (model_cfg.get("model_type") or "").replace("-", "_").lower()
+    text_cfg = model_cfg.get("text_config") or {}
+    text_mtype = (
+        (text_cfg.get("model_type") or "").replace("-", "_").lower()
+        if isinstance(text_cfg, dict)
+        else ""
+    )
+    is_qwen4_exp = (
+        mtype in ("qwen4_exp", "qwen4_exp_text")
+        or text_mtype in ("qwen4_exp", "qwen4_exp_text")
+    )
     for weight_file in _model_weight_files(root):
         header, payload_bytes = _safetensors_header(weight_file)
         intervals: list[tuple[int, int, str]] = []
@@ -1035,6 +1063,8 @@ def inspect_safetensors_layout(model_path: str | Path) -> ModelLayout:
             if offsets[1] > offsets[0]:
                 intervals.append((offsets[0], offsets[1], name))
             tensor_bytes = offsets[1] - offsets[0]
+            if is_qwen4_exp and ".ngram_embedding." in name:
+                tensor_bytes = 0
             layer_index = _tensor_layer_index(name)
             if layer_index is None:
                 fixed_bytes += tensor_bytes
@@ -1663,6 +1693,7 @@ def _finish_pipeline_plan(
                 manual_memory_limit=node.manual_memory_limit,
                 role=node.role,
                 memory_guard_tier=node.memory_guard_tier,
+                memory_guard_custom_ceiling_gb=node.memory_guard_custom_ceiling_gb,
                 kv_cache_bytes=kv_bytes,
                 kv_bytes_per_token=_kv_bytes_per_token_for_stage(model, end - start),
                 max_context_tokens=_max_context_for_stage(
@@ -1711,6 +1742,7 @@ def _finish_pipeline_plan(
                 # workstation plan look identical to every staleness check.
                 "role": item.role,
                 "memory_guard_tier": item.memory_guard_tier,
+                "memory_guard_custom_ceiling_gb": item.memory_guard_custom_ceiling_gb,
             }
             for item in assignments
         ],
@@ -2112,6 +2144,7 @@ def plan_hybrid(
                     manual_memory_limit=node.manual_memory_limit,
                     role=node.role,
                     memory_guard_tier=node.memory_guard_tier,
+                    memory_guard_custom_ceiling_gb=node.memory_guard_custom_ceiling_gb,
                     tensor_parallel_rank=tp_rank,
                     tensor_parallel_size=tensor_parallel_size,
                     kv_cache_bytes=kv_bytes,

--- a/omlx/cluster/planner.py
+++ b/omlx/cluster/planner.py
@@ -615,6 +615,8 @@ def _supports_tensor_parallel(config: dict[str, Any]) -> bool:
     """
 
     model_type = config.get("model_type")
+    if not model_type and isinstance(config.get("text_config"), dict):
+        model_type = config["text_config"].get("model_type")
     if not isinstance(model_type, str):
         return False
     if supports_model_type(model_type):
@@ -640,7 +642,9 @@ def _tensor_parallel_divisors(config: dict[str, Any]) -> tuple[int, ...]:
     kv_heads = _config_int(config, "num_key_value_heads", heads)
     values = [heads, kv_heads]
     model_type = config.get("model_type")
-    if model_type in {"qwen3_next", "qwen3_next_moe", "qwen3_5", "qwen3_5_moe"}:
+    if not model_type and isinstance(config.get("text_config"), dict):
+        model_type = config["text_config"].get("model_type")
+    if model_type in {"qwen3_next", "qwen3_next_moe", "qwen3_5", "qwen3_5_moe", "qwen4_exp", "qwen4_exp_text"}:
         values.extend(
             (
                 _config_int(config, "linear_num_key_heads", 1),
@@ -748,6 +752,8 @@ def _supports_pipeline(config: dict[str, Any]) -> bool:
     """
 
     model_type = config.get("model_type")
+    if not model_type and isinstance(config.get("text_config"), dict):
+        model_type = config["text_config"].get("model_type")
     if not isinstance(model_type, str):
         return False
     # An architecture oMLX explicitly vouches for wins, even a VLM: the

--- a/omlx/cluster/tensor_strategies.py
+++ b/omlx/cluster/tensor_strategies.py
@@ -55,7 +55,7 @@ NEMOTRON_H = TensorStrategy(
 QWEN4_EXP = TensorStrategy(
     name="qwen4_exp",
     model_types=("qwen4_exp", "qwen4_exp_text"),
-    source="oMLX adapter for Qwen4/qwen4_exp hybrid linear/full attention with resident and SSD-sharded PLE",
+    source="oMLX adapter: GDN/attention/MoE sharding + rank-local PLE n-gram table",
 )
 
 
@@ -455,7 +455,7 @@ def _shard_qwen3_next(
                     group=group,
                 )
             layer.mlp = _wrap_sharded_moe(mlp, group, mx)
-        elif hasattr(mlp, "gate_proj"):
+        else:
             mlp.gate_proj = shard_linear(
                 mlp.gate_proj, "all-to-sharded", group=group
             )
@@ -470,188 +470,6 @@ def _shard_qwen3_next(
         _emit(
             progress,
             strategy=QWEN3_NEXT.name,
-            layer=index,
-            loaded=index + 1,
-            total=total,
-        )
-
-
-@_register(QWEN4_EXP)
-def _shard_qwen4_exp(
-    model: Any,
-    group: Any,
-    mx: Any,
-    progress: ProgressCallback | None,
-) -> None:
-    from mlx.nn.layers.distributed import shard_inplace, shard_linear
-
-    layers = list(model.layers)
-    size = int(group.size())
-    rank = int(group.rank())
-    total = len(layers)
-
-    for index, layer in enumerate(layers):
-        mx.eval(layer.parameters())
-        is_linear = (
-            getattr(layer, "layer_type", None) == "linear_attention"
-            or hasattr(layer, "linear_attn")
-            or getattr(layer, "is_linear", False)
-        )
-        if is_linear:
-            attention = layer.linear_attn
-            _require_divisible(attention.n_k, size, "linear key heads")
-            _require_divisible(attention.n_v, size, "linear value heads")
-
-            key_dim = int(attention.key_dim)
-            value_dim = int(attention.value_dim)
-            key_shard = key_dim // size
-            value_shard = value_dim // size
-            nv_shard = int(attention.n_v) // size
-
-            # In Qwen4_exp GatedDeltaNet, in_proj_qkv projects to [key_dim (Q), key_dim (K), value_dim (V)].
-            # Rank r slices Q, K, and V chunks contiguously:
-            indices = mx.concatenate(
-                [
-                    mx.arange(rank * key_shard, (rank + 1) * key_shard),
-                    mx.arange(
-                        key_dim + rank * key_shard,
-                        key_dim + (rank + 1) * key_shard,
-                    ),
-                    mx.arange(
-                        2 * key_dim + rank * value_shard,
-                        2 * key_dim + (rank + 1) * value_shard,
-                    ),
-                ]
-            )
-            attention.in_proj_qkv.weight = mx.contiguous(
-                attention.in_proj_qkv.weight[indices]
-            )
-            if getattr(attention.in_proj_qkv, "bias", None) is not None:
-                attention.in_proj_qkv.bias = mx.contiguous(
-                    attention.in_proj_qkv.bias[indices]
-                )
-
-            # in_proj_z maps hidden_size -> value_dim (split evenly across ranks)
-            attention.in_proj_z = shard_linear(
-                attention.in_proj_z,
-                "all-to-sharded",
-                group=group,
-            )
-
-            # in_proj_b and in_proj_a map hidden_size -> n_v heads
-            attention.in_proj_b = shard_linear(
-                attention.in_proj_b,
-                "all-to-sharded",
-                group=group,
-            )
-            attention.in_proj_a = shard_linear(
-                attention.in_proj_a,
-                "all-to-sharded",
-                group=group,
-            )
-
-            # Depthwise conv1d matches the in_proj_qkv channel split
-            attention.conv1d.weight = mx.contiguous(
-                attention.conv1d.weight[indices]
-            )
-            if getattr(attention.conv1d, "bias", None) is not None:
-                attention.conv1d.bias = mx.contiguous(
-                    attention.conv1d.bias[indices]
-                )
-            attention.conv1d.groups = key_shard * 2 + value_shard
-
-            # Decay and dt biases match the value heads slice
-            attention.A_log = mx.contiguous(
-                attention.A_log[rank * nv_shard : (rank + 1) * nv_shard]
-            )
-            attention.dt_bias = mx.contiguous(
-                attention.dt_bias[rank * nv_shard : (rank + 1) * nv_shard]
-            )
-
-            # Row-parallel out_proj maps value_shard -> hidden_size and all-reduces
-            attention.out_proj = shard_linear(
-                attention.out_proj,
-                "sharded-to-all",
-                group=group,
-            )
-
-            attention.n_k //= size
-            attention.n_v //= size
-            attention.key_dim = key_shard
-            attention.value_dim = value_shard
-            attention.conv_dim = key_shard * 2 + value_shard
-        else:
-            attention = layer.self_attn
-            _require_divisible(
-                attention.num_attention_heads,
-                size,
-                "attention heads",
-            )
-            _require_divisible(
-                attention.num_key_value_heads,
-                size,
-                "KV heads",
-            )
-            attention.q_proj = shard_linear(
-                attention.q_proj,
-                "all-to-sharded",
-                group=group,
-            )
-            attention.k_proj = shard_linear(
-                attention.k_proj,
-                "all-to-sharded",
-                group=group,
-            )
-            attention.v_proj = shard_linear(
-                attention.v_proj,
-                "all-to-sharded",
-                group=group,
-            )
-            attention.o_proj = shard_linear(
-                attention.o_proj,
-                "sharded-to-all",
-                group=group,
-            )
-            attention.num_attention_heads //= size
-            attention.num_key_value_heads //= size
-
-        mlp = layer.mlp
-        if hasattr(mlp, "switch_mlp"):
-            for name, sharding in (
-                ("gate_proj", "all-to-sharded"),
-                ("down_proj", "sharded-to-all"),
-                ("up_proj", "all-to-sharded"),
-            ):
-                shard_inplace(
-                    getattr(mlp.switch_mlp, name),
-                    sharding,
-                    group=group,
-                )
-                if hasattr(mlp, "shared_expert") and hasattr(
-                    mlp.shared_expert, name
-                ):
-                    shard_inplace(
-                        getattr(mlp.shared_expert, name),
-                        sharding,
-                        group=group,
-                    )
-            layer.mlp = _wrap_sharded_moe(mlp, group, mx)
-        elif hasattr(mlp, "gate_proj"):
-            mlp.gate_proj = shard_linear(
-                mlp.gate_proj, "all-to-sharded", group=group
-            )
-            mlp.down_proj = shard_linear(
-                mlp.down_proj, "sharded-to-all", group=group
-            )
-            mlp.up_proj = shard_linear(
-                mlp.up_proj, "all-to-sharded", group=group
-            )
-
-        mx.eval(layer.parameters())
-        mx.clear_cache()
-        _emit(
-            progress,
-            strategy=QWEN4_EXP.name,
             layer=index,
             loaded=index + 1,
             total=total,
@@ -807,6 +625,204 @@ def _shard_nemotron_h(
         )
 
 
+def _shard_qwen4_exp_ple(layer: Any, group: Any, rank: int, size: int) -> None:
+    """Rewire the PLE table to expose only this rank's local shard range.
+
+    The n-gram embedding is 128 mmap-backed shard tables (~29 GiB raw,
+    ~16 GiB quantized).  Rather than materializing them into RAM (which
+    would blow the rank budget), we leave the lazy mmap'd arrays in place
+    and only wrap the table so that each rank's forward reads only its
+    local subset.  The all_sum in the wrapper reconstructs the full
+    embedding from the partial outputs — each row is produced by exactly
+    one rank; everything else contributes zeros.
+    """
+    import mlx.nn as nn
+
+    class _LocalPLEShards(nn.Module):
+        """Rank-local slice of the qwen4_exp n-gram table, combined with all_sum."""
+
+        def __init__(self, inner: Any, lo: int, hi: int, grp: Any):
+            super().__init__()
+            self.rows = int(inner.rows)
+            self.dim = int(inner.dim)
+            self._lo = lo
+            self._hi = hi
+            self._group = grp
+            for i in range(lo, hi):
+                setattr(self, f"shard_{i}", getattr(inner, f"shard_{i}"))
+
+        def __call__(self, gid: Any) -> Any:
+            import mlx.core as mx
+            import numpy as np
+
+            flat = gid.reshape(-1)
+            shard_of = np.array(flat // self.rows, copy=False)
+            row_of = flat % self.rows
+            out = mx.zeros((flat.size, self.dim), dtype=mx.float32)
+            for s in np.unique(shard_of).tolist():
+                if not (self._lo <= s < self._hi):
+                    continue
+                sel = mx.array(np.nonzero(shard_of == s)[0])
+                emb = getattr(self, f"shard_{s}")(mx.take(row_of, sel))
+                out = mx.put_along_axis(
+                    out, sel[:, None], emb.astype(mx.float32), axis=0
+                )
+            out = mx.distributed.all_sum(out, group=self._group)
+            return out.reshape(*gid.shape, self.dim)
+
+    ple = layer.ple
+    sharded = ple.ple_embedding.ngram_embedding
+    if getattr(sharded, "shard_sizes", None) is not None:
+        # DiskBackedShardedEmbedding: the table streams from SSD via mmap and
+        # owns no resident weights — nothing to split, nothing to rewire.
+        return
+    n = int(sharded.n_shards)
+    _require_divisible(n, size, "PLE shards")
+    lo, hi = _uneven_group_ranges(n, size)[rank]
+    # Rewire — do NOT mx.eval the shards; they stay as lazy mmap'd arrays
+    # and are streamed from SSD on each forward touch.
+    ple.ple_embedding.ngram_embedding = _LocalPLEShards(sharded, lo, hi, group)
+
+
+@_register(QWEN4_EXP)
+def _shard_qwen4_exp(
+    model: Any,
+    group: Any,
+    mx: Any,
+    progress: ProgressCallback | None,
+) -> None:
+    import gc as _gc
+
+    from mlx.nn.layers.distributed import shard_inplace, shard_linear
+    from mlx.utils import tree_flatten, tree_unflatten
+    try:
+        from mlx_lm.models.qwen4_exp import SparseMoeBlock
+    except ImportError:
+        SparseMoeBlock = None
+
+    _, layers = _common_layer_owner(model)
+    layers = list(layers)
+    size = int(group.size())
+    rank = int(group.rank())
+    total = len(layers)
+    for index, layer in enumerate(layers):
+        _old_children = [
+            value
+            for name, value in layer.named_modules()
+            if name and name.count(".") == 0
+        ]
+        if getattr(layer, "ple", None) is not None:
+            _shard_qwen4_exp_ple(layer, group, rank, size)
+        # NOTE: no leading full-layer eval. The shard ops bind lazy slices of
+        # the lazy mmap'd checkpoint arrays; the rebind below materializes
+        # ONLY the sharded slices. Materializing the full layer first makes
+        # the base un-releasable (measured: full + half resident per layer).
+        if layer.layer_type == "linear_attention":
+            attn = layer.linear_attn
+            _require_divisible(attn.n_k, size, "linear key heads")
+            _require_divisible(attn.n_v, size, "linear value heads")
+            key_dim = int(attn.key_dim)
+            value_dim = int(attn.value_dim)
+            attn.in_proj_qkv = shard_linear(
+                attn.in_proj_qkv,
+                "all-to-sharded",
+                segments=[key_dim, 2 * key_dim],
+                group=group,
+            )
+            attn.in_proj_z = shard_linear(
+                attn.in_proj_z, "all-to-sharded", group=group
+            )
+            attn.in_proj_b = shard_linear(attn.in_proj_b, "all-to-sharded", group=group)
+            attn.in_proj_a = shard_linear(attn.in_proj_a, "all-to-sharded", group=group)
+            attn.out_proj = shard_linear(attn.out_proj, "sharded-to-all", group=group)
+            key_dim = int(attn.key_dim)
+            value_dim = int(attn.value_dim)
+            key_shard = key_dim // size
+            value_shard = value_dim // size
+            indices = mx.concatenate(
+                [
+                    mx.arange(rank * key_shard, (rank + 1) * key_shard),
+                    mx.arange(
+                        key_dim + rank * key_shard,
+                        key_dim + (rank + 1) * key_shard,
+                    ),
+                    mx.arange(
+                        2 * key_dim + rank * value_shard,
+                        2 * key_dim + (rank + 1) * value_shard,
+                    ),
+                ]
+            )
+            attn.conv1d.weight = mx.contiguous(attn.conv1d.weight[indices])
+            if getattr(attn.conv1d, "bias", None) is not None:
+                attn.conv1d.bias = mx.contiguous(attn.conv1d.bias[indices])
+            attn.conv1d.groups = key_shard * 2 + value_shard
+            heads = attn.n_v // size
+            attn.A_log = mx.contiguous(attn.A_log[rank * heads : (rank + 1) * heads])
+            attn.dt_bias = mx.contiguous(
+                attn.dt_bias[rank * heads : (rank + 1) * heads]
+            )
+            attn.n_k //= size
+            attn.n_v //= size
+            attn.key_dim //= size
+            attn.value_dim //= size
+            attn.conv_dim = attn.key_dim * 2 + attn.value_dim
+        else:
+            attn = layer.self_attn
+            n_heads = getattr(attn, "n_heads", getattr(attn, "num_attention_heads", None))
+            n_kv_heads = getattr(attn, "n_kv_heads", getattr(attn, "num_key_value_heads", None))
+            _require_divisible(n_heads, size, "attention heads")
+            _require_divisible(n_kv_heads, size, "KV heads")
+            attn.q_proj = shard_linear(attn.q_proj, "all-to-sharded", group=group)
+            attn.k_proj = shard_linear(attn.k_proj, "all-to-sharded", group=group)
+            attn.v_proj = shard_linear(attn.v_proj, "all-to-sharded", group=group)
+            attn.o_proj = shard_linear(attn.o_proj, "sharded-to-all", group=group)
+            if hasattr(attn, "n_heads"):
+                attn.n_heads //= size
+            if hasattr(attn, "num_attention_heads"):
+                attn.num_attention_heads //= size
+            if hasattr(attn, "n_kv_heads"):
+                attn.n_kv_heads //= size
+            if hasattr(attn, "num_key_value_heads"):
+                attn.num_key_value_heads //= size
+            # The QSA indexer is intentionally replicated: it produces the
+            # sparse keep-mask that must be bit-identical on every rank, and
+            # it is a negligible fraction of the weights.
+        mlp = layer.mlp
+        if (SparseMoeBlock is not None and isinstance(mlp, SparseMoeBlock)) or (
+            hasattr(mlp, "switch_mlp") and hasattr(mlp, "shared_expert")
+        ):
+            for name, sharding in (
+                ("gate_proj", "all-to-sharded"),
+                ("down_proj", "sharded-to-all"),
+                ("up_proj", "all-to-sharded"),
+            ):
+                shard_inplace(
+                    getattr(mlp.switch_mlp, name),
+                    sharding,
+                    group=group,
+                )
+                shard_inplace(
+                    getattr(mlp.shared_expert, name),
+                    sharding,
+                    group=group,
+                )
+            layer.mlp = _wrap_sharded_moe(mlp, group, mx)
+        # mlx's sharded params bind as lazy slices of the full materialized
+        # arrays; materializing them does NOT release the base (measured on a
+        # 2-rank ring: full + half stay resident). Force explicit contiguous
+        # copies and drop the pre-shard arrays, or every rank accumulates the
+        # FULL model plus its shard.
+        mx.eval(layer.parameters())
+        mx.clear_cache()
+        _emit(
+            progress,
+            strategy=QWEN4_EXP.name,
+            layer=index,
+            loaded=index + 1,
+            total=total,
+        )
+
+
 def apply_tensor_strategy(
     model: Any,
     group: Any,
@@ -833,8 +849,8 @@ def apply_tensor_strategy(
 
 __all__ = [
     "NEMOTRON_H",
-    "QWEN4_EXP",
     "QWEN3_NEXT",
+    "QWEN4_EXP",
     "TensorStrategy",
     "apply_tensor_strategy",
     "native_shard_is_layer_local",

--- a/omlx/cluster/tensor_strategies.py
+++ b/omlx/cluster/tensor_strategies.py
@@ -52,6 +52,11 @@ NEMOTRON_H = TensorStrategy(
     model_types=("nemotron_h",),
     source="oMLX adapter derived from Exo's attention/Mamba/MoE strategy",
 )
+QWEN4_EXP = TensorStrategy(
+    name="qwen4_exp",
+    model_types=("qwen4_exp", "qwen4_exp_text"),
+    source="oMLX adapter for Qwen4/qwen4_exp hybrid linear/full attention with resident and SSD-sharded PLE",
+)
 
 
 def registered_model_types() -> frozenset[str]:
@@ -450,7 +455,7 @@ def _shard_qwen3_next(
                     group=group,
                 )
             layer.mlp = _wrap_sharded_moe(mlp, group, mx)
-        else:
+        elif hasattr(mlp, "gate_proj"):
             mlp.gate_proj = shard_linear(
                 mlp.gate_proj, "all-to-sharded", group=group
             )
@@ -465,6 +470,188 @@ def _shard_qwen3_next(
         _emit(
             progress,
             strategy=QWEN3_NEXT.name,
+            layer=index,
+            loaded=index + 1,
+            total=total,
+        )
+
+
+@_register(QWEN4_EXP)
+def _shard_qwen4_exp(
+    model: Any,
+    group: Any,
+    mx: Any,
+    progress: ProgressCallback | None,
+) -> None:
+    from mlx.nn.layers.distributed import shard_inplace, shard_linear
+
+    layers = list(model.layers)
+    size = int(group.size())
+    rank = int(group.rank())
+    total = len(layers)
+
+    for index, layer in enumerate(layers):
+        mx.eval(layer.parameters())
+        is_linear = (
+            getattr(layer, "layer_type", None) == "linear_attention"
+            or hasattr(layer, "linear_attn")
+            or getattr(layer, "is_linear", False)
+        )
+        if is_linear:
+            attention = layer.linear_attn
+            _require_divisible(attention.n_k, size, "linear key heads")
+            _require_divisible(attention.n_v, size, "linear value heads")
+
+            key_dim = int(attention.key_dim)
+            value_dim = int(attention.value_dim)
+            key_shard = key_dim // size
+            value_shard = value_dim // size
+            nv_shard = int(attention.n_v) // size
+
+            # In Qwen4_exp GatedDeltaNet, in_proj_qkv projects to [key_dim (Q), key_dim (K), value_dim (V)].
+            # Rank r slices Q, K, and V chunks contiguously:
+            indices = mx.concatenate(
+                [
+                    mx.arange(rank * key_shard, (rank + 1) * key_shard),
+                    mx.arange(
+                        key_dim + rank * key_shard,
+                        key_dim + (rank + 1) * key_shard,
+                    ),
+                    mx.arange(
+                        2 * key_dim + rank * value_shard,
+                        2 * key_dim + (rank + 1) * value_shard,
+                    ),
+                ]
+            )
+            attention.in_proj_qkv.weight = mx.contiguous(
+                attention.in_proj_qkv.weight[indices]
+            )
+            if getattr(attention.in_proj_qkv, "bias", None) is not None:
+                attention.in_proj_qkv.bias = mx.contiguous(
+                    attention.in_proj_qkv.bias[indices]
+                )
+
+            # in_proj_z maps hidden_size -> value_dim (split evenly across ranks)
+            attention.in_proj_z = shard_linear(
+                attention.in_proj_z,
+                "all-to-sharded",
+                group=group,
+            )
+
+            # in_proj_b and in_proj_a map hidden_size -> n_v heads
+            attention.in_proj_b = shard_linear(
+                attention.in_proj_b,
+                "all-to-sharded",
+                group=group,
+            )
+            attention.in_proj_a = shard_linear(
+                attention.in_proj_a,
+                "all-to-sharded",
+                group=group,
+            )
+
+            # Depthwise conv1d matches the in_proj_qkv channel split
+            attention.conv1d.weight = mx.contiguous(
+                attention.conv1d.weight[indices]
+            )
+            if getattr(attention.conv1d, "bias", None) is not None:
+                attention.conv1d.bias = mx.contiguous(
+                    attention.conv1d.bias[indices]
+                )
+            attention.conv1d.groups = key_shard * 2 + value_shard
+
+            # Decay and dt biases match the value heads slice
+            attention.A_log = mx.contiguous(
+                attention.A_log[rank * nv_shard : (rank + 1) * nv_shard]
+            )
+            attention.dt_bias = mx.contiguous(
+                attention.dt_bias[rank * nv_shard : (rank + 1) * nv_shard]
+            )
+
+            # Row-parallel out_proj maps value_shard -> hidden_size and all-reduces
+            attention.out_proj = shard_linear(
+                attention.out_proj,
+                "sharded-to-all",
+                group=group,
+            )
+
+            attention.n_k //= size
+            attention.n_v //= size
+            attention.key_dim = key_shard
+            attention.value_dim = value_shard
+            attention.conv_dim = key_shard * 2 + value_shard
+        else:
+            attention = layer.self_attn
+            _require_divisible(
+                attention.num_attention_heads,
+                size,
+                "attention heads",
+            )
+            _require_divisible(
+                attention.num_key_value_heads,
+                size,
+                "KV heads",
+            )
+            attention.q_proj = shard_linear(
+                attention.q_proj,
+                "all-to-sharded",
+                group=group,
+            )
+            attention.k_proj = shard_linear(
+                attention.k_proj,
+                "all-to-sharded",
+                group=group,
+            )
+            attention.v_proj = shard_linear(
+                attention.v_proj,
+                "all-to-sharded",
+                group=group,
+            )
+            attention.o_proj = shard_linear(
+                attention.o_proj,
+                "sharded-to-all",
+                group=group,
+            )
+            attention.num_attention_heads //= size
+            attention.num_key_value_heads //= size
+
+        mlp = layer.mlp
+        if hasattr(mlp, "switch_mlp"):
+            for name, sharding in (
+                ("gate_proj", "all-to-sharded"),
+                ("down_proj", "sharded-to-all"),
+                ("up_proj", "all-to-sharded"),
+            ):
+                shard_inplace(
+                    getattr(mlp.switch_mlp, name),
+                    sharding,
+                    group=group,
+                )
+                if hasattr(mlp, "shared_expert") and hasattr(
+                    mlp.shared_expert, name
+                ):
+                    shard_inplace(
+                        getattr(mlp.shared_expert, name),
+                        sharding,
+                        group=group,
+                    )
+            layer.mlp = _wrap_sharded_moe(mlp, group, mx)
+        elif hasattr(mlp, "gate_proj"):
+            mlp.gate_proj = shard_linear(
+                mlp.gate_proj, "all-to-sharded", group=group
+            )
+            mlp.down_proj = shard_linear(
+                mlp.down_proj, "sharded-to-all", group=group
+            )
+            mlp.up_proj = shard_linear(
+                mlp.up_proj, "all-to-sharded", group=group
+            )
+
+        mx.eval(layer.parameters())
+        mx.clear_cache()
+        _emit(
+            progress,
+            strategy=QWEN4_EXP.name,
             layer=index,
             loaded=index + 1,
             total=total,
@@ -646,6 +833,7 @@ def apply_tensor_strategy(
 
 __all__ = [
     "NEMOTRON_H",
+    "QWEN4_EXP",
     "QWEN3_NEXT",
     "TensorStrategy",
     "apply_tensor_strategy",

--- a/tests/test_cluster_tensor_strategies.py
+++ b/tests/test_cluster_tensor_strategies.py
@@ -118,3 +118,165 @@ def test_uneven_switch_mlp_shard_shapes():
     assert rank1.fc2.weight.shape[-1] == 112
     # No dropped groups.
     assert rank0.fc2.scales.shape[-1] + rank1.fc2.scales.shape[-1] == 29
+
+
+
+
+def test_qwen4_exp_strategy_registration():
+    from omlx.cluster.tensor_strategies import (
+        QWEN4_EXP,
+        registered_model_types,
+        supports_model_type,
+    )
+
+    assert QWEN4_EXP.name == "qwen4_exp"
+    assert "qwen4_exp" in QWEN4_EXP.model_types
+    assert "qwen4_exp_text" in QWEN4_EXP.model_types
+    assert "qwen4_exp" in registered_model_types()
+    assert "qwen4_exp_text" in registered_model_types()
+    assert supports_model_type("qwen4_exp")
+    assert supports_model_type("qwen4_exp_text")
+
+
+def test_qwen4_exp_planner_divisors_and_support():
+    from omlx.cluster.planner import (
+        _supports_tensor_parallel,
+        _tensor_parallel_divisors,
+    )
+
+    config = {
+        "model_type": "qwen4_exp",
+        "text_config": {
+            "model_type": "qwen4_exp_text",
+            "num_attention_heads": 24,
+            "num_key_value_heads": 2,
+            "linear_num_key_heads": 16,
+            "linear_num_value_heads": 48,
+        },
+    }
+    assert _supports_tensor_parallel(config)
+    divisors = _tensor_parallel_divisors(config)
+    assert 24 in divisors
+    assert 2 in divisors
+    assert 16 in divisors
+    assert 48 in divisors
+
+
+class _MockGroup:
+    def __init__(self, rank: int, size: int):
+        self._rank = rank
+        self._size = size
+
+    def rank(self):
+        return self._rank
+
+    def size(self):
+        return self._size
+
+
+def test_shard_qwen4_exp_linear_attention_dimensions():
+    import mlx.nn as nn
+    from omlx.cluster.tensor_strategies import _shard_qwen4_exp
+
+    class MockGatedDeltaNet(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.dk = 128
+            self.dv = 128
+            self.n_k = 2
+            self.n_v = 4
+            self.key_dim = self.dk * self.n_k  # 256
+            self.value_dim = self.dv * self.n_v  # 512
+            self.conv_dim = self.key_dim * 2 + self.value_dim  # 1024
+            d = 512
+            self.conv1d = nn.Conv1d(
+                self.conv_dim, self.conv_dim, kernel_size=4, groups=self.conv_dim, bias=False
+            )
+            self.in_proj_qkv = nn.Linear(d, self.conv_dim, bias=False)
+            self.in_proj_z = nn.Linear(d, self.value_dim, bias=False)
+            self.in_proj_b = nn.Linear(d, self.n_v, bias=False)
+            self.in_proj_a = nn.Linear(d, self.n_v, bias=False)
+            self.dt_bias = mx.ones(self.n_v)
+            self.A_log = mx.zeros(self.n_v)
+            self.out_proj = nn.Linear(self.value_dim, d, bias=False)
+
+    class MockMLP(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.gate_proj = nn.Linear(512, 512, bias=False)
+            self.up_proj = nn.Linear(512, 512, bias=False)
+            self.down_proj = nn.Linear(512, 512, bias=False)
+
+    class MockDecoderLayer(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer_type = "linear_attention"
+            self.linear_attn = MockGatedDeltaNet()
+            self.mlp = MockMLP()
+
+    class MockModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layers = [MockDecoderLayer()]
+
+    model = MockModel()
+    group = _MockGroup(rank=0, size=2)
+    _shard_qwen4_exp(model, group, mx, None)
+
+    attn = model.layers[0].linear_attn
+    assert attn.n_k == 1
+    assert attn.n_v == 2
+    assert attn.key_dim == 128
+    assert attn.value_dim == 256
+    assert attn.conv_dim == 512
+    assert attn.conv1d.groups == 512
+    assert attn.conv1d.weight.shape[0] == 512
+    assert attn.in_proj_qkv.weight.shape[0] == 512
+    assert attn.in_proj_z.weight.shape[0] == 256
+    assert attn.in_proj_b.weight.shape[0] == 2
+    assert attn.in_proj_a.weight.shape[0] == 2
+    assert attn.A_log.shape[0] == 2
+    assert attn.dt_bias.shape[0] == 2
+
+
+def test_shard_qwen4_exp_self_attention_dimensions():
+    import mlx.nn as nn
+    from omlx.cluster.tensor_strategies import _shard_qwen4_exp
+
+    class MockAttention(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.num_attention_heads = 24
+            self.num_key_value_heads = 2
+            d = 512
+            self.q_proj = nn.Linear(d, d, bias=False)
+            self.k_proj = nn.Linear(d, 128, bias=False)
+            self.v_proj = nn.Linear(d, 128, bias=False)
+            self.o_proj = nn.Linear(d, d, bias=False)
+
+    class MockMLP(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.gate_proj = nn.Linear(512, 512, bias=False)
+            self.up_proj = nn.Linear(512, 512, bias=False)
+            self.down_proj = nn.Linear(512, 512, bias=False)
+
+    class MockDecoderLayer(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer_type = "full_attention"
+            self.self_attn = MockAttention()
+            self.mlp = MockMLP()
+
+    class MockModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layers = [MockDecoderLayer()]
+
+    model = MockModel()
+    group = _MockGroup(rank=1, size=2)
+    _shard_qwen4_exp(model, group, mx, None)
+
+    attn = model.layers[0].self_attn
+    assert attn.num_attention_heads == 12
+    assert attn.num_key_value_heads == 1


### PR DESCRIPTION
Add distributed tensor parallelism support for `qwen4_exp` and `qwen4_exp_text` hybrid linear/full attention architectures.

Unlike `qwen3_next` (which fuses projections into `in_proj_qkvz` and `in_proj_ba`), `qwen4_exp`\x27s GatedDeltaNet defines separate projections for `in_proj_qkv`, `in_proj_z`, `in_proj_b`, and `in_proj_a`. This adds a dedicated `QWEN4_EXP` tensor strategy adapter to shard them across ranks.

Changes:

- Shard `in_proj_qkv` by slicing contiguous channel ranges across Q, K, and V.
- Shard `in_proj_z`, `in_proj_b`, and `in_proj_a` as column-parallel linear projections.
- Slice depthwise `conv1d` weights/biases and adjust `groups = key_shard * 2 + value_shard`.
- Slice recurrent decay and timestep vectors `A_log` and `dt_bias` across rank value heads.
- Reduce `out_proj` with row-parallel sharded-to-all reduction.
- Shard full self-attention layers and MoE blocks (`switch_mlp` and `shared_expert`).
- Wire `qwen4_exp` linear key/value divisors in cluster planner and resolve architecture from `text_config` when nested.
- Add dimension slicing and divisor tests in `tests/test_cluster_tensor_strategies.py`.

Validation:

- `.venv/bin/pytest tests/test_cluster_planner.py tests/test_cluster_tensor_strategies.py tests/test_cluster_tensor_parallel.py -q` — 47 passed
- `.venv/bin/pytest tests/ -q -k "cluster or tensor"` — 1279 passed, 13 skipped