### PR TITLE
fix(server): serialize non-API validation errors with jsonable_encoder

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -55,6 +55,7 @@ from typing import Optional, Union
 
 from fastapi import Depends, FastAPI, HTTPException, Response
 from fastapi import Request as FastAPIRequest
+from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, RedirectResponse, StreamingResponse
@@ -893,7 +894,7 @@ async def validation_exception_handler(
         param = errors[0].get("loc", [None])[-1] if errors else None
         content = _openai_error_body(detail_str, 422, param=param)
     else:
-        content = {"detail": exc.errors()}
+        content = {"detail": jsonable_encoder(exc.errors())}
     return JSONResponse(status_code=422, content=content)
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for omlx.server module - sampling parameter resolution and exception handlers."""
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -518,6 +519,47 @@ class TestExceptionHandlers:
         assert response.status_code == 404
         data = response.json()
         assert "detail" in data
+
+    def test_non_api_validation_error_with_value_error_ctx_returns_422(self):
+        """A ValueError-raising validator on a non-/v1/ route must 422, not 500.
+
+        Pydantic v2 stashes the raw exception in ``ctx``, which ``JSONResponse``
+        cannot serialize, so the admin handler used to die building the body
+        ("Object of type ValueError is not JSON serializable") and the client
+        saw a 500 with no detail.
+        """
+        import json
+
+        from fastapi.exceptions import RequestValidationError
+        from pydantic import BaseModel, ValidationError, field_validator
+
+        from omlx.server import validation_exception_handler
+
+        class _ExternalApiLike(BaseModel):
+            base_url: str
+
+            @field_validator("base_url")
+            @classmethod
+            def _validate_base_url(cls, v: str) -> str:
+                if not v.startswith(("http://", "https://")):
+                    raise ValueError("base_url must start with http:// or https://")
+                return v
+
+        with pytest.raises(ValidationError) as exc_info:
+            _ExternalApiLike(base_url="ftp://x")
+        errors = exc_info.value.errors()
+        assert isinstance(errors[0].get("ctx", {}).get("error"), ValueError)
+
+        request = SimpleNamespace(
+            method="PUT",
+            url=SimpleNamespace(path="/admin/api/models/x/settings"),
+        )
+        response = asyncio.run(
+            validation_exception_handler(request, RequestValidationError(errors))
+        )
+        assert response.status_code == 422
+        body = json.loads(response.body.decode())
+        assert body["detail"][0]["loc"][-1] == "base_url"
 
 
 class TestModelFallback:


### PR DESCRIPTION
### Problem

Requests to non-/v1/ routes (the whole admin API) that fail a Pydantic validator raising ValueError return HTTP 500 instead of 422. The handler logs the 422 correctly, then dies building the response body: pydantic v2 puts the raw ValueError instance into ctx, and JSONResponse cannot serialize it ("Object of type ValueError is not JSON serializable"). The client sees a 500 with no useful detail.

### Change

One line in validation_exception_handler: pass exc.errors() through jsonable_encoder before handing it to JSONResponse, matching the fix suggested in the issue. The /v1/ branch is untouched (it already flattens errors to strings), and error content is preserved — the ValueError encodes to {} under its ctx key rather than dropping the entry.

### Tests

- New regression test in tests/test_server.py drives the handler with a ValueError-carrying error list shaped like the real omlx/admin/external_api.py base_url validator: fails before (TypeError: Object of type ValueError is not JSON serializable), passes after with a 422 body.
- tests/test_server.py, tests/test_external_api.py, tests/test_api_auth.py: 172 passed.

Fixes #3387