### PR TITLE
fix(glm5_next): remap quantized forget-gate scales/biases in sanitize

### DIFF
--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/language.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/language.py
@@ -933,7 +933,16 @@ class LanguageModel(nn.Module):
 
         remapped = {}
         conv_parts = {}
-        fg_parts = ("A_log", "dt_bias", "f_a_proj.weight", "f_b_proj.weight")
+        fg_parts = (
+            "A_log",
+            "dt_bias",
+            "f_a_proj.weight",
+            "f_a_proj.scales",
+            "f_a_proj.biases",
+            "f_b_proj.weight",
+            "f_b_proj.scales",
+            "f_b_proj.biases",
+        )
         for k, v in weights.items():
             nk = k.replace(".hc_attn_", ".attn_hc.").replace(".hc_ffn_", ".ffn_hc.")
 

--- a/tests/test_mlx_vlm_glm5_next_compat.py
+++ b/tests/test_mlx_vlm_glm5_next_compat.py
@@ -492,6 +492,31 @@ def test_sanitize_and_oq_keep_sensitive_parameters_in_fp32():
     ) == {"bits": 8, "group_size": 64, "mode": "affine"}
 
 
+def test_sanitize_remaps_quantized_forget_gate_sidecars():
+    from mlx_vlm.models.glm5_next.language import LanguageModel
+
+    config = _tiny_config()
+    model = LanguageModel(config.text_config, config)
+    prefix = "language_model.model.layers.0.self_attn."
+    weights = {
+        prefix + "f_a_proj.weight": mx.ones((32, 32)),
+        prefix + "f_a_proj.scales": mx.ones((2,), dtype=mx.bfloat16),
+        prefix + "f_a_proj.biases": mx.ones((2,), dtype=mx.bfloat16),
+        prefix + "f_b_proj.weight": mx.ones((32, 32)),
+        prefix + "f_b_proj.scales": mx.ones((2,), dtype=mx.bfloat16),
+        prefix + "f_b_proj.biases": mx.ones((2,), dtype=mx.bfloat16),
+    }
+    sanitized = model.sanitize(dict(weights))
+    gate = prefix + "forget_gate."
+    for proj in ("f_a_proj", "f_b_proj"):
+        for part in ("weight", "scales", "biases"):
+            assert gate + proj + "." + part in sanitized
+    assert not any(
+        key.startswith(prefix + "f_") and ".forget_gate." not in key
+        for key in sanitized
+    )
+
+
 def test_vector_gate_kernel_matches_reference_with_padding_mask():
     from mlx_vlm.models.glm5_next.gated_delta import gated_delta_update
 


### PR DESCRIPTION
### Problem

Affine-quantized GLM-5.3-Flash checkpoints (e.g. ai2apps/GLM-5.3-Flash-MLX-4bit-MTP) fail to load with 'Received 136 parameters not in model' for f_a_proj/f_b_proj .scales/.biases. sanitize() only remapped the float .weight names into the forget_gate submodule, so the 34 KDA layers x 2 projections x 2 sidecars kept their flat self_attn names and tripped strict load. Fixes #3400.

### Change

Extend fg_parts with the .scales/.biases names so the sidecars remap alongside the weights. One-line-class fix, same loop, no behavior change for float checkpoints.

### Tests

New test_sanitize_remaps_quantized_forget_gate_sidecars fails before, passes after (verified via stash). tests/test_mlx_vlm_glm5_next_compat.py: 15 passed, 8 skipped. tests/test_oq.py + tests/test_vlm_engine.py failure sets identical before/after (20 pre-existing env failures, unrelated).