### PR TITLE
feat(deepseek_v41): CSA2 + Engram support for DeepSeek-V4.1-Flash

### DIFF
--- a/omlx/adapter/output_parser.py
+++ b/omlx/adapter/output_parser.py
@@ -189,8 +189,10 @@ def _is_deepseek_v4_model(
     tokenizer: Any,
     model_config: dict[str, Any] | None = None,
 ) -> bool:
+    from omlx.patches.deepseek_v41.predicates import is_deepseek_v4
+
     model_type = str(model_config.get("model_type", "")) if model_config else ""
-    if model_type.startswith("deepseek_v4"):
+    if is_deepseek_v4(model_type):
         return True
 
     if (

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/deepseek_v4_sparse_attention.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/deepseek_v4_sparse_attention.cpp
@@ -88,7 +88,7 @@ class DeepseekV4SparseAttentionPrimitive : public Primitive {
         sinks.shape(0) != q.shape(1)) {
       return true;
     }
-    if (q.shape(2) <= 1 || local_kv.shape(2) < q.shape(2) ||
+    if (q.shape(2) < 1 || local_kv.shape(2) < q.shape(2) ||
         pooled.shape(1) <= 0 || topk_indices.shape(3) <= 0 ||
         topk_indices.dtype() != uint32) {
       return true;

--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 from omlx.exceptions import PrefillMemoryExceededError, describe_ceiling_binding
 from omlx.patches.deepseek_v4.indexer_dispatch import native_indexer_eligible
 from omlx.utils.hardware import format_bytes, get_max_working_set_bytes
+from omlx.patches.deepseek_v41.predicates import is_deepseek_v4_family
 
 logger = logging.getLogger(__name__)
 
@@ -1421,7 +1422,7 @@ def make_prefill_memory_profile(
         return _make_qwen4_exp_prefill_memory_profile(
             config, compute_dtype_size=compute_dtype_size
         )
-    if not model_type.startswith("deepseek_v4"):
+    if not is_deepseek_v4_family(model_type):
         return None
 
     num_layers = _cfg_get(config, "num_hidden_layers")

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -146,8 +146,10 @@ def _bpw_targets_for_level(oq_level: float) -> tuple[float, float] | None:
 
 
 def _is_deepseek_v4_config(config: dict) -> bool:
+    from omlx.patches.deepseek_v41.predicates import is_deepseek_v4
+
     model_type = str(config.get("model_type", "")).lower()
-    if model_type.startswith("deepseek_v4"):
+    if is_deepseek_v4(model_type):
         return True
 
     architectures = config.get("architectures") or []
@@ -4151,7 +4153,17 @@ def _build_model_sanitizer(
         # into ``sys.modules`` by oMLX's base patch. Trigger that here so
         # ``_get_classes(config)`` for deepseek_v4* model types succeeds.
         # No-op for other model types.
-        if str(config.get("model_type", "")).startswith("deepseek_v4"):
+        from omlx.patches.deepseek_v41.predicates import is_deepseek_v4, is_deepseek_v41
+
+        mt = str(config.get("model_type", ""))
+        if is_deepseek_v41(mt):
+            try:
+                from omlx.patches.deepseek_v41 import apply_deepseek_v41_patch
+
+                apply_deepseek_v41_patch()
+            except Exception as patch_err:
+                logger.debug(f"deepseek_v41 base patch not applied: {patch_err}")
+        elif is_deepseek_v4(mt):
             try:
                 from omlx.patches.deepseek_v4 import apply_deepseek_v4_patch
 
@@ -7329,7 +7341,8 @@ def _prepare_layer_inputs(model, layers, calib_data, inputs):
             for layer in layers
         ]
         return hidden, masks, {"kind": _GLM5_NEXT_LAYER_STATE_KIND}
-    if model_type.startswith("deepseek_v4"):
+    from omlx.patches.deepseek_v41.predicates import is_deepseek_v4_family
+    if is_deepseek_v4_family(model_type):
         args = model.args
         h = mx.broadcast_to(
             inputs[:, :, None, :],

--- a/omlx/patches/deepseek_v4/__init__.py
+++ b/omlx/patches/deepseek_v4/__init__.py
@@ -25,8 +25,9 @@ without modifying the pinned mlx-lm. The patch:
    prefix-cache / SSD-cache state extraction does not silently fall
    through to ``DefaultCacheHandler``.
 
-The whole patch is gated on ``model_type.startswith("deepseek_v4")`` in
-``config.json``; other models pay zero cost.
+The whole patch is gated on DeepSeek-V4 model types in ``config.json``
+(exact ``deepseek_v4`` / ``deepseek_v4_*`` — **not** ``deepseek_v41``).
+Other models pay zero cost.
 
 Once mlx-lm merges PR 1192 upstream this package can be removed in a
 single delete (along with the conditional dispatch in

--- a/omlx/patches/deepseek_v4/tokenizer_patch.py
+++ b/omlx/patches/deepseek_v4/tokenizer_patch.py
@@ -163,17 +163,17 @@ def _register_chat_template_and_parser_modules() -> None:
 
 
 def _is_deepseek_v4_model(model_path) -> bool:
-    """Return True if ``model_path/config.json`` declares deepseek_v4*."""
+    """Return True if ``model_path/config.json`` declares deepseek_v4 (not v41)."""
     import json
     from pathlib import Path
+
+    from omlx.patches.deepseek_v41.predicates import is_deepseek_v4
 
     p = Path(model_path) / "config.json"
     if not p.exists():
         return False
     try:
-        return str(json.loads(p.read_text()).get("model_type", "")).startswith(
-            "deepseek_v4"
-        )
+        return is_deepseek_v4(str(json.loads(p.read_text()).get("model_type", "")))
     except Exception:
         return False
 

--- a/omlx/patches/deepseek_v4/utils_patch.py
+++ b/omlx/patches/deepseek_v4/utils_patch.py
@@ -6,7 +6,7 @@ Two surgical changes from PR 1192 are applied:
 1. Weight loading goes through ``_load_safetensors`` instead of ``mx.load`` so
    safetensors files declaring the F8_E8M0 dtype (used by DeepSeek V4 fp8
    block-scale tensors) can be reinterpreted as U8 in-place.
-2. The ``elif quant_method == "fp8" and model_type.startswith("deepseek_v4")``
+2. The ``elif quant_method == "fp8" and is_deepseek_v4(model_type)``
    branch
    in the quantization config dispatch builds the per-layer quantization
    spec via ``deepseek_v4.make_quantization_config``.
@@ -19,6 +19,8 @@ When mlx-lm merges PR 1192 upstream this patch should be removed.
 """
 
 from __future__ import annotations
+
+from omlx.patches.deepseek_v41.predicates import is_deepseek_v4, is_deepseek_v41
 
 import glob
 import importlib.util
@@ -39,12 +41,30 @@ logger = logging.getLogger(__name__)
 
 SAFETENSORS_DTYPE_FALLBACKS = {"F8_E8M0": "U8"}
 
+
+def _skip_engram_embed_key(key: str) -> bool:
+    """When OMLX_DSV41_ENGRAM=mmap/ssd, never materialize ~200GB embed tables."""
+    if "engram.embed.weight" not in key and "engram.embed.scale" not in key:
+        return False
+    try:
+        from omlx.patches.deepseek_v41.engram import engram_is_mmap
+
+        return engram_is_mmap()
+    except Exception:
+        import os
+
+        return os.environ.get("OMLX_DSV41_ENGRAM", "stub").strip().lower() in (
+            "mmap",
+            "ssd",
+        )
+
+
 _PATCHED = False
 
 
 def _native_ratio128_attention_enabled(config: dict[str, Any]) -> bool:
     """Keep the native ratio-128 attention path off for sub-4-bit V4."""
-    if not str(config.get("model_type", "")).startswith("deepseek_v4"):
+    if not is_deepseek_v4(str(config.get('model_type', ''))):
         return True
 
     quantizations = [config.get("quantization"), config.get("quantization_config")]
@@ -70,13 +90,31 @@ def _load_safetensors(path: str) -> dict:
     exponent scale tensors. ``mx.load`` rejects unknown dtypes; the
     fallback rewrites the safetensors header in place to advertise the
     bytes as ``U8`` (raw uint8), loads, and restores the original header.
+
+    When Engram mmap mode is active, ``engram.embed.*`` tensors are removed
+    from the header before load so ~200GB tables are never materialized.
     """
+    needs_engram_strip = False
     try:
-        return mx.load(path)
-    except RuntimeError as e:
-        if not any(dtype in str(e) for dtype in SAFETENSORS_DTYPE_FALLBACKS):
-            raise
-        load_error = e
+        with open(path, "rb") as peek:
+            header_len = struct.unpack("<Q", peek.read(8))[0]
+            header_peek = json.loads(peek.read(header_len))
+        needs_engram_strip = any(
+            _skip_engram_embed_key(k)
+            for k in header_peek.keys()
+            if k != "__metadata__"
+        )
+    except Exception:
+        needs_engram_strip = False
+
+    load_error = None
+    if not needs_engram_strip:
+        try:
+            return mx.load(path)
+        except RuntimeError as e:
+            if not any(dtype in str(e) for dtype in SAFETENSORS_DTYPE_FALLBACKS):
+                raise
+            load_error = e
 
     with open(path, "r+b") as f:
         header_len = struct.unpack("<Q", f.read(8))[0]
@@ -84,7 +122,14 @@ def _load_safetensors(path: str) -> dict:
         header = json.loads(original_header)
         changed = False
 
-        for tensor_info in header.values():
+        for key in list(header.keys()):
+            if key == "__metadata__":
+                continue
+            if _skip_engram_embed_key(key):
+                del header[key]
+                changed = True
+                continue
+            tensor_info = header[key]
             if not isinstance(tensor_info, dict):
                 continue
             dtype = tensor_info.get("dtype")
@@ -93,7 +138,9 @@ def _load_safetensors(path: str) -> dict:
                 changed = True
 
         if not changed:
-            raise load_error
+            if load_error is not None:
+                raise load_error
+            return mx.load(path)
 
         patched_header = json.dumps(header, separators=(",", ":")).encode("utf-8")
         if len(patched_header) > header_len:
@@ -171,7 +218,7 @@ def _build_patched_load_model() -> Callable:
             if "quantization_config" in text_config:
                 config["quantization_config"] = text_config["quantization_config"]
 
-        if str(config.get("model_type", "")).startswith("deepseek_v4"):
+        if is_deepseek_v4(str(config.get('model_type', ''))):
             config["use_native_ratio128_attention"] = bool(
                 config.get("use_native_ratio128_attention", True)
             ) and _native_ratio128_attention_enabled(config)
@@ -223,10 +270,19 @@ def _build_patched_load_model() -> Callable:
                 config["quantization"] = quantization
                 config["quantization_config"] = quantization
                 _quantize(quantization)
-            elif quant_method == "fp8" and str(config.get("model_type", "")).startswith(
-                "deepseek_v4"
+            elif quant_method == "fp8" and is_deepseek_v4(
+                str(config.get("model_type", ""))
             ):  # PR 1192 new branch
                 from mlx_lm.models.deepseek_v4 import make_quantization_config
+
+                quantization = make_quantization_config(model)
+                config["quantization"] = quantization
+                config["quantization_config"] = quantization
+                _quantize(quantization)
+            elif quant_method == "fp8" and is_deepseek_v41(
+                str(config.get("model_type", ""))
+            ):
+                from mlx_lm.models.deepseek_v41 import make_quantization_config
 
                 quantization = make_quantization_config(model)
                 config["quantization"] = quantization

--- a/omlx/patches/deepseek_v41/README.md
+++ b/omlx/patches/deepseek_v41/README.md
@@ -1,0 +1,108 @@
+# DeepSeek-V4.1 (CSA2) omlx patch
+
+Loads `deepseek-ai/DeepSeek-V4.1-Flash` (`model_type=deepseek_v41`) into omlx / mlx-lm on Apple Silicon.
+
+## Engram hot-row cache
+
+The quantized RAM working-set cache lives in **`engram_cache.py`**.
+
+| Piece | Where |
+| --- | --- |
+| Cache class | `QuantHotRowCache` in `engram_cache.py` |
+| Bound on tables | `MmapEngramTable.hot_cache` in `engram.py` |
+| Budget | `OMLX_DSV41_ENGRAM_CACHE_GB` (default `50`) |
+| Policy | `OMLX_DSV41_ENGRAM_CACHE_POLICY` (`lru` \| `clock`) |
+| Stats | `engram_cache_stats(model)` |
+| FP8 helpers | `engram_fp8.py` |
+| SSD tables | `OMLX_DSV41_ENGRAM_DIR` + `OMLX_DSV41_ENGRAM=mmap` |
+
+Full tables stay on SSD via memmap; only touched rows enter the hot cache as FP8+scale (~264 B/row).
+
+
+## Architecture (exactness)
+
+Source of truth: HuggingFace `inference/model.py` + `DeepSeek_V41_Tech_Report.pdf`.
+
+| Topic | V4.1 behavior |
+|--------|----------------|
+| Attention | Unified CSA2: window + optional compress top-k |
+| Sharing | `SharedAttentionRuntime` via `kv_source_layer_ids` / `index_source_layer_ids` |
+| compress_ratios | `{0,1,2}` only — **no** V4 `{4,128}`, **no APE**, **no ratio-4 overlap** |
+| Indexer | `wk` from compressor latent; `index_n_heads=32`; `select_candidate_blocks` |
+| mHC | **Deferred**: attn uses prior FFN `pre_mix`; FFN uses this attn `pre` |
+| Norm | `rms_norm_eps=1e-20` |
+| MoE gate | `sqrtsoftplus`; bias for select; scores for weights; `bias_vl` for VL |
+| Engram | Layers `[1,14]` (stub tables by default — see below) |
+| DSpark | Config fields wired (`dspark_target_layer_ids=[37,38,39]`); MTP forward TODO |
+| Vision | Phase-2 stub: raises if `images=` passed |
+
+## Gate collision
+
+**Never** use `model_type.startswith("deepseek_v4")` — it matches `deepseek_v41`.
+Use `omlx.patches.deepseek_v41.predicates`:
+
+- `is_deepseek_v4` — V4 / V4-Flash only
+- `is_deepseek_v41` — V4.1 only
+- `is_deepseek_v4_family` — either (shared tooling)
+
+## Quant notes
+
+- Weight block: 32×32
+- Window KV: fp8 @ 32
+- Compress KV: fp4 @ 16 / E4M3 scales
+- Index: fp4 @ 32
+- Experts: mxfp4; shared / attn: mxfp8 (`make_quantization_config`)
+
+## Engram memory
+
+Full tables are ~200GB FP8 (layers 1 and 14). Modes:
+
+```bash
+export OMLX_DSV41_ENGRAM=stub   # default: no real tables
+export OMLX_DSV41_ENGRAM=mmap   # SSD memmap + optional hot-row cache
+# export OMLX_DSV41_ENGRAM=full  # resident embeddings (not for 512GB hosts)
+export OMLX_DSV41_ENGRAM_DIR=~/llm/DeepSeek-V4.1-Flash-engram
+export OMLX_DSV41_ENGRAM_CACHE_GB=50   # see engram_cache.py
+```
+
+Hot-row cache details: **`engram_cache.py`** (section above).
+
+## How to load (once weights are local)
+
+```python
+from omlx.patches.deepseek_v41 import apply_deepseek_v41_patch
+apply_deepseek_v41_patch()
+
+from mlx_lm import load
+model, tokenizer = load("/Volumes/TB5/llm/DeepSeek-V4.1-Flash")  # or HF id after convert
+```
+
+Via omlx server: set model path / HF id with `model_type=deepseek_v41` in `config.json`;
+`maybe_apply_pre_load_patches` applies this package automatically.
+
+Converted MLX weights (after official `convert.py` / omlx oq) should sanitize through
+`Model.sanitize` (embed/head/hc_*/expert stack remaps).
+
+## Tests
+
+```bash
+cd /Users/homecorpstudio/third-party/omlx
+/Users/homecorpstudio/omlx-venv313/bin/pytest tests/test_deepseek_v41.py -q
+```
+
+## Reused from V4 (do not break V4)
+
+- `PoolingCache` / generate patch / cache handlers
+- `hyper_connection` Sinkhorn kernels + `HyperHead`
+- `SwitchGLU` (MXFP4)
+- `wsdpa_attention` prefill paths
+- `decode_consistency.matmul`
+
+## Known gaps
+
+1. Vision ViT/aligner not implemented (explicit error).
+2. DSpark speculative loop / `mtp.*` modules not executed (config retained).
+3. Engram hash state + full mmap tables optional.
+4. Chat template: use shipped tokenizer_config / encoding until a dedicated
+   `chat_template_v41` is ported (V4 DSML template is a starting point for tools).
+5. Native DSA indexer kernels tuned for H=64; V4.1 uses H=32 — MLX fallback path.

--- a/omlx/patches/deepseek_v41/__init__.py
+++ b/omlx/patches/deepseek_v41/__init__.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DeepSeek-V4.1 (CSA2) monkey-patch for mlx-lm.
+
+Registers ``mlx_lm.models.deepseek_v41`` from this package so omlx can load
+``deepseek-ai/DeepSeek-V4.1-Flash`` (``model_type=deepseek_v41``).
+
+Architecture notes (see DeepSeek_V41_Tech_Report.pdf + inference/model.py):
+- Compressed Sparse Attention 2 (CSA2) with cross-layer KV / indexer reuse
+- Hierarchical Sparse Indexer + candidate block prefilter
+- compress_ratios in {0,1,2} (no V4 ratio-4/128 / APE / overlap)
+- Deferred single-pass mHC (attn uses prior FFN pre_mix)
+- Engram conditional memory; DSpark draft head; optional vision
+
+Critical: must NOT share the naive ``startswith("deepseek_v4")`` gate with
+the V4 patch — that predicate matches ``deepseek_v41``.
+"""
+from __future__ import annotations
+
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+
+from .predicates import is_deepseek_v41
+
+logger = logging.getLogger(__name__)
+
+_APPLIED = False
+
+
+def is_applied() -> bool:
+    return _APPLIED
+
+
+def _register_module(qualname: str, file_name: str) -> None:
+    if qualname in sys.modules:
+        return
+    here = Path(__file__).parent
+    file_path = here / file_name
+    spec = importlib.util.spec_from_file_location(qualname, str(file_path))
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not create spec for {qualname} from {file_path}")
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = "mlx_lm.models"
+    sys.modules[qualname] = module
+    spec.loader.exec_module(module)
+    logger.info("Registered %s from %s", qualname, file_path.name)
+
+
+def _register_model_type_aliases() -> None:
+    try:
+        import mlx_lm.utils as _utils
+    except Exception as e:  # pragma: no cover
+        logger.debug("mlx_lm.utils unavailable for V4.1 alias: %s", e)
+        return
+    remapping = getattr(_utils, "MODEL_REMAPPING", None)
+    if not isinstance(remapping, dict):
+        return
+    remapping.setdefault("deepseek_v41", "deepseek_v41")
+    remapping.setdefault("deepseek_v41_text", "deepseek_v41")
+    remapping.setdefault("deepseek_v41_mtp", "deepseek_v41")
+
+
+def apply_deepseek_v41_patch() -> bool:
+    """Idempotent. Returns True if this call performed the registration."""
+    global _APPLIED
+    if _APPLIED:
+        return False
+
+    # Reuse V4 PoolingCache injection / handlers when present; V4.1 also needs
+    # shared-pool cache types but PoolingCache remains useful for ratio-1/2.
+    try:
+        from omlx.patches.deepseek_v4 import apply_pooling_cache_support
+
+        apply_pooling_cache_support()
+    except Exception as e:
+        logger.warning("V4.1: PoolingCache support not applied: %s", e)
+
+
+    # HyperConnection Sinkhorn kernels — shared with V4.
+    hc_path = Path(__file__).resolve().parent.parent / "deepseek_v4" / "hyper_connection.py"
+    if "mlx_lm.models.hyper_connection" not in sys.modules:
+        spec = importlib.util.spec_from_file_location(
+            "mlx_lm.models.hyper_connection", str(hc_path)
+        )
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Could not load hyper_connection from {hc_path}")
+        module = importlib.util.module_from_spec(spec)
+        module.__package__ = "mlx_lm.models"
+        sys.modules["mlx_lm.models.hyper_connection"] = module
+        spec.loader.exec_module(module)
+        logger.info("Registered mlx_lm.models.hyper_connection from deepseek_v4")
+
+    _register_module("mlx_lm.models.deepseek_v41", "deepseek_v41_model.py")
+    _register_model_type_aliases()
+
+    try:
+        from .utils_patch import apply_utils_patch
+
+        apply_utils_patch()
+    except Exception as e:
+        logger.warning("V4.1 utils_patch skipped: %s", e)
+
+    try:
+        from .tokenizer_patch import apply_tokenizer_patch
+
+        apply_tokenizer_patch()
+    except Exception as e:
+        logger.warning("V4.1 tokenizer_patch skipped: %s", e)
+
+    _APPLIED = True
+    logger.info("DeepSeek-V4.1 patch applied")
+    return True
+
+
+def maybe_apply_for_config(config: dict | None) -> bool:
+    if not isinstance(config, dict):
+        return False
+    mt = config.get("model_type")
+    if mt is None and isinstance(config.get("text_config"), dict):
+        mt = config["text_config"].get("model_type")
+    if is_deepseek_v41(mt):
+        return apply_deepseek_v41_patch()
+    return False
+
+
+__all__ = [
+    "apply_deepseek_v41_patch",
+    "is_applied",
+    "is_deepseek_v41",
+    "maybe_apply_for_config",
+]

--- a/omlx/patches/deepseek_v41/chat_template_v41.py
+++ b/omlx/patches/deepseek_v41/chat_template_v41.py
@@ -1,0 +1,998 @@
+"""
+DeepSeek-V4.1 Text and Vision Encoding
+
+A fully self-contained implementation for encoding/decoding DeepSeek-V4.1 chat
+messages with tool calling, thinking mode, quick instruction tasks, and image
+content blocks. No dependency on encoding_dsv4.
+
+V4.1 changes relative to V4:
+
+1. DSML tag names: tool calls are wrapped in "<｜DSML｜ calls>" blocks with
+   "<｜DSML｜ invoke>" / "<｜DSML｜ parameter>" tags (leading-space tag names).
+2. Numeric reasoning effort: "Reasoning Effort: {budget} (range 1-100, ...)".
+   Accepts an int in [1, 100] or one of "low"/"high"/"xhigh"/"max"
+   (mapped to 25/50/75/100). Defaults to "high". Only rendered in thinking mode.
+3. Mid-conversation system messages are supported via the "<｜System｜>" token.
+   A mid-conversation system message behaves like a user message for the purpose
+   of appending the assistant generation header.
+"""
+
+from typing import Any, Dict, List, Union, Optional, Tuple
+import copy
+import json
+import re
+
+# ============================================================
+# Special Tokens
+# ============================================================
+
+bos_token: str = "<｜begin▁of▁sentence｜>"
+eos_token: str = "<｜end▁of▁sentence｜>"
+thinking_start_token: str = "<think>"
+thinking_end_token: str = "</think>"
+dsml_token: str = "｜DSML｜"
+
+USER_SP_TOKEN = "<｜User｜>"
+ASSISTANT_SP_TOKEN = "<｜Assistant｜>"
+LATEST_REMINDER_SP_TOKEN = "<｜latest_reminder｜>"
+
+IMAGE_PLACEHOLDER = "<｜deepseek_image｜>"
+IMAGE_TAG_PATTERN = re.compile(r"<image>(.*?)</image>", re.DOTALL)
+
+# Task special tokens for internal classification tasks
+DS_TASK_SP_TOKENS = {
+    "action": "<｜action｜>",
+    "query": "<｜query｜>",
+    "authority": "<｜authority｜>",
+    "domain": "<｜domain｜>",
+    "title": "<｜title｜>",
+    "read_url": "<｜read_url｜>",
+}
+VALID_TASKS = set(DS_TASK_SP_TOKENS.keys())
+
+# ============================================================
+# Templates
+# ============================================================
+
+system_msg_template: str = "{content}"
+user_msg_template: str = "{content}"
+latest_reminder_msg_template: str = "{content}"
+assistant_msg_template: str = "{reasoning}{content}{tool_calls}" + eos_token
+assistant_msg_wo_eos_template: str = "{reasoning}{content}{tool_calls}"
+thinking_template: str = "{reasoning_content}"
+
+response_format_template: str = (
+    "## Response Format:\n\nYou MUST strictly adhere to the following schema to reply:\n{schema}"
+)
+
+tool_output_template: str = (
+    "<tool_result>{content}</tool_result>"
+)
+
+# ============================================================
+# Utility Functions
+# ============================================================
+
+def to_json(value: Any) -> str:
+    """Serialize a value to JSON string."""
+    try:
+        return json.dumps(value, ensure_ascii=False)
+    except:
+        return json.dumps(value, ensure_ascii=True)
+
+
+def tools_from_openai_format(tools):
+    """Extract function definitions from OpenAI-format tool list."""
+    return [tool["function"] for tool in tools]
+
+
+def tool_calls_from_openai_format(tool_calls):
+    """Convert OpenAI-format tool calls to internal format."""
+    return [
+        {
+            "name": tool_call["function"]["name"],
+            "arguments": tool_call["function"]["arguments"],
+        }
+        for tool_call in tool_calls
+    ]
+
+
+def tool_calls_to_openai_format(tool_calls):
+    """Convert internal tool calls to OpenAI format."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": tool_call["name"],
+                "arguments": tool_call["arguments"],
+            }
+        }
+        for tool_call in tool_calls
+    ]
+
+
+def decode_dsml_to_arguments(tool_name: str, tool_args: Dict[str, Tuple[str, str]]) -> Dict[str, str]:
+    """
+    Decode DSML parameters back to a tool call dict.
+
+    Args:
+        tool_name: Name of the tool.
+        tool_args: Dict mapping param_name -> (value, is_string_flag).
+
+    Returns:
+        Dict with "name" and "arguments" (JSON string) keys.
+    """
+    def _decode_value(key: str, value: str, string: str):
+        if string == "true":
+            value = to_json(value)
+        return f"{to_json(key)}: {value}"
+
+    tool_args_json = "{" + ", ".join([_decode_value(k, v, string=is_str) for k, (v, is_str) in tool_args.items()]) + "}"
+    return dict(name=tool_name, arguments=tool_args_json)
+
+
+# ============================================================
+# Preprocessing
+# ============================================================
+
+def merge_tool_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Merge tool messages into the preceding user message using content_blocks format.
+
+    DeepSeek-V4.1 does not have a standalone "tool" role; instead, tool results
+    are encoded as <tool_result> blocks within user messages.
+    """
+    merged: List[Dict[str, Any]] = []
+
+    for msg in messages:
+        msg = copy.deepcopy(msg)
+        role = msg.get("role")
+
+        if role == "tool":
+            # Convert tool message to a user message with tool_result block
+            tool_block = {
+                "type": "tool_result",
+                "tool_use_id": msg.get("tool_call_id", ""),
+                "content": msg.get("content", ""),
+            }
+            # Merge into previous message if it's already a user (merged tool)
+            if merged and merged[-1].get("role") == "user" and "content_blocks" in merged[-1]:
+                merged[-1]["content_blocks"].append(tool_block)
+            else:
+                merged.append({
+                    "role": "user",
+                    "content_blocks": [tool_block],
+                })
+        elif role == "user":
+            content_blocks = msg.get("content_blocks")
+            if content_blocks is None:
+                content_blocks = [{"type": "text", "text": msg.get("content", "")}]
+            if merged and merged[-1].get("role") == "user" and "content_blocks" in merged[-1] and merged[-1].get("task") is None:
+                merged[-1]["content_blocks"].extend(content_blocks)
+            else:
+                # Preserve structured content and all message-level metadata.
+                new_msg = msg
+                new_msg["content_blocks"] = content_blocks
+                merged.append(new_msg)
+        else:
+            merged.append(msg)
+
+    return merged
+
+
+def sort_tool_results_by_call_order(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Sort tool_result blocks within user messages by the order of tool_calls
+    in the preceding assistant message.
+    """
+    last_tool_call_order: Dict[str, int] = {}
+
+    for msg in messages:
+        role = msg.get("role")
+        if role == "assistant" and msg.get("tool_calls"):
+            last_tool_call_order = {}
+            for idx, tc in enumerate(msg["tool_calls"]):
+                tc_id = tc.get("id") or tc.get("function", {}).get("id", "")
+                if tc_id:
+                    last_tool_call_order[tc_id] = idx
+
+        elif role == "user" and msg.get("content_blocks"):
+            tool_blocks = [b for b in msg["content_blocks"] if b.get("type") == "tool_result"]
+            if len(tool_blocks) > 1 and last_tool_call_order:
+                sorted_blocks = sorted(
+                    tool_blocks,
+                    key=lambda b: last_tool_call_order.get(b.get("tool_use_id", ""), 0)
+                )
+                sorted_idx = 0
+                new_blocks = []
+                for block in msg["content_blocks"]:
+                    if block.get("type") == "tool_result":
+                        new_blocks.append(sorted_blocks[sorted_idx])
+                        sorted_idx += 1
+                    else:
+                        new_blocks.append(block)
+                msg["content_blocks"] = new_blocks
+
+    return messages
+
+
+# ============================================================
+# Vision Message Preprocessing
+# ============================================================
+
+def parse_tagged_text(text: str) -> Union[str, List[Dict[str, Any]]]:
+    """Convert ``<image>path</image>`` text into standard content blocks."""
+    matches = list(IMAGE_TAG_PATTERN.finditer(text))
+    remaining = IMAGE_TAG_PATTERN.sub("", text)
+    if "<image>" in remaining or "</image>" in remaining:
+        raise ValueError("Malformed <image>path</image> tag")
+    if not matches:
+        return text
+
+    blocks: List[Dict[str, Any]] = []
+    cursor = 0
+    for match in matches:
+        if match.start() > cursor:
+            blocks.append({"type": "text", "text": text[cursor:match.start()]})
+        path = match.group(1)
+        if not path:
+            raise ValueError("Image path must not be empty")
+        blocks.append({
+            "type": "image_url",
+            "image_url": {"url": path},
+        })
+        cursor = match.end()
+    if cursor < len(text):
+        blocks.append({"type": "text", "text": text[cursor:]})
+    return blocks
+
+
+def _is_image_block(block: Dict[str, Any]) -> bool:
+    """Return whether a content block is an OpenAI/Anthropic/internal image."""
+    return isinstance(block, dict) and block.get("type") in ("image", "image_url")
+
+
+def _extract_image(block: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize a supported image block into an internal image record."""
+    record: Dict[str, Any] = {"type": "image"}
+    if block.get("type") == "image_url":
+        image_url = block.get("image_url")
+        if isinstance(image_url, str):
+            record["url"] = image_url
+        else:
+            record["url"] = (image_url or {}).get("url", "")
+    else:
+        for key in ("source", "url", "data"):
+            if key in block:
+                record[key] = block[key]
+    if not any(record.get(key) for key in ("source", "url", "data")):
+        raise ValueError("Image block does not contain a valid source")
+    return record
+
+
+def _process_image_blocks(
+    blocks: List[Any], image_placeholder: str = IMAGE_PLACEHOLDER
+) -> Tuple[List[Any], List[Dict[str, Any]]]:
+    """Replace image blocks and collect their records in one ordered traversal."""
+    new_blocks: List[Any] = []
+    images: List[Dict[str, Any]] = []
+    for block in blocks:
+        if not isinstance(block, dict):
+            new_blocks.append(block)
+            continue
+        if _is_image_block(block):
+            new_blocks.append({"type": "text", "text": image_placeholder})
+            images.append(_extract_image(block))
+        elif block.get("type") == "tool_result" and isinstance(block.get("content"), list):
+            block = copy.copy(block)
+            block["content"], nested_images = _process_image_blocks(
+                block["content"], image_placeholder)
+            new_blocks.append(block)
+            images.extend(nested_images)
+        elif block.get("type") == "text":
+            text = block.get("text") or ""
+            if IMAGE_PLACEHOLDER in text:
+                raise ValueError(
+                    f"Text block contains image placeholder '{IMAGE_PLACEHOLDER}': "
+                    f"'{text[:100]}'. Images should be separate content blocks."
+                )
+            new_blocks.append(block)
+        else:
+            new_blocks.append(block)
+    return new_blocks, images
+
+
+def _validate_no_image_sp_tokens(msg: Dict[str, Any]) -> None:
+    """Reject user-supplied image placeholder tokens in textual fields."""
+    content = msg.get("content")
+    if isinstance(content, str) and IMAGE_PLACEHOLDER in content:
+        raise ValueError(
+            f"Message content contains image special token '{IMAGE_PLACEHOLDER}'. "
+            "Images should be provided as image content blocks."
+        )
+    reasoning_content = msg.get("reasoning_content")
+    if isinstance(reasoning_content, str) and IMAGE_PLACEHOLDER in reasoning_content:
+        raise ValueError(
+            f"reasoning_content contains image special token '{IMAGE_PLACEHOLDER}'"
+        )
+
+
+def process_image_messages(
+    messages: List[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Normalize image blocks and return their records in prompt order."""
+    processed: List[Dict[str, Any]] = []
+    images: List[Dict[str, Any]] = []
+    for msg in messages:
+        msg = copy.deepcopy(msg)
+        _validate_no_image_sp_tokens(msg)
+
+        if isinstance(msg.get("content"), list) and "content_blocks" not in msg:
+            msg["content_blocks"] = msg.pop("content")
+
+        if msg.get("content_blocks"):
+            msg["content_blocks"], message_images = _process_image_blocks(
+                msg["content_blocks"])
+            images.extend(message_images)
+            if not isinstance(msg.get("content"), str):
+                texts = [
+                    block.get("text", "")
+                    for block in msg["content_blocks"]
+                    if isinstance(block, dict) and block.get("type") == "text"
+                ]
+                msg["content"] = "\n\n".join(texts)
+
+        processed.append(msg)
+    return processed, images
+
+
+def _read_until_stop(index: int, text: str, stop: List[str]) -> Tuple[int, str, Optional[str]]:
+    """
+    Read text from index until one of the stop strings is found.
+
+    Returns:
+        Tuple of (new_index, content_before_stop, matched_stop_string_or_None).
+    """
+    min_pos = len(text)
+    matched_stop = None
+
+    for s in stop:
+        pos = text.find(s, index)
+        if pos != -1 and pos < min_pos:
+            min_pos = pos
+            matched_stop = s
+
+    if matched_stop:
+        content = text[index:min_pos]
+        return min_pos + len(matched_stop), content, matched_stop
+    else:
+        content = text[index:]
+        return len(text), content, None
+
+# ============================================================
+# V4.1 Special Tokens and DSML Tag Names
+# ============================================================
+
+SYSTEM_SP_TOKEN = "<｜System｜>"
+
+tool_calls_block_name: str = " calls"
+tool_call_tag_name: str = " invoke"
+tool_parameter_tag_name: str = " parameter"
+
+tool_call_template: str = (
+    "<{dsml_token}{tool_call_tag_name} name=\"{name}\">\n{arguments}\n</{dsml_token}{tool_call_tag_name}>"
+)
+tool_calls_template = (
+    "<{dsml_token}{tc_block_name}>\n{tool_calls}\n</{dsml_token}{tc_block_name}>"
+)
+
+# ============================================================
+# Reasoning Effort (numeric budget)
+# ============================================================
+
+REASONING_EFFORT_TEMPLATE = (
+    "Reasoning Effort: {budget} "
+    "(range 1-100, the higher the value, the more thorough the reasoning)\n\n"
+)
+
+REASONING_EFFORT_MAPPINGS: Dict[str, int] = {
+    "low": 25,
+    "high": 50,
+    "xhigh": 75,
+    "max": 100,
+}
+DEFAULT_REASONING_EFFORT = "high"
+
+
+def render_reasoning_effort(
+    index: int,
+    thinking_mode: str,
+    effort: Union[str, int, None],
+) -> str:
+    """Render the V4.1 numeric reasoning effort prefix (thinking mode, index 0 only)."""
+    if effort is None:
+        effort = DEFAULT_REASONING_EFFORT
+    assert (
+        type(effort) is int and 1 <= effort <= 100
+    ) or effort in REASONING_EFFORT_MAPPINGS, (
+        "Invalid reasoning effort for deepseek_v41: "
+        f"{effort}, should be int within [1,100] or {list(REASONING_EFFORT_MAPPINGS)}"
+    )
+    if type(effort) is str:
+        effort = REASONING_EFFORT_MAPPINGS[effort]
+    if index == 0 and thinking_mode == "thinking":
+        return REASONING_EFFORT_TEMPLATE.format(budget=effort)
+    return ""
+
+
+# ============================================================
+# Tools rendering
+# ============================================================
+
+TOOLS_TEMPLATE = """## Tools
+
+You have access to a set of tools to help answer the user's question. You can invoke tools by writing a "<{dsml_token}{tc_block_name}>" block like the following:
+
+<{dsml_token}{tc_block_name}>
+<{dsml_token}{tool_call_tag_name} name="$TOOL_NAME">
+<{dsml_token}{tool_parameter_tag_name} name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</{dsml_token}{tool_parameter_tag_name}>
+...
+</{dsml_token}{tool_call_tag_name}>
+<{dsml_token}{tool_call_tag_name} name="$TOOL_NAME2">
+...
+</{dsml_token}{tool_call_tag_name}>
+</{dsml_token}{tc_block_name}>
+
+String parameters should be specified as is and set `string="true"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string="false"`.
+
+If thinking_mode is enabled (triggered by {thinking_start_token}), you MUST output your complete reasoning inside {thinking_start_token}...{thinking_end_token} BEFORE any tool calls or final response.
+
+Otherwise, output directly after {thinking_end_token} with tool calls or final response.
+
+### Available Tool Schemas
+
+{tool_schemas}
+
+You MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.
+"""
+
+
+def render_tools(tools: List[Dict[str, Union[str, Dict[str, Any]]]]) -> str:
+    """Render tool schemas into the V4.1 system prompt format."""
+    tools_json = [to_json(t) for t in tools]
+
+    return TOOLS_TEMPLATE.format(
+        tool_schemas="\n".join(tools_json),
+        dsml_token=dsml_token,
+        tc_block_name=tool_calls_block_name,
+        tool_call_tag_name=tool_call_tag_name,
+        tool_parameter_tag_name=tool_parameter_tag_name,
+        thinking_start_token=thinking_start_token,
+        thinking_end_token=thinking_end_token,
+    )
+
+
+def encode_arguments_to_dsml(tool_call: Dict[str, Any]) -> str:
+    """Encode tool call arguments into V4.1 DSML parameter format."""
+    p_dsml_template = (
+        '<{dsml_token}{tool_parameter_tag_name} name="{key}" string="{is_str}">'
+        '{value}</{dsml_token}{tool_parameter_tag_name}>'
+    )
+    P_dsml_strs = []
+
+    arguments = tool_call["arguments"]
+    if not isinstance(arguments, dict):
+        # Tolerate JSON strings, including double-encoded ones.
+        for _ in range(2):
+            if isinstance(arguments, str):
+                try:
+                    arguments = json.loads(arguments)
+                except Exception:
+                    break
+            else:
+                break
+        if not isinstance(arguments, dict):
+            arguments = {"arguments": tool_call["arguments"]}
+
+    for k, v in arguments.items():
+        P_dsml_strs.append(p_dsml_template.format(
+            dsml_token=dsml_token,
+            tool_parameter_tag_name=tool_parameter_tag_name,
+            key=k,
+            is_str="true" if isinstance(v, str) else "false",
+            value=v if isinstance(v, str) else to_json(v),
+        ))
+
+    return "\n".join(P_dsml_strs)
+
+
+# ============================================================
+# Message Rendering
+# ============================================================
+
+def find_last_user_index(messages: List[Dict[str, Any]]) -> int:
+    """
+    Find the index of the last user message.
+
+    V4.1 supports mid-conversation system messages, which count as user
+    messages for the purposes of the assistant generation header.
+    """
+    last_user_index = -1
+    for idx in range(len(messages) - 1, -1, -1):
+        role = messages[idx].get("role")
+        if role == "user" or (role == "system" and idx > 0):
+            last_user_index = idx
+            break
+    return last_user_index
+
+
+def render_message(
+    index: int,
+    messages: List[Dict[str, Any]],
+    thinking_mode: str,
+    drop_thinking: bool = True,
+    reasoning_effort: Union[str, int, None] = None,
+) -> str:
+    """
+    Render a single message at the given index into its V4.1 encoded string form.
+    """
+    assert 0 <= index < len(messages)
+    assert thinking_mode in ["chat", "thinking"], f"Invalid thinking_mode `{thinking_mode}`"
+
+    msg = messages[index]
+    last_user_idx = find_last_user_index(messages)
+
+    role = msg.get("role")
+    content = msg.get("content")
+    tools = msg.get("tools")
+    response_format = msg.get("response_format")
+    tool_calls = msg.get("tool_calls")
+    reasoning_content = msg.get("reasoning_content")
+    wo_eos = msg.get("wo_eos", False)
+
+    if tools:
+        tools = tools_from_openai_format(tools)
+    if tool_calls:
+        tool_calls = tool_calls_from_openai_format(tool_calls)
+
+    # Reasoning effort prefix (thinking mode, index 0 only)
+    reasoning_effort_prompt = render_reasoning_effort(index, thinking_mode, reasoning_effort)
+    # System token leads the conversation when there is a reasoning effort prompt
+    # or the first message is a system message.
+    prompt = SYSTEM_SP_TOKEN if index == 0 and (reasoning_effort_prompt or role == "system") else ""
+    prompt += reasoning_effort_prompt
+
+    if role == "system":
+        if index > 0:
+            # Mid-conversation system message
+            prompt += SYSTEM_SP_TOKEN
+        prompt += system_msg_template.format(content=content or "")
+        if tools:
+            prompt += "\n\n" + render_tools(tools)
+        if response_format:
+            prompt += "\n\n" + response_format_template.format(schema=to_json(response_format))
+
+    elif role == "user":
+        prompt += USER_SP_TOKEN
+
+        # Handle content blocks (tool results mixed with text)
+        content_blocks = msg.get("content_blocks")
+        if content_blocks:
+            parts = []
+            for block in content_blocks:
+                block_type = block.get("type")
+                if block_type == "text":
+                    parts.append(block.get("text", ""))
+                elif block_type == "tool_result":
+                    tool_content = block.get("content", "")
+                    if isinstance(tool_content, list):
+                        text_parts = []
+                        for b in tool_content:
+                            if b.get("type") == "text":
+                                text_parts.append(b.get("text", ""))
+                            else:
+                                text_parts.append(f"[Unsupported {b.get('type')}]")
+                        tool_content = "\n\n".join(text_parts)
+                    parts.append(tool_output_template.format(content=tool_content))
+                else:
+                    parts.append(f"[Unsupported {block_type}]")
+            prompt += "\n\n".join(parts)
+        else:
+            prompt += content or ""
+
+    elif role == "latest_reminder":
+        prompt += LATEST_REMINDER_SP_TOKEN + latest_reminder_msg_template.format(content=content)
+
+    elif role == "tool":
+        raise NotImplementedError("deepseek_v41 merges tool messages into user; please preprocess with merge_tool_messages()")
+
+    elif role == "assistant":
+        thinking_part = ""
+        tc_content = ""
+
+        if tool_calls:
+            tc_list = [
+                tool_call_template.format(
+                    dsml_token=dsml_token,
+                    tool_call_tag_name=tool_call_tag_name,
+                    name=tc.get("name"),
+                    arguments=encode_arguments_to_dsml(tc)
+                )
+                for tc in tool_calls
+            ]
+            tc_content += '\n\n' + tool_calls_template.format(
+                dsml_token=dsml_token,
+                tool_calls="\n".join(tc_list),
+                tc_block_name=tool_calls_block_name,
+            )
+
+        summary_content = content or ""
+        rc = reasoning_content or ""
+
+        # Check if previous message has a task - if so, this is a task output (no thinking)
+        prev_has_task = index - 1 >= 0 and messages[index - 1].get("task") is not None
+
+        if thinking_mode == "thinking" and not prev_has_task:
+            if not drop_thinking or index > last_user_idx:
+                thinking_part = thinking_template.format(reasoning_content=rc) + thinking_end_token
+            else:
+                thinking_part = ""
+
+        if wo_eos:
+            prompt += assistant_msg_wo_eos_template.format(
+                reasoning=thinking_part,
+                content=summary_content,
+                tool_calls=tc_content,
+            )
+        else:
+            prompt += assistant_msg_template.format(
+                reasoning=thinking_part,
+                content=summary_content,
+                tool_calls=tc_content,
+            )
+    else:
+        raise NotImplementedError(f"Unknown role: {role}")
+
+    # Append transition tokens based on what follows
+    if index + 1 < len(messages) and messages[index + 1].get("role") not in ["assistant", "latest_reminder"]:
+        return prompt
+
+    task = messages[index].get("task")
+    if task is not None:
+        # Task special token for internal classification tasks
+        assert task in VALID_TASKS, f"Invalid task: '{task}'. Valid tasks are: {list(VALID_TASKS)}"
+        task_sp_token = DS_TASK_SP_TOKENS[task]
+
+        if task != "action":
+            # Non-action tasks: append task sp token directly after the message
+            prompt += task_sp_token
+        else:
+            # Action task: append Assistant + thinking token + action sp token
+            prompt += ASSISTANT_SP_TOKEN
+            prompt += thinking_end_token if thinking_mode != "thinking" else thinking_start_token
+            prompt += task_sp_token
+
+    elif role == "user" or (role == "system" and index > 0):
+        # Normal generation: append Assistant + thinking token
+        # (mid-conversation system messages also trigger the assistant header)
+        prompt += ASSISTANT_SP_TOKEN
+        if not drop_thinking and thinking_mode == "thinking":
+            prompt += thinking_start_token
+        elif drop_thinking and thinking_mode == "thinking" and index >= last_user_idx:
+            prompt += thinking_start_token
+        else:
+            prompt += thinking_end_token
+
+    return prompt
+
+
+# ============================================================
+# Main Encoding Function
+# ============================================================
+
+def _drop_thinking_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Drop reasoning_content and non-essential messages before the last user message.
+    Same as V4, but uses the V4.1 last-user definition (mid systems count).
+    """
+    last_user_idx = find_last_user_index(messages)
+    result = []
+    keep_roles = {"user", "system", "tool", "latest_reminder", "direct_search_results"}
+
+    for idx, msg in enumerate(messages):
+        role = msg.get("role")
+        if role in keep_roles or idx >= last_user_idx:
+            result.append(msg)
+        elif role == "assistant":
+            msg = copy.copy(msg)
+            msg.pop("reasoning_content", None)
+            result.append(msg)
+
+    return result
+
+
+def _encode_messages_text(
+    messages: List[Dict[str, Any]],
+    thinking_mode: str,
+    context: Optional[List[Dict[str, Any]]] = None,
+    drop_thinking: bool = True,
+    add_default_bos_token: bool = True,
+    reasoning_effort: Union[str, int, None] = None,
+) -> str:
+    """Encode preprocessed (text-only) messages into the V4.1 prompt format."""
+    context = context if context else []
+
+    # Preprocess: merge tool messages and sort tool results
+    messages = merge_tool_messages(messages)
+    messages = sort_tool_results_by_call_order(context + messages)[len(context):]
+    if context:
+        context = merge_tool_messages(context)
+        context = sort_tool_results_by_call_order(context)
+
+    full_messages = context + messages
+
+    prompt = bos_token if add_default_bos_token and len(context) == 0 else ""
+
+    # Resolve drop_thinking: if any message has tools defined, don't drop thinking
+    effective_drop_thinking = drop_thinking
+    if any(m.get("tools") for m in full_messages):
+        effective_drop_thinking = False
+
+    if thinking_mode == "thinking" and effective_drop_thinking:
+        full_messages = _drop_thinking_messages(full_messages)
+        num_to_render = len(full_messages) - len(_drop_thinking_messages(context))
+        context_len = len(full_messages) - num_to_render
+    else:
+        num_to_render = len(messages)
+        context_len = len(context)
+
+    for idx in range(num_to_render):
+        prompt += render_message(
+            idx + context_len,
+            full_messages,
+            thinking_mode=thinking_mode,
+            drop_thinking=effective_drop_thinking,
+            reasoning_effort=reasoning_effort,
+        )
+
+    return prompt
+
+
+def encode_messages(
+    messages: List[Dict[str, Any]],
+    thinking_mode: str,
+    context: Optional[List[Dict[str, Any]]] = None,
+    drop_thinking: bool = True,
+    add_default_bos_token: bool = True,
+    reasoning_effort: Union[str, int, None] = None,
+    return_multi_modal_data: bool = False,
+) -> Any:
+    """Encode text or multimodal messages into the DeepSeek-V4.1 prompt format.
+
+    Text-only calls return the prompt string. When return_multi_modal_data is
+    true, the result is ``(prompt, media_data)``.
+    """
+    context = context or []
+    processed_context, _ = process_image_messages(context) if context else ([], [])
+    processed_messages, images = process_image_messages(messages)
+    prompt = _encode_messages_text(
+        processed_messages,
+        thinking_mode=thinking_mode,
+        context=processed_context if processed_context else None,
+        drop_thinking=drop_thinking,
+        add_default_bos_token=add_default_bos_token,
+        reasoning_effort=reasoning_effort,
+    )
+    if return_multi_modal_data:
+        return prompt, {"images": images}
+    return prompt
+
+
+def load_cases(input_file: str) -> List[Dict[str, Any]]:
+    """Load one or more OpenAI-format conversation cases from JSON."""
+    with open(input_file) as file:
+        data = json.load(file)
+    if isinstance(data, dict):
+        data = [data]
+    elif data and isinstance(data[0], dict) and "role" in data[0]:
+        data = [{"messages": data}]
+
+    cases = []
+    for case in data:
+        messages = copy.deepcopy(case["messages"])
+        if "tools" in case:
+            if not messages:
+                raise ValueError("A case with tools must contain at least one message")
+            messages[0]["tools"] = case["tools"]
+        cases.append({
+            "messages": messages,
+            "context": case.get("context"),
+            "thinking_mode": case.get("thinking_mode"),
+            "reasoning_effort": case.get("reasoning_effort"),
+        })
+    return cases
+
+
+def encode_case(
+    case: Dict[str, Any], thinking_mode: str
+) -> Tuple[str, List[Dict[str, Any]]]:
+    """Encode one JSON case and return its current-turn image records."""
+    prompt, media_data = encode_messages(
+        case["messages"],
+        thinking_mode=case.get("thinking_mode") or thinking_mode,
+        context=case.get("context"),
+        reasoning_effort=case.get("reasoning_effort"),
+        return_multi_modal_data=True,
+    )
+    return prompt, media_data["images"]
+
+
+# ============================================================
+# Parsing (Decoding model output)
+# ============================================================
+
+def parse_tool_calls(index: int, text: str) -> Tuple[int, Optional[str], List[Dict[str, str]]]:
+    """
+    Parse V4.1 DSML tool calls from text starting at the given index.
+
+    Returns:
+        Tuple of (new_index, last_stop_token, list_of_tool_call_dicts).
+    """
+    tool_calls: List[Dict[str, Any]] = []
+    stop_token = None
+    tool_calls_end_token = f"</{dsml_token}{tool_calls_block_name}>"
+    tool_call_start_token = f"<{dsml_token}{tool_call_tag_name}"
+    tool_call_end_token = f"</{dsml_token}{tool_call_tag_name}"
+    tool_parameter_start_token = f"<{dsml_token}{tool_parameter_tag_name}"
+    tool_parameter_end_token = f"/{dsml_token}{tool_parameter_tag_name}"
+
+    while index < len(text):
+        index, _, stop_token = _read_until_stop(index, text, [tool_call_start_token, tool_calls_end_token])
+        if _ != ">\n":
+            raise ValueError(f"Tool call format error: expected '>\\n' but got '{_}'")
+
+        if stop_token == tool_calls_end_token:
+            break
+
+        if stop_token is None:
+            raise ValueError("Missing special token in tool calls")
+
+        index, tool_name_content, stop_token = _read_until_stop(index, text, [tool_parameter_start_token, tool_call_end_token])
+
+        p_tool_name = re.findall(r'^\s*name="(.*?)">\n$', tool_name_content, flags=re.DOTALL)
+        if len(p_tool_name) != 1:
+            raise ValueError(f"Tool name format error: '{tool_name_content}'")
+        tool_name = p_tool_name[0]
+
+        tool_args: Dict[str, Tuple[str, str]] = {}
+        while stop_token == tool_parameter_start_token:
+            index, param_content, stop_token = _read_until_stop(index, text, [tool_parameter_end_token])
+
+            param_kv = re.findall(r'^ name="(.*?)" string="(true|false)">(.*?)<$', param_content, flags=re.DOTALL)
+            if len(param_kv) != 1:
+                raise ValueError(f"Parameter format error: '{param_content}'")
+            param_name, string, param_value = param_kv[0]
+
+            if param_name in tool_args:
+                raise ValueError(f"Duplicate parameter name: '{param_name}'")
+            tool_args[param_name] = (param_value, string)
+
+            index, content, stop_token = _read_until_stop(index, text, [tool_parameter_start_token, tool_call_end_token])
+            if content != ">\n":
+                raise ValueError(f"Parameter format error: expected '>\\n' but got '{content}'")
+
+        tool_call = decode_dsml_to_arguments(tool_name=tool_name, tool_args=tool_args)
+        tool_calls.append(tool_call)
+
+    return index, stop_token, tool_calls
+
+
+def parse_message_from_completion_text(text: str, thinking_mode: str) -> Dict[str, Any]:
+    """
+    Parse a model completion text into a structured assistant message (V4.1 format).
+
+    Returns:
+        Dict with keys: "role", "content", "reasoning_content", "tool_calls".
+        tool_calls are in OpenAI format.
+    """
+    summary_content, reasoning_content, tool_calls = "", "", []
+    index, stop_token = 0, None
+    tool_calls_start_token = f"\n\n<{dsml_token}{tool_calls_block_name}"
+
+    is_thinking = thinking_mode == "thinking"
+    is_tool_calling = False
+
+    if is_thinking:
+        index, content_delta, stop_token = _read_until_stop(index, text, [thinking_end_token, tool_calls_start_token])
+        reasoning_content = content_delta
+        assert stop_token == thinking_end_token, "Invalid thinking format: missing </think>"
+
+    index, content_delta, stop_token = _read_until_stop(index, text, [eos_token, tool_calls_start_token])
+    summary_content = content_delta
+    if stop_token == tool_calls_start_token:
+        is_tool_calling = True
+    else:
+        assert stop_token == eos_token, "Invalid format: missing EOS token"
+
+    if is_tool_calling:
+        index, stop_token, tool_calls = parse_tool_calls(index, text)
+
+        index, tool_ends_text, stop_token = _read_until_stop(index, text, [eos_token])
+        assert not tool_ends_text, "Unexpected content after tool calls"
+
+    assert len(text) == index and stop_token in [eos_token, None], "Unexpected content at end"
+
+    for sp_token in [bos_token, eos_token, thinking_start_token, thinking_end_token, dsml_token]:
+        assert sp_token not in summary_content and sp_token not in reasoning_content, \
+            f"Unexpected special token '{sp_token}' in content"
+
+    return {
+        "role": "assistant",
+        "content": summary_content,
+        "reasoning_content": reasoning_content,
+        "tool_calls": tool_calls_to_openai_format(tool_calls)
+    }
+
+
+# ============================================================
+# mlx-lm adapter
+# ============================================================
+
+supports_mid_system_messages = True
+
+
+def apply_chat_template(
+    messages,
+    continue_final_message: bool = False,
+    add_generation_prompt: bool = False,
+    **kwargs,
+):
+    """Expose the official V4.1 encoder through mlx-lm's template API."""
+    if continue_final_message and add_generation_prompt:
+        raise ValueError(
+            "Only one of continue_final_message or add_generation_prompt can be True"
+        )
+
+    # mlx TokenizerWrapper always injects enable_thinking=self.has_thinking
+    # (a property True when think tokens exist). Ignore that auto flag;
+    # callers who want thinking must pass thinking_mode="thinking".
+    kwargs.pop("enable_thinking", None)
+    kwargs.setdefault("thinking_mode", "chat")
+    kwargs.setdefault("add_default_bos_token", True)
+    if kwargs.get("thinking_mode") != "thinking":
+        kwargs.setdefault("reasoning_effort", None)
+
+    accepted = {
+        "thinking_mode",
+        "context",
+        "drop_thinking",
+        "add_default_bos_token",
+        "reasoning_effort",
+    }
+    encode_kwargs = {key: value for key, value in kwargs.items() if key in accepted}
+    # Drop tools kw if present — full DSML tool wiring can land later.
+    kwargs.pop("tools", None)
+
+    out = encode_messages(messages, **encode_kwargs)
+
+    if not add_generation_prompt:
+        out = out.removesuffix(ASSISTANT_SP_TOKEN + thinking_start_token)
+        out = out.removesuffix(ASSISTANT_SP_TOKEN + thinking_end_token)
+    elif not out.endswith(
+        (
+            ASSISTANT_SP_TOKEN + thinking_start_token,
+            ASSISTANT_SP_TOKEN + thinking_end_token,
+            ASSISTANT_SP_TOKEN,
+        )
+    ):
+        if encode_kwargs.get("thinking_mode", "chat") == "thinking":
+            out += ASSISTANT_SP_TOKEN + thinking_start_token
+        else:
+            out += ASSISTANT_SP_TOKEN + thinking_end_token
+
+    if continue_final_message and messages and messages[-1].get("role") == "assistant":
+        out = out.removesuffix(eos_token)
+    return out
+
+
+apply_chat_template.supports_mid_system_messages = True  # type: ignore[attr-defined]

--- a/omlx/patches/deepseek_v41/deepseek_v41_model.py
+++ b/omlx/patches/deepseek_v41/deepseek_v41_model.py
@@ -1,0 +1,1622 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DeepSeek-V4.1 Flash MLX model (CSA2) for omlx.
+
+Ported from HuggingFace ``inference/model.py`` to MLX, following
+``omlx.patches.deepseek_v4.deepseek_v4_model`` style and reusing V4 kernels
+(wsdpa, SwitchGLU, HC sinkhorn, decode_consistency) without breaking V4.
+"""
+from __future__ import annotations
+
+import inspect
+import logging
+import math
+from dataclasses import dataclass, field
+from functools import partial
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.utils import tree_flatten
+
+from omlx.patches.deepseek_v4.decode_consistency import matmul as decode_matmul
+from omlx.patches.deepseek_v4.indexer_dispatch import (
+    disable_native_indexer,
+    native_indexer_available,
+    native_indexer_disabled,
+    native_indexer_shape_eligible,
+)
+from omlx.patches.deepseek_v4.switch_layers import SwitchGLU
+from omlx.patches.deepseek_v4.wsdpa_attention import wsdpa_prefill, wsdpa_topk_prefill
+from omlx.patches.deepseek_v41.deferred_hc import (
+    DeferredHyperConnection,
+    hc_collapse,
+    hc_expand,
+    make_identity_pre_mix,
+)
+from omlx.patches.deepseek_v41.engram import (
+    Engram,
+    EngramLayout,
+    bind_engram_hash,
+    engram_is_mmap,
+    engram_mode,
+    engram_tables_enabled,
+    prefetch_engram_layer,
+)
+from omlx.patches.deepseek_v41.select_candidates import select_candidate_blocks
+from omlx.patches.deepseek_v41.shared_runtime import SharedAttentionRuntime, shared_attn
+
+from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
+from .cache import CacheList, PoolingCache, RotatingKVCache
+from .hyper_connection import HyperHead
+from .mla import MultiLinear
+from .pipeline import PipelineMixin
+
+logger = logging.getLogger(__name__)
+
+_SUPPORTED_COMPRESS = frozenset({0, 1, 2})
+_V41_INDEXER_FALLBACK_WARNED = False
+
+
+def _extend_mask(mask: Optional[mx.array], pool_mask: Optional[mx.array], N: int):
+    """Append pooled-KV visibility onto a window mask (V4 helper port)."""
+    if mask is None:
+        return None
+    if mask.ndim == 2:
+        mask = mask[None, None]
+    B, H, L, S = mask.shape
+    if pool_mask is None:
+        pool_mask = mx.ones((B, H, L, N - S), dtype=mx.bool_)
+    elif pool_mask.ndim == 2:
+        pool_mask = mx.broadcast_to(pool_mask, (B, H, L, N - S))
+    elif pool_mask.ndim == 3:
+        pool_mask = mx.broadcast_to(pool_mask[:, None], (B, H, L, N - S))
+    return mx.concatenate([mask, pool_mask], axis=-1)
+
+
+
+def _flatten_text_config(params: dict) -> dict:
+    """Merge nested HF ``text_config`` into top-level ModelArgs fields."""
+    out = dict(params)
+    text = out.pop("text_config", None)
+    if isinstance(text, dict):
+        for k, v in text.items():
+            out.setdefault(k, v)
+    # Drop vision_config from text ModelArgs (vision is Phase-2 stub).
+    out.pop("vision_config", None)
+    # Alias HF -> internal names when needed
+    aliases = {
+        "score_func": "scoring_func",
+        "route_scale": "routed_scaling_factor",
+        "n_activated_experts": "num_experts_per_tok",
+        "window_size": "sliding_window",
+        "norm_eps": "rms_norm_eps",
+        "dim": "hidden_size",
+        "n_layers": "num_hidden_layers",
+        "n_heads": "num_attention_heads",
+        "moe_inter_dim": "moe_intermediate_size",
+        "rope_head_dim": "qk_rope_head_dim",
+        "kv_source_layers": "kv_source_layer_ids",
+        "index_source_layers": "index_source_layer_ids",
+        "candidate_source_layer": "candidate_source_layer_id",
+        "engram_pad_id": "engram_pad_token_id",
+        "dspark_n_activated_experts": "dspark_num_experts_per_tok",
+    }
+    for src, dst in aliases.items():
+        if src in out and dst not in out:
+            out[dst] = out[src]
+    # YaRN fields may be nested under rope_scaling already in HF config.
+    if "rope_scaling" not in out and out.get("original_seq_len"):
+        out["rope_scaling"] = {
+            "rope_type": "yarn",
+            "factor": out.get("rope_factor", 16),
+            "beta_fast": out.get("beta_fast", 32),
+            "beta_slow": out.get("beta_slow", 1),
+            "original_max_position_embeddings": out["original_seq_len"],
+        }
+    return out
+
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    model_type: str = "deepseek_v41"
+    vocab_size: int = 129280
+    hidden_size: int = 5120
+    intermediate_size: int = 18432
+    moe_intermediate_size: int = 2304
+    num_hidden_layers: int = 40
+    num_attention_heads: int = 64
+    num_key_value_heads: int = 1
+    n_shared_experts: int = 1
+    n_routed_experts: int = 384
+    routed_scaling_factor: float = 1.5
+    q_lora_rank: int = 1280
+    qk_rope_head_dim: int = 64
+    num_experts_per_tok: int = 6
+    norm_topk_prob: bool = True
+    hidden_act: str = "silu"
+    max_position_embeddings: int = 1048576
+    rms_norm_eps: float = 1e-20
+    rope_theta: float = 10000.0
+    rope_scaling: Optional[Dict] = None
+    attention_bias: bool = False
+    attention_dropout: float = 0.0
+    head_dim: int = 512
+    scoring_func: str = "sqrtsoftplus"
+    compress_ratios: List[int] = field(default_factory=list)
+    compress_rope_theta: float = 160000.0
+    hc_mult: int = 4
+    hc_sinkhorn_iters: int = 20
+    hc_eps: float = 1e-6
+    swiglu_limit: float = 10.0
+    sliding_window: int = 128
+    o_groups: int = 8
+    o_lora_rank: int = 1024
+    index_n_heads: int = 32
+    index_head_dim: int = 128
+    index_topk: int = 512
+    kv_source_layer_ids: List[int] = field(default_factory=list)
+    index_source_layer_ids: List[int] = field(default_factory=list)
+    candidate_source_layer_id: int = -1
+    candidate_topk_blocks: int = 2048
+    candidate_block_size: int = 8
+    engram_layer_ids: List[int] = field(default_factory=list)
+    engram_num_embeddings: List[int] = field(default_factory=list)
+    engram_max_ngram_size: int = 4
+    engram_vocab_size: int = 16000000
+    engram_n_heads: int = 8
+    engram_head_dim: int = 256
+    engram_pad_token_id: int = 2
+    engram_compressed_vocab_size: int = 99092
+    num_nextn_predict_layers: int = 3
+    n_mtp_layers: int = 3
+    dspark_block_size: int = 5
+    dspark_noise_token_id: int = 128799
+    dspark_target_layer_ids: List[int] = field(default_factory=list)
+    dspark_markov_rank: int = 256
+    dspark_n_routed_experts: int = 128
+    dspark_num_experts_per_tok: int = 3
+    tie_word_embeddings: bool = False
+    topk_method: str = "noaux_tc"
+    image_token_id: int = 129264
+    # Vision stub markers
+    vision_enabled: bool = False
+    vision_config: Optional[Dict] = None
+
+    @classmethod
+    def from_dict(cls, params):
+        flat = _flatten_text_config(params)
+        # vision_enabled from nested vision_config
+        vc = params.get("vision_config") if isinstance(params, dict) else None
+        if isinstance(vc, dict) and int(vc.get("num_hidden_layers", 0) or 0) > 0:
+            flat["vision_enabled"] = True
+            flat["vision_config"] = vc
+        sig = inspect.signature(cls)
+        return cls(**{k: v for k, v in flat.items() if k in sig.parameters})
+
+    def __post_init__(self):
+        if isinstance(self.compress_ratios, tuple):
+            self.compress_ratios = list(self.compress_ratios)
+        if not self.compress_ratios:
+            # Minimal default for tiny unit tests: all window-only
+            self.compress_ratios = [0] * self.num_hidden_layers
+        # Config may include MTP trailing ratios; trim or pad to backbone layers
+        ratios = list(self.compress_ratios)
+        if len(ratios) < self.num_hidden_layers:
+            ratios = ratios + [0] * (self.num_hidden_layers - len(ratios))
+        self.compress_ratios = ratios[: self.num_hidden_layers]
+        bad = [r for r in self.compress_ratios if r not in _SUPPORTED_COMPRESS]
+        if bad:
+            raise ValueError(
+                f"Unsupported DeepSeek-V4.1 compress ratios {bad}; "
+                f"allowed {_SUPPORTED_COMPRESS}"
+            )
+        self.kv_source_layer_ids = list(self.kv_source_layer_ids or [])
+        self.index_source_layer_ids = list(self.index_source_layer_ids or [])
+        self.engram_layer_ids = list(self.engram_layer_ids or [])
+        self.engram_num_embeddings = list(self.engram_num_embeddings or [])
+        self.dspark_target_layer_ids = list(self.dspark_target_layer_ids or [])
+        if self.n_mtp_layers <= 0 and self.num_nextn_predict_layers:
+            self.n_mtp_layers = int(self.num_nextn_predict_layers)
+        # Engram tables are ~190GB on Flash. stub/off: disable layer hooks.
+        # mmap/ssd/full: keep engram_layer_ids (mmap does not allocate tables in RAM).
+        if not engram_tables_enabled():
+            self.engram_layer_ids = []
+            self.engram_num_embeddings = []
+
+    def get_moe_config(self, layer_id: int) -> Tuple[int, int]:
+        if layer_id < self.num_hidden_layers:
+            return self.n_routed_experts, self.num_experts_per_tok
+        return (
+            self.dspark_n_routed_experts or self.n_routed_experts,
+            self.dspark_num_experts_per_tok or self.num_experts_per_tok,
+        )
+
+
+def make_quantization_config(model):
+    """Quant notes (paper / convert): window fp8@32; compress KV fp4@16/E4M3;
+    index fp4@32; weight block 32x32. Experts mxfp4; shared/attn mxfp8."""
+    mxfp4 = {"group_size": 32, "bits": 4, "mode": "mxfp4"}
+    mxfp8 = {"group_size": 32, "bits": 8, "mode": "mxfp8"}
+
+    flat_modules = tree_flatten(model.leaf_modules(), is_leaf=nn.Module.is_module)
+    experts = {
+        k: mxfp4
+        for k, _ in flat_modules
+        if ".ffn.switch_mlp." in k and k.endswith("_proj")
+    }
+    shared_experts = {k: mxfp8 for k, _ in flat_modules if ".ffn.shared_experts." in k}
+    attn = {
+        k: mxfp8
+        for k, _ in flat_modules
+        # indexer.wk is bf16 in the official checkpoint (not fp8).
+        if ".attn.w" in k or ".attn.indexer.wq" in k
+    }
+    mtp_projs = {
+        k: mxfp8
+        for k, _ in flat_modules
+        if k.startswith("mtp.")
+        and (k.endswith(".e_proj") or k.endswith(".h_proj") or k.endswith(".main_proj"))
+    }
+    engram_wkv = {k: mxfp8 for k, _ in flat_modules if k.endswith(".engram.wkv")}
+    return {
+        "group_size": 32,
+        "bits": 8,
+        "mode": "affine",
+        **experts,
+        **shared_experts,
+        **attn,
+        **mtp_projs,
+        **engram_wkv,
+    }
+
+
+def _score_func(scores: mx.array, func: str) -> mx.array:
+    if func == "softmax":
+        return mx.softmax(scores, axis=-1, precise=True)
+    if func == "sigmoid":
+        return mx.sigmoid(scores)
+    if func == "sqrtsoftplus":
+        return mx.sqrt(nn.softplus(scores))
+    raise ValueError(f"Unsupported scoring function: {func}")
+
+
+@mx.compile
+def _expert_select(
+    logits: mx.array,
+    e_score_correction_bias: mx.array,
+    top_k: int,
+    routed_scaling_factor: float,
+    norm_topk_prob: bool,
+    scoring_func: str,
+) -> Tuple[mx.array, mx.array]:
+    """Bias selects experts; weights come from unbiased scores (official Gate)."""
+    logits = logits.astype(mx.float32)
+    scores = _score_func(logits, scoring_func)
+    biased = scores + e_score_correction_bias
+    inds = mx.argpartition(-biased, kth=top_k - 1, axis=-1)[..., :top_k]
+    weights = mx.take_along_axis(scores, inds, axis=-1)
+    if scoring_func != "softmax" and norm_topk_prob:
+        weights = weights / (weights.sum(axis=-1, keepdims=True) + 1e-20)
+    weights = weights * routed_scaling_factor
+    return inds, weights
+
+
+@mx.compile
+def _limited_swiglu(gate: mx.array, up: mx.array, limit: float) -> mx.array:
+    if limit and limit > 0:
+        gate = mx.minimum(gate, limit)
+        up = mx.clip(up, -limit, limit)
+    return nn.silu(gate) * up
+
+
+class LimitedSwiGLU(nn.Module):
+    def __init__(self, limit: float):
+        super().__init__()
+        self.limit = limit
+
+    def __call__(self, x, gate):
+        return _limited_swiglu(gate, x, self.limit)
+
+
+class DeepseekV41RoPE(nn.Module):
+    def __init__(
+        self,
+        dims: int,
+        base: float,
+        scaling_config: Optional[Dict] = None,
+        max_position_embeddings: int = 1048576,
+        freq_scale: int = 1,
+    ):
+        super().__init__()
+        self.dims = dims
+        self.freq_scale = freq_scale
+        inv_freq = 1.0 / (base ** (mx.arange(0, dims, 2, dtype=mx.float32) / dims))
+        rope_type = None
+        if scaling_config is not None:
+            rope_type = scaling_config.get("type") or scaling_config.get("rope_type")
+        if rope_type in ("yarn", "deepseek_yarn"):
+            factor = scaling_config["factor"]
+            original_max_position_embeddings = scaling_config[
+                "original_max_position_embeddings"
+            ]
+            beta_fast = scaling_config.get("beta_fast", 32)
+            beta_slow = scaling_config.get("beta_slow", 1)
+
+            def correction_dim(num_rotations):
+                return (
+                    dims
+                    * math.log(
+                        original_max_position_embeddings / (num_rotations * 2 * math.pi)
+                    )
+                    / (2 * math.log(base))
+                )
+
+            low = max(math.floor(correction_dim(beta_fast)), 0)
+            high = min(math.ceil(correction_dim(beta_slow)), dims - 1)
+            if low == high:
+                high += 0.001
+            ramp = (mx.arange(dims // 2, dtype=mx.float32) - low) / (high - low)
+            smooth = 1 - mx.clip(ramp, 0, 1)
+            inv_freq = inv_freq / factor * (1 - smooth) + inv_freq * smooth
+        elif rope_type not in (None, "default"):
+            raise ValueError(f"Unsupported RoPE type: {rope_type}")
+        self._freqs = 1.0 / inv_freq
+        self._freqs_cache = {}
+
+    def _get_freqs(self, head_dim: int, inverse: bool):
+        key = (head_dim, inverse)
+        if key not in self._freqs_cache:
+            f = self._freqs
+            if self.freq_scale != 1:
+                f = f / self.freq_scale
+            if inverse:
+                f = -f
+            nope_pairs = (head_dim - self.dims) // 2
+            if nope_pairs > 0:
+                f = mx.concatenate([mx.full((nope_pairs,), mx.inf), f])
+            self._freqs_cache[key] = f
+        return self._freqs_cache[key]
+
+    def __call__(self, x: mx.array, offset: Any = 0, inverse: bool = False) -> mx.array:
+        head_dim = x.shape[-1]
+        freqs = self._get_freqs(head_dim, inverse)
+        offset = offset // self.freq_scale if self.freq_scale != 1 else offset
+        return mx.fast.rope(
+            x,
+            head_dim,
+            traditional=True,
+            base=None,
+            scale=1.0,
+            offset=offset,
+            freqs=freqs,
+        )
+
+
+@partial(mx.compile, shapeless=True)
+def _simple_compress_kv(kv, gate, head_dim):
+    """Softmax-gate pool over compress_ratio tokens. No APE (V4.1)."""
+    weights = mx.softmax(gate.astype(mx.float32), axis=-2)
+    weights = weights.astype(kv.dtype)
+    return (kv * weights).sum(axis=-2)
+
+class MoEGate(nn.Module):
+    def __init__(self, config: ModelArgs, layer_idx: int):
+        super().__init__()
+        n_routed, top_k = config.get_moe_config(layer_idx)
+        self.top_k = top_k
+        self.num_experts = n_routed
+        self.hidden_dim = config.hidden_size
+        self.scoring_func = config.scoring_func
+        self.routed_scaling_factor = config.routed_scaling_factor
+        self.norm_topk_prob = config.norm_topk_prob
+        self.weight = mx.zeros((self.num_experts, self.hidden_dim))
+        self.e_score_correction_bias = mx.zeros((self.num_experts,), dtype=mx.float32)
+        self.bias_vl = None
+        if config.vision_enabled:
+            self.bias_vl = mx.zeros((self.num_experts,), dtype=mx.float32)
+
+    def __call__(self, x: mx.array, image_mask: Optional[mx.array] = None):
+        logits = decode_matmul(x, self.weight.T)
+        bias = self.e_score_correction_bias
+        if image_mask is not None and self.bias_vl is not None:
+            m = image_mask
+            while m.ndim < logits.ndim:
+                m = m[..., None]
+            bias = mx.where(m, self.bias_vl, bias)
+        return _expert_select(
+            logits,
+            bias,
+            self.top_k,
+            self.routed_scaling_factor,
+            self.norm_topk_prob,
+            self.scoring_func,
+        )
+
+
+class DeepseekV41MLP(nn.Module):
+    def __init__(
+        self,
+        config: ModelArgs,
+        intermediate_size: Optional[int] = None,
+        swiglu_limit: float = 0.0,
+    ):
+        super().__init__()
+        hs = config.hidden_size
+        mid = intermediate_size or config.intermediate_size
+        self.gate_proj = nn.Linear(hs, mid, bias=False)
+        self.up_proj = nn.Linear(hs, mid, bias=False)
+        self.down_proj = nn.Linear(mid, hs, bias=False)
+        self.swiglu_limit = swiglu_limit
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(
+            _limited_swiglu(self.gate_proj(x), self.up_proj(x), self.swiglu_limit)
+        )
+
+
+class DeepseekV41MoE(nn.Module):
+    def __init__(self, config: ModelArgs, layer_idx: int):
+        super().__init__()
+        n_routed, _ = config.get_moe_config(layer_idx)
+        self.gate = MoEGate(config, layer_idx)
+        self.switch_mlp = SwitchGLU(
+            config.hidden_size,
+            config.moe_intermediate_size,
+            n_routed,
+            activation=LimitedSwiGLU(config.swiglu_limit),
+        )
+        self.shared_experts = DeepseekV41MLP(
+            config,
+            intermediate_size=config.moe_intermediate_size * config.n_shared_experts,
+            swiglu_limit=config.swiglu_limit,
+        )
+
+    def __call__(self, x: mx.array, image_mask: Optional[mx.array] = None) -> mx.array:
+        inds, scores = self.gate(x, image_mask)
+        y = self.switch_mlp(x, inds, scores=scores)
+        if y.ndim == scores.ndim + 1:
+            y = (y * scores[..., None].astype(y.dtype)).sum(-2)
+        return y + self.shared_experts(x)
+
+
+class Compressor(nn.Module):
+    """Pools compress_ratio tokens. No APE / no ratio-4 overlap (V4.1)."""
+
+    def __init__(self, config: ModelArgs, compress_ratio: int, head_dim: int):
+        super().__init__()
+        if compress_ratio not in (1, 2):
+            raise ValueError(f"V4.1 compressor expects ratio 1 or 2, got {compress_ratio}")
+        self.compress_ratio = compress_ratio
+        self.head_dim = head_dim
+        self.wkv = nn.Linear(config.hidden_size, head_dim, bias=False)
+        self.wgate = (
+            nn.Linear(config.hidden_size, head_dim, bias=False)
+            if compress_ratio > 1
+            else None
+        )
+        self.norm = nn.RMSNorm(head_dim, eps=config.rms_norm_eps)
+        self.rope = DeepseekV41RoPE(
+            config.qk_rope_head_dim,
+            config.compress_rope_theta,
+            config.rope_scaling,
+            config.max_position_embeddings,
+            freq_scale=compress_ratio,
+        )
+
+    def project(self, x: mx.array):
+        return self.wkv(x), (self.wgate(x) if self.wgate is not None else None)
+
+    def consume(
+        self,
+        kv: mx.array,
+        gate: Optional[mx.array],
+        pool_cache: Optional[PoolingCache],
+        offset: Union[int, mx.array],
+        apply_rope: bool = True,
+    ) -> mx.array:
+        B = kv.shape[0]
+        ratio = self.compress_ratio
+        if ratio == 1:
+            new_pooled = self.norm(kv)
+            if apply_rope:
+                new_pooled = self.rope(new_pooled[:, None], offset=offset).squeeze(1)
+            if pool_cache is not None:
+                new_pooled = pool_cache.update_and_fetch(new_pooled)
+            return new_pooled
+
+        if pool_cache is None:
+            usable = (kv.shape[1] // ratio) * ratio
+            ready_kv = kv[:, :usable]
+            ready_gate = gate[:, :usable]
+            pool_base = offset
+        else:
+            ready_kv, ready_gate, pool_base = pool_cache.accumulate_windows(
+                kv, gate, offset
+            )
+
+        if ready_kv.size == 0:
+            new_pooled = mx.zeros((B, 0, self.head_dim), dtype=kv.dtype)
+        else:
+            kv_u = mx.unflatten(ready_kv, 1, (-1, ratio))
+            gate_u = mx.unflatten(ready_gate, 1, (-1, ratio))
+            new_pooled = self.norm(_simple_compress_kv(kv_u, gate_u, self.head_dim))
+            if apply_rope:
+                new_pooled = self.rope(new_pooled[:, None], offset=pool_base).squeeze(1)
+
+        if pool_cache is not None:
+            new_pooled = pool_cache.update_and_fetch(new_pooled)
+        return new_pooled
+
+    def __call__(
+        self,
+        x: mx.array,
+        pool_cache: Optional[PoolingCache],
+        offset: Union[int, mx.array],
+        apply_rope: bool = True,
+    ) -> mx.array:
+        return self.consume(*self.project(x), pool_cache, offset, apply_rope=apply_rope)
+
+
+def _stable_topk_indices(scores: mx.array, k: int) -> mx.array:
+    partition = mx.argpartition(-scores, kth=k - 1, axis=-1)[..., :k]
+    selected = mx.take_along_axis(scores, partition, axis=-1)
+    threshold = mx.min(selected, axis=-1, keepdims=True)
+    size = scores.shape[-1]
+    positions = mx.arange(size, dtype=mx.uint32)
+    region = mx.where(
+        scores > threshold,
+        0,
+        mx.where(scores == threshold, 1, 2),
+    ).astype(mx.uint32)
+    keys = region * size + positions
+    indices = mx.argpartition(keys, kth=k - 1, axis=-1)[..., :k]
+    # wsdpa_topk / native sparse require uint32 temporally-sorted indices.
+    return mx.sort(indices, axis=-1).astype(mx.uint32)
+
+
+class Indexer(nn.Module):
+    """Indexer with wk from compressor latent; optional candidate blocks."""
+
+    def __init__(self, config: ModelArgs, layer_id: int):
+        super().__init__()
+        self.layer_id = layer_id
+        self.owns_k = layer_id in config.kv_source_layer_ids
+        self.compress_ratio = config.compress_ratios[layer_id]
+        self.is_candidate_source = layer_id == config.candidate_source_layer_id
+        self.uses_candidates = 0 <= config.candidate_source_layer_id < layer_id
+        self.candidate_topk_blocks = config.candidate_topk_blocks
+        self.candidate_block_size = config.candidate_block_size
+        self.n_heads = config.index_n_heads
+        self.index_head_dim = config.index_head_dim
+        self.index_topk = config.index_topk
+        self.softmax_scale = self.index_head_dim**-0.5
+        self.wq_b = nn.Linear(
+            config.q_lora_rank, self.n_heads * self.index_head_dim, bias=False
+        )
+        self.weights_proj = nn.Linear(config.hidden_size, self.n_heads, bias=False)
+        self.wk = None
+        self.k_norm = None
+        if self.owns_k:
+            self.wk = nn.Linear(config.head_dim, self.index_head_dim, bias=False)
+            self.k_norm = nn.RMSNorm(self.index_head_dim, eps=config.rms_norm_eps)
+        self.rope = DeepseekV41RoPE(
+            config.qk_rope_head_dim,
+            config.compress_rope_theta,
+            config.rope_scaling,
+            config.max_position_embeddings,
+            freq_scale=max(self.compress_ratio, 1),
+        )
+
+    def _resolve_index_k(
+        self,
+        latent: Optional[mx.array],
+        index_pool: Optional[PoolingCache],
+        offset: Union[int, mx.array],
+        runtime: SharedAttentionRuntime,
+    ) -> Optional[mx.array]:
+        if self.owns_k and latent is not None and latent.shape[1] > 0:
+            k = self.k_norm(self.wk(latent))
+            k = self.rope(k[:, None], offset=offset).squeeze(1)
+            if index_pool is not None:
+                k = index_pool.update_and_fetch(k)
+                runtime.index_k = index_pool
+            else:
+                runtime.index_k = k
+            return k
+        src = runtime.index_k
+        if src is None:
+            return None
+        if isinstance(src, PoolingCache):
+            return src.pooled
+        return src
+
+    def __call__(
+        self,
+        x: mx.array,
+        qr: mx.array,
+        latent: Optional[mx.array],
+        index_pool: Optional[PoolingCache],
+        offset: Union[int, mx.array],
+        runtime: SharedAttentionRuntime,
+        k_offset: Optional[Union[int, mx.array]] = None,
+    ) -> Optional[mx.array]:
+        B, L, _ = x.shape
+        if self.compress_ratio <= 0:
+            return None
+        # K RoPE uses group-start positions (pool_base); Q uses absolute tokens.
+        ko = offset if k_offset is None else k_offset
+        pooled_k = self._resolve_index_k(latent, index_pool, ko, runtime)
+        if pooled_k is None or pooled_k.shape[1] == 0:
+            return None
+
+        q = self.wq_b(qr).reshape(B, L, self.n_heads, self.index_head_dim)
+        q = self.rope(q.transpose(0, 2, 1, 3), offset)  # [B,H,L,D]
+        weights = self.weights_proj(x) * (self.softmax_scale * self.n_heads**-0.5)
+        P = pooled_k.shape[1]
+        off = int(offset) if not isinstance(offset, mx.array) else 0
+        k = min(self.index_topk, P)
+
+        if L > 1:
+            compress_lens = ((mx.arange(1, L + 1) + off) // self.compress_ratio)[
+                None, :, None
+            ]
+            compress_lens_arg = compress_lens.squeeze(-1)
+        else:
+            compress_lens = None
+            compress_lens_arg = (off + L) // self.compress_ratio
+
+        # Prefill: fuse score GEMM via dsa_indexer_scores when Flash shapes match
+        # (H=32, D=128, topk=512). Kernel tiles are 64x64 — pad L/P then slice.
+        # Decode stays on the MLX row path (+ Metal top-k) by design.
+        if (
+            isinstance(offset, int)
+            and native_indexer_shape_eligible(
+                query_tokens=L,
+                pooled_tokens=P,
+                n_heads=self.n_heads,
+                head_dim=self.index_head_dim,
+                index_topk=self.index_topk,
+                dtype_supported=q.dtype in (mx.float16, mx.bfloat16),
+            )
+        ):
+            try:
+                from omlx.custom_kernels.glm_moe_dsa import fast as glm_fast
+
+                global _V41_INDEXER_FALLBACK_WARNED
+                if not native_indexer_available() and not native_indexer_disabled():
+                    if not _V41_INDEXER_FALLBACK_WARNED:
+                        _V41_INDEXER_FALLBACK_WARNED = True
+                        logger.warning(
+                            "deepseek_v41: native dsa_indexer_scores/"
+                            "dsa_topk_indices unavailable; falling back to MLX"
+                        )
+                if native_indexer_available():
+                    tile = 64
+                    Lp = (L + tile - 1) // tile * tile
+                    Pp = (P + tile - 1) // tile * tile
+                    q_in = q
+                    w_in = weights.astype(q.dtype)
+                    k_in = pooled_k
+                    if Lp > L:
+                        q_in = mx.pad(q_in, [(0, 0), (0, 0), (0, Lp - L), (0, 0)])
+                        w_in = mx.pad(w_in, [(0, 0), (0, Lp - L), (0, 0)])
+                    if Pp > P:
+                        k_in = mx.pad(k_in, [(0, 0), (0, Pp - P), (0, 0)])
+                    # mask_ratio=0: apply compress_lens after slicing so padded
+                    # pooled columns cannot leak past the real compress horizon.
+                    scores4 = glm_fast.dsa_indexer_scores(
+                        mx.contiguous(q_in),
+                        mx.contiguous(k_in[:, None]),
+                        mx.contiguous(w_in),
+                        causal=False,
+                        mask_ratio=0,
+                        mask_q_offset=0,
+                    )
+                    scores = scores4[:, 0, :L, :P]
+                    if L > 1:
+                        pos = mx.arange(P)[None, None, :]
+                        scores = mx.where(
+                            pos >= compress_lens,
+                            mx.array(-mx.inf, dtype=scores.dtype),
+                            scores,
+                        )
+                    else:
+                        pos = mx.arange(P)
+                        scores = mx.where(
+                            pos >= compress_lens_arg,
+                            mx.array(-mx.inf, dtype=scores.dtype),
+                            scores,
+                        )
+
+                    if self.is_candidate_source:
+                        runtime.candidates = select_candidate_blocks(
+                            scores,
+                            compress_lens_arg,
+                            self.candidate_topk_blocks,
+                            self.candidate_block_size,
+                        )
+                    elif self.uses_candidates and runtime.candidates is not None:
+                        scores = mx.where(
+                            runtime.candidates,
+                            scores,
+                            mx.array(-mx.inf, dtype=scores.dtype),
+                        )
+
+                    scores4 = scores[:, None]
+                    indices = glm_fast.dsa_topk_indices(
+                        scores4,
+                        self.index_topk,
+                        bucketed=False,
+                    )
+                    if indices.ndim == 4:
+                        indices = indices[:, 0]
+                    return mx.sort(indices, axis=-1).astype(mx.uint32)
+            except Exception:
+                disable_native_indexer()
+                logger.warning(
+                    "DSV4.1 native indexer top-k failed; MLX fallback for "
+                    "the rest of this process",
+                    exc_info=True,
+                )
+
+        # Official: einsum bshd,btd->bsht then (relu * weights).sum(heads)
+        # Decode: fused Metal score row when H=32 / D=128 / L=1.
+        scores = None
+        if L == 1 and self.n_heads == 32 and self.index_head_dim == 128:
+            try:
+                from omlx.custom_kernels.glm_moe_dsa import fast as glm_fast
+
+                if glm_fast.has_symbol("dsa_decode_scores"):
+                    scores4 = glm_fast.dsa_decode_scores(
+                        mx.contiguous(q),
+                        mx.contiguous(pooled_k[:, None]),
+                        mx.contiguous(weights.astype(q.dtype)),
+                        fp32_scores=True,
+                    )
+                    scores = scores4[:, 0] if scores4.ndim == 4 else scores4
+            except Exception:
+                scores = None
+        if scores is None:
+            scores = q @ pooled_k[:, None].swapaxes(-1, -2)  # [B,H,L,P]
+            wh = weights.transpose(0, 2, 1)[:, :, :, None]  # [B,H,L,1]
+            scores = (mx.maximum(scores, 0) * wh).sum(axis=1)  # [B,L,P]
+
+        if L > 1:
+            pos = mx.arange(P)[None, None, :]
+            scores = mx.where(
+                pos >= compress_lens,
+                mx.array(-mx.inf, dtype=scores.dtype),
+                scores,
+            )
+        else:
+            pos = mx.arange(P)
+            scores = mx.where(
+                pos >= compress_lens_arg,
+                mx.array(-mx.inf, dtype=scores.dtype),
+                scores,
+            )
+
+        if self.is_candidate_source:
+            runtime.candidates = select_candidate_blocks(
+                scores,
+                compress_lens_arg,
+                self.candidate_topk_blocks,
+                self.candidate_block_size,
+            )
+        elif self.uses_candidates and runtime.candidates is not None:
+            scores = mx.where(
+                runtime.candidates,
+                scores,
+                mx.array(-mx.inf, dtype=scores.dtype),
+            )
+
+        # Decode: Metal top-k over the materialised score row (topk fixed at 512).
+        if L == 1 and k == 512 and P > k:
+            try:
+                from omlx.custom_kernels.glm_moe_dsa import fast as glm_fast
+
+                if glm_fast.has_symbol("dspark_fp32_topk_indices"):
+                    flat = scores.reshape(-1, P).astype(mx.float32)
+                    indices = glm_fast.dspark_fp32_topk_indices(flat, 512)
+                    indices = indices.reshape(B, L, 512)
+                    return mx.sort(indices, axis=-1).astype(mx.uint32)
+            except Exception:
+                pass
+
+        return _stable_topk_indices(scores, k)
+
+
+def _project_attention_output(attn: nn.Module, out: mx.array, offset: Any) -> mx.array:
+    out = attn.rope(out, offset, inverse=True)
+
+    def prepare(row: mx.array) -> mx.array:
+        batch, _, length, _ = row.shape
+        row = row.reshape(batch, attn.o_groups, -1, length, attn.head_dim)
+        return row.transpose(0, 1, 3, 2, 4).flatten(-2)
+
+    def finish(row: mx.array) -> mx.array:
+        return row.transpose(0, 2, 1, 3).flatten(-2)
+
+    return attn.wo_b(finish(attn.wo_a(prepare(out))))
+
+
+_V41_SPARSE_NATIVE_DISABLED = False
+
+
+def _try_native_sparse_attention(
+    q: mx.array,
+    local_kv: mx.array,
+    pooled: mx.array,
+    topk: mx.array,
+    sinks: mx.array,
+    scale: float,
+    offset: int,
+    compress_ratio: int,
+    local_window: int,
+) -> Optional[mx.array]:
+    """Fused window+topk sparse attention (Metal). Prefill L>1; decode via wsdpa."""
+    global _V41_SPARSE_NATIVE_DISABLED
+    if _V41_SPARSE_NATIVE_DISABLED:
+        return None
+    if (
+        q.shape[0] != 1
+        or q.shape[1] != 64
+        # Extension builds historically reject L==1; keep prefill-only until
+        # deepseek_v4_sparse_attention.cpp allows decode (then drop this).
+        or q.shape[2] <= 1
+        or q.shape[3] != 512
+        or topk.dtype != mx.uint32
+        or topk.ndim != 3
+        or pooled is None
+        or pooled.shape[1] == 0
+    ):
+        return None
+    try:
+        from omlx.custom_kernels.glm_moe_dsa import fast as glm_fast
+
+        if not glm_fast.has_symbol("deepseek_v4_sparse_attention"):
+            _V41_SPARSE_NATIVE_DISABLED = True
+            return None
+        return glm_fast.deepseek_v4_sparse_attention(
+            q,
+            local_kv,
+            pooled,
+            topk[:, None],
+            sinks,
+            scale,
+            int(offset),
+            int(compress_ratio),
+            int(local_window),
+        )
+    except Exception:
+        _V41_SPARSE_NATIVE_DISABLED = True
+        logger.warning(
+            "DSV4.1 native sparse attention failed; using MLX fallback",
+            exc_info=True,
+        )
+        return None
+
+
+class Attention(nn.Module):
+    """Unified CSA2 attention: window KV + optional compressed top-k.
+
+    compress_ratio > 0 does not imply this layer owns compression — only
+    ``kv_source_layer_ids`` run the compressor; others reuse SharedAttentionRuntime.
+    """
+
+    def __init__(self, config: ModelArgs, layer_id: int, runtime: SharedAttentionRuntime):
+        super().__init__()
+        self.config = config
+        self.layer_id = layer_id
+        self.runtime = runtime
+        self.n_heads = config.num_attention_heads
+        self.head_dim = config.head_dim
+        self.o_groups = config.o_groups
+        self.o_lora_rank = config.o_lora_rank
+        self.compress_ratio = config.compress_ratios[layer_id]
+        self.is_kv_source = layer_id in config.kv_source_layer_ids
+        self.is_index_source = layer_id in config.index_source_layer_ids
+        self.scale = self.head_dim**-0.5
+
+        self.attn_sink = mx.zeros((self.n_heads,), dtype=mx.float32)
+        self.wq_a = nn.Linear(config.hidden_size, config.q_lora_rank, bias=False)
+        self.q_norm = nn.RMSNorm(config.q_lora_rank, eps=config.rms_norm_eps)
+        self.wq_b = nn.Linear(
+            config.q_lora_rank, self.n_heads * self.head_dim, bias=False
+        )
+        self.wkv = nn.Linear(config.hidden_size, self.head_dim, bias=False)
+        self.kv_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.wo_a = MultiLinear(
+            (self.n_heads * self.head_dim) // self.o_groups,
+            self.o_lora_rank,
+            self.o_groups,
+        )
+        self.wo_b = nn.Linear(self.o_groups * self.o_lora_rank, config.hidden_size, bias=False)
+
+        rope_theta = (
+            config.compress_rope_theta if self.compress_ratio else config.rope_theta
+        )
+        rope_scaling = config.rope_scaling if self.compress_ratio else config.rope_scaling
+        # Pure window layers still use YaRN from config in HF; match official:
+        # ratio==0 disables YaRN (original_seq_len=0) and uses base rope_theta.
+        if self.compress_ratio == 0:
+            rope_scaling = None
+            rope_theta = config.rope_theta
+        self.rope = DeepseekV41RoPE(
+            config.qk_rope_head_dim,
+            rope_theta,
+            rope_scaling,
+            config.max_position_embeddings,
+            freq_scale=1,
+        )
+
+        self.compressor = None
+        self.indexer = None
+        if self.is_kv_source and self.compress_ratio > 0:
+            self.compressor = Compressor(config, self.compress_ratio, self.head_dim)
+        if self.is_index_source and self.compress_ratio > 0:
+            self.indexer = Indexer(config, layer_id)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+        *,
+        _standard_mask: bool = False,
+    ) -> mx.array:
+        B, L, _ = x.shape
+        runtime = self.runtime
+
+        local_cache = None
+        kv_pool = None
+        index_pool = None
+        if isinstance(cache, CacheList):
+            local_cache = cache[0]
+            if len(cache.caches) > 1:
+                kv_pool = cache[1]
+            if len(cache.caches) > 2:
+                index_pool = cache[2]
+        else:
+            local_cache = cache
+
+        offset = 0
+        if local_cache is not None:
+            offset = local_cache.offset
+
+        qr = self.q_norm(self.wq_a(x))
+        q = self.wq_b(qr).reshape(B, L, self.n_heads, self.head_dim)
+        q = self.rope(q.transpose(0, 2, 1, 3), offset)
+
+        # Window KV (MLA-style single latent head, broadcast)
+        kv = self.kv_norm(self.wkv(x))
+        kv = self.rope(kv[:, None], offset)  # [B,1,L,D]
+        empty_v = mx.zeros((*kv.shape[:-1], 0), dtype=kv.dtype)
+        if local_cache is not None:
+            keys, _ = local_cache.update_and_fetch(kv, empty_v)
+        else:
+            keys = kv
+
+        sinks = self.attn_sink.astype(q.dtype)
+        pooled = None
+        topk = None
+        pool_base_for_index = offset
+
+        if self.compress_ratio > 0:
+            latent = None
+            if self.is_kv_source and self.compressor is not None:
+                kv_proj, gate = self.compressor.project(x)
+                if self.compress_ratio == 1:
+                    latent = self.compressor.norm(kv_proj)
+                    roped = self.compressor.rope(latent[:, None], offset=offset).squeeze(1)
+                    pooled = (
+                        kv_pool.update_and_fetch(roped)
+                        if kv_pool is not None
+                        else roped
+                    )
+                    pool_base_for_index = offset
+                else:
+                    # Official order: accumulate complete windows -> unroped
+                    # latent for indexer -> RoPE into compress KV pool.
+                    ratio = self.compress_ratio
+                    if kv_pool is not None:
+                        ready_kv, ready_gate, pool_base = kv_pool.accumulate_windows(
+                            kv_proj, gate, offset
+                        )
+                    else:
+                        usable = (kv_proj.shape[1] // ratio) * ratio
+                        ready_kv = kv_proj[:, :usable]
+                        ready_gate = gate[:, :usable]
+                        pool_base = offset
+                    pool_base_for_index = pool_base
+                    if ready_kv.size == 0:
+                        latent = mx.zeros((B, 0, self.head_dim), dtype=x.dtype)
+                        pooled = kv_pool.pooled if kv_pool is not None else latent
+                        if pooled is None:
+                            pooled = latent
+                    else:
+                        kv_u = mx.unflatten(ready_kv, 1, (-1, ratio))
+                        gate_u = mx.unflatten(ready_gate, 1, (-1, ratio))
+                        latent = self.compressor.norm(
+                            _simple_compress_kv(kv_u, gate_u, self.head_dim)
+                        )
+                        roped = self.compressor.rope(
+                            latent[:, None], offset=pool_base
+                        ).squeeze(1)
+                        pooled = (
+                            kv_pool.update_and_fetch(roped)
+                            if kv_pool is not None
+                            else roped
+                        )
+                runtime.compress_kv = kv_pool if kv_pool is not None else pooled
+            else:
+                src = runtime.compress_kv
+                if isinstance(src, PoolingCache):
+                    pooled = src.pooled
+                else:
+                    pooled = src
+
+            if self.is_index_source and self.indexer is not None:
+                topk = self.indexer(
+                    x,
+                    qr,
+                    latent,
+                    index_pool,
+                    offset,
+                    runtime,
+                    k_offset=pool_base_for_index,
+                )
+                runtime.topk_idxs = topk
+            else:
+                topk = runtime.topk_idxs
+
+        # Attention: window (+ optional pooled). Always extend mask when
+        # concatenating pooled rows so decode/prefill without wsdpa stay valid.
+        pooled_mask = None
+        if (
+            pooled is not None
+            and pooled.shape[1] > 0
+            and kv_pool is not None
+            and L > 1
+        ):
+            pooled_mask = kv_pool.make_mask(L, offset)
+
+        if pooled is None or pooled.shape[1] == 0:
+            out = None
+            if _standard_mask and B == 1 and L > 1:
+                out = wsdpa_prefill(
+                    q,
+                    keys,
+                    None,
+                    sinks,
+                    self.scale,
+                    offset,
+                    self.config.sliding_window,
+                    self.compress_ratio or 1,
+                )
+            if out is None:
+                out = scaled_dot_product_attention(
+                    q,
+                    keys,
+                    keys,
+                    cache=None,
+                    scale=self.scale,
+                    mask=mask,
+                    sinks=sinks,
+                )
+        elif topk is not None and pooled.shape[1] > self.config.index_topk:
+            # Sparse top-k: native / wsdpa_topk for prefill; gather for decode.
+            out = None
+            if L > 1 and _standard_mask and B == 1:
+                if topk.dtype != mx.uint32:
+                    topk = topk.astype(mx.uint32)
+                # Prefer native Metal sparse (faster on measured V4.1 ratios);
+                # fall back to wsdpa_topk then gather/dense.
+                out = _try_native_sparse_attention(
+                    q,
+                    keys,
+                    pooled,
+                    topk,
+                    sinks,
+                    self.scale,
+                    offset,
+                    self.compress_ratio or 1,
+                    self.config.sliding_window,
+                )
+                if out is None:
+                    out = wsdpa_topk_prefill(
+                        q,
+                        keys,
+                        pooled,
+                        topk,
+                        sinks,
+                        self.scale,
+                        offset,
+                        self.config.sliding_window,
+                        self.compress_ratio or 1,
+                    )
+            if out is None and L == 1:
+                # Gather K rows without materializing [B,1,1,P,D].
+                # topk: [B,1,K] -> gathered [B,1,K,D]
+                k = int(topk.shape[-1])
+                idx = mx.broadcast_to(
+                    topk.reshape(B, k)[:, :, None],
+                    (B, k, self.head_dim),
+                )
+                gathered = mx.take_along_axis(pooled, idx, axis=1)
+                gathered = gathered.reshape(B, 1, k, self.head_dim)
+                full_kv = mx.concatenate([keys, gathered], axis=2)
+                out = scaled_dot_product_attention(
+                    q,
+                    full_kv,
+                    full_kv,
+                    cache=None,
+                    scale=self.scale,
+                    mask=None,
+                    sinks=sinks,
+                )
+            if out is None:
+                # Last resort: dense pooled (correct but heavier than top-k).
+                full_kv = mx.concatenate([keys, pooled[:, None]], axis=2)
+                if _standard_mask and B == 1 and L > 1:
+                    out = wsdpa_prefill(
+                        q,
+                        keys,
+                        pooled,
+                        sinks,
+                        self.scale,
+                        offset,
+                        self.config.sliding_window,
+                        self.compress_ratio or 1,
+                    )
+                if out is None:
+                    attn_mask = _extend_mask(mask, pooled_mask, full_kv.shape[2])
+                    out = scaled_dot_product_attention(
+                        q,
+                        full_kv,
+                        full_kv,
+                        cache=None,
+                        scale=self.scale,
+                        mask=attn_mask,
+                        sinks=sinks,
+                    )
+        else:
+            full_kv = mx.concatenate([keys, pooled[:, None]], axis=2)
+            out = None
+            if _standard_mask and B == 1 and L > 1:
+                out = wsdpa_prefill(
+                    q,
+                    keys,
+                    pooled,
+                    sinks,
+                    self.scale,
+                    offset,
+                    self.config.sliding_window,
+                    self.compress_ratio or 1,
+                )
+            if out is None:
+                attn_mask = _extend_mask(mask, pooled_mask, full_kv.shape[2])
+                out = scaled_dot_product_attention(
+                    q,
+                    full_kv,
+                    full_kv,
+                    cache=None,
+                    scale=self.scale,
+                    mask=attn_mask,
+                    sinks=sinks,
+                )
+
+        return _project_attention_output(self, out, offset)
+
+
+class DeepseekV41Block(nn.Module):
+    """Deferred mHC block: attn uses prior pre_mix; FFN uses this attn pre."""
+
+    def __init__(
+        self,
+        config: ModelArgs,
+        layer_idx: int,
+        runtime: SharedAttentionRuntime,
+        engram_layout: Optional[EngramLayout] = None,
+    ):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.attn = Attention(config, layer_idx, runtime)
+        self.ffn = DeepseekV41MoE(config, layer_idx)
+        self.attn_norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.ffn_norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.attn_hc = DeferredHyperConnection(config)
+        self.ffn_hc = DeferredHyperConnection(config)
+        self.engram = None
+        if engram_layout is not None and layer_idx in engram_layout.layer_ids:
+            self.engram = Engram(config, layer_idx, engram_layout)
+
+    def __call__(
+        self,
+        h: mx.array,
+        mask: Optional[mx.array],
+        cache: Optional[Any],
+        pre_mix: mx.array,
+        image_mask: Optional[mx.array] = None,
+        hash_ids: Optional[mx.array] = None,
+        *,
+        _standard_mask: bool = False,
+    ):
+        if self.engram is not None:
+            h = self.engram(h, hash_ids, None if image_mask is None else ~image_mask)
+
+        residual = h
+        attn_pre, attn_post, attn_comb = self.attn_hc.mixes(h)
+        x = hc_collapse(h, pre_mix)
+        x = self.attn_norm(x)
+        x = self.attn(x, mask=mask, cache=cache, _standard_mask=_standard_mask)
+        h = hc_expand(x, residual, attn_post, attn_comb)
+
+        residual = h
+        ffn_pre, ffn_post, ffn_comb = self.ffn_hc.mixes(h)
+        x = hc_collapse(h, attn_pre)
+        x = self.ffn_norm(x)
+        x = self.ffn(x, image_mask)
+        h = hc_expand(x, residual, ffn_post, ffn_comb)
+        return h, ffn_pre
+
+
+class DeepseekV41Model(PipelineMixin, nn.Module):
+    def __init__(self, config: ModelArgs):
+        super().__init__()
+        self.args = config
+        self.vocab_size = config.vocab_size
+        self.runtime = SharedAttentionRuntime()
+        global shared_attn
+        shared_attn = self.runtime
+
+        self.engram_layout = EngramLayout.from_args(config)
+        self.engram_hash = None  # bound later via bind_engram_hash / ensure_engram
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.layers = [
+            DeepseekV41Block(config, idx, self.runtime, self.engram_layout)
+            for idx in range(config.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        # No HyperHead in V4.1 Flash checkpoints (uses ParallelHead/lm_head).
+        self.dspark_target_layer_ids = list(config.dspark_target_layer_ids or [])
+        # TODO(dspark): wire mtp.* DSpark blocks using dspark_target_layer_ids
+        # [37,38,39], dspark_block_size, markov/confidence heads when speculative
+        # decode is enabled in omlx. Config fields are parsed and retained.
+        self.mtp = []
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[Any] = None,
+        images=None,
+        image_mask: Optional[mx.array] = None,
+    ) -> mx.array:
+        if images is not None:
+            raise NotImplementedError(
+                "DeepSeek-V4.1 vision is Phase-2: text path only. "
+                "Do not pass images until ViT/aligner is implemented."
+            )
+
+        h = self.embed_tokens(inputs)
+        h = mx.contiguous(
+            mx.broadcast_to(
+                h[:, :, None, :],
+                (h.shape[0], h.shape[1], self.args.hc_mult, h.shape[2]),
+            )
+        )
+
+        if cache is None:
+            cache = [None] * len(self.pipeline_layers)
+
+        first_cache = cache[0]
+        mask_cache = (
+            first_cache[0] if isinstance(first_cache, CacheList) else first_cache
+        )
+        mask = create_attention_mask(
+            h[:, :, 0, :],
+            mask_cache,
+            window_size=self.args.sliding_window,
+            return_array=True,
+        )
+
+        pre_mix = make_identity_pre_mix(h, self.args.hc_mult)
+        self.runtime.reset_forward_slots()
+
+        # Engram n-gram hashes from input_ids; start_pos from KV cache offset.
+        start_pos = 0
+        if mask_cache is not None and hasattr(mask_cache, 'offset'):
+            try:
+                start_pos = int(mask_cache.offset)
+            except Exception:
+                start_pos = 0
+        engram_hashes = None
+        if self.engram_hash is not None:
+            import numpy as _np
+
+            mx.eval(inputs)
+            ids_np = _np.array(inputs, dtype=_np.int64)
+            if ids_np.ndim == 1:
+                ids_np = ids_np[None, :]
+            tok_mask = None
+            if image_mask is not None:
+                mx.eval(image_mask)
+                tok_mask = ~_np.array(image_mask, dtype=bool)
+            engram_hashes = self.engram_hash.forward(ids_np, start_pos, tok_mask)
+            # Overlap later Engram SSD gathers with earlier layer compute.
+            # Prefetch every Engram layer up-front (threaded dequant); first layer
+            # usually completes during embed/layer0, later ones during intervening FFN/attn.
+            if engram_is_mmap() and engram_hashes is not None:
+                for layer in self.pipeline_layers:
+                    eng = getattr(layer, "engram", None)
+                    if eng is None:
+                        continue
+                    layer_hash = engram_hashes[:, :, eng.layer_hash_index, :]
+                    prefetch_engram_layer(self, eng.layer_id, layer_hash)
+
+        for layer, layer_cache in zip(self.pipeline_layers, cache):
+            layer_hash = None
+            if engram_hashes is not None and getattr(layer, 'engram', None) is not None:
+                # Keep CPU ndarray; Engram mmap path gathers without mx roundtrip.
+                layer_hash = engram_hashes[:, :, layer.engram.layer_hash_index, :]
+            h, pre_mix = layer(
+                h,
+                mask,
+                layer_cache,
+                pre_mix,
+                image_mask,
+                layer_hash,
+                _standard_mask=True,
+            )
+
+        # Official end: collapse with last FFN pre_mix, then RMSNorm.
+        # Checkpoint has no HyperHead weights (ParallelHead is lm_head).
+        return self.norm(hc_collapse(h, pre_mix))
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelArgs):
+        super().__init__()
+        self.args = config
+        self.model_type = config.model_type
+        self.model = DeepseekV41Model(config)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        if engram_tables_enabled() and self.model.engram_layout is not None:
+            try:
+                bind_engram_hash(self, config)
+            except FileNotFoundError as e:
+                logger.warning('Engram bind deferred (missing meta/token_map): %s', e)
+
+    def ensure_engram(self):
+        """Bind NgramHashState + mmap tables if not yet attached."""
+        if self.model.engram_layout is None:
+            return None
+        if self.model.engram_hash is None or engram_is_mmap():
+            return bind_engram_hash(self, self.args)
+        return self.model.engram_hash
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[Any] = None,
+        images=None,
+        skip_lm_head: bool = False,
+    ):
+        out = self.model(inputs, cache, images=images)
+        if skip_lm_head:
+            # Chunked prefill discards per-chunk logits; first decode scores
+            # the prompt's last token. Skip the full-vocab lm_head GEMM.
+            return None
+        return self.lm_head(out)
+
+    @property
+    def layers(self):
+        return self.model.pipeline_layers
+
+    @property
+    def cast_predicate(self):
+        def predicate(k):
+            return not (
+                "attn_sink" in k
+                or "e_score_correction_bias" in k
+                or "bias_vl" in k
+                or ".attn_hc." in k
+                or ".ffn_hc." in k
+                or ".hc_head." in k
+            )
+
+        return predicate
+
+    def make_cache(self):
+        """Per-layer caches; KV/index source layers own shared PoolingCaches."""
+        runtime = self.model.runtime
+        args = self.args
+        caches = []
+        # Build pools in layer order so reuse layers see the same object.
+        for layer in self.model.layers:
+            ratio = layer.attn.compress_ratio
+            lid = layer.attn.layer_id
+            window = RotatingKVCache(max_size=args.sliding_window)
+            if ratio == 0:
+                caches.append(window)
+                continue
+            if layer.attn.is_kv_source:
+                kv_pool = runtime.register_kv_pool(lid, PoolingCache(ratio))
+                if layer.attn.is_index_source:
+                    idx_pool = runtime.register_index_pool(lid, PoolingCache(ratio))
+                    caches.append(CacheList(window, kv_pool, idx_pool))
+                else:
+                    caches.append(CacheList(window, kv_pool))
+            elif layer.attn.is_index_source:
+                src = runtime.kv_source_for(lid, args.kv_source_layer_ids)
+                kv_pool = (
+                    runtime.kv_pool_by_source.get(src) if src is not None else None
+                )
+                idx_pool = runtime.register_index_pool(lid, PoolingCache(ratio))
+                if kv_pool is None:
+                    kv_pool = PoolingCache(ratio)
+                caches.append(CacheList(window, kv_pool, idx_pool))
+            else:
+                src = runtime.kv_source_for(lid, args.kv_source_layer_ids)
+                kv_pool = (
+                    runtime.kv_pool_by_source.get(src) if src is not None else None
+                )
+                if kv_pool is not None:
+                    caches.append(CacheList(window, kv_pool))
+                else:
+                    # Should not happen when kv_source_layer_ids is well-formed;
+                    # keep a window-only cache rather than inventing a private pool.
+                    caches.append(window)
+        return caches
+
+    def sanitize(self, weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+        n_layers = self.args.num_hidden_layers
+        new_weights = {}
+        for k, v in weights.items():
+            if k.startswith("mtp."):
+                # Keep config-visible but skip loading until DSpark wired.
+                continue
+            if "engram" in k:
+                # stub: skip all engram keys. mmap/ssd: skip only embed tables
+                # (wkv/q_weight/k_weight load normally). full: keep everything.
+                mode = engram_mode()
+                if mode in ("mmap", "ssd"):
+                    if "embed.weight" in k or "embed.scale" in k:
+                        continue
+                elif mode != "full":
+                    continue
+            if k.startswith("vision.") or k.startswith("aligner.") or k.startswith(
+                "image_"
+            ):
+                continue
+            parts = k.split(".")
+            if len(parts) >= 2 and parts[0] == "layers":
+                try:
+                    if int(parts[1]) >= n_layers:
+                        continue
+                except ValueError:
+                    pass
+            new_weights[k] = v
+        weights = new_weights
+
+        # Scale / packed weight handling (same spirit as V4)
+        new_weights = {}
+        for k, v in weights.items():
+            if not k.endswith(".scale"):
+                if k not in new_weights:
+                    new_weights[k] = v
+                continue
+            wk = k[: -len(".scale")] + ".weight"
+            weight = weights.get(wk)
+            if weight is None:
+                new_weights[k] = v
+                continue
+            if (
+                ".ffn.experts." in wk
+                and ".shared_experts." not in wk
+                and weight.dtype in (mx.int8, mx.uint8)
+                and v.shape[-1] * 16 == weight.shape[-1]
+            ):
+                new_weights[k + "s"] = v
+                new_weights[wk] = weight.view(mx.uint32)
+            elif weight.dtype == mx.uint8:
+                # Flash UE8M0 scales are one value per 32x32 weight block:
+                # shape (out/32, in/32). Expand to (out, in/32) for mlx mxfp8.
+                scales = v
+                if weight.ndim >= 2 and scales.ndim >= 2:
+                    out_rep = weight.shape[0] // scales.shape[0]
+                    in_rep = (weight.shape[-1] // 32) // scales.shape[-1]
+                    if out_rep > 1:
+                        scales = mx.repeat(scales, out_rep, 0)
+                    if in_rep > 1:
+                        scales = mx.repeat(scales, in_rep, -1)
+                new_weights[k + "s"] = scales
+                new_weights[wk] = weight.view(mx.uint32)
+
+            else:
+                new_weights[k] = v
+        weights = new_weights
+
+        top_remap = {
+            "embed.weight": "model.embed_tokens.weight",
+            "norm.weight": "model.norm.weight",
+            "head.weight": "lm_head.weight",
+            "hc_head_fn": "model.hc_head.fn",
+            "hc_head_base": "model.hc_head.base",
+            "hc_head_scale": "model.hc_head.scale",
+        }
+        for old, new in top_remap.items():
+            if old in weights:
+                weights[new] = weights.pop(old)
+
+        remapped = {}
+        w_remap = {"w1": "gate_proj", "w2": "down_proj", "w3": "up_proj"}
+        for k, v in weights.items():
+            nk = "model." + k if k.startswith("layers.") else k
+            if nk.endswith(".ffn.gate.bias_vl"):
+                pass  # keep MoEGate.bias_vl
+            elif nk.endswith(".ffn.gate.bias"):
+                nk = nk[: -len("bias")] + "e_score_correction_bias"
+            for sub in ("attn", "ffn"):
+                for param in ("fn", "base", "scale"):
+                    nk = nk.replace(f".hc_{sub}_{param}", f".{sub}_hc.{param}")
+            skip = False
+            for old, new in ((".hc_attn.", ".attn_hc."), (".hc_ffn.", ".ffn_hc.")):
+                if old in nk:
+                    candidate = nk.replace(old, new)
+                    if candidate in weights or candidate in remapped:
+                        skip = True
+                        break
+                    nk = candidate
+            if skip:
+                continue
+            for old, new in w_remap.items():
+                nk = nk.replace(f".shared_experts.{old}.", f".shared_experts.{new}.")
+            remapped[nk] = v
+        weights = remapped
+
+        for layer_idx in range(n_layers):
+            prefix = f"model.layers.{layer_idx}.ffn.experts"
+            for src, dst in (
+                ("w1", "gate_proj"),
+                ("w2", "down_proj"),
+                ("w3", "up_proj"),
+            ):
+                for suffix in ("weight", "scales", "biases"):
+                    key0 = f"{prefix}.0.{src}.{suffix}"
+                    if key0 in weights:
+                        n_exp = self.args.get_moe_config(layer_idx)[0]
+                        stacked = [
+                            weights.pop(f"{prefix}.{e}.{src}.{suffix}")
+                            for e in range(n_exp)
+                        ]
+                        weights[
+                            f"model.layers.{layer_idx}.ffn.switch_mlp.{dst}.{suffix}"
+                        ] = mx.stack(stacked)
+
+        for layer_idx in range(n_layers):
+            prefix = f"model.layers.{layer_idx}.attn.wo_a"
+            for key in (f"{prefix}.weight", f"{prefix}.scales", f"{prefix}.biases"):
+                if key in weights and weights[key].ndim == 2:
+                    weights[key] = weights[key].reshape(
+                        self.args.o_groups, self.args.o_lora_rank, -1
+                    )
+
+        return weights
+
+
+# Re-export helpers used by tests
+__all__ = [
+    "Model",
+    "ModelArgs",
+    "SharedAttentionRuntime",
+    "select_candidate_blocks",
+    "make_quantization_config",
+    "make_identity_pre_mix",
+    "hc_collapse",
+    "hc_expand",
+    "Compressor",
+    "Indexer",
+    "Attention",
+    "DeepseekV41Block",
+]

--- a/omlx/patches/deepseek_v41/deferred_hc.py
+++ b/omlx/patches/deepseek_v41/deferred_hc.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Deferred Hyper-Connection mixes for DeepSeek-V4.1.
+
+V4 applies ``HyperConnection.__call__`` which collapses with the *same*
+stream's freshly computed ``pre``. V4.1 instead:
+
+- Attention collapses with the **previous** sublayer's ``pre_mix`` (FFN of
+  prior block, or identity at layer 0).
+- FFN collapses with **this** attention's ``pre``.
+- Each sublayer still computes post/comb from the current residual and
+  returns its ``pre`` for the next consumer.
+
+See official ``Block.forward`` in inference/model.py.
+"""
+from __future__ import annotations
+
+from typing import Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from omlx.patches.deepseek_v4.decode_consistency import matmul as decode_matmul
+from omlx.patches.deepseek_v4.hyper_connection import (
+    _hc_split_sinkhorn_ops,
+    hc_expand,
+)
+
+
+def make_identity_pre_mix(x: mx.array, hc_mult: int) -> mx.array:
+    """One-hot pre_mix selecting stream 0. Shape [B, L, hc_mult]."""
+    B, L = x.shape[0], x.shape[1]
+    pre = mx.zeros((B, L, hc_mult), dtype=mx.float32)
+    # set index 0 to 1
+    ones = mx.ones((B, L, 1), dtype=mx.float32)
+    zeros = mx.zeros((B, L, hc_mult - 1), dtype=mx.float32) if hc_mult > 1 else None
+    if zeros is None:
+        return ones
+    return mx.concatenate([ones, zeros], axis=-1)
+
+
+def hc_collapse(x: mx.array, pre_mix: mx.array) -> mx.array:
+    """[B,L,hc,D] x [B,L,hc] -> [B,L,D]."""
+    y = (pre_mix[..., None].astype(mx.float32) * x.astype(mx.float32)).sum(axis=2)
+    return y.astype(x.dtype)
+
+
+class DeferredHyperConnection(nn.Module):
+    """Stores HC parameters; exposes mix computation without collapsing."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.hc_mult = config.hc_mult
+        self.sinkhorn_iters = config.hc_sinkhorn_iters
+        self.hc_eps = config.hc_eps
+        self.norm_eps = config.rms_norm_eps
+        mix = (2 + self.hc_mult) * self.hc_mult
+        self.fn = mx.zeros((mix, self.hc_mult * config.hidden_size), dtype=mx.float32)
+        self.base = mx.zeros((mix,), dtype=mx.float32)
+        self.scale = mx.ones((3,), dtype=mx.float32)
+
+    def mixes(self, x: mx.array) -> Tuple[mx.array, mx.array, mx.array]:
+        """Return (pre, post, comb) from residual stream ``x`` [B,L,hc,D]."""
+        y = x.astype(mx.float32)
+        z = mx.fast.rms_norm(y.flatten(-2), None, self.norm_eps)
+        mixes = decode_matmul(z, self.fn.T)
+        return _hc_split_sinkhorn_ops(
+            mixes,
+            self.scale,
+            self.base,
+            self.hc_mult,
+            self.sinkhorn_iters,
+            self.hc_eps,
+        )
+
+
+__all__ = [
+    "DeferredHyperConnection",
+    "hc_collapse",
+    "hc_expand",
+    "make_identity_pre_mix",
+]

--- a/omlx/patches/deepseek_v41/engram.py
+++ b/omlx/patches/deepseek_v41/engram.py
@@ -1,0 +1,855 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Engram conditional memory for DeepSeek-V4.1.
+
+Official tables are hundreds of millions of rows (see ``engram_num_embeddings``).
+
+Hot-row RAM cache lives in ``engram_cache.py`` (``OMLX_DSV41_ENGRAM_CACHE_GB`` / ``QuantHotRowCache``).
+
+Modes via ``OMLX_DSV41_ENGRAM``:
+- ``stub`` / ``lazy`` / ``off`` (default): no Engram layers (ModelArgs clears ids).
+- ``mmap`` / ``ssd``: keep layer hooks; embed tables stay on SSD via numpy.memmap;
+  only gathered rows are promoted to MLX arrays. Small params (wkv/q/k) load normally.
+- ``full``: allocate resident Embedding tables (not recommended on 512GB hosts).
+
+Optional ``OMLX_DSV41_ENGRAM_DIR`` points at a metadata dir (default
+``~/llm/DeepSeek-V4.1-Flash-engram``) with ``meta.json`` + ``token_map.npy``.
+
+Mmap gather: unique-index SSD dequant + bf16 upload. Threaded row fetches,
+optional madvise prefetch, a tiny per-layer dequant LRU
+(``OMLX_DSV41_ENGRAM_ROW_BUF``, default 8192), and an optional multi-GB
+**quantized** hot-row cache (``OMLX_DSV41_ENGRAM_CACHE_GB``, default 50)
+that keeps FP8 E4M3 + UE8M0 scales in RAM and evicts oldest (LRU) or CLOCK
+when full — ~2× denser than a bf16 hot cache.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import mmap as mmap_mod
+import os
+from collections import OrderedDict
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from omlx.patches.deepseek_v41.engram_cache import (
+    QuantHotRowCache,
+    _quant_cache_rows_per_layer,
+    engram_cache_gb,
+    engram_cache_policy,
+    engram_cache_stats,
+)
+from omlx.patches.deepseek_v41.engram_fp8 import (
+    _e4m3_lut,
+    _e4m3_to_float32,
+    _ue8m0_to_float32,
+)
+
+logger = logging.getLogger(__name__)
+
+_DEAD = -1
+
+
+def engram_mode() -> str:
+    return os.environ.get("OMLX_DSV41_ENGRAM", "stub").strip().lower()
+
+
+def engram_tables_enabled() -> bool:
+    return engram_mode() in ("mmap", "ssd", "full")
+
+
+def engram_is_mmap() -> bool:
+    return engram_mode() in ("mmap", "ssd")
+
+
+def engram_dir() -> Path:
+    raw = os.environ.get("OMLX_DSV41_ENGRAM_DIR", "").strip()
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / "llm" / "DeepSeek-V4.1-Flash-engram"
+
+
+def engram_gather_threads() -> int:
+    """Worker threads for SSD row gathers (default 16). 1 disables threading."""
+    raw = os.environ.get("OMLX_DSV41_ENGRAM_GATHER_THREADS", "16").strip()
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return 16
+
+
+def engram_row_buf() -> int:
+    """Tiny per-layer working-set row buffer (default 8192). 0 disables.
+
+    Not the old multi-GB HotRowCache — only a small LRU of recently gathered
+    rows to accelerate decode without pinning tens of GB of RAM.
+    """
+    raw = os.environ.get("OMLX_DSV41_ENGRAM_ROW_BUF", "8192").strip()
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return 8192
+
+
+def engram_prefetch() -> bool:
+    raw = os.environ.get("OMLX_DSV41_ENGRAM_PREFETCH", "1").strip().lower()
+    return raw not in ("0", "false", "off", "no")
+
+
+def _is_prime(n: int) -> bool:
+    if n < 2:
+        return False
+    if n < 4:
+        return True
+    if n % 2 == 0 or n % 3 == 0:
+        return False
+    i = 5
+    while i * i <= n:
+        if n % i == 0 or n % (i + 2) == 0:
+            return False
+        i += 6
+    return True
+
+
+def find_next_prime(start: int, seen_primes: set) -> int:
+    candidate = start + 1
+    while not _is_prime(candidate) or candidate in seen_primes:
+        candidate += 1
+    return candidate
+
+
+def compute_hash_multipliers(
+    layer_ids: Tuple[int, ...], max_ngram_size: int, tokenizer_vocab_size: int
+) -> np.ndarray:
+    max_long = np.iinfo(np.int64).max
+    multiplier_bound = max(1, (max_long // tokenizer_vocab_size) // 2)
+    rows = []
+    for layer_id in layer_ids:
+        generator = np.random.default_rng(10007 * layer_id)
+        values = generator.integers(
+            low=0,
+            high=multiplier_bound,
+            size=(max_ngram_size,),
+            dtype=np.int64,
+        )
+        rows.append(values * 2 + 1)
+    return np.stack(rows, axis=0)
+
+
+@dataclass(frozen=True)
+class EngramLayout:
+    """Bucket layout of the n-gram hash tables (mirrors official EngramLayout)."""
+
+    max_ngram_size: int
+    layer_ids: Tuple[int, ...]
+    num_embeddings: Tuple[int, ...]
+    primes: Tuple[Tuple[Tuple[int, ...], ...], ...]
+    n_heads: int
+    head_dim: int
+
+    @classmethod
+    def from_args(cls, args) -> Optional["EngramLayout"]:
+        layer_ids = tuple(getattr(args, "engram_layer_ids", ()) or ())
+        if not layer_ids:
+            return None
+        nums = tuple(int(x) for x in (getattr(args, "engram_num_embeddings", ()) or ()))
+        if len(nums) != len(layer_ids):
+            raise ValueError(
+                f"engram_num_embeddings length {len(nums)} != "
+                f"engram_layer_ids length {len(layer_ids)}"
+            )
+        max_ngram_size = int(args.engram_max_ngram_size)
+        n_heads = int(args.engram_n_heads)
+        vocab_size = int(getattr(args, "engram_vocab_size", 0) or 0)
+        primes_list: List[Tuple[Tuple[int, ...], ...]] = []
+        seen: set = set()
+        for _ in layer_ids:
+            per_ngram = []
+            for _ in range(max_ngram_size - 1):
+                sizes = []
+                current = vocab_size - 1
+                for _ in range(n_heads):
+                    current = find_next_prime(current, seen)
+                    seen.add(current)
+                    sizes.append(current)
+                per_ngram.append(tuple(sizes))
+            primes_list.append(tuple(per_ngram))
+        return cls(
+            max_ngram_size=max_ngram_size,
+            layer_ids=layer_ids,
+            num_embeddings=nums,
+            primes=tuple(primes_list),
+            n_heads=n_heads,
+            head_dim=int(args.engram_head_dim),
+        )
+
+    @property
+    def n_hash_cols(self) -> int:
+        return (self.max_ngram_size - 1) * self.n_heads
+
+
+def _row_storage_dtype():
+    """Prefer bfloat16 (matches MLX); fall back to float16."""
+    try:
+        import ml_dtypes
+
+        return ml_dtypes.bfloat16
+    except Exception:
+        return np.float16
+
+
+class _TinyRowLRU:
+    """Fixed-capacity LRU of dequantized rows (bf16/f16). Decode working set only."""
+
+    def __init__(self, capacity: int, head_dim: int):
+        self.capacity = max(0, int(capacity))
+        self.head_dim = int(head_dim)
+        self.enabled = self.capacity > 0
+        self.dtype = _row_storage_dtype()
+        self._map: "OrderedDict[int, int]" = OrderedDict()
+        self._n = 0
+        self.hits = 0
+        self.misses = 0
+        if self.enabled:
+            self.data = np.empty((self.capacity, self.head_dim), dtype=self.dtype)
+        else:
+            self.data = None
+
+    def get_many(self, keys: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+        n = int(keys.shape[0])
+        hit = np.zeros(n, dtype=bool)
+        out = np.empty((n, self.head_dim), dtype=np.float32)
+        if not self.enabled or n == 0:
+            self.misses += n
+            return hit, out
+        m = self._map
+        data = self.data
+        hit_idx = []
+        slots = []
+        for i in range(n):
+            k = int(keys[i])
+            slot = m.get(k)
+            if slot is None:
+                self.misses += 1
+                continue
+            hit[i] = True
+            hit_idx.append(i)
+            slots.append(slot)
+            self.hits += 1
+            m.move_to_end(k)
+        if slots:
+            out[np.asarray(hit_idx, dtype=np.int64)] = np.asarray(
+                data[np.asarray(slots, dtype=np.int64)], dtype=np.float32
+            )
+        return hit, out
+
+    def put_many(self, keys: np.ndarray, values_f32: np.ndarray) -> None:
+        if not self.enabled or keys.size == 0:
+            return
+        vals = values_f32.astype(self.dtype, copy=False)
+        m = self._map
+        data = self.data
+        for i in range(int(keys.shape[0])):
+            k = int(keys[i])
+            slot = m.get(k)
+            if slot is not None:
+                data[slot] = vals[i]
+                m.move_to_end(k)
+                continue
+            if self._n < self.capacity:
+                slot = self._n
+                self._n += 1
+            else:
+                _old_k, slot = m.popitem(last=False)
+            m[k] = slot
+            data[slot] = vals[i]
+
+
+
+# Prefetch pool only (whole-layer background jobs). Per-gather I/O uses a
+# short-lived executor so nested weight/scale/chunk work cannot deadlock.
+_PREFETCH_POOL: Optional[ThreadPoolExecutor] = None
+
+# Module-level E4M3 LUT (built once).
+def _threaded_memmap_gather(mm: np.memmap, idxs: np.ndarray, n_workers: int) -> np.ndarray:
+    """Gather rows from memmap; use threads when idxs is large (SSD random I/O)."""
+    n = int(idxs.shape[0])
+    cols = int(mm.shape[1])
+    if n == 0:
+        return np.empty((0, cols), dtype=mm.dtype)
+    if n_workers <= 1 or n < 256:
+        return np.asarray(mm[idxs])
+    out = np.empty((n, cols), dtype=mm.dtype)
+    # Split into contiguous index-slices (idxs itself is usually sorted unique).
+    bounds = np.linspace(0, n, num=n_workers + 1, dtype=np.int64)
+
+    def _work(lo: int, hi: int) -> None:
+        if hi <= lo:
+            return
+        out[lo:hi] = np.asarray(mm[idxs[lo:hi]])
+
+    # Fresh executor per call: safe under nested prefetch → dequant → gather.
+    with ThreadPoolExecutor(max_workers=n_workers) as pool:
+        futs = [
+            pool.submit(_work, int(bounds[i]), int(bounds[i + 1]))
+            for i in range(n_workers)
+        ]
+        for f in futs:
+            f.result()
+    return out
+
+
+def _madvise_rows(mm: np.memmap, idxs: np.ndarray, merge_gap: int = 65536) -> None:
+    """Advise the kernel that sorted row ranges will be needed soon."""
+    underlying = getattr(mm, "_mmap", None)
+    if underlying is None or idxs.size == 0:
+        return
+    row_bytes = int(mm.shape[1]) * int(mm.dtype.itemsize)
+    starts = idxs.astype(np.int64, copy=False) * row_bytes
+    i = 0
+    n = int(starts.shape[0])
+    try:
+        while i < n:
+            s = int(starts[i])
+            e = s + row_bytes
+            j = i + 1
+            while j < n and int(starts[j]) <= e + merge_gap:
+                e = int(starts[j]) + row_bytes
+                j += 1
+            underlying.madvise(mmap_mod.MADV_WILLNEED, s, e - s)
+            i = j
+    except Exception:
+        # Best-effort; platforms / numpy builds may lack madvise.
+        return
+
+
+class MmapEngramTable:
+    """SSD-backed FP8 Engram embedding table (weight + UE8M0 scales)."""
+
+    def __init__(
+        self,
+        weight_path: str,
+        weight_offset: int,
+        scale_path: str,
+        scale_offset: int,
+        num_embeddings: int,
+        head_dim: int,
+        block_size: int = 32,
+        row_buf: int = 0,
+        hot_cache: Optional["QuantHotRowCache"] = None,
+    ):
+        self.num_embeddings = int(num_embeddings)
+        self.head_dim = int(head_dim)
+        self.block_size = int(block_size)
+        n_scales = self.head_dim // self.block_size
+        self.weight_path = weight_path
+        self.weight_offset = int(weight_offset)
+        self.scale_path = scale_path
+        self.scale_offset = int(scale_offset)
+        self.weight = np.memmap(
+            weight_path,
+            dtype=np.uint8,
+            mode="r",
+            offset=int(weight_offset),
+            shape=(self.num_embeddings, self.head_dim),
+        )
+        self.scale = np.memmap(
+            scale_path,
+            dtype=np.uint8,
+            mode="r",
+            offset=int(scale_offset),
+            shape=(self.num_embeddings, n_scales),
+        )
+        self.hot_cache = hot_cache
+        # Tiny dequant LRU is redundant when the multi-GB quantized cache is on.
+        if hot_cache is not None and hot_cache.enabled:
+            self.row_buf = None
+        else:
+            self.row_buf = _TinyRowLRU(row_buf, head_dim) if row_buf > 0 else None
+        self._n_workers = engram_gather_threads()
+        self._do_prefetch = engram_prefetch()
+        self._prefetch_fut: Optional[Future] = None
+        self._prefetch_uniq: Optional[np.ndarray] = None
+
+    def bind_hot_cache(self, cache: Optional["QuantHotRowCache"]) -> None:
+        self.hot_cache = cache
+        if cache is not None and cache.enabled:
+            self.row_buf = None
+
+    def _gather_u8(self, mm: np.memmap, uniq: np.ndarray) -> np.ndarray:
+        if self._do_prefetch and uniq.size >= 512:
+            _madvise_rows(mm, uniq)
+        return _threaded_memmap_gather(mm, uniq, self._n_workers)
+
+    def _gather_quant_rows(self, flat: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+        """SSD-gather quantized weight+scale for unique ids."""
+        if flat.size == 0:
+            n_scales = self.head_dim // self.block_size
+            return (
+                np.empty((0, self.head_dim), dtype=np.uint8),
+                np.empty((0, n_scales), dtype=np.uint8),
+            )
+        n_workers = self._n_workers
+        if n_workers > 1 and flat.size >= 256:
+            with ThreadPoolExecutor(max_workers=2) as pool:
+                fw = pool.submit(self._gather_u8, self.weight, flat)
+                fs = pool.submit(self._gather_u8, self.scale, flat)
+                return fw.result(), fs.result()
+        return self._gather_u8(self.weight, flat), self._gather_u8(self.scale, flat)
+
+    @staticmethod
+    def _dequant_u8(
+        w: np.ndarray, s: np.ndarray, head_dim: int, block_size: int
+    ) -> np.ndarray:
+        w_f = _e4m3_lut()[w].reshape(w.shape[0], -1, block_size)
+        s_f = _ue8m0_to_float32(s)[..., None]
+        return (w_f * s_f).reshape(w.shape[0], head_dim).astype(np.float32, copy=False)
+
+    def _dequant_rows(self, flat: np.ndarray) -> np.ndarray:
+        """Dequant unique row indices -> float32 [M, head_dim]."""
+        if flat.size == 0:
+            return np.empty((0, self.head_dim), dtype=np.float32)
+        w, s = self._gather_quant_rows(flat)
+        return self._dequant_u8(w, s, self.head_dim, self.block_size)
+
+    def prefetch_unique(self, uniq: np.ndarray) -> None:
+        """Kick off background SSD gather+dequant (overlap with compute).
+
+        When a quantized hot-cache is bound, the job also returns the FP8+scale
+        rows so ``gather`` can insert them without a second SSD round-trip.
+        """
+        if uniq.size == 0:
+            return
+        self._prefetch_uniq = np.asarray(uniq, dtype=np.int64)
+        ids = self._prefetch_uniq
+        hot = self.hot_cache
+        want_quant = hot is not None and hot.enabled
+
+        def _job():
+            if want_quant:
+                w, s = self._gather_quant_rows(ids)
+                rows = self._dequant_u8(w, s, self.head_dim, self.block_size)
+                return rows, w, s
+            return self._dequant_rows(ids), None, None
+
+        self._prefetch_fut = _prefetch_pool().submit(_job)
+
+    def _take_prefetch(
+        self, uniq: np.ndarray
+    ) -> Tuple[Optional[np.ndarray], Optional[np.ndarray], Optional[np.ndarray]]:
+        """Returns (dequant_rows, weight_u8, scale_u8); quant arrays may be None."""
+        fut = self._prefetch_fut
+        cached = self._prefetch_uniq
+        self._prefetch_fut = None
+        self._prefetch_uniq = None
+        if fut is None or cached is None:
+            return None, None, None
+        if cached.shape != uniq.shape or not np.array_equal(cached, uniq):
+            try:
+                fut.result()
+            except Exception:
+                pass
+            return None, None, None
+        rows, w, s = fut.result()
+        return rows, w, s
+
+    def gather(self, indices: np.ndarray) -> mx.array:
+        """Gather + dequant rows. ``indices`` any int shape -> bf16/f16 [..., head_dim].
+
+        Order: quantized hot-cache hits first (RAM dequant), then prefetch/SSD
+        for misses only. Prefetch must not bypass the hot-cache or warm reuse
+        never gets credit and never skips I/O.
+        """
+        idx = np.asarray(indices, dtype=np.int64)
+        orig_shape = idx.shape
+        flat = np.clip(idx.reshape(-1), 0, self.num_embeddings - 1)
+        if flat.size == 0:
+            return mx.zeros((*orig_shape, self.head_dim), dtype=mx.float32)
+
+        uniq, inv = np.unique(flat, return_inverse=True)
+        hot = self.hot_cache
+        buf = self.row_buf
+        rows: Optional[np.ndarray] = None
+
+        if hot is not None and hot.enabled:
+            hit_mask, rows = hot.get_many(uniq)
+            miss_pos = np.flatnonzero(~hit_mask)
+            if miss_pos.size == 0:
+                # Full hot hit — drop any pending prefetch result.
+                self._take_prefetch(uniq)
+            else:
+                miss_keys = uniq[miss_pos]
+                pref, pref_w, pref_s = self._take_prefetch(uniq)
+                if pref is not None and pref_w is not None:
+                    # Prefetch covered the full unique set; take miss slice only.
+                    rows[miss_pos] = pref[miss_pos]
+                    hot.put_many(miss_keys, pref_w[miss_pos], pref_s[miss_pos])
+                else:
+                    w, s = self._gather_quant_rows(miss_keys)
+                    hot.put_many(miss_keys, w, s)
+                    rows[miss_pos] = self._dequant_u8(
+                        w, s, self.head_dim, self.block_size
+                    )
+        else:
+            pref, pref_w, pref_s = self._take_prefetch(uniq)
+            if pref is not None:
+                rows = pref
+                if buf is not None and buf.enabled:
+                    buf.put_many(uniq, rows)
+            elif buf is not None and buf.enabled:
+                hit_mask, rows = buf.get_many(uniq)
+                miss_pos = np.flatnonzero(~hit_mask)
+                if miss_pos.size:
+                    miss_keys = uniq[miss_pos]
+                    dequant = self._dequant_rows(miss_keys)
+                    rows[miss_pos] = dequant
+                    buf.put_many(miss_keys, dequant)
+            else:
+                rows = self._dequant_rows(uniq)
+
+        out = rows[inv].reshape(*orig_shape, self.head_dim)
+        storage = _row_storage_dtype()
+        if out.dtype != storage:
+            out = out.astype(storage)
+        return mx.array(out)
+
+
+def load_mmap_tables_from_meta(
+    layout: EngramLayout, meta_dir: Optional[Path] = None
+) -> Dict[int, MmapEngramTable]:
+    meta_dir = meta_dir or engram_dir()
+    meta_path = meta_dir / "meta.json"
+    with open(meta_path) as f:
+        meta = json.load(f)
+    tables: Dict[int, MmapEngramTable] = {}
+    block = int(meta.get("config", {}).get("fp8_block_size", 32))
+    row_buf = engram_row_buf()
+    n_layers = len(layout.layer_ids)
+    rows_each = _quant_cache_rows_per_layer(n_layers, layout.head_dim, block)
+    policy = engram_cache_policy()
+    for i, layer_id in enumerate(layout.layer_ids):
+        entry = meta["layers"][str(layer_id)]
+        w, s = entry["weight"], entry["scale"]
+        hot = None
+        if rows_each > 0:
+            hot = QuantHotRowCache(
+                rows_each, layout.head_dim, block_size=block, policy=policy
+            )
+            logger.info(
+                "Engram quant hot-cache layer %s: %s rows (%.2f GB, policy=%s, "
+                "%s B/row fp8+scale)",
+                layer_id,
+                rows_each,
+                rows_each * hot.bytes_per_row / (1024**3),
+                policy,
+                hot.bytes_per_row,
+            )
+        tables[layer_id] = MmapEngramTable(
+            weight_path=w["file"],
+            weight_offset=w["offset"],
+            scale_path=s["file"],
+            scale_offset=s["offset"],
+            num_embeddings=layout.num_embeddings[i],
+            head_dim=layout.head_dim,
+            block_size=block,
+            row_buf=row_buf,
+            hot_cache=hot,
+        )
+        logger.info(
+            "Engram mmap layer %s: %s rows from %s @%s (gather_threads=%s row_buf=%s hot=%s)",
+            layer_id,
+            layout.num_embeddings[i],
+            w["file"],
+            w["offset"],
+            engram_gather_threads(),
+            0 if hot is not None and hot.enabled else row_buf,
+            "on" if hot is not None and hot.enabled else "off",
+        )
+    return tables
+
+
+def prefetch_engram_layer(model: Any, layer_id: int, hash_ids: np.ndarray) -> None:
+    """Background-dequant hash ids for one Engram layer (overlap with other layers)."""
+    layers = getattr(getattr(model, "model", model), "layers", None)
+    if layers is None:
+        layers = getattr(model, "layers", [])
+    for layer in layers:
+        eng = getattr(layer, "engram", None)
+        if eng is None or int(eng.layer_id) != int(layer_id):
+            continue
+        table = getattr(eng, "_mmap_table", None)
+        if table is None:
+            return
+        idx = np.asarray(hash_ids, dtype=np.int64)
+        flat = np.clip(idx.reshape(-1), 0, table.num_embeddings - 1)
+        uniq = np.unique(flat)
+        table.prefetch_unique(uniq)
+        return
+
+
+class NgramHashState:
+    """Maps each position to hash ids of n-grams ending there (official NgramHashState)."""
+
+    def __init__(self, args, layout: EngramLayout, token_map: np.ndarray):
+        self.layout = layout
+        vocab_size = int(getattr(args, "engram_compressed_vocab_size", 0) or 0)
+        if vocab_size and int(token_map.max()) + 1 > vocab_size:
+            logger.warning(
+                "token_map max+1=%s > engram_compressed_vocab_size=%s",
+                int(token_map.max()) + 1,
+                vocab_size,
+            )
+        if vocab_size and int(token_map.max()) + 1 != vocab_size:
+            # Official asserts exact equality; we warn but continue if close.
+            computed = int(token_map.max()) + 1
+            # unique count may be lower than max+1 if sparse; multipliers use vocab_size.
+            if abs(computed - vocab_size) > 1:
+                logger.warning(
+                    "token_map max+1=%s != engram_compressed_vocab_size=%s "
+                    "(hash multipliers use expected)",
+                    computed,
+                    vocab_size,
+                )
+        use_vocab = vocab_size or int(token_map.max()) + 1
+        pad_token_id = int(
+            getattr(args, "engram_pad_token_id", getattr(args, "engram_pad_id", 2))
+        )
+        self.pad_id = int(token_map[pad_token_id])
+        flat = [[p for per_ngram in layer for p in per_ngram] for layer in layout.primes]
+        offsets = [np.cumsum([0, *sizes[:-1]]).astype(np.int64) for sizes in flat]
+        multipliers = compute_hash_multipliers(
+            layout.layer_ids, layout.max_ngram_size, use_vocab
+        )
+        # primes: [n_layers, max_ngram-1, n_heads]
+        self.primes = np.asarray(layout.primes, dtype=np.int64)
+        self.offsets = np.asarray(offsets, dtype=np.int64)  # [n_layers, n_hash_cols]
+        self.multipliers = multipliers  # [n_layers, max_ngram]
+        self.token_map = np.asarray(token_map, dtype=np.int64)
+        self._cache: Optional[np.ndarray] = None  # [B, max_seq]
+        self._cache_batch = 0
+
+    @classmethod
+    def from_engram_dir(cls, args, layout: EngramLayout, meta_dir: Optional[Path] = None):
+        meta_dir = meta_dir or engram_dir()
+        meta_path = meta_dir / "meta.json"
+        token_path = meta_dir / "token_map.npy"
+        if meta_path.exists():
+            meta = json.load(open(meta_path))
+            tp = meta.get("token_map")
+            if tp:
+                token_path = Path(tp)
+        token_map = np.load(token_path)
+        return cls(args, layout, token_map)
+
+    def _ensure_cache(self, batch: int, need_len: int):
+        if (
+            self._cache is None
+            or self._cache.shape[0] < batch
+            or self._cache.shape[1] < need_len
+        ):
+            new_len = max(need_len, 4096 if self._cache is None else self._cache.shape[1])
+            new_batch = max(batch, 1 if self._cache is None else self._cache.shape[0])
+            cache = np.full((new_batch, new_len), _DEAD, dtype=np.int64)
+            if self._cache is not None:
+                b = min(self._cache.shape[0], new_batch)
+                l = min(self._cache.shape[1], new_len)
+                cache[:b, :l] = self._cache[:b, :l]
+            self._cache = cache
+
+    def forward(
+        self,
+        input_ids: np.ndarray,
+        start_pos: int,
+        token_mask: Optional[np.ndarray] = None,
+    ) -> np.ndarray:
+        """Return hash ids [B, L, n_engram_layers, n_hash_cols] as int64 numpy."""
+        input_ids = np.asarray(input_ids, dtype=np.int64)
+        if input_ids.ndim == 1:
+            input_ids = input_ids[None, :]
+        batch, seqlen = input_ids.shape
+        self._ensure_cache(batch, start_pos + seqlen)
+        compressed = self.token_map[input_ids]
+        if token_mask is not None:
+            compressed = np.where(token_mask, compressed, _DEAD)
+        self._cache[:batch, start_pos : start_pos + seqlen] = compressed
+
+        positions = np.broadcast_to(
+            np.arange(start_pos, start_pos + seqlen, dtype=np.int64)[None, :],
+            (batch, seqlen),
+        )
+        blocked = np.zeros_like(positions, dtype=bool)
+        tokens = []
+        for shift in range(self.layout.max_ngram_size):
+            src_pos = np.maximum(positions - shift, 0)
+            # gather along seq
+            source = np.take_along_axis(self._cache[:batch], src_pos, axis=1)
+            blocked = blocked | (positions < shift) | (source == _DEAD)
+            tokens.append(np.where(blocked, self.pad_id, source))
+        tokens_a = np.stack(tokens, axis=-1)  # [B, L, max_ngram]
+
+        # products: [B, L, n_layers, max_ngram]
+        products = tokens_a[:, :, None, :] * self.multipliers[None, None, :, :]
+        rolling = products[..., 0]
+        hashes = []
+        for i in range(1, self.layout.max_ngram_size):
+            rolling = np.bitwise_xor(rolling, products[..., i])
+            # primes[:, i-1] -> [n_layers, n_heads]
+            mod = rolling[..., None] % self.primes[:, i - 1][None, None, :, :]
+            hashes.append(mod)
+        out = np.concatenate(hashes, axis=-1) + self.offsets[None, None, :, :]
+        return out.astype(np.int64)
+
+
+class Engram(nn.Module):
+    """Per-layer Engram: hash-id embedding + gated residual into HC streams."""
+
+    def __init__(self, args, layer_id: int, layout: EngramLayout):
+        super().__init__()
+        self.layer_id = layer_id
+        self.layout = layout
+        self.layer_hash_index = layout.layer_ids.index(layer_id)
+        self.dim = int(args.hidden_size)
+        self.hc_mult = int(args.hc_mult)
+        self.head_dim = layout.head_dim
+        self.n_hash_cols = layout.n_hash_cols
+        self.eps = float(getattr(args, "rms_norm_eps", 1e-20))
+        self.clamp_value = 1e-6
+        mode = engram_mode()
+        full_rows = int(layout.num_embeddings[self.layer_hash_index])
+        self.full_num_embeddings = full_rows
+        self.stub = False
+        self._mmap_table: Optional[MmapEngramTable] = None
+
+        if engram_is_mmap():
+            # No resident Embedding — tables come from MmapEngramTable.
+            logger.info(
+                "deepseek_v41 Engram layer %s mmap mode (rows=%s); "
+                "tables via OMLX_DSV41_ENGRAM_DIR",
+                layer_id,
+                full_rows,
+            )
+        elif mode == "full":
+            self.embed = nn.Embedding(full_rows, layout.head_dim)
+            logger.warning(
+                "deepseek_v41 Engram layer %s FULL resident table (%s rows) — "
+                "expects ~100GB+ unified memory per layer",
+                layer_id,
+                full_rows,
+            )
+        else:
+            # Should not normally construct Engram in stub (ids cleared), but keep safe.
+            rows = 1024
+            self.embed = nn.Embedding(rows, layout.head_dim)
+            self.stub = True
+            logger.info(
+                "deepseek_v41 Engram layer %s stub table %s rows (full=%s)",
+                layer_id,
+                rows,
+                full_rows,
+            )
+
+        self.wkv = nn.Linear(
+            self.n_hash_cols * layout.head_dim,
+            self.dim * (self.hc_mult + 1),
+            bias=False,
+        )
+        # Official: Parameter ones; loaded from checkpoint (bf16).
+        self.q_weight = mx.ones((self.hc_mult, self.dim))
+        self.k_weight = mx.ones((self.hc_mult, self.dim))
+
+    def bind_mmap_table(self, table: MmapEngramTable) -> None:
+        self._mmap_table = table
+
+    def _embed_ids(self, hash_ids) -> mx.array:
+        if self._mmap_table is not None:
+            # Prefer ndarray (model forward already hashed on CPU) to avoid mx↔np roundtrip.
+            if isinstance(hash_ids, np.ndarray):
+                ids_np = np.asarray(hash_ids, dtype=np.int64)
+            else:
+                mx.eval(hash_ids)
+                ids_np = np.asarray(hash_ids, dtype=np.int64)
+            return self._mmap_table.gather(ids_np)
+        embed = getattr(self, "embed", None)
+        assert embed is not None
+        if isinstance(hash_ids, np.ndarray):
+            hash_ids = mx.array(hash_ids)
+        if self.stub:
+            ids = hash_ids % embed.weight.shape[0]
+        else:
+            ids = hash_ids
+        return embed(ids)
+
+    def __call__(
+        self,
+        x: mx.array,
+        hash_ids=None,
+        token_mask: Optional[mx.array] = None,
+    ) -> mx.array:
+        """x: [B,L,hc,D]. Without hash_ids, returns x unchanged."""
+        if hash_ids is None:
+            return x
+        gathered = self._embed_ids(hash_ids)  # [B,L,n_hash_cols,head_dim]
+        b, l = gathered.shape[0], gathered.shape[1]
+        flat = gathered.reshape(b, l, -1)
+        if flat.dtype != x.dtype:
+            flat = flat.astype(x.dtype)
+        kv = self.wkv(flat)
+        key = kv[..., : self.hc_mult * self.dim].astype(mx.float32).reshape(
+            b, l, self.hc_mult, self.dim
+        )
+        value = kv[..., self.hc_mult * self.dim :]
+        weight = self.q_weight.astype(mx.float32) * self.k_weight.astype(mx.float32)
+        h = x.astype(mx.float32)
+        rstd = mx.rsqrt(mx.mean(mx.square(h), axis=-1) + self.eps) * mx.rsqrt(
+            mx.mean(mx.square(key), axis=-1) + self.eps
+        )
+        inv_sqrt_d = self.dim**-0.5
+        dot = mx.sum(h * weight * key, axis=-1) * rstd * inv_sqrt_d
+        mag = mx.sqrt(mx.maximum(mx.abs(dot), self.clamp_value))
+        signed = mx.where(dot < 0, -mag, mag)
+        gate = mx.sigmoid(signed)
+        if token_mask is not None:
+            gate = mx.where(token_mask[..., None], gate, mx.zeros_like(gate))
+        out = h + gate[..., None] * value.astype(mx.float32)[..., None, :]
+        return out.astype(x.dtype)
+
+
+def bind_mmap_tables(model: Any, layout: Optional[EngramLayout] = None) -> int:
+    """Attach MmapEngramTable to each Engram module. Returns number bound."""
+    if not engram_is_mmap():
+        return 0
+    layout = layout or getattr(getattr(model, "model", model), "engram_layout", None)
+    if layout is None:
+        return 0
+    tables = load_mmap_tables_from_meta(layout)
+    bound = 0
+    layers = getattr(getattr(model, "model", model), "layers", None)
+    if layers is None:
+        layers = getattr(model, "layers", [])
+    for layer in layers:
+        eng = getattr(layer, "engram", None)
+        if eng is None:
+            continue
+        table = tables.get(eng.layer_id)
+        if table is not None:
+            eng.bind_mmap_table(table)
+            bound += 1
+    return bound
+
+
+def bind_engram_hash(model: Any, args=None) -> Optional[NgramHashState]:
+    """Create NgramHashState from ENGRAM_DIR token_map and attach to model.model."""
+    inner = getattr(model, "model", model)
+    layout = getattr(inner, "engram_layout", None)
+    if layout is None:
+        return None
+    args = args or getattr(model, "args", None) or getattr(inner, "args", None)
+    state = NgramHashState.from_engram_dir(args, layout)
+    inner.engram_hash = state
+    bind_mmap_tables(model, layout)
+    return state

--- a/omlx/patches/deepseek_v41/engram_cache.py
+++ b/omlx/patches/deepseek_v41/engram_cache.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Quantized Engram hot-row cache (FP8 E4M3 + UE8M0 scales).
+
+**Point here for the Engram RAM working-set cache.**
+
+* Env: ``OMLX_DSV41_ENGRAM_CACHE_GB`` (default 50),
+  ``OMLX_DSV41_ENGRAM_CACHE_POLICY`` (``lru`` | ``clock``)
+* Class: :class:`QuantHotRowCache`
+* Bound on: ``MmapEngramTable.hot_cache`` in ``engram.py``
+* Stats: :func:`engram_cache_stats` (also re-exported from ``engram``)
+
+Full Engram tables stay on SSD via ``numpy.memmap``; only touched rows are
+stored here as on-disk FP8+scale bytes (~264 B/row at D=256).
+"""
+from __future__ import annotations
+
+import os
+from collections import OrderedDict
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+
+from omlx.patches.deepseek_v41.engram_fp8 import _e4m3_lut, _ue8m0_to_float32
+
+def engram_cache_gb() -> float:
+    """Total RAM budget (GB) for quantized Engram hot-row cache across layers.
+
+    Default 50. Set 0 to disable. Rows are stored as FP8+UE8M0 (~264 B/row
+    at D=256), so 50 GB holds ~200M rows (~2× a bf16 cache).
+    """
+    raw = os.environ.get("OMLX_DSV41_ENGRAM_CACHE_GB", "50").strip()
+    if not raw:
+        return 0.0
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        return 50.0
+
+
+def engram_cache_policy() -> str:
+    """``lru`` (default, oldest-used) or ``clock``."""
+    return os.environ.get("OMLX_DSV41_ENGRAM_CACHE_POLICY", "lru").strip().lower()
+
+class QuantHotRowCache:
+    """Fixed-capacity hot-row cache storing **quantized** Engram rows.
+
+    Each slot keeps FP8 E4M3 weights ``[D]`` plus UE8M0 scales ``[D/block]`` —
+    the on-disk layout — so a 50 GB budget holds ~2× as many rows as bf16.
+    Hits dequant in RAM (LUT); misses come from SSD then populate the cache.
+    Eviction: LRU (oldest-used, default) or CLOCK.
+    """
+
+    def __init__(
+        self,
+        capacity_rows: int,
+        head_dim: int,
+        block_size: int = 32,
+        policy: str = "lru",
+    ):
+        self.capacity = max(0, int(capacity_rows))
+        self.head_dim = int(head_dim)
+        self.block_size = int(block_size)
+        self.n_scales = self.head_dim // self.block_size
+        self.policy = (policy or "lru").strip().lower()
+        self.enabled = self.capacity > 0
+        # uint8 weight + uint8 scale (no padding bookkeeping beyond slot_key/ref)
+        self.bytes_per_row = self.head_dim + self.n_scales
+        self.hits = 0
+        self.misses = 0
+        self.inserts = 0
+        self.evictions = 0
+        self._hand = 0
+        self._n = 0
+        self._key_to_slot: Dict[int, int] = {}
+        self._lru: Optional["OrderedDict[int, int]"] = None
+        if not self.enabled:
+            self.weight = None
+            self.scale = None
+            self.slot_key = None
+            self.ref = None
+            return
+        self.weight = np.empty((self.capacity, self.head_dim), dtype=np.uint8)
+        self.scale = np.empty((self.capacity, self.n_scales), dtype=np.uint8)
+        self.slot_key = np.full(self.capacity, -1, dtype=np.int64)
+        self.ref = np.zeros(self.capacity, dtype=np.uint8)
+        if self.policy == "lru":
+            self._lru = OrderedDict()
+
+    @property
+    def size(self) -> int:
+        return self._n
+
+    @property
+    def hit_rate(self) -> float:
+        total = self.hits + self.misses
+        return (self.hits / total) if total else 0.0
+
+    def stats(self) -> Dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "capacity_rows": self.capacity,
+            "size": self._n,
+            "bytes_per_row": self.bytes_per_row,
+            "budget_gb": self.capacity * self.bytes_per_row / (1024**3),
+            "policy": self.policy,
+            "storage": "fp8_e4m3+ue8m0",
+            "hits": self.hits,
+            "misses": self.misses,
+            "inserts": self.inserts,
+            "evictions": self.evictions,
+            "hit_rate": self.hit_rate,
+        }
+
+    def reset_stats(self) -> None:
+        self.hits = self.misses = self.inserts = self.evictions = 0
+
+    def _dequant_slots(self, slots: np.ndarray) -> np.ndarray:
+        """Dequant cached slots -> float32 [N, D]."""
+        if slots.size == 0:
+            return np.empty((0, self.head_dim), dtype=np.float32)
+        w = self.weight[slots]
+        s = self.scale[slots]
+        w_f = _e4m3_lut()[w].reshape(slots.shape[0], -1, self.block_size)
+        s_f = _ue8m0_to_float32(s)[..., None]
+        return (w_f * s_f).reshape(slots.shape[0], self.head_dim).astype(
+            np.float32, copy=False
+        )
+
+    def get_many(self, keys: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+        """Lookup unique keys. Returns (hit_mask [N], rows_f32 [N, D] valid on hits)."""
+        n = int(keys.shape[0])
+        hit = np.zeros(n, dtype=bool)
+        out = np.empty((n, self.head_dim), dtype=np.float32)
+        if not self.enabled or n == 0:
+            self.misses += n
+            return hit, out
+        kmap = self._key_to_slot
+        lru = self._lru
+        hit_idx: List[int] = []
+        slots: List[int] = []
+        for i in range(n):
+            k = int(keys[i])
+            slot = kmap.get(k)
+            if slot is None:
+                self.misses += 1
+                continue
+            hit[i] = True
+            hit_idx.append(i)
+            slots.append(slot)
+            self.hits += 1
+            if lru is not None:
+                lru.move_to_end(k)
+        if slots:
+            slot_arr = np.asarray(slots, dtype=np.int64)
+            out[np.asarray(hit_idx, dtype=np.int64)] = self._dequant_slots(slot_arr)
+            self.ref[slot_arr] = 1
+        return hit, out
+
+    def _evict_clock(self) -> int:
+        cap = self.capacity
+        hand = self._hand
+        ref = self.ref
+        for _ in range(cap * 2):
+            if ref[hand] == 0:
+                victim = hand
+                self._hand = (hand + 1) % cap
+                return victim
+            ref[hand] = 0
+            hand = (hand + 1) % cap
+        self._hand = (hand + 1) % cap
+        return hand
+
+    def _evict_lru(self) -> int:
+        lru = self._lru
+        assert lru is not None
+        old_key, _ = lru.popitem(last=False)
+        slot = self._key_to_slot.pop(old_key)
+        self.slot_key[slot] = -1
+        return slot
+
+    def put_many(
+        self, keys: np.ndarray, weight_u8: np.ndarray, scale_u8: np.ndarray
+    ) -> None:
+        """Insert quantized rows (uint8 weight + scale) into the cache."""
+        if not self.enabled or keys.size == 0:
+            return
+        kmap = self._key_to_slot
+        lru = self._lru
+        for i in range(int(keys.shape[0])):
+            k = int(keys[i])
+            slot = kmap.get(k)
+            if slot is not None:
+                self.weight[slot] = weight_u8[i]
+                self.scale[slot] = scale_u8[i]
+                self.ref[slot] = 1
+                if lru is not None:
+                    lru.move_to_end(k)
+                continue
+            if self._n < self.capacity:
+                slot = self._n
+                self._n += 1
+            else:
+                if self.policy == "lru" and lru is not None:
+                    slot = self._evict_lru()
+                else:
+                    slot = self._evict_clock()
+                    old = int(self.slot_key[slot])
+                    if old >= 0:
+                        kmap.pop(old, None)
+                        if lru is not None:
+                            lru.pop(old, None)
+                self.evictions += 1
+            old = int(self.slot_key[slot])
+            if old >= 0 and old != k:
+                kmap.pop(old, None)
+                if lru is not None:
+                    lru.pop(old, None)
+            self.slot_key[slot] = k
+            kmap[k] = slot
+            self.weight[slot] = weight_u8[i]
+            self.scale[slot] = scale_u8[i]
+            self.ref[slot] = 1
+            if lru is not None:
+                lru[k] = slot
+                lru.move_to_end(k)
+            self.inserts += 1
+
+def _quant_cache_rows_per_layer(n_layers: int, head_dim: int, block_size: int = 32) -> int:
+    """Split ``OMLX_DSV41_ENGRAM_CACHE_GB`` evenly; row = FP8[D] + UE8M0[D/block]."""
+    gb = engram_cache_gb()
+    if gb <= 0 or n_layers <= 0:
+        return 0
+    bytes_per_row = int(head_dim) + int(head_dim) // int(block_size)
+    total_bytes = int(gb * (1024**3))
+    per_layer = total_bytes // n_layers
+    return max(0, per_layer // bytes_per_row)
+
+def engram_cache_stats(model: Any = None) -> Dict[int, Dict[str, Any]]:
+    """Return per-layer quantized hot-cache stats from a bound model."""
+    out: Dict[int, Dict[str, Any]] = {}
+    if model is None:
+        return out
+    layers = getattr(getattr(model, "model", model), "layers", None)
+    if layers is None:
+        layers = getattr(model, "layers", [])
+    for layer in layers:
+        eng = getattr(layer, "engram", None)
+        if eng is None:
+            continue
+        table = getattr(eng, "_mmap_table", None)
+        hot = getattr(table, "hot_cache", None) if table is not None else None
+        if hot is None or not hot.enabled:
+            continue
+        out[int(eng.layer_id)] = hot.stats()
+    return out

--- a/omlx/patches/deepseek_v41/engram_fp8.py
+++ b/omlx/patches/deepseek_v41/engram_fp8.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+"""FP8 E4M3 / UE8M0 helpers for DeepSeek-V4.1 Engram tables."""
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+_E4M3_LUT: Optional[np.ndarray] = None
+
+
+def _ue8m0_to_float32(scale_u8: np.ndarray) -> np.ndarray:
+    """Decode UE8M0 / float8_e8m0fnu bytes to float32 powers of two."""
+    return np.ldexp(1.0, scale_u8.astype(np.int32) - 127).astype(np.float32)
+
+
+def _e4m3_to_float32(weight_u8: np.ndarray) -> np.ndarray:
+    """Decode float8_e4m3fn bytes to float32."""
+    try:
+        import ml_dtypes
+
+        return weight_u8.view(ml_dtypes.float8_e4m3fn).astype(np.float32)
+    except Exception:
+        # Manual E4M3: 1 sign, 4 exp, 3 mant; bias 7; max finite 448.
+        u = weight_u8.astype(np.uint8)
+        sign = ((u >> 7) & 1).astype(np.float32)
+        exp = (u >> 3) & 0xF
+        mant = u & 0x7
+        out = np.empty(u.shape, dtype=np.float32)
+        # zeros
+        zero = exp == 0
+        # subnormals: (-1)^s * 2^(1-bias) * (mant/8)
+        sub = zero & (mant != 0)
+        out[zero & (mant == 0)] = 0.0
+        out[sub] = (mant[sub].astype(np.float32) / 8.0) * np.ldexp(1.0, 1 - 7)
+        # normals
+        norm = ~zero
+        out[norm] = (1.0 + mant[norm].astype(np.float32) / 8.0) * np.ldexp(
+            1.0, exp[norm].astype(np.int32) - 7
+        )
+        out[sign == 1] = -out[sign == 1]
+        return out
+
+def _e4m3_lut() -> np.ndarray:
+    global _E4M3_LUT
+    if _E4M3_LUT is None:
+        _E4M3_LUT = _e4m3_to_float32(np.arange(256, dtype=np.uint8))
+    return _E4M3_LUT

--- a/omlx/patches/deepseek_v41/predicates.py
+++ b/omlx/patches/deepseek_v41/predicates.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Model-type predicates that avoid the deepseek_v4 / deepseek_v41 collision.
+
+``str.startswith("deepseek_v4")`` matches both ``deepseek_v4`` and
+``deepseek_v41``. Use these helpers everywhere we dispatch patches.
+"""
+from __future__ import annotations
+
+
+def is_deepseek_v41(model_type: str | None) -> bool:
+    if not isinstance(model_type, str):
+        return False
+    return model_type == "deepseek_v41" or model_type.startswith("deepseek_v41")
+
+
+def is_deepseek_v4(model_type: str | None) -> bool:
+    """True for DeepSeek-V4 / V4-Flash, NOT V4.1."""
+    if not isinstance(model_type, str):
+        return False
+    if is_deepseek_v41(model_type):
+        return False
+    return model_type == "deepseek_v4" or model_type.startswith("deepseek_v4_")
+
+
+def is_deepseek_v4_family(model_type: str | None) -> bool:
+    """True for either V4 or V4.1 (shared tooling that is version-agnostic)."""
+    return is_deepseek_v4(model_type) or is_deepseek_v41(model_type)

--- a/omlx/patches/deepseek_v41/select_candidates.py
+++ b/omlx/patches/deepseek_v41/select_candidates.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Level-1 candidate block prefilter for the V4.1 hierarchical indexer."""
+from __future__ import annotations
+
+import mlx.core as mx
+
+
+def select_candidate_blocks(
+    logits: mx.array,
+    compress_lens,
+    topk_blocks: int,
+    block_size: int,
+) -> mx.array:
+    """Keep the ``topk_blocks`` highest-scoring blocks per query.
+
+    ``logits`` is ``[..., n_positions]`` with unreachable positions at ``-inf``.
+    ``compress_lens`` is an int (decode) or an array broadcastable against the
+    leading dims of ``logits`` (prefill). Returns a bool mask shaped like
+    ``logits``.
+
+    Mirrors official ``select_candidate_blocks`` in inference/model.py.
+    """
+    width = logits.shape[-1]
+    pad = (-width) % block_size
+    if pad:
+        logits_p = mx.pad(
+            logits,
+            [(0, 0)] * (logits.ndim - 1) + [(0, pad)],
+            constant_values=-mx.inf,
+        )
+    else:
+        logits_p = logits
+
+    # [..., num_blocks, block_size] -> amax over block
+    scores = mx.unflatten(logits_p, -1, (-1, block_size)).max(axis=-1)
+    num_blocks = scores.shape[-1]
+
+    # Pin the block that holds this query's newest compressed position.
+    if isinstance(compress_lens, mx.array):
+        last = (compress_lens - 1) // block_size
+        while last.ndim < scores.ndim:
+            last = last[..., None]
+        block_ids = mx.arange(num_blocks)
+        while block_ids.ndim < scores.ndim:
+            block_ids = block_ids.reshape((1,) * (scores.ndim - 1) + (num_blocks,))
+        scores = mx.where(block_ids == last, mx.array(mx.inf, dtype=scores.dtype), scores)
+    else:
+        last = (int(compress_lens) - 1) // block_size
+        if 0 <= last < num_blocks:
+            # Set that block's score to +inf via scatter-like where
+            block_ids = mx.arange(num_blocks)
+            scores = mx.where(block_ids == last, mx.array(mx.inf, dtype=scores.dtype), scores)
+
+    k = min(int(topk_blocks), int(num_blocks))
+    # top-k indices; drop -inf leftovers
+    part = mx.argpartition(-scores, kth=k - 1, axis=-1)[..., :k]
+    selected = mx.take_along_axis(scores, part, axis=-1)
+    # Vectorized keep mask: [..., num_blocks, k] membership without a Python loop.
+    block_ids = mx.arange(num_blocks)
+    while block_ids.ndim < scores.ndim:
+        block_ids = block_ids.reshape((1,) * (scores.ndim - 1) + (num_blocks,))
+    hit = block_ids[..., None] == part[..., None, :]
+    valid = selected > -mx.inf
+    keep = mx.any(mx.logical_and(hit, valid[..., None, :]), axis=-1)
+
+    # Expand blocks to positions and trim pad
+    keep = mx.repeat(keep, block_size, axis=-1)[..., :width]
+    return keep

--- a/omlx/patches/deepseek_v41/shared_runtime.py
+++ b/omlx/patches/deepseek_v41/shared_runtime.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cross-layer shared attention state for DeepSeek-V4.1 CSA2.
+
+Matches official ``SharedAttentionRuntime`` in inference/model.py: sources
+write before consumers read within a single forward, so one slot each is
+enough. Pool *identity* is the PoolingCache (or tensor buffer) object that
+kv/index source layers own and that consumers reuse.
+"""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+class SharedAttentionRuntime:
+    """Mutable hand-off between CSA2 layers in stack order."""
+
+    def __init__(self) -> None:
+        self.compress_kv: Any = None
+        self.index_k: Any = None
+        self.topk_idxs: Any = None
+        self.candidates: Any = None
+        # Stable pool objects keyed by owning source layer id (for make_cache
+        # identity tests and cross-layer reuse).
+        self.kv_pool_by_source: dict[int, Any] = {}
+        self.index_pool_by_source: dict[int, Any] = {}
+
+    def reset_forward_slots(self) -> None:
+        """Clear per-forward pointers (not the registered pools)."""
+        self.compress_kv = None
+        self.index_k = None
+        self.topk_idxs = None
+        self.candidates = None
+
+    def register_kv_pool(self, source_layer_id: int, pool: Any) -> Any:
+        existing = self.kv_pool_by_source.get(source_layer_id)
+        if existing is not None:
+            return existing
+        self.kv_pool_by_source[source_layer_id] = pool
+        return pool
+
+    def register_index_pool(self, source_layer_id: int, pool: Any) -> Any:
+        existing = self.index_pool_by_source.get(source_layer_id)
+        if existing is not None:
+            return existing
+        self.index_pool_by_source[source_layer_id] = pool
+        return pool
+
+    def kv_source_for(self, layer_id: int, source_ids: list[int]) -> Optional[int]:
+        """Largest kv_source_layer_id <= layer_id (official reuse rule)."""
+        candidates = [s for s in source_ids if s <= layer_id]
+        return max(candidates) if candidates else None
+
+    def index_source_for(self, layer_id: int, source_ids: list[int]) -> Optional[int]:
+        candidates = [s for s in source_ids if s <= layer_id]
+        return max(candidates) if candidates else None
+
+
+# Process-global runtime matching the official module-level singleton.
+shared_attn = SharedAttentionRuntime()

--- a/omlx/patches/deepseek_v41/tokenizer_patch.py
+++ b/omlx/patches/deepseek_v41/tokenizer_patch.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tokenizer + chat-template hooks for DeepSeek-V4.1.
+
+HF ``tokenizer_config.json`` ships ``add_bos_token: false``, but the official
+encoder always prefixes ``<｜begin▁of▁sentence｜>``. Without BOS, greedy
+completion collapses after the first token.
+
+Mirrors the V4 tokenizer load patch: wrap ``mlx_lm.tokenizer_utils.load``
+*and* rebind ``mlx_lm.utils._load_tokenizer`` (already imported at module
+load time).
+
+BOS handling: ensure encode prepends bos_token_id when missing, without
+doubling when the chat template already embedded the BOS string.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+
+from omlx.patches.deepseek_v41.predicates import is_deepseek_v41
+
+logger = logging.getLogger(__name__)
+_PATCHED = False
+
+_BOS_STRING = "<｜begin▁of▁sentence｜>"
+
+
+def _register_chat_template_module() -> None:
+    if "mlx_lm.chat_templates.deepseek_v41" not in sys.modules:
+        from . import chat_template_v41 as _ct
+
+        sys.modules["mlx_lm.chat_templates.deepseek_v41"] = _ct
+        sys.modules["mlx_lm.chat_templates.deepseek_v41_text"] = _ct
+
+
+def _is_deepseek_v41_model(model_path) -> bool:
+    try:
+        cfg_path = Path(model_path) / "config.json"
+        if not cfg_path.is_file():
+            return False
+        cfg = json.loads(cfg_path.read_text())
+        mt = cfg.get("model_type")
+        if mt is None and isinstance(cfg.get("text_config"), dict):
+            mt = cfg["text_config"].get("model_type")
+        return is_deepseek_v41(mt)
+    except Exception:
+        return False
+
+
+def _ensure_bos_on_encode(wrapper) -> None:
+    """Wrap inner encode so raw prompts get a leading BOS exactly once."""
+    inner = getattr(wrapper, "_tokenizer", None)
+    if inner is None or getattr(inner, "_omlx_dsv41_bos_wrapped", False):
+        return
+    bos_id = getattr(inner, "bos_token_id", None)
+    if bos_id is None:
+        return
+    orig_encode = inner.encode
+
+    def encode(text, *args, **kwargs):
+        add_special = kwargs.get("add_special_tokens", True)
+        ids = orig_encode(text, *args, **kwargs)
+        if not add_special:
+            return ids
+        # list-ify for mutation across HF return types
+        out = list(ids)
+        if out and out[0] == bos_id:
+            return ids
+        # Chat-template strings already contain the BOS marker; encoding
+        # that marker yields bos_id as the first token. Raw prompts don't.
+        return [bos_id] + out
+
+    inner.encode = encode  # type: ignore[method-assign]
+    inner._omlx_dsv41_bos_wrapped = True
+
+
+def apply_tokenizer_patch() -> bool:
+    """Inject V4.1 chat template + BOS-on-encode into TokenizerWrapper load."""
+    global _PATCHED
+    if _PATCHED:
+        return False
+
+    try:
+        import mlx_lm.tokenizer_utils as _tu
+    except Exception as e:  # pragma: no cover
+        logger.warning("V4.1 tokenizer patch: mlx_lm.tokenizer_utils missing: %s", e)
+        return False
+
+    _register_chat_template_module()
+    orig_load = _tu.load
+
+    def patched_load(model_path, tokenizer_config_extra=None, eos_token_ids=None):
+        wrapper = orig_load(
+            model_path,
+            tokenizer_config_extra=tokenizer_config_extra,
+            eos_token_ids=eos_token_ids,
+        )
+        if not _is_deepseek_v41_model(model_path):
+            return wrapper
+
+        from . import chat_template_v41 as _ct
+
+        _ensure_bos_on_encode(wrapper)
+        # Avoid mlx auto-enabling thinking via has_thinking.
+        try:
+            wrapper.has_thinking = False
+        except Exception:
+            pass
+
+        if getattr(wrapper, "_chat_template", None) is None:
+            wrapper._chat_template = _ct.apply_chat_template
+            wrapper.has_chat_template = True
+            logger.info(
+                "Injected deepseek_v41 chat_template into TokenizerWrapper for %s",
+                model_path,
+            )
+        return wrapper
+
+    _tu.load = patched_load
+    try:
+        import mlx_lm.utils as _mu
+
+        if hasattr(_mu, "_load_tokenizer"):
+            _mu._load_tokenizer = patched_load
+    except Exception as e:
+        logger.warning(
+            "Could not patch mlx_lm.utils._load_tokenizer (V4.1 chat_template "
+            "injection may not fire): %s",
+            e,
+        )
+
+    _PATCHED = True
+    logger.info(
+        "mlx_lm.tokenizer_utils.load wrapped "
+        "(injects chat_template + BOS encode for deepseek_v41)"
+    )
+    return True
+
+
+__all__ = ["apply_tokenizer_patch"]

--- a/omlx/patches/deepseek_v41/utils_patch.py
+++ b/omlx/patches/deepseek_v41/utils_patch.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+"""V4.1-specific load_model hooks (fp8 quant via make_quantization_config).
+
+Reuses the V4 utils_patch F8_E8M0 loader when already installed; adds a
+``deepseek_v41`` fp8 branch if the active load_model does not yet route V4.1.
+"""
+from __future__ import annotations
+
+import logging
+
+from omlx.patches.deepseek_v41.predicates import is_deepseek_v41
+
+logger = logging.getLogger(__name__)
+_PATCHED = False
+
+
+def apply_utils_patch() -> bool:
+    """Ensure V4.1 fp8 quantization uses ``make_quantization_config``.
+
+    The V4 ``utils_patch`` already replaces ``mlx_lm.utils.load_model`` with
+    F8_E8M0 handling. We wrap that (or the stock function) so ``deepseek_v41``
+    hits the same fp8 path with V4.1's quantization config.
+    """
+    global _PATCHED
+    if _PATCHED:
+        return False
+
+    # Prefer installing V4 utils patch first for shared safetensors fallback.
+    try:
+        from omlx.patches.deepseek_v4.utils_patch import apply_utils_patch as v4_utils
+
+        v4_utils()
+    except Exception as e:
+        logger.debug("V4 utils_patch not applied before V4.1: %s", e)
+
+    import mlx_lm.utils as _utils
+
+    original = _utils.load_model
+
+    # If V4 patch already handles only is_deepseek_v4, wrap to add v41.
+    # Monkey-patch make_quantization_config lookup via a thin wrapper around
+    # the quant branch is fragile; instead register a helper used by tests and
+    # document that omlx model_loading applies this patch before load.
+    def _ensure_v41_quant(config, model):
+        qc = config.get("quantization_config") or {}
+        if qc.get("quant_method") == "fp8" and is_deepseek_v41(
+            str(config.get("model_type", ""))
+        ):
+            from mlx_lm.models.deepseek_v41 import make_quantization_config
+
+            return make_quantization_config(model)
+        return None
+
+    _utils._omlx_deepseek_v41_quant = _ensure_v41_quant  # type: ignore[attr-defined]
+    _PATCHED = True
+    logger.info("deepseek_v41 utils helpers installed")
+    return True
+
+
+def flatten_text_config(config: dict) -> dict:
+    """Public helper used by tests and loaders."""
+    if not isinstance(config, dict):
+        return config
+    out = dict(config)
+    text = out.get("text_config")
+    if isinstance(text, dict):
+        for k, v in text.items():
+            out.setdefault(k, v)
+    return out

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -513,11 +513,19 @@ def maybe_apply_pre_load_patches(
                 )
 
     model_type = config.get("model_type")
-    if isinstance(model_type, str) and model_type.startswith("deepseek_v4"):
-        from ..patches.deepseek_v4 import apply_deepseek_v4_patch
+    if isinstance(model_type, str):
+        from ..patches.deepseek_v41.predicates import is_deepseek_v4, is_deepseek_v41
 
-        if apply_deepseek_v4_patch():
-            logger.info("DeepSeek V4 pre-load patch applied for %s", model_name)
+        if is_deepseek_v41(model_type):
+            from ..patches.deepseek_v41 import apply_deepseek_v41_patch
+
+            if apply_deepseek_v41_patch():
+                logger.info("Applied DeepSeek-V4.1 mlx-lm patch for model_type=%s", model_type)
+        elif is_deepseek_v4(model_type):
+            from ..patches.deepseek_v4 import apply_deepseek_v4_patch
+
+            if apply_deepseek_v4_patch():
+                logger.info("DeepSeek V4 pre-load patch applied for %s", model_name)
 
     if model_type == "step3p7":
         from ..patches.step3p7 import apply_step3p7_patch
@@ -1113,6 +1121,8 @@ def _is_mtp_compatible(config: dict, model_type: str | None) -> bool:
     only). The model also has to declare MTP heads in the config; otherwise
     the patch is a no-op.
     """
+    from ..patches.deepseek_v41.predicates import is_deepseek_v4_family
+
     if not _has_mtp_heads(config):
         return False
     if not model_type:
@@ -1120,7 +1130,7 @@ def _is_mtp_compatible(config: dict, model_type: str | None) -> bool:
     return (
         model_type.startswith("qwen3_5")
         or model_type.startswith("qwen3_6")
-        or model_type.startswith("deepseek_v4")
+        or is_deepseek_v4_family(model_type)
         or model_type.startswith("nemotron_h")
         or model_type == "glm_moe_dsa"
         or model_type in ("gemma4", "gemma4_unified")

--- a/tests/test_deepseek_v41.py
+++ b/tests/test_deepseek_v41.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for DeepSeek-V4.1 Flash omlx patch (no full weights required)."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import mlx.core as mx
+import pytest
+
+
+@pytest.fixture(scope="module")
+def applied_patch():
+    from omlx.patches.deepseek_v41 import apply_deepseek_v41_patch
+
+    apply_deepseek_v41_patch()
+    return True
+
+
+class TestPredicates:
+    def test_v4_excludes_v41(self):
+        from omlx.patches.deepseek_v41.predicates import (
+            is_deepseek_v4,
+            is_deepseek_v41,
+            is_deepseek_v4_family,
+        )
+
+        assert is_deepseek_v41("deepseek_v41")
+        assert is_deepseek_v41("deepseek_v41_text")
+        assert not is_deepseek_v4("deepseek_v41")
+        assert not is_deepseek_v4("deepseek_v41_text")
+        assert is_deepseek_v4("deepseek_v4")
+        assert is_deepseek_v4("deepseek_v4_mtp")
+        assert is_deepseek_v4_family("deepseek_v41")
+        assert is_deepseek_v4_family("deepseek_v4")
+
+    def test_startswith_collision(self):
+        # Document the bug we fixed
+        assert "deepseek_v41".startswith("deepseek_v4")
+        from omlx.patches.deepseek_v41.predicates import is_deepseek_v4
+
+        assert not is_deepseek_v4("deepseek_v41")
+
+
+class TestModelArgs:
+    def test_flatten_text_config(self, applied_patch):
+        from mlx_lm.models.deepseek_v41 import ModelArgs
+
+        raw = {
+            "model_type": "deepseek_v41",
+            "text_config": {
+                "hidden_size": 5120,
+                "num_hidden_layers": 4,
+                "moe_intermediate_size": 2304,
+                "n_routed_experts": 8,
+                "num_experts_per_tok": 2,
+                "rms_norm_eps": 1e-20,
+                "compress_ratios": [0, 2, 1, 0],
+                "kv_source_layer_ids": [1],
+                "index_source_layer_ids": [1],
+                "index_n_heads": 32,
+                "hc_mult": 4,
+                "engram_layer_ids": [1],
+                "engram_num_embeddings": [1024],
+                "engram_max_ngram_size": 4,
+                "engram_n_heads": 8,
+                "engram_head_dim": 256,
+                "dspark_target_layer_ids": [37, 38, 39],
+                "dspark_block_size": 5,
+            },
+        }
+        args = ModelArgs.from_dict(raw)
+        assert args.model_type == "deepseek_v41"
+        assert args.hidden_size == 5120
+        assert args.num_hidden_layers == 4
+        assert args.rms_norm_eps == 1e-20
+        assert args.compress_ratios == [0, 2, 1, 0]
+        assert args.index_n_heads == 32
+        assert args.kv_source_layer_ids == [1]
+        assert args.dspark_target_layer_ids == [37, 38, 39]
+
+    def test_compress_ratios_validation(self, applied_patch):
+        from mlx_lm.models.deepseek_v41 import ModelArgs
+
+        with pytest.raises(ValueError, match="compress ratios"):
+            ModelArgs(
+                num_hidden_layers=3,
+                compress_ratios=[0, 4, 128],
+            )
+
+        ok = ModelArgs(num_hidden_layers=3, compress_ratios=[0, 1, 2])
+        assert ok.compress_ratios == [0, 1, 2]
+
+    def test_official_config_json(self, applied_patch):
+        cfg_path = Path("/tmp/dsv41-work/config.json")
+        if not cfg_path.exists():
+            pytest.skip("official config not available")
+        from mlx_lm.models.deepseek_v41 import ModelArgs
+
+        raw = json.loads(cfg_path.read_text())
+        args = ModelArgs.from_dict(raw)
+        assert args.num_hidden_layers == 40
+        assert set(args.compress_ratios) <= {0, 1, 2}
+        import os
+        if os.environ.get("OMLX_DSV41_ENGRAM", "stub").strip().lower() == "full":
+            assert args.engram_layer_ids == [1, 14]
+        else:
+            assert args.engram_layer_ids == []  # stub mode strips Engram hooks
+        assert args.index_n_heads == 32
+
+
+class TestSelectCandidateBlocks:
+    def test_shapes_and_pin_last(self):
+        from omlx.patches.deepseek_v41.select_candidates import select_candidate_blocks
+
+        # 1 query, 16 positions, block_size=4 -> 4 blocks
+        positions = mx.arange(16)
+        logits = mx.where(positions == 0, mx.array(100.0), mx.array(-10.0))
+        logits = logits[None, :]
+        mask = select_candidate_blocks(logits, compress_lens=16, topk_blocks=2, block_size=4)
+        assert mask.shape == (1, 16)
+        assert mask.dtype == mx.bool_
+        # last block (positions 12-15) pinned + block 0
+        assert bool(mask[0, 0])
+        assert bool(mask[0, 15])
+
+
+class TestSharedAttentionRuntime:
+    def test_pool_identity(self, applied_patch):
+        from omlx.patches.deepseek_v4 import apply_pooling_cache_support
+
+        apply_pooling_cache_support()
+        from mlx_lm.models.cache import PoolingCache
+        from omlx.patches.deepseek_v41.shared_runtime import SharedAttentionRuntime
+
+        rt = SharedAttentionRuntime()
+        p1 = rt.register_kv_pool(2, PoolingCache(2))
+        p2 = rt.register_kv_pool(2, PoolingCache(2))
+        assert p1 is p2
+        assert rt.kv_source_for(5, [2, 8, 14]) == 2
+        assert rt.kv_source_for(10, [2, 8, 14]) == 8
+
+
+class TestDeferredHC:
+    def test_mix_shapes(self, applied_patch):
+        from mlx_lm.models.deepseek_v41 import ModelArgs
+        from omlx.patches.deepseek_v41.deferred_hc import (
+            DeferredHyperConnection,
+            hc_collapse,
+            make_identity_pre_mix,
+        )
+
+        args = ModelArgs(
+            num_hidden_layers=2,
+            hidden_size=64,
+            hc_mult=4,
+            compress_ratios=[0, 0],
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            moe_intermediate_size=32,
+            num_attention_heads=4,
+            head_dim=16,
+            q_lora_rank=32,
+            o_lora_rank=32,
+            o_groups=2,
+            index_n_heads=4,
+            index_head_dim=16,
+        )
+        hc = DeferredHyperConnection(args)
+        B, L, H, D = 1, 3, 4, 64
+        x = mx.random.normal((B, L, H, D))
+        pre, post, comb = hc.mixes(x)
+        assert pre.shape == (B, L, H)
+        assert post.shape == (B, L, H)
+        assert comb.shape == (B, L, H, H)
+        identity = make_identity_pre_mix(x, H)
+        collapsed = hc_collapse(x, identity)
+        assert collapsed.shape == (B, L, D)
+
+
+class TestSanitize:
+    def test_key_remaps(self, applied_patch):
+        from mlx_lm.models.deepseek_v41 import Model, ModelArgs
+
+        args = ModelArgs(
+            num_hidden_layers=2,
+            hidden_size=64,
+            vocab_size=128,
+            compress_ratios=[0, 0],
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            moe_intermediate_size=32,
+            num_attention_heads=4,
+            head_dim=16,
+            q_lora_rank=32,
+            o_lora_rank=32,
+            o_groups=2,
+            index_n_heads=4,
+            hc_mult=4,
+        )
+        model = Model(args)
+        fake = {
+            "embed.weight": mx.zeros((128, 64)),
+            "head.weight": mx.zeros((128, 64)),
+            "norm.weight": mx.zeros((64,)),
+            "hc_head_fn": mx.zeros((4, 256)),
+            "layers.0.ffn.gate.bias": mx.zeros((4,)),
+            "mtp.0.main_proj.weight": mx.zeros((64, 64)),
+        }
+        out = model.sanitize(fake)
+        assert "model.embed_tokens.weight" in out
+        assert "lm_head.weight" in out
+        assert "model.hc_head.fn" in out
+        assert "model.layers.0.ffn.gate.e_score_correction_bias" in out
+        assert "mtp.0.main_proj.weight" not in out
+
+
+class TestSmokeImport:
+    def test_apply_patch_import(self):
+        from omlx.patches.deepseek_v41 import apply_deepseek_v41_patch
+
+        apply_deepseek_v41_patch()
+        assert "mlx_lm.models.deepseek_v41" in sys.modules
+
+    def test_make_cache_shared_pools(self, applied_patch):
+        from mlx_lm.models.deepseek_v41 import Model, ModelArgs
+
+        args = ModelArgs(
+            num_hidden_layers=6,
+            hidden_size=64,
+            vocab_size=128,
+            compress_ratios=[0, 0, 2, 2, 2, 0],
+            kv_source_layer_ids=[2],
+            index_source_layer_ids=[2],
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            moe_intermediate_size=32,
+            num_attention_heads=4,
+            head_dim=16,
+            q_lora_rank=32,
+            o_lora_rank=32,
+            o_groups=2,
+            index_n_heads=4,
+            hc_mult=4,
+        )
+        model = Model(args)
+        caches = model.make_cache()
+        assert len(caches) == 6
+        # layers 3,4 should reuse layer 2's kv pool
+        from mlx_lm.models.cache import CacheList
+
+        assert isinstance(caches[2], CacheList)
+        assert isinstance(caches[3], CacheList)
+        assert caches[2][1] is caches[3][1]

--- a/tests/test_deepseek_v41_candidate.py
+++ b/tests/test_deepseek_v41_candidate.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Candidate-block prefilter exactness tests (Hierarchical Sparse Indexer L1)."""
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+
+def _select_candidate_blocks_np(
+    logits: np.ndarray,
+    compress_lens,
+    topk_blocks: int,
+    block_size: int,
+) -> np.ndarray:
+    """NumPy reference matching inference/model.py:select_candidate_blocks."""
+    width = logits.shape[-1]
+    pad = (-width) % block_size
+    if pad:
+        logits_p = np.pad(logits, [(0, 0)] * (logits.ndim - 1) + [(0, pad)], constant_values=-np.inf)
+    else:
+        logits_p = logits
+    scores = logits_p.reshape(*logits.shape[:-1], -1, block_size).max(axis=-1)
+    num_blocks = scores.shape[-1]
+    last = (np.asarray(compress_lens) - 1) // block_size
+    # pin newest block
+    ar = np.arange(num_blocks)
+    if np.ndim(last) == 0:
+        scores = scores.copy()
+        scores[..., ar == int(last)] = np.inf
+    else:
+        scores = scores.copy()
+        # broadcast last against scores leading dims — keep simple for unit tests
+        for idx in np.ndindex(scores.shape[:-1]):
+            scores[idx][ar == int(np.asarray(last)[idx])] = np.inf
+    k = min(topk_blocks, num_blocks)
+    # topk
+    part = np.argpartition(-scores, kth=k - 1, axis=-1)[..., :k]
+    top_vals = np.take_along_axis(scores, part, axis=-1)
+    keep = np.zeros_like(scores, dtype=bool)
+    # scatter
+    for idx in np.ndindex(keep.shape[:-1]):
+        for j, (bi, val) in enumerate(zip(part[idx], top_vals[idx])):
+            if val > -np.inf:
+                keep[idx][bi] = True
+    mask = np.repeat(keep, block_size, axis=-1)[..., :width]
+    return mask
+
+
+@pytest.fixture
+def select_fn():
+    from omlx.patches.deepseek_v41.select_candidates import select_candidate_blocks
+
+    return select_candidate_blocks
+
+
+def test_newest_block_always_kept(select_fn):
+    # 3 blocks of size 8; only first 20 positions reachable
+    width = 20
+    logits = np.full((1, 1, width), -1.0, dtype=np.float32)
+    # make block 0 huge, block 1 tiny, block 2 (newest, partial) tiny
+    logits[..., 0:8] = 10.0
+    logits[..., 8:16] = -5.0
+    logits[..., 16:20] = -5.0
+    compress_lens = 20
+    mask = select_fn(mx.array(logits), compress_lens, topk_blocks=2, block_size=8)
+    m = np.array(mask)
+    # newest block positions 16..19 must be True despite low score
+    assert m[..., 16:20].all()
+    # block 0 kept as high score
+    assert m[..., 0:8].all()
+
+
+def test_mask_width_matches_logits(select_fn):
+    logits = mx.full((2, 3, 17), -1.0)
+    mask = select_fn(logits, compress_lens=17, topk_blocks=4, block_size=8)
+    assert mask.shape == logits.shape

--- a/tests/test_deepseek_v41_hc_runtime.py
+++ b/tests/test_deepseek_v41_hc_runtime.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import mlx.core as mx
+
+
+def test_deferred_hc_attn_uses_prior_pre_mix():
+    from omlx.patches.deepseek_v41 import apply_deepseek_v41_patch
+
+    apply_deepseek_v41_patch()
+    from omlx.patches.deepseek_v41.deferred_hc import (
+        DeferredHyperConnection,
+        hc_collapse,
+        make_identity_pre_mix,
+    )
+    import mlx_lm.models.deepseek_v41 as m
+
+    args = m.ModelArgs(num_hidden_layers=2, compress_ratios=[0, 0], hidden_size=64, hc_mult=4)
+    hc = DeferredHyperConnection(args)
+    B, L, H, D = 1, 3, args.hc_mult, args.hidden_size
+    x = mx.random.normal((B, L, H, D))
+    pre_mix = make_identity_pre_mix(x, args.hc_mult)
+    collapsed = hc_collapse(x, pre_mix)
+    assert collapsed.shape == (B, L, D)
+    pre, post, comb = hc.mixes(x)
+    assert pre.shape == (B, L, H)
+    assert post.shape == (B, L, H)
+    assert comb.shape == (B, L, H, H)
+
+
+def test_shared_runtime_source_selection():
+    from omlx.patches.deepseek_v41.shared_runtime import SharedAttentionRuntime
+
+    rt = SharedAttentionRuntime()
+    assert rt.kv_source_for(5, [2, 8, 14]) == 2
+    assert rt.kv_source_for(8, [2, 8, 14]) == 8
+    assert rt.index_source_for(30, [2, 8, 14, 20, 24, 28, 32, 36]) == 28
+
+
+def test_tiny_window_only_forward():
+    from omlx.patches.deepseek_v41 import apply_deepseek_v41_patch
+
+    apply_deepseek_v41_patch()
+    import mlx_lm.models.deepseek_v41 as m
+
+    args = m.ModelArgs(
+        vocab_size=128,
+        hidden_size=64,
+        intermediate_size=128,
+        moe_intermediate_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        q_lora_rank=32,
+        o_lora_rank=16,
+        o_groups=2,
+        head_dim=16,
+        qk_rope_head_dim=8,
+        n_routed_experts=4,
+        num_experts_per_tok=2,
+        n_shared_experts=1,
+        compress_ratios=[0, 0],
+        kv_source_layer_ids=[],
+        index_source_layer_ids=[],
+        candidate_source_layer_id=-1,
+        index_n_heads=2,
+        index_head_dim=8,
+        index_topk=4,
+        sliding_window=16,
+        engram_layer_ids=[],
+        dspark_block_size=0,
+        n_mtp_layers=0,
+        num_nextn_predict_layers=0,
+        vision_enabled=False,
+    )
+    model = m.Model(args)
+    tokens = mx.array([[1, 2, 3, 4]])
+    out = model(tokens)
+    assert out.shape == (1, 4, args.vocab_size)

--- a/tests/test_deepseek_v41_latent_pool.py
+++ b/tests/test_deepseek_v41_latent_pool.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Compressor -> indexer unroped latent exactness (PoolingCache path)."""
+from __future__ import annotations
+
+import mlx.core as mx
+
+
+def test_ratio2_decode_emits_unroped_latent_on_complete_window():
+    from omlx.patches.deepseek_v41 import apply_deepseek_v41_patch
+
+    apply_deepseek_v41_patch()
+    import mlx_lm.models.deepseek_v41 as m
+    from mlx_lm.models.cache import PoolingCache
+
+    args = m.ModelArgs(
+        vocab_size=64,
+        hidden_size=32,
+        moe_intermediate_size=16,
+        num_hidden_layers=3,
+        num_attention_heads=2,
+        q_lora_rank=16,
+        o_lora_rank=8,
+        o_groups=2,
+        head_dim=16,
+        qk_rope_head_dim=8,
+        n_routed_experts=2,
+        num_experts_per_tok=1,
+        n_shared_experts=1,
+        compress_ratios=[0, 2, 2],
+        kv_source_layer_ids=[1],
+        index_source_layer_ids=[1],
+        candidate_source_layer_id=-1,
+        index_n_heads=2,
+        index_head_dim=8,
+        index_topk=4,
+        sliding_window=8,
+        engram_layer_ids=[],
+        dspark_block_size=0,
+        n_mtp_layers=0,
+        num_nextn_predict_layers=0,
+        vision_enabled=False,
+    )
+    model = m.Model(args)
+    layer = model.layers[1]
+    attn = layer.attn
+    assert attn.compressor is not None and attn.indexer is not None
+    cache = model.make_cache()
+    layer_cache = cache[1]
+    kv_pool = layer_cache[1]
+    assert isinstance(kv_pool, PoolingCache)
+
+    # Prefill 3 tokens -> one complete window of 2, remainder 1
+    x = mx.random.normal((1, 3, args.hidden_size))
+    out = attn(x, mask=None, cache=layer_cache, _standard_mask=True)
+    assert out.shape == (1, 3, args.hidden_size)
+    assert kv_pool.pooled is not None
+    assert kv_pool.pooled.shape[1] == 1  # one compressed token
+    assert kv_pool.remainder == 1
+
+    # One more decode token completes the second window
+    x1 = mx.random.normal((1, 1, args.hidden_size))
+    # offset from window cache
+    out2 = attn(x1, mask=None, cache=layer_cache, _standard_mask=False)
+    assert out2.shape[-1] == args.hidden_size
+    assert kv_pool.pooled.shape[1] == 2
+    assert kv_pool.remainder == 0
+
+
+def test_shared_pool_identity_reuse_layers():
+    from omlx.patches.deepseek_v41 import apply_deepseek_v41_patch
+
+    apply_deepseek_v41_patch()
+    import mlx_lm.models.deepseek_v41 as m
+
+    args = m.ModelArgs(
+        vocab_size=64,
+        hidden_size=32,
+        moe_intermediate_size=16,
+        num_hidden_layers=6,
+        num_attention_heads=2,
+        q_lora_rank=16,
+        o_lora_rank=8,
+        o_groups=2,
+        head_dim=16,
+        qk_rope_head_dim=8,
+        n_routed_experts=2,
+        num_experts_per_tok=1,
+        compress_ratios=[0, 0, 2, 2, 2, 2],
+        kv_source_layer_ids=[2],
+        index_source_layer_ids=[2, 4],
+        candidate_source_layer_id=-1,
+        index_n_heads=2,
+        index_head_dim=8,
+        index_topk=4,
+        sliding_window=8,
+        engram_layer_ids=[],
+        dspark_block_size=0,
+        n_mtp_layers=0,
+        num_nextn_predict_layers=0,
+        vision_enabled=False,
+    )
+    model = m.Model(args)
+    caches = model.make_cache()
+    # layer 2 owns kv pool; layer 3 reuse; layer 4 reindex shares kv
+    kv2 = caches[2][1]
+    kv3 = caches[3][1]
+    kv4 = caches[4][1]
+    assert kv2 is kv3 is kv4
+

--- a/tests/test_deepseek_v41_model_args.py
+++ b/tests/test_deepseek_v41_model_args.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+"""ModelArgs parsing tests against the real V4.1-Flash config.json."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+CONFIG = Path("/Volumes/TB5/llm/DeepSeek-V4.1-Flash/config.json")
+
+
+@pytest.fixture(scope="module")
+def raw_config():
+    if not CONFIG.exists():
+        pytest.skip(f"missing {CONFIG}")
+    return json.loads(CONFIG.read_text())
+
+
+def test_flatten_and_parse_model_args(raw_config):
+    from omlx.patches.deepseek_v41 import apply_deepseek_v41_patch
+    from omlx.patches.deepseek_v41.utils_patch import flatten_text_config
+
+    apply_deepseek_v41_patch()
+    flat = flatten_text_config(raw_config)
+    import mlx_lm.models.deepseek_v41 as m
+
+    args = m.ModelArgs.from_dict(flat)
+    assert args.model_type.startswith("deepseek_v41")
+    assert args.hidden_size == 5120
+    assert args.q_lora_rank == 1280
+    assert abs(args.rms_norm_eps - 1e-20) < 1e-30
+    assert args.n_routed_experts == 384
+    assert set(args.compress_ratios) <= {0, 1, 2}
+    assert 2 in args.kv_source_layer_ids or 2 in getattr(args, "kv_source_layers", [])
+    # candidate source
+    assert getattr(args, "candidate_source_layer_id", getattr(args, "candidate_source_layer", -1)) == 20
+
+
+def test_v4_compress_ratios_rejected_on_v41_parser():
+    from omlx.patches.deepseek_v41 import apply_deepseek_v41_patch
+
+    apply_deepseek_v41_patch()
+    import mlx_lm.models.deepseek_v41 as m
+
+    with pytest.raises(ValueError):
+        m.ModelArgs(
+            compress_ratios=[0, 4, 128] + [0] * 37,
+            num_hidden_layers=40,
+        )

--- a/tests/test_deepseek_v41_predicates.py
+++ b/tests/test_deepseek_v41_predicates.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Gate collision tests for DeepSeek-V4 vs V4.1 predicates."""
+from __future__ import annotations
+
+from omlx.patches.deepseek_v41.predicates import (
+    is_deepseek_v4,
+    is_deepseek_v41,
+    is_deepseek_v4_family,
+)
+
+
+def test_v41_not_classified_as_v4():
+    assert is_deepseek_v41("deepseek_v41")
+    assert is_deepseek_v41("deepseek_v41_text")
+    assert not is_deepseek_v4("deepseek_v41")
+    assert not is_deepseek_v4("deepseek_v41_text")
+
+
+def test_v4_still_matches():
+    assert is_deepseek_v4("deepseek_v4")
+    assert is_deepseek_v4("deepseek_v4_mtp")
+    assert not is_deepseek_v41("deepseek_v4")
+
+
+def test_family():
+    assert is_deepseek_v4_family("deepseek_v4")
+    assert is_deepseek_v4_family("deepseek_v41")
+    assert not is_deepseek_v4_family("llama")
+
+
+def test_naive_startswith_is_the_bug_we_fixed():
+    # Document why predicates exist.
+    assert "deepseek_v41".startswith("deepseek_v4")
+    assert not is_deepseek_v4("deepseek_v41")


### PR DESCRIPTION
## Summary
- Add a dedicated `omlx/patches/deepseek_v41` package for DeepSeek-V4.1-Flash (CSA2 shared KV/index, compress ratios `{0,1,2}`, deferred mHC, Engram, predicates that avoid the `startswith("deepseek_v4")` / `deepseek_v41` gate collision).
- Engram SSD mmap mode with a **modular quantized hot-row cache** in `engram_cache.py` (`OMLX_DSV41_ENGRAM_CACHE_GB`, default 50; FP8+scale ~264 B/row). FP8 helpers live in `engram_fp8.py`; table/mmap logic stays in `engram.py`.
- Wire loaders / oq / memory monitor / output parser / sparse-attn `L>=1` allow through `is_deepseek_v4` / `is_deepseek_v41` / `is_deepseek_v4_family`.

## Engram cache pointer
| Piece | Location |
| --- | --- |
| Hot-row cache | `omlx/patches/deepseek_v41/engram_cache.py` (`QuantHotRowCache`) |
| Bound on | `MmapEngramTable.hot_cache` in `engram.py` |
| Budget / policy | `OMLX_DSV41_ENGRAM_CACHE_GB`, `OMLX_DSV41_ENGRAM_CACHE_POLICY` |
| SSD tables | `OMLX_DSV41_ENGRAM=mmap` + `OMLX_DSV41_ENGRAM_DIR` |

## Test plan
- [x] `pytest tests/test_deepseek_v41*.py` (24 passed)
- [ ] Load `model_type=deepseek_v41` with `OMLX_DSV41_ENGRAM=stub` and generate a short completion
- [ ] Optional: `OMLX_DSV41_ENGRAM=mmap` + prepared `ENGRAM_DIR`; confirm `engram_cache_stats(model)` shows hits on warm reuse
- [ ] Confirm V4 / V4-Flash still routes via `is_deepseek_v4` (not the V4.1 patch)