### PR TITLE
Add safe idle-only model unload endpoint

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -2286,6 +2286,32 @@ async def _require_admin_or_bearer(request: Request) -> bool:
     )
 
 
+@router.post("/api/models/{model_id}/unload-if-idle")
+async def unload_model_if_idle(
+    model_id: str,
+    is_admin: bool = Depends(_require_admin_or_bearer),
+):
+    """Unload an unpinned model only when it is atomically observed idle."""
+    engine_pool = _get_engine_pool()
+    if engine_pool is None:
+        raise HTTPException(status_code=503, detail="Engine pool not initialized")
+    if engine_pool.get_entry(model_id) is None:
+        raise HTTPException(status_code=404, detail=f"Model not found: {model_id}")
+
+    if not await engine_pool.unload_if_idle_unpinned(model_id):
+        raise HTTPException(
+            status_code=409,
+            detail=f"Model is not loaded, idle, and unpinned: {model_id}",
+        )
+
+    logger.info("Safely unloaded idle model: %s", model_id)
+    return {
+        "status": "ok",
+        "model_id": model_id,
+        "message": f"Unloaded idle model {model_id}",
+    }
+
+
 @router.post("/api/models/{model_id}/load")
 async def load_model(
     model_id: str,

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -1897,11 +1897,10 @@ class EnginePool:
                 or entry.engine is None
                 or entry.is_loading
                 or entry.is_pinned
-                or entry.in_use > 0
             ):
                 return False
 
-            if self._entry_has_active_requests(entry):
+            if not self._entry_is_quiescent(entry):
                 entry.last_access = time.time()
                 return False
 

--- a/tests/test_admin_unload.py
+++ b/tests/test_admin_unload.py
@@ -5,7 +5,8 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
 
 from omlx import server
 from omlx.admin import routes as admin_routes
@@ -51,6 +52,128 @@ async def test_idle_model_unload_returns_completed():
         "model_id": "model-a",
         "message": "Unloaded model-a",
     }
+
+
+def _idle_only_client():
+    app = FastAPI()
+    app.include_router(admin_routes.router)
+    settings = MagicMock()
+    settings.auth.skip_api_key_verification = False
+    settings.auth.api_key = "test-admin-key"
+    settings.auth.sub_keys = []
+    return app, settings
+
+
+def test_idle_only_unload_accepts_valid_bearer_and_returns_exact_model():
+    pool = MagicMock()
+    pool.get_entry.return_value = MagicMock()
+    pool.unload_if_idle_unpinned = AsyncMock(return_value=True)
+    app, settings = _idle_only_client()
+
+    with (
+        patch.object(admin_routes, "_get_engine_pool", return_value=pool),
+        patch.object(admin_routes, "_get_global_settings", return_value=settings),
+        patch.object(admin_routes, "verify_session", return_value=False),
+        TestClient(app) as client,
+    ):
+        response = client.post(
+            "/admin/api/models/model-a/unload-if-idle",
+            headers={"Authorization": "Bearer test-admin-key"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ok",
+        "model_id": "model-a",
+        "message": "Unloaded idle model model-a",
+    }
+    pool.unload_if_idle_unpinned.assert_awaited_once_with("model-a")
+
+
+def test_idle_only_unload_accepts_valid_admin_session():
+    pool = MagicMock()
+    pool.get_entry.return_value = MagicMock()
+    pool.unload_if_idle_unpinned = AsyncMock(return_value=True)
+    app, settings = _idle_only_client()
+
+    with (
+        patch.object(admin_routes, "_get_engine_pool", return_value=pool),
+        patch.object(admin_routes, "_get_global_settings", return_value=settings),
+        patch.object(admin_routes, "verify_session", return_value=True),
+        TestClient(app) as client,
+    ):
+        response = client.post("/admin/api/models/model-a/unload-if-idle")
+
+    assert response.status_code == 200
+    assert response.json()["model_id"] == "model-a"
+    pool.unload_if_idle_unpinned.assert_awaited_once_with("model-a")
+
+
+@pytest.mark.parametrize("authorization", [None, "Bearer wrong-key"])
+def test_idle_only_unload_rejects_missing_or_invalid_bearer(authorization):
+    pool = MagicMock()
+    pool.unload_if_idle_unpinned = AsyncMock(return_value=False)
+    app, settings = _idle_only_client()
+    headers = {} if authorization is None else {"Authorization": authorization}
+
+    with (
+        patch.object(admin_routes, "_get_engine_pool", return_value=pool),
+        patch.object(admin_routes, "_get_global_settings", return_value=settings),
+        patch.object(admin_routes, "verify_session", return_value=False),
+        TestClient(app) as client,
+    ):
+        response = client.post(
+            "/admin/api/models/model-a/unload-if-idle", headers=headers
+        )
+
+    assert response.status_code == 401
+    assert response.headers["www-authenticate"] == "Bearer"
+    pool.get_entry.assert_not_called()
+    pool.unload_if_idle_unpinned.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "state, expected_status", [("unavailable", 503), ("missing", 404)]
+)
+def test_idle_only_unload_reports_unavailable_or_missing(state, expected_status):
+    pool = None if state == "unavailable" else MagicMock()
+    if state == "missing":
+        pool.get_entry.return_value = None
+    app, settings = _idle_only_client()
+
+    with (
+        patch.object(admin_routes, "_get_engine_pool", return_value=pool),
+        patch.object(admin_routes, "_get_global_settings", return_value=settings),
+        patch.object(admin_routes, "verify_session", return_value=False),
+        TestClient(app) as client,
+    ):
+        response = client.post(
+            "/admin/api/models/model-a/unload-if-idle",
+            headers={"Authorization": "Bearer test-admin-key"},
+        )
+
+    assert response.status_code == expected_status
+
+
+def test_idle_only_unload_reports_conflict_without_unloading():
+    pool = MagicMock()
+    pool.get_entry.return_value = MagicMock()
+    pool.unload_if_idle_unpinned = AsyncMock(return_value=False)
+    app, settings = _idle_only_client()
+
+    with (
+        patch.object(admin_routes, "_get_engine_pool", return_value=pool),
+        patch.object(admin_routes, "_get_global_settings", return_value=settings),
+        patch.object(admin_routes, "verify_session", return_value=False),
+        TestClient(app) as client,
+    ):
+        response = client.post(
+            "/admin/api/models/model-a/unload-if-idle",
+            headers={"Authorization": "Bearer test-admin-key"},
+        )
+
+    assert response.status_code == 409
+    pool.unload_if_idle_unpinned.assert_awaited_once_with("model-a")
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -3766,6 +3766,58 @@ class TestEnginePoolInUseLease:
         assert entry.engine.abort_all_requests.await_count == 0
 
     @pytest.mark.asyncio
+    async def test_idle_only_unload_rechecks_under_lock_without_aborting(self):
+        pool = _make_pool(ceiling=0)
+        entry = self._loaded_entry("model-a")
+        entry.engine.abort_all_requests = AsyncMock(return_value=1)
+        pool._entries = {"model-a": entry}
+        pool._unload_engine = AsyncMock()
+
+        await pool._lock.acquire()
+        unload = asyncio.create_task(pool.unload_if_idle_unpinned("model-a"))
+        await asyncio.sleep(0)
+        entry.in_use = 1  # A lease won before the idle-only operation got the lock.
+        pool._lock.release()
+
+        assert await unload is False
+        assert entry.pending_unload_reason is None
+        assert entry.abort_requested is False
+        entry.engine.abort_all_requests.assert_not_awaited()
+        pool._unload_engine.assert_not_awaited()
+
+        entry.in_use = 0
+        assert await pool.unload_if_idle_unpinned("model-a") is True
+        pool._unload_engine.assert_awaited_once_with("model-a")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "state", ["missing", "nonresident", "loading", "pinned", "active", "scheduler"]
+    )
+    async def test_idle_only_unload_refuses_every_non_quiescent_state(self, state):
+        pool = _make_pool(ceiling=0)
+        entry = self._loaded_entry("model-a")
+        if state == "missing":
+            pool._entries = {}
+        else:
+            pool._entries = {"model-a": entry}
+            if state == "nonresident":
+                entry.engine = None
+            elif state == "loading":
+                entry.is_loading = True
+            elif state == "pinned":
+                entry.is_pinned = True
+            elif state == "active":
+                entry.engine.has_active_requests.return_value = True
+            elif state == "scheduler":
+                scheduler = MagicMock()
+                scheduler.has_requests.return_value = True
+                entry.engine.scheduler = scheduler
+        pool._unload_engine = AsyncMock()
+
+        assert await pool.unload_if_idle_unpinned("model-a") is False
+        pool._unload_engine.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_acquire_leases_then_releases_on_success(self):
         """acquire() leases on enter and releases in finally on normal exit."""
         pool = _make_pool(ceiling=0)


### PR DESCRIPTION
The existing manual unload endpoint may abort active requests. This adds an authenticated `POST /admin/api/models/{model_id}/unload-if-idle` endpoint backed by `EnginePool.unload_if_idle_unpinned()`. It returns 409 for pinned, loading, leased, active, or scheduler-busy models and never queues an unload or calls the aborting path.

The helper now uses the existing full quiescence predicate under the engine-pool lock, covering scheduler work that can remain after collectors disappear. Tests cover Bearer and session authentication, HTTP status binding, lease races, and latent scheduler activity.

Validation: 31 focused tests passed; Python compilation and `git diff --check` passed.

<!-- gitkeeper-pr:e56911fd250335d7757778175a6de9c7b7f5917fc5a8da027ab1cf89d94af0d2 -->