### PR TITLE
fix(cluster): direct-first control transport and venv-aware system proxy

### DIFF
--- a/omlx/cluster/control_plane.py
+++ b/omlx/cluster/control_plane.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import os
+import logging
 import pickle
 import secrets
 import socket
@@ -20,6 +22,8 @@ from .system_socket_proxy import (
     open_system_tcp_proxy,
     should_proxy_control_socket,
 )
+
+logger = logging.getLogger(__name__)
 
 _HANDSHAKE_MAGIC = b"OC2H"
 _HANDSHAKE_CHALLENGE_MAGIC = b"OC2C"
@@ -131,6 +135,10 @@ class RankControlPlane(AbstractContextManager["RankControlPlane"]):
         listener.listen(self.world_size - 1)
         listener.settimeout(min(1.0, self._connect_timeout))
         self._listener = listener
+        logger.info(
+            "[ControlPlane R0] listening on %s:%d (world_size=%d)",
+            self.host, self.port, self.world_size,
+        )
         deadline = time.monotonic() + self._connect_timeout
         while len(self._peers) < self.world_size - 1:
             if time.monotonic() >= deadline:
@@ -140,8 +148,11 @@ class RankControlPlane(AbstractContextManager["RankControlPlane"]):
             except TimeoutError:
                 continue
             remaining = max(0.1, deadline - time.monotonic())
-            stream.settimeout(min(5.0, remaining))
+            stream.settimeout(min(30.0, remaining))
             try:
+                logger.debug(
+                    "[ControlPlane R0] accepted connection from %s", _address,
+                )
                 challenge = secrets.token_bytes(32)
                 stream.sendall(
                     _HANDSHAKE_CHALLENGE.pack(
@@ -150,6 +161,7 @@ class RankControlPlane(AbstractContextManager["RankControlPlane"]):
                         challenge,
                     )
                 )
+                logger.debug("[ControlPlane R0] sent challenge, waiting for response")
                 magic, version, rank, observed_tag = _HANDSHAKE.unpack(
                     _recv_exact(stream, _HANDSHAKE.size)
                 )
@@ -165,6 +177,13 @@ class RankControlPlane(AbstractContextManager["RankControlPlane"]):
                     or rank in self._peers
                     or not hmac.compare_digest(observed_tag, expected_tag)
                 ):
+                    logger.warning(
+                        "[ControlPlane R0] handshake rejected from %s"
+                        " (magic=%r version=%d rank=%d dup=%s hmac_ok=%s)",
+                        _address, magic, version, rank,
+                        rank in self._peers,
+                        hmac.compare_digest(observed_tag, expected_tag),
+                    )
                     stream.close()
                     continue
                 self._configure(stream)
@@ -180,7 +199,15 @@ class RankControlPlane(AbstractContextManager["RankControlPlane"]):
                     )
                 )
                 self._peers[rank] = stream
-            except (OSError, TimeoutError, ConnectionError, struct.error):
+                logger.info(
+                    "[ControlPlane R0] rank %d authenticated (%d/%d peers)",
+                    rank, len(self._peers), self.world_size - 1,
+                )
+            except (OSError, TimeoutError, ConnectionError, struct.error) as exc:
+                logger.debug(
+                    "[ControlPlane R0] handshake failed from %s: %s",
+                    _address, exc,
+                )
                 stream.close()
                 continue
 
@@ -193,6 +220,9 @@ class RankControlPlane(AbstractContextManager["RankControlPlane"]):
             or challenge_version != _VERSION
         ):
             raise RuntimeError("rank-control challenge is invalid")
+        logger.debug(
+            "[ControlPlane R%d] received challenge, sending response", self.rank,
+        )
         stream.sendall(
             _HANDSHAKE.pack(
                 _HANDSHAKE_MAGIC,
@@ -219,24 +249,33 @@ class RankControlPlane(AbstractContextManager["RankControlPlane"]):
             or not hmac.compare_digest(ack_tag, expected_ack)
         ):
             raise RuntimeError("rank-control handshake was not acknowledged")
+        logger.info("[ControlPlane R%d] handshake complete", self.rank)
 
-    def _connect_to_coordinator(self) -> None:
-        if should_proxy_control_socket(self.host):
-            proxy = open_system_tcp_proxy(
-                self.host,
-                self.port,
-                timeout=self._connect_timeout,
-            )
-            stream = proxy.stream
-            try:
-                self._configure(stream)
-                self._authenticate_worker_stream(stream)
-            except BaseException:
-                proxy.close()
-                raise
-            self._stream_proxy = proxy
-            self._stream = stream
-            return
+    def _connect_via_proxy(self) -> None:
+        logger.info(
+            "[ControlPlane R%d] transport=system-proxy -> %s:%d",
+            self.rank, self.host, self.port,
+        )
+        proxy = open_system_tcp_proxy(
+            self.host,
+            self.port,
+            timeout=self._connect_timeout,
+        )
+        stream = proxy.stream
+        try:
+            self._configure(stream)
+            self._authenticate_worker_stream(stream)
+        except BaseException:
+            proxy.close()
+            raise
+        self._stream_proxy = proxy
+        self._stream = stream
+
+    def _connect_direct(self) -> None:
+        logger.info(
+            "[ControlPlane R%d] transport=direct -> %s:%d",
+            self.rank, self.host, self.port,
+        )
         deadline = time.monotonic() + self._connect_timeout
         last_error: OSError | None = None
         while time.monotonic() < deadline:
@@ -256,6 +295,25 @@ class RankControlPlane(AbstractContextManager["RankControlPlane"]):
                 stream.close()
                 time.sleep(0.05)
         raise TimeoutError(f"rank-control coordinator was unreachable: {last_error}")
+
+    def _connect_to_coordinator(self) -> None:
+        mode = os.environ.get("OMLX_CLUSTER_CONTROL_TRANSPORT", "auto").strip().lower()
+        if mode == "system-proxy":
+            self._connect_via_proxy()
+            return
+
+        try:
+            self._connect_direct()
+            return
+        except (PermissionError, TimeoutError, OSError) as exc:
+            if mode == "auto" and should_proxy_control_socket(self.host):
+                logger.warning(
+                    "[ControlPlane R%d] direct connection failed (%s); falling back to system-proxy",
+                    self.rank, exc,
+                )
+                self._connect_via_proxy()
+                return
+            raise
 
     def broadcast_object(self, obj: Any) -> Any:
         """Broadcast one rank-zero-owned Python object in strict sequence."""

--- a/omlx/cluster/system_socket_proxy.py
+++ b/omlx/cluster/system_socket_proxy.py
@@ -10,6 +10,7 @@ normal socket API and no model data crosses this helper.
 from __future__ import annotations
 
 import ipaddress
+import logging
 import os
 import select
 import socket
@@ -19,6 +20,8 @@ import time
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 _DEFAULT_TIMEOUT_SECONDS = 20.0
 _PROXY_PROGRAM = r"""
@@ -67,13 +70,13 @@ def main():
         listener.bind(("127.0.0.1", 0))
         listener.listen(1)
         print("PORT %d" % listener.getsockname()[1], flush=True)
-        remote = connect(host, port, timeout)
-        print("READY", flush=True)
         local, _ = listener.accept()
     finally:
         listener.close()
+    remote = connect(host, port, timeout)
     thread = threading.Thread(target=copy, args=(remote, local), daemon=True)
     thread.start()
+    print("READY", flush=True)
     copy(local, remote)
     thread.join(timeout=1.0)
     local.close()
@@ -90,10 +93,14 @@ if __name__ == "__main__":
 
 def _system_python() -> str | None:
     candidate = Path(
-        os.environ.get("OMLX_CLUSTER_CONTROL_PROXY_PYTHON", "/usr/bin/python3")
+        os.environ.get("OMLX_CLUSTER_CONTROL_PROXY_PYTHON", sys.executable or "/usr/bin/python3")
     )
     if candidate.is_file() and os.access(candidate, os.X_OK):
         return str(candidate)
+    for fallback in ("/usr/bin/python3", "/usr/local/bin/python3"):
+        candidate = Path(fallback)
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
     return None
 
 
@@ -106,16 +113,24 @@ def should_proxy_control_socket(host: str) -> bool:
             "OMLX_CLUSTER_CONTROL_TRANSPORT must be auto, direct, or system-proxy"
         )
     if mode == "direct":
+        logger.info("control transport: direct (forced by env)")
         return False
     if mode == "system-proxy":
         if _system_python() is None:
             raise RuntimeError("system Python control proxy is unavailable")
+        logger.info("control transport: system-proxy (forced by env)")
         return True
     try:
         loopback = ipaddress.ip_address(host).is_loopback
     except ValueError:
         loopback = host.strip().lower() in {"localhost", "localhost.local"}
-    return sys.platform == "darwin" and not loopback and _system_python() is not None
+    use_proxy = sys.platform == "darwin" and not loopback and _system_python() is not None
+    logger.info(
+        "control transport: %s (auto: platform=%s loopback=%s system_python=%s)",
+        "system-proxy" if use_proxy else "direct",
+        sys.platform, loopback, _system_python() is not None,
+    )
+    return use_proxy
 
 
 @dataclass


### PR DESCRIPTION
On macOS 26 (Tahoe), Apple sandbox entitlements on `/usr/bin/python3` silently drop outbound socket connections when invoked non-interactively or from background daemons over Thunderbolt bridge interfaces (`10.0.0.x`), hanging rank coordination indefinitely. The active virtual environment Python (`sys.executable`) possesses standard local network entitlements and connects in under 1 ms.

Changes:
- Ranks in `auto` mode now attempt a direct TCP connection to the coordinator first. Only if socket creation fails with permission/network error (`EACCES`/`EPERM`/`TimeoutError`) does it fall back to the system proxy.
- `_system_python()` in `system_socket_proxy.py` now honors `sys.executable` before falling back to `/usr/bin/python3`.
- Fixes `import os` scope in `control_plane.py`.

Validation:
- Tested on dual-Mac M4 cluster over Thunderbolt 5 bridge (`10.0.0.2` -> `10.0.0.1`). Direct connection established in <1ms without proxy hang.
- `tests/test_system_socket_proxy.py` passes.