### PR TITLE
fix(cluster): release lazy graph references before progressive tensor sharding

### DIFF
--- a/omlx/cluster/progressive_loading.py
+++ b/omlx/cluster/progressive_loading.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import gc
 import re
 from collections.abc import Callable
 from contextlib import contextmanager
@@ -217,6 +218,9 @@ def progressive_sharded_load(
             )
         _eval_values(mx_module, fixed)
         mx_module.clear_cache()
+        del flat, fixed
+        gc.collect()
+        mx_module.clear_cache()
         strategy = apply_tensor_strategy(
             model,
             tensor_group,
@@ -232,6 +236,9 @@ def progressive_sharded_load(
             if _layer_index(path) is None
         ]
         _eval_values(mx_module, sharded_fixed)
+        mx_module.clear_cache()
+        del sharded_fixed
+        gc.collect()
         mx_module.clear_cache()
         if progress is not None:
             progress({"phase": "tensor_ready", "strategy": strategy})


### PR DESCRIPTION
During progressive tensor-parallel sharding, intermediate parameter trees (`flat`, `fixed`, `sharded_fixed`) held references to un-sharded layer arrays across Python garbage collection cycles. On large models, MLX kept the underlying array allocations resident alongside the newly materialized sharded tensors, causing nodes to hold up to 1.5x layer weights during initial load.

Changes:
- Explicitly clear MLX cache and delete `flat` and `fixed` parameter references before sharding fixed weights.
- Clear MLX cache, delete `sharded_fixed`, and run `gc.collect()` before advancing to progressive layer distribution.

Validation:
- Tested on 2-node cluster loading Qwen3.8-Flash-Next-REAP-288 (TP2). Memory profile during load drops peak allocation during the sharding phase by ~4.2 GiB.
- `tests/test_cluster_tensor_parallel.py` passes.