### PR TITLE
feat(sampling): honor frequency_penalty in model settings

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -213,6 +213,7 @@ class ModelSettingsRequest(BaseModel):
     repetition_penalty: float | None = None
     min_p: float | None = None
     presence_penalty: float | None = None
+    frequency_penalty: float | None = None
     force_sampling: bool | None = None
     max_tool_result_tokens: int | None = None
     chat_template_kwargs: dict[str, Any] | None = None
@@ -2462,6 +2463,8 @@ async def update_model_settings(
         current_settings.min_p = request.min_p
     if "presence_penalty" in sent:
         current_settings.presence_penalty = request.presence_penalty
+    if "frequency_penalty" in sent:
+        current_settings.frequency_penalty = request.frequency_penalty
     if "force_sampling" in sent:
         current_settings.force_sampling = request.force_sampling
     if "max_tool_result_tokens" in sent:

--- a/omlx/model_profiles.py
+++ b/omlx/model_profiles.py
@@ -27,6 +27,7 @@ UNIVERSAL_PROFILE_FIELDS = (
     "min_p",
     "repetition_penalty",
     "presence_penalty",
+    "frequency_penalty",
     "force_sampling",
     "enable_thinking",
     "preserve_thinking",

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -145,6 +145,7 @@ class ModelSettings:
         min_p: Minimum probability threshold (None = use global default).
         repetition_penalty: Repetition penalty (None = use default 1.0, i.e. disabled).
         presence_penalty: Presence penalty (None = use global default).
+        frequency_penalty: Frequency penalty (None = use global default).
         force_sampling: Force sampling even with temperature=0.
         max_tool_result_tokens: Maximum tokens in tool result (None = use global default).
         chat_template_kwargs: Extra chat template keyword arguments.
@@ -246,6 +247,7 @@ class ModelSettings:
     repetition_penalty: Optional[float] = None
     min_p: Optional[float] = None
     presence_penalty: Optional[float] = None
+    frequency_penalty: Optional[float] = None
     force_sampling: bool = False
     max_tool_result_tokens: Optional[int] = None
     chat_template_kwargs: Optional[Dict[str, Any]] = None

--- a/tests/test_model_settings.py
+++ b/tests/test_model_settings.py
@@ -33,6 +33,17 @@ class TestModelSettings:
         # Issue #926: opt-in per model. Default off.
         assert settings.trust_remote_code is False
 
+    def test_frequency_penalty_defaults_to_none(self):
+        settings = ModelSettings()
+        assert settings.frequency_penalty is None
+
+    def test_frequency_penalty_roundtrip(self):
+        original = ModelSettings(frequency_penalty=0.4)
+        d = original.to_dict()
+        assert d["frequency_penalty"] == 0.4
+        restored = ModelSettings.from_dict(d)
+        assert restored.frequency_penalty == 0.4
+
     def test_trust_remote_code_roundtrip(self):
         """Test trust_remote_code field survives to_dict -> from_dict roundtrip."""
         original = ModelSettings(trust_remote_code=True)


### PR DESCRIPTION
## Summary

Add `frequency_penalty` to `ModelSettings` so operators can configure a per-model frequency penalty default in `model_settings.json`.

## Background

`server.py:get_sampling_params()` already contains logic checking `model_settings.frequency_penalty` as a fallback when the client request omits it (identical to `presence_penalty`). However, `frequency_penalty` was never declared as a field on the `ModelSettings` dataclass in `omlx/model_settings.py`.

As a result, `ModelSettings.from_dict()` filtered out `frequency_penalty` as an unrecognized key during dictionary deserialization, preventing per-model frequency penalty defaults from taking effect.

## Behavior

- When a request provides `frequency_penalty`, the request value takes precedence.
- Otherwise, `model_settings.json` supplies the configured default.
- If neither is set, sampling defaults to `0.0` (disabled).

## Validation

- `pytest tests/test_model_settings.py tests/test_server.py -q -k 'frequency or sampling'` — 89 passed