### PR TITLE
fix(oq): declare MLX format on DeepSeek V4.1 exported shards

### DIFF
--- a/omlx/patches/deepseek_v41/oq.py
+++ b/omlx/patches/deepseek_v41/oq.py
@@ -204,7 +204,11 @@ def quantize_engram(
         offset += length
     names = {key: f"{module_name}.{key}" if module_name else key for key in shapes}
     encoded = json.dumps(
-        {names[key]: value for key, value in header.items()}, separators=(",", ":")
+        {
+            **{names[key]: value for key, value in header.items()},
+            "__metadata__": {"format": "mlx"},
+        },
+        separators=(",", ":"),
     ).encode()
     encoded += b" " * (-len(encoded) % 8)
     data_start = 8 + len(encoded)

--- a/omlx/patches/deepseek_v41/sharding.py
+++ b/omlx/patches/deepseek_v41/sharding.py
@@ -36,7 +36,11 @@ class ShardWriter:
         if not self._values:
             return
         name = f".model-shard-{len(self._shards) + 1:05d}.safetensors"
-        mx.save_safetensors(str(self.destination / name), self._values)
+        mx.save_safetensors(
+            str(self.destination / name),
+            self._values,
+            metadata={"format": "mlx"},
+        )
         self._shards.append((name, tuple(self._values)))
         self._values = {}
         self._bytes = 0

--- a/tests/test_deepseek_v41_oq.py
+++ b/tests/test_deepseek_v41_oq.py
@@ -2,6 +2,7 @@
 
 import json
 import math
+import struct
 
 import mlx.core as mx
 import numpy as np
@@ -51,6 +52,57 @@ def test_shard_writer_keeps_oversized_projection_intact(tmp_path):
     mapping = writer.finish()
     assert mapping["big.weight"] == mapping["big.scales"]
     assert mapping["big.weight"] != mapping["small.weight"]
+
+
+def _declared_format(path):
+    with open(path, "rb") as handle:
+        length = struct.unpack("<Q", handle.read(8))[0]
+        return json.loads(handle.read(length)).get("__metadata__")
+
+
+def test_exported_shards_declare_mlx_format(tmp_path):
+    from omlx.patches.deepseek_v41.sharding import ShardWriter
+
+    writer = ShardWriter(tmp_path, max_shard_bytes=16)
+    writer.add({"a.weight": mx.ones((16,), mx.bfloat16)})
+    writer.add({"b.weight": mx.ones((1,), mx.bfloat16)})
+    mapping = writer.finish()
+    shards = sorted(set(mapping.values()))
+    assert len(shards) == 2
+    assert not list(tmp_path.glob(".model-shard-*"))
+    for name in shards:
+        assert _declared_format(tmp_path / name) == {"format": "mlx"}
+
+    mx.random.seed(7)
+    weight = mx.random.normal((9, 128)).astype(mx.bfloat16)
+    mx.save_safetensors(str(tmp_path / "source.safetensors"), {"embed.weight": weight})
+    spec = quantize_engram(
+        tmp_path,
+        tmp_path / "engram.safetensors",
+        {"weight_file": "source.safetensors", "weight_key": "embed.weight"},
+        rows_per_chunk=4,
+        bits=4,
+        module_name="language_model.embed_tokens",
+    )
+    assert _declared_format(tmp_path / spec["weight_file"]) == {"format": "mlx"}
+
+    embed = DiskEngramEmbedding(
+        tmp_path / spec["weight_file"],
+        spec["weight_key"],
+        spec["scale_key"],
+        bias_key=spec["bias_key"],
+        bits=4,
+        group_size=32,
+    )
+    try:
+        expected = mx.quantize(weight, bits=4, group_size=32)
+        ids = mx.array([[0, 4, 8]])
+        np.testing.assert_array_equal(
+            embed(ids).astype(mx.float32),
+            mx.dequantize(*expected, bits=4, group_size=32)[ids].astype(mx.float32),
+        )
+    finally:
+        embed.close()
 
 
 @pytest.mark.parametrize("switched", [False, True])


### PR DESCRIPTION
## Problem

When `Jundot/DeepSeek-V4.1-Flash-oQ3e-mtp` is downloaded to the huggingface cache, it's not discovered and doesn't show up in the per-model settings list.

## Cause

`model_discovery._is_hf_cache_mlx_compatible()` accepts an HF-cache entry only when it matches at least one of three signals:

1. safetensors `__metadata__["format"] == "mlx"`
2. a standalone `mlx` token in the repo id (`_MLX_NAME_RE = (^|[-_/])mlx($|[-_/])`), or an `mlx-community/` prefix
3. `_is_helper_checkpoint()`

A V4.1 oQ export hits none of them: the repo name carries `mtp` rather than a standalone `mlx` token; `model_type` is `deepseek_v41` / `DeepseekV41ForCausalLM` with no `dflash_config`; and **the shards carry no `__metadata__` block at all**. The rejection is `logger.debug("Skipping non-MLX HF cache model: …")`, so at the default `log_level: info` the model is simply absent with no trace.

Two writers in the V4.1 patch omit the metadata:

| Writer | Location | Shards |
|---|---|---|
| `ShardWriter._flush()` | `omlx/patches/deepseek_v41/sharding.py` — `mx.save_safetensors()` without `metadata` | 61 |
| `quantize_engram()` | `omlx/patches/deepseek_v41/oq.py` — hand-rolls the header JSON from tensor entries only, never emits `__metadata__` | 4 (engram) |

`ShardWriter.finish()` only *renames* the `.model-shard-NNNNN` temporaries to `model-NNNNN-of-NNNNN`, so the published filenames inherit whatever `_flush()` wrote.

Every `mx.save_safetensors` site in `omlx/oq.py` already passes `metadata={"format": "mlx"}`, and `omlx/patches/deepseek_v4/` contains no export code at all — which is why the earlier V4 release enumerates correctly while V4.1 stays invisible.

## Changes

- `sharding.py` — `ShardWriter._flush()` passes `metadata={"format": "mlx"}`.
- `oq.py` — `quantize_engram()` emits `"__metadata__": {"format": "mlx"}` last in the header dict. Padding and `data_start` are derived from the encoded length, so the longer header needs no offset changes.
- `tests/test_deepseek_v41_oq.py` — `test_exported_shards_declare_mlx_format`.

Reader safety:

## Measurements

Read directly from the safetensors headers (`struct.unpack("<Q", …)` + JSON), not via a library that might synthesise defaults.

| Repo | Shards | Bytes | `__metadata__` | Status |
|---|---|---|---|---|
| `Jundot/DeepSeek-V4.1-Flash-oQ3e-mtp` @ `e242364f` | 65 | 355.3 GB | `None` — all 65 | measured |
| `Jundot/DeepSeek-V4-Flash-0731-oQ2e-mtp` @ `11771976` | 20 | 105.2 GB | `{"format": "mlx"}` — all 20 | measured |
| `Jundot/DeepSeek-V4.1-Flash-oQ4e-mtp` | — | — | unmeasured, not downloaded | inferred affected |

Index split on the oQ3e snapshot: 4 files hold engram keys, 61 come from `ShardWriter` = 65/65, matching the two writers exactly.

## Validation

```
tests/test_deepseek_v41_oq.py + tests/test_oq.py  ->  470 passed
ruff check (changed files)                          ->  All checks passed
```

Mutation-verified: reverting either fix alone makes the new test fail with `assert None == {'format': 'mlx'}` — once at the `model-NNNNN-of-NNNNN` shard (`ShardWriter` reverted) and once at `engram.safetensors` (`quantize_engram` reverted). Neither assertion is vacuous.

## Follow-ups

- This only affects **future** exports. Already-published V4.1 shards need a re-export (or a header rewrite) to gain the metadata.
