### PR TITLE
fix(cache): drop unreachable PagedCacheManager.free_blocks(blocks) shadowed by the free_blocks property

### DIFF
--- a/omlx/cache/paged_cache.py
+++ b/omlx/cache/paged_cache.py
@@ -787,40 +787,6 @@ class PagedCacheManager(CacheManager):
 
             return False
 
-    def free_blocks(self, blocks: Iterable[CacheBlock]) -> None:
-        """
-        Free multiple blocks (vLLM style).
-
-        Blocks with ref_count=0 are added to the free queue.
-
-        Args:
-            blocks: Blocks to free (in eviction order)
-        """
-        with self._lock:
-            blocks_list = list(blocks)
-            to_free = []
-
-            for block in blocks_list:
-                if block.is_null:
-                    continue
-
-                block.ref_count -= 1
-
-                if block.ref_count <= 0:
-                    # Remove from hash cache
-                    if block.block_hash is not None:
-                        self.cached_block_hash_to_block.pop(block.block_hash, block.block_id)
-                        self._notify_hash_dropped(block.block_hash)
-
-                    del self.allocated_blocks[block.block_id]
-                    to_free.append(block)
-                    self.stats.allocated_blocks -= 1
-                    self.stats.free_blocks += 1
-                    self.stats.total_tokens_cached -= block.token_count
-
-            # Add to free queue (back = MRU, evicted last)
-            self.free_block_queue.append_n(to_free)
-
     def touch(self, blocks: Iterable[CacheBlock]) -> None:
         """
         Touch blocks to prevent eviction (cache hit, vLLM style).


### PR DESCRIPTION
### What

`PagedCacheManager` binds the name `free_blocks` twice in the same class body:

| | line | form | signature |
|---|---|---|---|
| first | `omlx/cache/paged_cache.py:790` | plain method | `free_blocks(self, blocks: Iterable[CacheBlock]) -> None` |
| second | `omlx/cache/paged_cache.py:1330` | `@property` | `free_blocks(self) -> int` |

Class bodies execute top-to-bottom, so the `@property` is the only binding that
survives in the class dict. The 33-line batch-free method is unreachable, and any
call of the form `manager.free_blocks(blocks)` fails with
`TypeError: 'int' object is not callable`.

### Why the property is the one to keep

The property is load-bearing, the method is not:

* `usage` reads it as a number — `return 1.0 - (self.free_blocks / total)` (`paged_cache.py:1340`)
* the test-suite asserts on it as a number — `assert manager.free_blocks == 49`,
  `initial_free = manager.free_blocks`, … (`tests/test_paged_cache.py`)
* **nothing anywhere in the repository calls `free_blocks(...)` with arguments** —
  the batch-free path has never been reachable.

So this patch deletes the shadowed method. It is a no-op at runtime.

### Verification

I don't have an Apple machine, so I could not execute the MLX runtime. Instead I
verified the claim structurally against this file at `main`
(`b390b31`) and by replicating the exact binding shape:

```
STEP 1 — definitions of PagedCacheManager.free_blocks at HEAD: 2
   L790-822  decorators=[]          args=self, blocks: Iterable[CacheBlock]
   L1330-1332 decorators=['property'] args=self

STEP 2 — class dict entry for 'free_blocks': property
   obj.free_blocks           -> 42
   obj.free_blocks([...])    -> TypeError: 'int' object is not callable

STEP 3 — calls of the form <x>.free_blocks(<args>) in paged_cache.py: 0
STEP 4 — `self.free_blocks` value-reads in paged_cache.py at lines: [1340]
```

Step 2 is this minimal replica of the shape in the class:

```python
class Shape:
    def free_blocks(self, blocks):
        return "BATCH-FREE RAN"
    @property
    def free_blocks(self):
        return 42
```

After the patch `PagedCacheManager` has exactly one `free_blocks` (the property),
the module still parses, and the `Iterable` import stays in use by the adjacent
`touch(self, blocks: Iterable[CacheBlock])`.

### Note / alternative

The deleted method looks like it was meant to be the sibling of the live
`touch(blocks)` — both are the "vLLM style" batch APIs over `Iterable[CacheBlock]`,
and `FreeKVCacheBlockQueue.append_n` (which it used) is still used elsewhere at
`paged_cache.py:623`. If you would rather **keep** the batch-free API instead of
dropping it, the equivalent fix is to rename it (e.g. `free_block_objects`) rather
than delete it — happy to switch this PR over if you prefer that. I went with
deletion because it has no callers and `free_block(block_id)` already covers the
single-block case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
