### PR TITLE
fix(qwen35_ane): drain the hybrid merge before the next tile reuses the ANE output surface

### DIFF
--- a/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.mm
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.mm
@@ -2655,6 +2655,27 @@ public:
     }
     encoder.dispatch_threads(MTL::Size(output_n, M, 1),
                              MTL::Size(16, 16, 1));
+    // The merge encoder reads this program's single output IOSurface. MLX
+    // commits this command buffer lazily, so without draining it here the
+    // next dispatch to the same program (the next 2K tile of one chunk on
+    // hosts with 4K prefill chunks) can begin its ANE evaluation and overwrite
+    // the surface before the merge kernel has executed. begin() only orders
+    // against the previous evaluation, not the previous merge. Commit and
+    // wait: the ANE and qmm branches were already joined on the host above,
+    // so the only added latency is the merge kernel itself.
+    {
+      encoder.end_encoding();
+      auto *merge_buffer = encoder.get_command_buffer();
+      merge_buffer->retain();
+      encoder.commit();
+      merge_buffer->waitUntilCompleted();
+      if (merge_buffer->status() == MTL::CommandBufferStatusError) {
+        merge_buffer->release();
+        throw std::runtime_error("ANE hybrid merge command buffer failed");
+      }
+      merge_buffer->release();
+    }
+
 
     // This primitive deliberately commits intermediate command buffers. MLX's
     // evaluator retains the original buffer and only switches to its safe
@@ -2979,6 +3000,27 @@ public:
     }
     encoder.dispatch_threads(MTL::Size(output_n, M, 1),
                              MTL::Size(16, 16, 1));
+    // The merge encoder reads this program's single output IOSurface. MLX
+    // commits this command buffer lazily, so without draining it here the
+    // next dispatch to the same program (the next 2K tile of one chunk on
+    // hosts with 4K prefill chunks) can begin its ANE evaluation and overwrite
+    // the surface before the merge kernel has executed. begin() only orders
+    // against the previous evaluation, not the previous merge. Commit and
+    // wait: the ANE and qmm branches were already joined on the host above,
+    // so the only added latency is the merge kernel itself.
+    {
+      encoder.end_encoding();
+      auto *merge_buffer = encoder.get_command_buffer();
+      merge_buffer->retain();
+      encoder.commit();
+      merge_buffer->waitUntilCompleted();
+      if (merge_buffer->status() == MTL::CommandBufferStatusError) {
+        merge_buffer->release();
+        throw std::runtime_error("ANE hybrid merge command buffer failed");
+      }
+      merge_buffer->release();
+    }
+
 
     if (!encoder.needs_commit()) {
       auto guard = device.get_kernel("qwen35_ane_commit_guard", library);
@@ -3332,6 +3374,27 @@ public:
     }
     encoder.dispatch_threads(MTL::Size(output_dim, M, 1),
                              MTL::Size(16, 16, 1));
+    // The merge encoder reads this program's single output IOSurface. MLX
+    // commits this command buffer lazily, so without draining it here the
+    // next dispatch to the same program (the next 2K tile of one chunk on
+    // hosts with 4K prefill chunks) can begin its ANE evaluation and overwrite
+    // the surface before the merge kernel has executed. begin() only orders
+    // against the previous evaluation, not the previous merge. Commit and
+    // wait: the ANE and qmm branches were already joined on the host above,
+    // so the only added latency is the merge kernel itself.
+    {
+      encoder.end_encoding();
+      auto *merge_buffer = encoder.get_command_buffer();
+      merge_buffer->retain();
+      encoder.commit();
+      merge_buffer->waitUntilCompleted();
+      if (merge_buffer->status() == MTL::CommandBufferStatusError) {
+        merge_buffer->release();
+        throw std::runtime_error("ANE hybrid merge command buffer failed");
+      }
+      merge_buffer->release();
+    }
+
 
     if (!encoder.needs_commit()) {
       auto guard = device.get_kernel("qwen35_ane_commit_guard", library);


### PR DESCRIPTION
The ANE hybrid merge kernel reads the ANE program's single output IOSurface, but MLX commits the enclosing command buffer lazily. On hosts whose prefill chunk is larger than the 2048-token ANE tile, the next tile dispatches to the same program and its ANE evaluation can overwrite the surface before the previous merge has executed. `begin()` only orders against the previous evaluation, not the previous merge, so nothing prevents the race.

This commits the merge command buffer and waits for it at each of the three hybrid merge sites. The ANE and qmm branches were already joined on the host at that point, so the only added latency is the merge kernel itself. A failed command buffer now raises instead of silently producing a corrupted tile.

Validation on an M5 Pro 64 GB, macOS 27, MLX 0.32.2:

- `tests/test_qwen35_ane_prefill.py`: 143 passed.
- Qwen3.8-27B oQ4e with `qwen35_ane_prefill_enabled` and a 2048 tile: 3461, 5157 and 6852-token prompts (two to four tiles per chunk) prefilled through the ANE/GPU hybrid path with no command buffer errors, and the greedy output matched the GPU-only path.