### PR TITLE
perf(moe): read missing experts in parallel with pread before the slot writes

### DIFF
--- a/docs/MoE_Expert_Offload.md
+++ b/docs/MoE_Expert_Offload.md
@@ -35,6 +35,13 @@ with a resident-fraction selector (12.5% – 75%). Or via the settings API:
 Toggling triggers an engine reload (it is a load-time transform). The env
 kill switch `OMLX_MOE_EXPERT_OFFLOAD=0` disables it regardless of settings.
 
+Two env vars tune the reader, and neither changes what is computed:
+
+| variable | default | effect |
+|---|---|---|
+| `OMLX_MOE_OFFLOAD_IO_WORKERS` | 12 | threads reading missing experts. `1` or less (or an unparseable value) keeps the serial path and starts no threads |
+| `OMLX_MOE_OFFLOAD_IO_BATCH` | `4 x workers` | experts whose reads may be in flight at once — the bound on the host memory the pipeline holds ahead of the slot writes |
+
 ## Performance
 
 `gemma-4-26b-a4b-it-4bit`, 585-token prompt, 256 generated tokens, warm
@@ -50,12 +57,20 @@ fill):
 
 Decode throughput degrades gracefully; TTFT is the pain point at low
 residency, because a long prefill routes to most experts per layer and pays
-the fetch churn up front. That is also the clearest follow-up: v1 fetches
-synchronously on miss, while prefill's full expert-access schedule is
-computable *before* any fetch (run the router over the whole prompt — no
-prediction needed), and decode prefetch (layer L+1's fetches during layer
-L's compute) has measured LRU→optimal headroom of +17pp hit rate at low
-residency.
+the fetch churn up front. A call's misses are therefore read *in parallel*:
+`ensure()` first classifies every expert the call needs without touching the
+cache, starts the missing experts' reads on a shared pool (`os.pread`, so a
+read needs nothing but a descriptor and an offset), and only then runs the
+serial install loop, which takes bytes from the pipeline instead of reading
+them itself. The slot writes, the LRU order, the eviction victims and the
+hit/miss counters all stay on the calling thread in the serial order, so the
+pipeline changes nothing but *when* the bytes arrive.
+
+The remaining headroom is scheduling, not IO width: prefill's full
+expert-access schedule is computable *before* any fetch (run the router over
+the whole prompt — no prediction needed), and decode prefetch (layer L+1's
+fetches during layer L's compute) has measured LRU→optimal headroom of
++17pp hit rate at low residency.
 
 ## Supported models
 

--- a/omlx/patches/moe_expert_offload.py
+++ b/omlx/patches/moe_expert_offload.py
@@ -3,11 +3,11 @@
 
 For Mixture-of-Experts models whose expert tables do not fit in memory, keep
 only ``resident_fraction`` of each layer's experts in a contiguous slot tensor
-and fetch the rest on demand from the model's own safetensors shards (mmap
-slab reads — no converted copy of the checkpoint, no write path). Routing is
-computed exactly as shipped; a cache miss changes *when* an expert's weights
-are read, never *which* expert runs. Accuracy is therefore preserved by
-construction, at a latency cost (measured on a 26B/128-expert model: accuracy
+and fetch the rest on demand from the model's own safetensors shards
+(positional slab reads — no converted copy of the checkpoint, no write
+path). Routing is computed exactly as shipped; a cache miss changes *when*
+an expert's weights are read, never *which* expert runs. Accuracy is
+therefore preserved by construction, at a latency cost (measured on a 26B/128-expert model: accuracy
 flat down to 12% residency, throughput falling roughly as memory^0.5).
 
 Applied once post-load, before lazy weights materialize: each stock
@@ -30,11 +30,15 @@ assertion policy).
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
 import re
 import struct
+import threading
+from collections import namedtuple
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import mlx.core as mx
@@ -56,6 +60,11 @@ _PER_EXPERT_PROJ_RE = re.compile(
     r"^(?P<parent>.+)\.experts\.(?P<idx>\d+)\."
     r"(?P<proj>gate_proj|up_proj|down_proj)\.(?P<field>weight|scales|biases)$"
 )
+
+# A pending slab read: everything needed to turn a byte range of a shard
+# into an mx.array, and nothing that touches MLX or cache state — so the
+# ``os.pread`` half can run on any thread.
+_ReadPlan = namedtuple("_ReadPlan", "fd offset nbytes np_dtype mx_view shape")
 
 # safetensors dtype tag -> (numpy transport dtype, mlx dtype to view as).
 # bf16 has no numpy equivalent, so it travels as raw uint16 and is
@@ -94,15 +103,17 @@ class CheckpointExpertStore:
 
     Expert tables are stored stacked with the expert axis leading
     (``[num_experts, ...]``), so one expert is a contiguous byte range in the
-    shard. Shards are memory-mapped read-only; a fetch copies out exactly one
-    expert's slab. No MLX/Metal calls happen here except the final host-side
-    ``mx.array`` construction, so fetches are safe to move off the Metal
-    thread later (prefetch).
+    shard. Each shard is opened once read-only and read with ``os.pread``,
+    which takes the offset as an argument instead of carrying one on the
+    descriptor — so reads of different experts are safe to run concurrently,
+    off the calling thread. The read splits in two: :meth:`read` produces
+    bytes and touches neither MLX nor cache state (any thread), :meth:`to_mx`
+    turns those bytes into an array (the calling thread's stream).
     """
 
     def __init__(self, model_path: str | Path):
         self._specs: dict[str, tuple[Path, str, tuple[int, ...], int]] = {}
-        self._mm: dict[Path, np.memmap] = {}
+        self._fds: dict[Path, int] = {}
         model_path = Path(model_path)
         for shard in sorted(model_path.glob("*.safetensors")):
             with open(shard, "rb") as f:
@@ -118,6 +129,15 @@ class CheckpointExpertStore:
                     tuple(spec["shape"]),
                     data_base + spec["data_offsets"][0],
                 )
+            # Opened once here, read-only and never mutated afterwards: the
+            # store is fully populated before any fetch, which is what makes
+            # concurrent reads against it safe without a lock.
+            self._fds[shard] = os.open(shard, os.O_RDONLY)
+
+    def __del__(self):
+        for fd in self._fds.values():
+            with contextlib.suppress(Exception):  # interpreter teardown
+                os.close(fd)
 
     def __bool__(self) -> bool:
         return bool(self._specs)
@@ -129,29 +149,60 @@ class CheckpointExpertStore:
         _, dtype, shape, _ = self._specs[name]
         return shape, dtype
 
-    def _read(self, name: str, start_elem: int, n_elems: int,
-              out_shape: tuple[int, ...]) -> mx.array:
+    def _plan(
+        self, name: str, start_elem: int, n_elems: int, out_shape: tuple[int, ...]
+    ) -> _ReadPlan:
         shard, dtype, _, offset = self._specs[name]
         np_dtype, mx_view = _DTYPES[dtype]
         itemsize = np.dtype(np_dtype).itemsize
-        mm = self._mm.get(shard)
-        if mm is None:
-            mm = self._mm[shard] = np.memmap(shard, dtype=np.uint8, mode="r")
-        start = offset + start_elem * itemsize
-        raw = np.array(mm[start : start + n_elems * itemsize])  # one copy
-        out = mx.array(raw.view(np_dtype).reshape(out_shape))
-        return out.view(mx_view) if mx_view is not None else out
+        return _ReadPlan(
+            self._fds[shard],
+            offset + start_elem * itemsize,
+            n_elems * itemsize,
+            np_dtype,
+            mx_view,
+            out_shape,
+        )
+
+    def plan_expert(self, name: str, expert: int) -> _ReadPlan:
+        """Plan one expert's slab of a stacked ``[num_experts, ...]`` tensor."""
+        _, _, shape, _ = self._specs[name]
+        slab = int(np.prod(shape[1:]))
+        return self._plan(name, expert * slab, slab, shape[1:])
+
+    def plan_tensor(self, name: str) -> _ReadPlan:
+        """Plan a whole tensor (per-expert checkpoint layouts)."""
+        _, _, shape, _ = self._specs[name]
+        return self._plan(name, 0, int(np.prod(shape)), shape)
+
+    @staticmethod
+    def read(plan: _ReadPlan) -> bytes:
+        """The plan's raw bytes. Thread-safe: positional reads only."""
+        chunks = []
+        got = 0
+        while got < plan.nbytes:
+            chunk = os.pread(plan.fd, plan.nbytes - got, plan.offset + got)
+            if not chunk:
+                raise OSError(f"short read of {plan.nbytes} bytes at {plan.offset}")
+            chunks.append(chunk)
+            got += len(chunk)
+        return chunks[0] if len(chunks) == 1 else b"".join(chunks)
+
+    @staticmethod
+    def to_mx(plan: _ReadPlan, raw: bytes) -> mx.array:
+        """Reinterpret a plan's bytes as its array (host-side, one copy)."""
+        out = mx.array(np.frombuffer(raw, dtype=plan.np_dtype).reshape(plan.shape))
+        return out.view(plan.mx_view) if plan.mx_view is not None else out
 
     def fetch_expert(self, name: str, expert: int) -> mx.array:
         """One expert's slab of a stacked ``[num_experts, ...]`` tensor."""
-        _, _, shape, _ = self._specs[name]
-        slab = int(np.prod(shape[1:]))
-        return self._read(name, expert * slab, slab, shape[1:])
+        plan = self.plan_expert(name, expert)
+        return self.to_mx(plan, self.read(plan))
 
     def fetch_tensor(self, name: str) -> mx.array:
         """A whole tensor (per-expert checkpoint layouts)."""
-        _, _, shape, _ = self._specs[name]
-        return self._read(name, 0, int(np.prod(shape)), shape)
+        plan = self.plan_tensor(name)
+        return self.to_mx(plan, self.read(plan))
 
 
 class _GLUStoreView:
@@ -179,10 +230,71 @@ class _GLUStoreView:
     def has(self, proj: str, field: str) -> bool:
         return self._store.has(self._name(proj, field, 0))
 
+    def plan(self, proj: str, field: str, expert: int) -> _ReadPlan:
+        if self._per_expert:
+            return self._store.plan_tensor(self._name(proj, field, expert))
+        return self._store.plan_expert(self._name(proj, field, 0), expert)
+
     def fetch(self, proj: str, field: str, expert: int) -> mx.array:
         if self._per_expert:
             return self._store.fetch_tensor(self._name(proj, field, expert))
         return self._store.fetch_expert(self._name(proj, field, 0), expert)
+
+
+# One reader pool for the whole process. A miss is IO, not compute: the
+# useful width is the storage queue depth, so the default is wider than the
+# core count. ``OMLX_MOE_OFFLOAD_IO_WORKERS`` <= 1 (or unparseable) keeps the
+# serial path and creates no threads at all;
+# ``OMLX_MOE_OFFLOAD_IO_BATCH`` caps how many experts' payloads may be in
+# flight, which is what bounds the extra host memory the pipeline holds.
+_IO_WORKERS = 12
+_IO_LOCK = threading.Lock()
+_IO_POOL: ThreadPoolExecutor | None = None
+_IO_BATCH = 0
+_IO_CONFIGURED = False
+
+
+def _env_int(name: str, default: int, invalid: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return invalid
+
+
+def _io_pool() -> ThreadPoolExecutor | None:
+    """The shared reader pool, or ``None`` when reads must stay serial."""
+    global _IO_POOL, _IO_BATCH, _IO_CONFIGURED
+    with _IO_LOCK:
+        if not _IO_CONFIGURED:
+            _IO_CONFIGURED = True
+            workers = _env_int("OMLX_MOE_OFFLOAD_IO_WORKERS", _IO_WORKERS, 0)
+            if workers > 1:
+                _IO_BATCH = max(
+                    1,
+                    _env_int("OMLX_MOE_OFFLOAD_IO_BATCH", 4 * workers, 4 * workers),
+                )
+                _IO_POOL = ThreadPoolExecutor(
+                    max_workers=workers, thread_name_prefix="omlx-moe-io"
+                )
+        return _IO_POOL
+
+
+def _io_batch() -> int:
+    """Experts whose reads may be in flight at once."""
+    _io_pool()
+    return _IO_BATCH
+
+
+def _shutdown_io_pool() -> None:
+    """Drop the pool; the next fetch re-reads the environment (tests)."""
+    global _IO_POOL, _IO_BATCH, _IO_CONFIGURED
+    with _IO_LOCK:
+        pool, _IO_POOL, _IO_BATCH, _IO_CONFIGURED = _IO_POOL, None, 0, False
+    if pool is not None:
+        pool.shutdown(wait=True)
 
 
 class ExpertCache:
@@ -231,19 +343,25 @@ class ExpertCache:
         self.hits = self.misses = 0
         self.warm = False
 
-    def _install(self, e: int) -> int:
+    def _plans(self, e: int) -> list:
+        """Read plans for expert ``e``'s tensors, in slot-write order."""
+        out = []
+        for name in self.projs:
+            rb = self.resident[name][2]
+            out.append((name, 0, self.disk.plan(name, "weight", e)))
+            out.append((name, 1, self.disk.plan(name, "scales", e)))
+            if rb is not None and self.disk.has(name, "biases"):
+                out.append((name, 2, self.disk.plan(name, "biases", e)))
+        return out
+
+    def _reserve(self, e: int) -> int:
+        """Claim a slot for ``e``, evicting the LRU expert if none is free."""
         if self.free:
             slot = self.free.pop()
         else:
             old_e = next(iter(self.slot_of))  # LRU victim
             slot = self.slot_of.pop(old_e)
             self.map[old_e] = -1
-        for name in self.projs:
-            rw, rs, rb = self.resident[name]
-            rw[slot] = self.disk.fetch(name, "weight", e)
-            rs[slot] = self.disk.fetch(name, "scales", e)
-            if rb is not None and self.disk.has(name, "biases"):
-                rb[slot] = self.disk.fetch(name, "biases", e)
         self.slot_of[e] = slot
         self.map[e] = slot
         # once every expert has a slot no eviction can occur, so residency is
@@ -251,8 +369,33 @@ class ExpertCache:
         self.warm = len(self.slot_of) == self.n_experts
         return slot
 
+    def _write(self, slot: int, payload: list) -> None:
+        """Copy one expert's fetched bytes into ``slot``."""
+        for name, field, plan, raw in payload:
+            self.resident[name][field][slot] = CheckpointExpertStore.to_mx(plan, raw)
+
+    def _install(self, e: int) -> int:
+        plans = self._plans(e)
+        slot = self._reserve(e)
+        self._write(
+            slot, [(n, f, pl, CheckpointExpertStore.read(pl)) for n, f, pl in plans]
+        )
+        return slot
+
     def ensure(self, idx: mx.array) -> None:
         """Make every expert in ``idx`` resident.
+
+        Two passes. The first classifies the call's misses without touching
+        any cache state and starts their reads on the IO pool, at most
+        ``OMLX_MOE_OFFLOAD_IO_BATCH`` experts in flight; the second is the
+        serial install loop, which takes bytes from the pipeline instead of
+        reading them itself (an expert the first pass did not queue, because
+        eviction unseated it in the meantime, falls back to a serial read).
+        Every mutation — ``slot_of``, ``free``, ``map``, the counters, the
+        slots — happens on the calling thread in the serial order, so LRU
+        victims, hit/miss counts and resident bytes are identical to the
+        serial path. Concurrent ``ensure`` calls on one cache stay
+        unsupported, exactly as before.
 
         The ``.tolist()`` is a device->host readback and therefore a sync per
         MoE layer per step. Removing it needs prefetch (resolve layer L+1's
@@ -261,14 +404,44 @@ class ExpertCache:
         if self.warm:  # nothing can miss; skip it
             return
         needed = set(int(e) for e in idx.reshape(-1).tolist())
+        pool = _io_pool()
+        queue = [e for e in needed if e not in self.slot_of] if pool is not None else []
+        window = _io_batch()
+        pending: dict[int, list] = {}
+        sent = 0
+
+        def prefetch(upto: int) -> None:
+            nonlocal sent
+            while sent < min(upto, len(queue)):
+                e = queue[sent]
+                sent += 1
+                pending[e] = [
+                    (name, field, plan, pool.submit(CheckpointExpertStore.read, plan))
+                    for name, field, plan in self._plans(e)
+                ]
+
+        prefetch(window)
+        done = 0
         for e in needed:
             if e in self.slot_of:
                 slot = self.slot_of.pop(e)  # re-insert: LRU order
                 self.slot_of[e] = slot
                 self.hits += 1
-            else:
-                self.misses += 1
+                continue
+            self.misses += 1
+            group = pending.pop(e, None)
+            if group is None:
                 self._install(e)
+                continue
+            # Refill before the writes, never after, and only up to the
+            # experts already drained: at most ``window`` experts' payloads
+            # exist at once, counting the one being written here.
+            prefetch(done + window)
+            self._write(
+                self._reserve(e),
+                [(name, field, plan, f.result()) for name, field, plan, f in group],
+            )
+            done += 1
         # No mx.eval here: installs are already-materialized host arrays, and
         # evaluating every resident tensor on every miss measured 22% slower
         # at identical peak memory. Prefill's transient is bounded by the

--- a/tests/test_moe_expert_offload.py
+++ b/tests/test_moe_expert_offload.py
@@ -11,6 +11,8 @@ output magnitude ~5), so those cases assert a rounding-scale tolerance —
 head-room for kernel choice, not for wrong experts, which show as O(1).
 """
 
+import threading
+
 import pytest
 
 try:
@@ -28,6 +30,8 @@ if HAS_MLX:
     from omlx.patches.moe_expert_offload import (
         CheckpointExpertStore,
         OffloadSwitchGLU,
+        _io_pool,
+        _shutdown_io_pool,
         apply_moe_expert_offload,
         moe_offload_stats,
     )
@@ -514,6 +518,145 @@ class TestApplyAndForward:
         assert apply_moe_expert_offload(model, tmp_path, 0.25) == 2
         # OffloadSwitchGLU is not `type(...) is SwitchGLU`; nothing to rewrap
         assert apply_moe_expert_offload(model, tmp_path, 0.25) == 0
+
+
+class TestParallelFetch:
+    """Misses are read off the calling thread; the cache state is not.
+
+    The pool only produces bytes: slots, LRU order, eviction victims and the
+    counters are still mutated serially on the calling thread, so a parallel
+    run must be indistinguishable from a serial one.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _fresh_pool(self):
+        _shutdown_io_pool()
+        yield
+        _shutdown_io_pool()
+
+    def _wrap(self, tmp_path, glu, workers, monkeypatch, fraction=0.25):
+        if workers is None:
+            monkeypatch.delenv("OMLX_MOE_OFFLOAD_IO_WORKERS", raising=False)
+        else:
+            monkeypatch.setenv("OMLX_MOE_OFFLOAD_IO_WORKERS", workers)
+        _shutdown_io_pool()
+        model = _MiniMoE([glu])
+        assert apply_moe_expert_offload(model, tmp_path, fraction) == 1
+        return model, model.layers[0].experts.switch_glu.cache
+
+    def test_parallel_fetch_matches_serial_slots(self, tmp_path, monkeypatch):
+        glu = _make_glu(seed=3)
+        _save_checkpoint(tmp_path, _glu_tensors(glu, "layers.0.experts.switch_glu"))
+        mx.random.seed(21)
+        calls = [(mx.random.normal((2, 3, D)), _ri(2, 3, K)) for _ in range(5)]
+
+        def run(workers):
+            model, cache = self._wrap(tmp_path, glu, workers, monkeypatch)
+            outs = [model(x, i) for x, i in calls]
+            mx.eval(*outs)
+            return cache, outs
+
+        serial, out_serial = run("1")
+        parallel, out_parallel = run("16")
+
+        assert parallel.misses > parallel.capacity  # the pool actually ran
+        assert bool(mx.array_equal(serial.map, parallel.map))
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            for a, b in zip(serial.resident[proj], parallel.resident[proj]):
+                assert (a is None) == (b is None)
+                if a is not None:
+                    assert bool(mx.array_equal(a, b))
+        for a, b in zip(out_serial, out_parallel):
+            assert bool(mx.array_equal(a, b))
+
+    def test_ensure_preserves_lru_order_and_counters(self, tmp_path, monkeypatch):
+        glu = _make_glu(seed=4)
+        _save_checkpoint(tmp_path, _glu_tensors(glu, "layers.0.experts.switch_glu"))
+        mx.random.seed(11)
+        # 12 indices per call over 8 slots: every call evicts, repeatedly
+        seq = [_ri(6, K) for _ in range(12)]
+
+        def run(workers):
+            _, cache = self._wrap(tmp_path, glu, workers, monkeypatch)
+            assert cache.capacity == 8
+            for i in seq:
+                cache.ensure(i)
+            return cache
+
+        serial, parallel = run("1"), run("12")
+        assert list(serial.slot_of.items()) == list(parallel.slot_of.items())
+        assert serial.free == parallel.free
+        assert (serial.hits, serial.misses) == (parallel.hits, parallel.misses)
+        assert serial.misses > serial.capacity
+
+    @pytest.mark.parametrize("workers", ["0", "-4", "abc", "1", None])
+    def test_io_workers_env_degenerate_values(self, tmp_path, monkeypatch, workers):
+        glu = _make_glu(seed=5)
+        _save_checkpoint(tmp_path, _glu_tensors(glu, "layers.0.experts.switch_glu"))
+        x, i = mx.random.normal((4, 1, D)), _ri(4, 1, K)
+        ref = glu(x, i)
+        mx.eval(ref)
+        model, _ = self._wrap(tmp_path, glu, workers, monkeypatch)
+        got = model.layers[0].experts.switch_glu(x, i)
+        mx.eval(got)
+        assert bool(mx.array_equal(ref, got))
+        assert (_io_pool() is None) is (workers is not None)
+
+    def test_store_reads_are_thread_safe(self, tmp_path):
+        glu = _make_glu(seed=6)
+        _save_checkpoint(tmp_path, _glu_tensors(glu, "layers.0.experts.switch_glu"))
+        store = CheckpointExpertStore(tmp_path)
+        name = "layers.0.experts.switch_glu.gate_proj.weight"
+        raws = {}
+
+        def read(e):
+            raws[e] = CheckpointExpertStore.read(store.plan_expert(name, e))
+
+        threads = [threading.Thread(target=read, args=(e,)) for e in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert len(raws) == 8
+        for e, raw in raws.items():  # mx stays on this thread
+            got = CheckpointExpertStore.to_mx(store.plan_expert(name, e), raw)
+            assert bool(mx.array_equal(got, glu.gate_proj["weight"][e]))
+
+    def test_prefetch_batching_bounds_inflight(self, tmp_path, monkeypatch):
+        """The pipeline may not hold more than a batch of experts' payloads:
+        that bound is the only thing standing between reading ahead and
+        buffering a whole layer's expert table in host memory."""
+        glu = _make_glu(seed=7)
+        _save_checkpoint(tmp_path, _glu_tensors(glu, "layers.0.experts.switch_glu"))
+        monkeypatch.setenv("OMLX_MOE_OFFLOAD_IO_BATCH", "4")
+        real_read, real_to_mx = CheckpointExpertStore.read, CheckpointExpertStore.to_mx
+        lock = threading.Lock()
+        live = {"now": 0, "peak": 0}
+
+        def counting_read(plan):  # a payload exists from here ...
+            raw = real_read(plan)
+            with lock:
+                live["now"] += 1
+                live["peak"] = max(live["peak"], live["now"])
+            return raw
+
+        def counting_to_mx(plan, raw):  # ... until it becomes an array
+            with lock:
+                live["now"] -= 1
+            return real_to_mx(plan, raw)
+
+        monkeypatch.setattr(CheckpointExpertStore, "read", staticmethod(counting_read))
+        monkeypatch.setattr(
+            CheckpointExpertStore, "to_mx", staticmethod(counting_to_mx)
+        )
+        _, cache = self._wrap(tmp_path, glu, "8", monkeypatch)
+        assert _io_pool() is not None
+        mx.random.seed(5)
+        for _ in range(6):
+            cache.ensure(_ri(8, K))
+        assert cache.misses > cache.capacity
+        assert live["peak"] <= 4 * 9  # batch x tensors per expert
+        assert live["now"] == 0  # nothing left holding bytes
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Follow-up to #2595 / #986. Every expert cache miss in `moe_expert_offload.py` was a serial, synchronous memmap copy on the compute thread, one projection tensor at a time. On a large-expert-count checkpoint that makes prefill and low-residency decode I/O-latency bound rather than bandwidth bound.

`ExpertCache.ensure()` now runs two passes. The first classifies the call's misses without touching cache state and starts their reads on a bounded thread pool with `os.pread` (one read-only fd per shard; the `np.memmap` store is gone). The second pass is the original serial install loop, taking bytes from the pipeline instead of reading them itself. Every mutation of `slot_of`, `free`, `map`, the counters and the resident slots still happens on the calling thread in the serial order, so LRU victims, hit/miss counts, resident bytes and the numerical contract are identical to the serial path. `OMLX_MOE_OFFLOAD_IO_WORKERS` (default 12; 1 or less selects the serial path and creates no pool) and `OMLX_MOE_OFFLOAD_IO_BATCH` (default 4x workers) bound the threads and the in-flight payload bytes. Docs updated.

Measured on an M5 Pro 64 GB with `Vontra/Qwen3.8-Flash-Next-MLX-oQ2-MTP` (48 layers x 512 experts, 10 active, about 1.84 MB per expert), PLE table mmapped, MTP off, greedy, same prompts before and after:

| residency | case | before | after |
|---|---|---|---|
| 25% | 3461-token TTFT | 183 s | 18.7 s |
| 25% | decode after that prompt | 4.4 tok/s | 17.7 tok/s |
| 25% | 122-token warm decode | 2.3 tok/s | 16.2 tok/s |
| 68.8% | 3461-token TTFT | 30.1 s | 4.5 s |
| 68.8% | decode after that prompt | 13.6 tok/s | 19.7 tok/s |
| 68.8% | 122-token warm decode | 23.9 tok/s | 22.4 tok/s |

Generated text was identical to the serial baseline in every case. Loaded size was unchanged (33.9 GB at 68.8 percent).

Tests: `tests/test_moe_expert_offload.py` 36 fast and 3 slow passed, and again with `OMLX_MOE_OFFLOAD_IO_WORKERS=1`. New `TestParallelFetch` covers parallel-vs-serial slot and output equality, LRU order and counters, degenerate env values, concurrent store reads, and the in-flight payload bound. The pre-existing ruff findings on untouched lines of these two files are left alone.

The natural next step, kept out of this PR, is issuing the next prefill chunk's reads while the current chunk computes in `OffloadSwitchGLU.__call__`; the distinct set per chunk is already known up front.