### PR TITLE
fix(cache): fall back to whole-request keying on unsorted VLM ranges

### DIFF
--- a/omlx/cache/paged_cache.py
+++ b/omlx/cache/paged_cache.py
@@ -50,17 +50,14 @@ def resolve_block_extra_keys(
     """Resolve which cache key salt applies to a block ending at ``block_end``.
 
     ``extra_key_ranges`` takes precedence over ``extra_keys`` and is intended
-    for segmented VLM cache keying.
-
-    ``extra_key_ranges`` must be sorted ascending by start position. The
-    function uses early break on the first non-matching entry, so unsorted
-    input will produce incorrect results.
+    for segmented VLM cache keying. Unsorted ranges (possible after a client
+    compacts a long VLM conversation) cannot be resolved positionally, so
+    they are ignored and resolution falls back to whole-request keying.
     """
-    if extra_key_ranges:
-        assert all(
-            extra_key_ranges[i][0] <= extra_key_ranges[i + 1][0]
-            for i in range(len(extra_key_ranges) - 1)
-        ), "extra_key_ranges must be sorted ascending by start position"
+    if extra_key_ranges and all(
+        extra_key_ranges[i][0] <= extra_key_ranges[i + 1][0]
+        for i in range(len(extra_key_ranges) - 1)
+    ):
         selected = None
         for start, keys in extra_key_ranges:
             if block_end > start:
@@ -68,6 +65,8 @@ def resolve_block_extra_keys(
             else:
                 break
         return selected
+    if extra_key_ranges:
+        logger.debug("Ignoring unsorted extra_key_ranges for cache key resolution")
     if extra_keys is not None and (
         extra_key_token_start is None or block_end > extra_key_token_start
     ):

--- a/tests/test_paged_cache.py
+++ b/tests/test_paged_cache.py
@@ -127,6 +127,33 @@ class TestResolveBlockExtraKeys:
 
         assert resolve_block_extra_keys(4, extra_key_ranges=ranges) == ("image-1",)
 
+    def test_unsorted_ranges_fall_back_to_legacy_keys(self):
+        """Non-monotonic boundaries must not raise; they resolve unsalted."""
+        ranges = [
+            (9, ("image-1", "image-2")),
+            (5, ("image-1",)),
+        ]
+
+        assert resolve_block_extra_keys(12, extra_key_ranges=ranges) is None
+        assert (
+            resolve_block_extra_keys(
+                12,
+                extra_key_token_start=16,
+                extra_keys=("legacy-image",),
+                extra_key_ranges=ranges,
+            )
+            is None
+        )
+
+    def test_unsorted_ranges_do_not_raise_without_legacy_keys(self):
+        """The scheduler lookup path must survive compacted VLM histories."""
+        ranges = [
+            (20, ("image-1",)),
+            (10, ("image-1", "image-2")),
+        ]
+
+        assert resolve_block_extra_keys(24, extra_key_ranges=ranges) is None
+
 
 class TestCacheBlock:
     """Tests for CacheBlock dataclass."""

--- a/tests/test_paged_cache.py
+++ b/tests/test_paged_cache.py
@@ -144,6 +144,15 @@ class TestResolveBlockExtraKeys:
             )
             is None
         )
+        assert (
+            resolve_block_extra_keys(
+                20,
+                extra_key_token_start=16,
+                extra_keys=("legacy-image",),
+                extra_key_ranges=ranges,
+            )
+            == ("legacy-image",)
+        )
 
     def test_unsorted_ranges_do_not_raise_without_legacy_keys(self):
         """The scheduler lookup path must survive compacted VLM histories."""


### PR DESCRIPTION
## Problem

Long VLM conversations that a client compacts can produce segmented cache boundaries whose start positions are no longer ascending. Prefix-cache lookup then hits `assert extra_key_ranges must be sorted ascending by start position` in `resolve_block_extra_keys` and the request fails instead of serving. Fixes #2921.

## Change

Unsorted `extra_key_ranges` are now ignored at resolution time, so lookup falls through to the whole-request image key — the same fallback the VLM engine already uses when segmented boundary computation fails. Sorted input resolves exactly as before.

## Tests

- New `TestResolveBlockExtraKeys` cases fail on the old code with the reported AssertionError and pass with the fix.
- `tests/test_paged_cache.py tests/test_prefix_cache.py tests/test_request.py tests/test_mtp_prompt_priming.py`: 273 passed.