### PR TITLE
fix(server): honor sse_keepalive_mode for non-streaming JSON responses

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2758,6 +2758,37 @@ async def _json_response_or_keepalive(
             )
         return Response(content=result, media_type=media_type, headers=headers)
 
+    global_settings = _server_state.global_settings
+    keepalive_mode = "chunk"
+    if global_settings is not None:
+        keepalive_mode = getattr(
+            global_settings.server, "sse_keepalive_mode", "chunk"
+        )
+
+    if keepalive_mode == "off":
+        try:
+            result = await task
+        except PrefillMemoryExceededError as e:
+            logger.warning(f"JSON keepalive prefill rejected: {e}")
+            return JSONResponse(
+                status_code=400,
+                content=_prefill_memory_openai_error_body(e),
+                headers=headers,
+            )
+        except HTTPException as e:
+            logger.warning(
+                "JSON keepalive request failed (%d): %s", e.status_code, e.detail
+            )
+            return JSONResponse(
+                status_code=e.status_code,
+                content=_openai_error_body(e.detail, e.status_code),
+                headers=headers,
+            )
+        finally:
+            if lease is not None:
+                await lease.release()
+        return Response(content=result, media_type=media_type, headers=headers)
+
     generator = _with_json_keepalive(http_request, task)
     if lease is not None:
         generator = _release_after_stream(generator, lease)

--- a/tests/test_sse_keepalive.py
+++ b/tests/test_sse_keepalive.py
@@ -10,9 +10,11 @@ from fastapi import HTTPException
 
 from omlx.server import (
     ClientDisconnectTrackingMiddleware,
+    _json_response_or_keepalive,
     _with_json_keepalive,
     _with_request_disconnect_abort,
     _with_sse_keepalive,
+    _server_state,
 )
 
 
@@ -447,3 +449,73 @@ async def test_json_keepalive_preserves_http_error_after_first_byte(
             "code": None,
         }
     }
+
+
+class TestJsonKeepaliveOff:
+    """When sse_keepalive_mode is 'off', non-streaming responses must not
+    emit keepalive spaces. The response should be a plain Response (not
+    StreamingResponse) so clients/proxies can use read timeouts normally."""
+
+    def _patch_mode(self, mode: str, monkeypatch):
+        from types import SimpleNamespace
+
+        mock_settings = SimpleNamespace(server=SimpleNamespace(sse_keepalive_mode=mode))
+        monkeypatch.setattr(_server_state, "global_settings", mock_settings)
+
+    @pytest.mark.asyncio
+    async def test_off_returns_plain_response(self, monkeypatch):
+        from fastapi.responses import Response
+
+        self._patch_mode("off", monkeypatch)
+
+        async def slow():
+            await asyncio.sleep(0.05)
+            return '{"ok": true}'
+
+        resp = await _json_response_or_keepalive(None, slow())
+        assert isinstance(resp, Response)
+        assert resp.status_code == 200
+        assert resp.body == b'{"ok": true}'
+
+    @pytest.mark.asyncio
+    async def test_off_no_keepalive_bytes_leaked(self, monkeypatch):
+        from fastapi.responses import Response
+
+        self._patch_mode("off", monkeypatch)
+
+        async def slow():
+            await asyncio.sleep(0.05)
+            return '{"result": 42}'
+
+        resp = await _json_response_or_keepalive(None, slow())
+        assert isinstance(resp, Response)
+        assert resp.body == b'{"result": 42}'
+
+    @pytest.mark.asyncio
+    async def test_off_preserves_http_error(self, monkeypatch):
+        from fastapi.responses import JSONResponse
+
+        self._patch_mode("off", monkeypatch)
+
+        async def failing():
+            await asyncio.sleep(3)
+            raise HTTPException(status_code=400, detail="bad request")
+
+        resp = await _json_response_or_keepalive(None, failing())
+        assert isinstance(resp, JSONResponse)
+        assert resp.status_code == 400
+        body = json.loads(resp.body)
+        assert body["error"]["message"] == "bad request"
+
+    @pytest.mark.asyncio
+    async def test_chunk_mode_still_streams(self, monkeypatch):
+        from fastapi.responses import StreamingResponse
+
+        self._patch_mode("chunk", monkeypatch)
+
+        async def slow():
+            await asyncio.sleep(3)
+            return '{"ok": true}'
+
+        resp = await _json_response_or_keepalive(None, slow())
+        assert isinstance(resp, StreamingResponse)


### PR DESCRIPTION
The non-streaming JSON keepalive in `_with_json_keepalive` emits a space every 10s unconditionally, and there is no setting to disable it. Since HTTP read timeouts reset on every byte received, this makes it impossible for any client or reverse proxy to bound how long it waits for a non-streaming completion. A queued request is indistinguishable from a progressing one.

The streaming path already respects `sse_keepalive_mode` (`off` supported — added for exactly this class of client problem). The non-streaming path has no equivalent.

This PR wires the same setting into `_json_response_or_keepalive`: when mode is `off`, await the task directly and return a plain `Response` instead of wrapping in `StreamingResponse`. Default behavior (`chunk`) is unchanged. Operators who front oMLX with a proxy that needs real timeouts can now set `server.sse_keepalive_mode: "off"` in `~/.omlx/settings.json` and get them back.

Observed in production: a fleet of three Macs behind LiteLLM with 120s timeouts saw requests run for 6384s recorded as successes — the proxy spent the whole time waiting for the first byte and never aborted because the keepalive kept resetting the read clock.

Complements #2072 (which defers the leading space but does not add an opt-out).

Fixes #3580