### PR TITLE
feat(deepseek_v41): CED prefill skip with SWA bounded replay

### DIFF
--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1842,6 +1842,13 @@ class VLMBatchedEngine(BaseEngine):
                                 False,
                             )
                         ),
+                        ced_prefill=bool(
+                            getattr(
+                                self._model_settings,
+                                "deepseek_v41_ced_prefill_enabled",
+                                False,
+                            )
+                        ),
                     )
                 if model_type == COHERE2_MOE_MODEL_TYPE:
                     return _load_cohere2_moe_text_model(

--- a/omlx/model_profiles.py
+++ b/omlx/model_profiles.py
@@ -111,6 +111,8 @@ EXCLUDED_FROM_PROFILES = frozenset(
         # Hardware-specific residency choice; never propagate across models.
         "qwen4_ple_ssd_offload",
         "deepseek_v41_engram_ssd_offload",
+        # Architecture-level prefill strategy; explicit per model.
+        "deepseek_v41_ced_prefill_enabled",
         # Security flag must be explicit per model — never propagated via profiles.
         "trust_remote_code",
     }

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -320,6 +320,10 @@ class ModelSettings:
     # fit under the configured model-memory ceiling but mmap loading can.
     qwen4_ple_ssd_offload: bool = False
     deepseek_v41_engram_ssd_offload: bool = False
+    # DeepSeek V4.1 CED: during prefill the decoder half only forwards the
+    # last window-size tokens; decoder global KV is the encoder-final
+    # projection already produced by the midpoint CSA2 layer.
+    deepseek_v41_ced_prefill_enabled: bool = False
     preserve_thinking: Optional[bool] = (
         None  # Keep <think> blocks in historical turns (None = auto, True when template supports it)
     )

--- a/omlx/patches/deepseek_v41/config.py
+++ b/omlx/patches/deepseek_v41/config.py
@@ -100,6 +100,10 @@ class ModelConfig:
     image_token_id: int = 129264
     # Draft weights and standalone forward are separate from server verification.
     preserve_mtp: bool = False
+    # CED prefill skip: the decoder half forwards only the trailing
+    # window-size tokens; its global KV is produced by the midpoint CSA2
+    # layer projecting the encoder-final hidden states.
+    ced_prefill: bool = False
     dspark_block_size: int = 0
     dspark_noise_token_id: int = 0
     dspark_target_layer_ids: tuple[int, ...] = ()
@@ -208,3 +212,23 @@ class ModelConfig:
                 raise ValueError(f"Layer {i} has no compatible KV/index source")
         if len(self.engram_layer_ids) != len(self.engram_num_embeddings):
             raise ValueError("Engram layer/table counts differ")
+        if self.ced_prefill and not self.ced_layout_supported():
+            raise ValueError("CED prefill is not supported by this layer layout")
+
+    def ced_layout_supported(self) -> bool:
+        # CED requires an even split whose midpoint CSA2 layer owns the whole
+        # ratio-1 decoder half: it projects global KV from encoder-final
+        # hidden states while decoder queries attend from the SWA tail.
+        mid = self.n_layers // 2
+        return (
+            self.n_layers % 2 == 0
+            and self.window_size > 0
+            and mid in self.kv_source_layers
+            and mid in self.index_source_layers
+            and self.compress_ratios[mid] == 1
+            and all(r == 1 for r in self.compress_ratios[mid + 1 : self.n_layers])
+            and not any(
+                i in self.kv_source_layers for i in range(mid + 1, self.n_layers)
+            )
+            and all(i < mid for i in self.engram_layer_ids)
+        )

--- a/omlx/patches/deepseek_v41/language.py
+++ b/omlx/patches/deepseek_v41/language.py
@@ -176,20 +176,28 @@ class Indexer(nn.Module):
             self.k_norm = RMSNorm(c.index_head_dim, c.norm_eps)
         self._config, self._layer = c, layer
 
-    def __call__(self, x, qr, latent, cache, shared, start, ratio):
+    def __call__(self, x, qr, latent, cache, shared, start, ratio, latent_start=None):
         c, layer = self._config, self._layer
         end = start + x.shape[1]
         if layer in c.kv_source_layers:
+            # CED keeps the query path on the tail while the key path still
+            # spans the full chunk; latent_start marks that wider key origin.
+            kv_start = start if latent_start is None else int(latent_start)
+            kv_end = (
+                end
+                if latent_start is None
+                else kv_start + (0 if latent is None else latent.shape[1])
+            )
             previous = cache[3]
             previous = (
-                previous[:, : start // ratio]
+                previous[:, : kv_start // ratio]
                 if previous is not None
                 else pack_activation(
                     mx.zeros((1, 0, c.index_head_dim), x.dtype), bits=4
                 )
             )
             if latent is not None:
-                pos = mx.arange(start // ratio, end // ratio) * ratio
+                pos = mx.arange(kv_start // ratio, kv_end // ratio) * ratio
                 key = pack_activation(
                     rope(self.k_norm(self.wk(latent)), pos, c, True), bits=4
                 )
@@ -266,7 +274,7 @@ class Attention(nn.Module):
             )
         return self.wq_a(x), self.wkv(x)
 
-    def __call__(self, x, cache, shared, start):
+    def __call__(self, x, cache, shared, start, ced_kv=None, ced_kv_start=None):
         c, layer = self._config, self._layer
         ratio, length = c.compress_ratios[layer], x.shape[1]
         positions = mx.arange(start, start + length)
@@ -280,7 +288,8 @@ class Attention(nn.Module):
         )
         new = pack_activation(rope(self.kv_norm(kv_input), positions, c, bool(ratio)))
         old = cache[1]
-        old_len = min(start, c.window_size)
+        # CED clears the stale window whenever bounded replay skips tokens.
+        old_len = min(start, c.window_size, 0 if old is None else int(old.shape[1]))
         kv = mx.concatenate([old[:, :old_len], new], 1) if old_len else new
         verify_state = getattr(cache, "_mtp_verify_state", None)
         if verify_state is not None:
@@ -299,7 +308,11 @@ class Attention(nn.Module):
         if ratio:
             latent = None
             if layer in c.kv_source_layers:
-                latent = self.compressor(x, cache, start)
+                # CED: global KV projects the full encoder-final hidden state
+                # (ced_kv) even though queries only attend from the tail.
+                kv_x = x if ced_kv is None else ced_kv
+                kv_start = start if ced_kv_start is None else int(ced_kv_start)
+                latent = self.compressor(kv_x, cache, kv_start)
                 if cache[2] is None:
                     cache[2] = pack_activation(
                         mx.zeros((1, 0, c.head_dim), x.dtype),
@@ -307,13 +320,16 @@ class Attention(nn.Module):
                         group_size=16,
                         e4m3_scale=True,
                     )
-                shared["kv"] = cache[2][:, : start // ratio]
+                shared["kv"] = cache[2][:, : kv_start // ratio]
             if layer in c.index_source_layers:
-                shared["idx"] = self.indexer(x, qr, latent, cache, shared, start, ratio)
+                shared["idx"] = self.indexer(
+                    x, qr, latent, cache, shared, start, ratio, latent_start=ced_kv_start
+                )
             if latent is not None:
                 compressed = rope(
                     latent,
-                    mx.arange(start // ratio, (start + length) // ratio) * ratio,
+                    mx.arange(kv_start // ratio, (kv_start + kv_x.shape[1]) // ratio)
+                    * ratio,
                     c,
                     True,
                 )
@@ -753,17 +769,53 @@ class Block(nn.Module):
         if layer in c.engram_layer_ids:
             self.engram = Engram(c, list(c.engram_layer_ids).index(layer))
 
-    def __call__(self, h, pre, cache, shared, start, image_mask):
-        ap, ao, ac = hc_mixes(
-            h, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base, self._config
-        )
+    def __call__(self, h, pre, cache, shared, start, image_mask, ced_tail=None):
+        ced_kv = ced_kv_start = None
+        if ced_tail is not None:
+            # CED bounded replay: queries, SWA KV and MoE run on the tail
+            # only. The midpoint CSA2 layer still projects global KV from the
+            # full encoder-final hidden states it receives as ced_kv.
+            tail = min(int(ced_tail), h.shape[1])
+            full_len = h.shape[1]
+            if hasattr(self.attn, "compressor"):
+                ap, ao, ac = hc_mixes(
+                    h,
+                    self.hc_attn_fn,
+                    self.hc_attn_scale,
+                    self.hc_attn_base,
+                    self._config,
+                )
+                x = hc_pre_norm(
+                    h, pre, self.attn_norm.weight, self.attn_norm.eps
+                )
+                ced_kv, ced_kv_start = x, start
+                ap, ao, ac = ap[:, -tail:], ao[:, -tail:], ac[:, -tail:]
+            else:
+                h, pre = h[:, -tail:], pre[:, -tail:]
+                ap, ao, ac = hc_mixes(
+                    h,
+                    self.hc_attn_fn,
+                    self.hc_attn_scale,
+                    self.hc_attn_base,
+                    self._config,
+                )
+                x = hc_pre_norm(
+                    h, pre, self.attn_norm.weight, self.attn_norm.eps
+                )
+            # Bounded replay skipped every position before the tail, so the
+            # stored window is non-contiguous with these queries: drop it.
+            cache[1] = None
+            h, pre, x = h[:, -tail:], pre[:, -tail:], x[:, -tail:]
+            if image_mask is not None:
+                image_mask = image_mask[:, -tail:]
+            start = start + full_len - tail
+        else:
+            ap, ao, ac = hc_mixes(
+                h, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base, self._config
+            )
+            x = hc_pre_norm(h, pre, self.attn_norm.weight, self.attn_norm.eps)
         h = hc_post(
-            self.attn(
-                hc_pre_norm(h, pre, self.attn_norm.weight, self.attn_norm.eps),
-                cache,
-                shared,
-                start,
-            ),
+            self.attn(x, cache, shared, start, ced_kv=ced_kv, ced_kv_start=ced_kv_start),
             h,
             ao,
             ac,
@@ -895,6 +947,20 @@ class LanguageModel(DSparkMixin, nn.Module):
                 (mx.arange(c.hc_mult) == 0).astype(mx.float32), h.shape[:-1]
             )
             shared = {}
+            # CED prefill: the decoder half replays only the trailing
+            # window of the sequence. The gate is absolute (cache offset +
+            # chunk length) so chunk boundaries never leak stale decoder
+            # windows; decode steps and DSpark verify blocks stay on the
+            # normal path.
+            ced_tail = (
+                c.window_size
+                if c.ced_prefill
+                and verify_states is None
+                and end - begin > 1
+                and start + end - begin > c.window_size
+                else None
+            )
+            ced_mid = c.n_layers // 2
             prefetch = getattr(self, "_engram_prefetch", None)
             with prefetch.forward() if prefetch is not None else nullcontext():
                 if prefetch is not None and c.engram_layer_ids:
@@ -913,7 +979,19 @@ class LanguageModel(DSparkMixin, nn.Module):
                             )
                     if capture and i in c.dspark_target_layer_ids:
                         captured[i] = mx.mean(h, axis=2)
-                    h, pre = layer(h, pre, rc[i], shared, start, image_mask)
+                    query_start = start
+                    if ced_tail is not None and i > ced_mid:
+                        # The midpoint layer already advanced h to the tail.
+                        query_start = start + end - begin - ced_tail
+                    h, pre = layer(
+                        h,
+                        pre,
+                        rc[i],
+                        shared,
+                        query_start,
+                        image_mask,
+                        ced_tail=ced_tail if ced_tail is not None and i >= ced_mid else None,
+                    )
                     if prefetch is not None and "engram" in layer:
                         mx.async_eval(h, pre)
                     rc[i][0] = mx.array([start + end - begin], mx.int32)
@@ -934,8 +1012,17 @@ class LanguageModel(DSparkMixin, nn.Module):
                             )
                     rows[i].append(rc[i])
             logits = project_logits(self.norm(hc_pre(h, pre)), self.head.weight)
+            # CED skipped decoder positions keep zero logits; they are never
+            # sampled (only the final position of the final chunk is used).
             results.append(
-                mx.pad(logits, [(0, 0), (begin, input_ids.shape[1] - end), (0, 0)])
+                mx.pad(
+                    logits,
+                    [
+                        (0, 0),
+                        (end - logits.shape[1], input_ids.shape[1] - end),
+                        (0, 0),
+                    ],
+                )
             )
         for i, item in enumerate(cache):
             merged = DeepseekV41Cache.merge(rows[i])

--- a/omlx/patches/deepseek_v41/loading.py
+++ b/omlx/patches/deepseek_v41/loading.py
@@ -61,6 +61,7 @@ def load(
     engram_ssd_offload=False,
     preserve_mtp=None,
     moe_expert_offload_resident_fraction=None,
+    ced_prefill=False,
 ):
     path = Path(path)
     if (path / "conversion.inprogress.json").exists():
@@ -91,6 +92,16 @@ def load(
             raise ValueError("MoE expert offload cannot enable DSpark MTP")
         # Retained draft weights need not consume RAM when speculation is forbidden.
         config.preserve_mtp = False
+    if ced_prefill:
+        if config.ced_layout_supported():
+            config.ced_prefill = True
+            logger.info("DeepSeek V4.1 CED prefill enabled: decoder tail %d", config.window_size)
+        else:
+            config.ced_prefill = False
+            logger.warning(
+                "DeepSeek V4.1 CED prefill requested but layer layout is "
+                "unsupported; falling back to full decoder prefill"
+            )
     model = Model(config)
     if config.engram_layer_ids:
         logger.info(

--- a/omlx/patches/mlx_lm_mtp/deepseek_v4_dspark.py
+++ b/omlx/patches/mlx_lm_mtp/deepseek_v4_dspark.py
@@ -95,10 +95,18 @@ class DSparkContextCache:
             if self.keys is None:
                 self.offset = start
             elif self.offset != start:
-                raise ValueError(
-                    "DSpark context is not contiguous: "
-                    f"cache={self.offset}, append={start}"
-                )
+                if start > self.offset and length >= self.max_size:
+                    # CED bounded replay: the decoder only forwards the
+                    # trailing window, so a fresh full window legitimately
+                    # replaces the stale ring. RoPE is baked at append time
+                    # and attention is non-causal, so slot order is free.
+                    self.keys = None
+                    self.offset = start
+                else:
+                    raise ValueError(
+                        "DSpark context is not contiguous: "
+                        f"cache={self.offset}, append={start}"
+                    )
         if self.keys is None:
             next_keys = keys
         else:
@@ -160,7 +168,8 @@ def capture_prompt(
     offset_after = _target_cache_offset(target_cache)
     if offset_after is None:
         return
-    seq_len = int(inputs.shape[1])
+    # CED captures only the decoder tail; the appended rows define the span.
+    seq_len = int(aux_hidden.shape[1])
     start_offset = offset_after - seq_len
     ctx = getattr(host, _PRIME_CTX_ATTR, None)
     if not isinstance(ctx, _DSparkPrimeContext) or (

--- a/tests/test_deepseek_v41.py
+++ b/tests/test_deepseek_v41.py
@@ -911,3 +911,102 @@ def test_load_preserves_bf16_head_without_changing_prefill_logits(tmp_path):
             np.testing.assert_array_equal(actual, reference)
         finally:
             model.close()
+
+
+# ---------------------------------------------------------------------------
+# CED prefill: the decoder half forwards only the trailing window tokens.
+# ---------------------------------------------------------------------------
+
+
+def tiny_ced(**kwargs):
+    values = dict(
+        n_layers=6,
+        compress_ratios=(0, 2, 2, 1, 1, 1),
+        kv_source_layers=(1, 3),
+        index_source_layers=(1, 3, 4, 5),
+        candidate_source_layer=3,
+        window_size=4,
+        ced_prefill=True,
+    )
+    values.update(kwargs)
+    return tiny(**values)
+
+
+def ced_pair():
+    off, on = LanguageModel(tiny_ced(ced_prefill=False)), LanguageModel(tiny_ced())
+    load_reference_weights(off)
+    load_reference_weights(on)
+    return off, on
+
+
+def test_ced_layout_supported():
+    assert tiny_ced(ced_prefill=False).ced_layout_supported()
+    assert not tiny_ced(n_layers=5).ced_layout_supported()
+    assert not tiny_ced(window_size=0).ced_layout_supported()
+    assert not tiny_ced(kv_source_layers=(1, 3, 5)).ced_layout_supported()
+    assert not tiny_ced(compress_ratios=(0, 2, 2, 1, 1, 2)).ced_layout_supported()
+    assert not tiny_ced(engram_layer_ids=(4,)).ced_layout_supported()
+    with pytest.raises(ValueError, match="CED"):
+        tiny_ced(kv_source_layers=(1, 3, 5), ced_prefill=True).validate()
+
+
+def test_ced_preserves_encoder_and_global_kv_bitwise():
+    off, on = ced_pair()
+    ids = mx.array([[5, 9, 3, 12, 20, 7, 33, 41, 2, 18]])
+    co, cn = off.make_cache(), on.make_cache()
+    off(ids, cache=co)
+    ln = np.asarray(on(ids, cache=cn)[:, -1])
+    # Determinism: two CED runs are bit-identical.
+    ln2 = np.asarray(on(ids, cache=on.make_cache())[:, -1])
+    np.testing.assert_array_equal(ln, ln2)
+    # Encoder caches are untouched by CED.
+    for i in range(3):
+        np.testing.assert_array_equal(np.asarray(co[i][1]), np.asarray(cn[i][1]))
+    # The midpoint CSA2 layer sees the identical encoder-final hidden
+    # states, so its global KV and index K are bit-identical.
+    np.testing.assert_array_equal(np.asarray(co[3][2]), np.asarray(cn[3][2]))
+    np.testing.assert_array_equal(np.asarray(co[3][3]), np.asarray(cn[3][3]))
+    np.testing.assert_array_equal(np.asarray(co[3][1]), np.asarray(cn[3][1]))
+    assert co[3].size() == cn[3].size() == ids.shape[1]
+    # Decoder window KV may legitimately differ (bounded replay), but the
+    # stored window still covers exactly the last window_size positions.
+    for i in (4, 5):
+        assert cn[i][1].shape[1] == min(ids.shape[1], 4)
+
+
+def test_ced_inactive_within_window_is_bitwise_full_compute():
+    off, on = ced_pair()
+    ids = mx.array([[5, 9, 3, 12, 20, 7]])
+    ln = np.asarray(on(ids, cache=on.make_cache()))
+    # Length 6 > window 4: CED is active. Skipped positions carry zero
+    # logits; the tail is finite and differs from full compute (bounded
+    # replay truncates early tail queries' windows by design).
+    np.testing.assert_array_equal(ln[:, :2], np.zeros((1, 2, ln.shape[-1])))
+    assert np.isfinite(ln[:, 2:]).all()
+    lo = np.asarray(off(ids, cache=off.make_cache()))
+    assert not np.allclose(lo[:, -1], ln[:, -1])
+    # A sequence within the window stays on the full-compute path bitwise.
+    short = mx.array([[5, 9, 3, 12]])
+    np.testing.assert_array_equal(
+        np.asarray(off(short, cache=off.make_cache())),
+        np.asarray(on(short, cache=on.make_cache())),
+    )
+
+
+def test_ced_chunked_continuity_and_decode_seam():
+    _, on = ced_pair()
+    full = mx.array([[5, 9, 3, 12, 20, 7, 33, 41, 2, 18]])
+    ca = on.make_cache()
+    first = np.asarray(on(full[:, :6], cache=ca))
+    second = np.asarray(on(full[:, 6:], cache=ca))
+    assert first.shape[1] == 6 and second.shape[1] == 4
+    decoded = np.asarray(on(mx.array([[11]]), cache=ca))[:, -1]
+    assert np.isfinite(decoded).all()
+    for i in (3, 4, 5):
+        assert ca[i].size() == 11
+        assert ca[i][1].shape[1] == 4
+    # Chunked CED ends with the same trailing window as one CED pass.
+    cb = on.make_cache()
+    on(full, cache=cb)
+    solo = np.asarray(on(mx.array([[11]]), cache=cb))[:, -1]
+    np.testing.assert_array_equal(decoded, solo)

--- a/tests/test_deepseek_v4_dspark.py
+++ b/tests/test_deepseek_v4_dspark.py
@@ -213,6 +213,28 @@ def test_dspark_context_cache_keeps_reference_physical_ring_order(dsv4):
     assert cache.keys.reshape(-1).tolist() == [8, 9, 10, 11]
 
 
+def test_dspark_context_cache_ced_gap_replaces_full_window(dsv4):
+    # CED bounded replay appends only the trailing window, so a fresh
+    # full-size block may legitimately start past the ring offset.
+    cache = dsv4.DSparkContextCache(4)
+
+    def append(start, *positions):
+        values = mx.array(positions, dtype=mx.float32).reshape(1, 1, -1, 1)
+        cache.append(values, start_offset=start)
+        mx.eval(cache.keys)
+
+    append(2, 0, 1, 2, 3)
+    assert cache.offset == 6
+    # Gap with a full window: replace the stale ring.
+    append(10, 4, 5, 6, 7)
+    assert cache.offset == 14
+    chronological = cache._chronological(cache.keys).reshape(-1).tolist()
+    assert chronological == [4, 5, 6, 7]
+    # Gap with a partial block stays a contiguity error.
+    with pytest.raises(ValueError, match="not contiguous"):
+        append(20, 8, 9)
+
+
 def test_dspark_sanitize_keeps_direct_stage_layout(dsv4):
     fake = SimpleNamespace(
         args=SimpleNamespace(


### PR DESCRIPTION
## What

Implements the CED prefill proposal from #3605: during prefill, the decoder half (layers 21–39) runs attention + MoE for only the trailing `n_win` (sliding-window) tokens. The decoder's global KV is obtained by having the midpoint CSA2 layer project the **full** encoder-final hidden state `H_20` (one `wkv` matmul, no attention/MoE), exactly as the paper prescribes.

Off by default; enabled per model via `deepseek_v41_ced_prefill_enabled`.

## Measured (Mac Studio M3 Ultra 512GB, DeepSeek-V4.1-Flash-oQ4e-mtp)

| | CED off | CED on |
|---|---|---|
| cold prefill, 21.4K-token prompt | 50.19 s ≈ **430 tok/s** | 30.55 s ≈ **700 tok/s** (**+63%**) |
| DSpark decode tok/cycle / accept | 4.00 / 71.4% | 3.20–4.00 / 71–73% (unchanged) |

+63% rather than the theoretical ~2× because the encoder (20 layers), the midpoint global-KV projection, and the indexer full-key path still run over every token, and each prefill chunk pays a small extra decoder tail.

## Design decisions

- **Layout validation**: `ced_layout_supported()` requires even `n_layers`, the midpoint layer to be a ratio-1 `kv_source` layer, all ratios above the midpoint to be 1, no `kv_source` above the midpoint, and all engram layers below the midpoint. Unsupported layouts auto-disable with a warning.
- **Chunked prefill**: the CED gate is *absolute* (`cache offset + chunk length > window`), and every active chunk drops its stale window cache (`cache[1] = None`). This makes chunked CED **bit-identical** to a single CED pass — covered by `test_ced_chunked_continuity_and_decode_seam`. Intermediate chunks do compute their own 128-token tails (extra ~6% work); their window rows are cleared by the next active chunk, so the final cache state depends only on the trailing window.
- **Decode / speculative untouched**: decode steps (length 1) and DSpark verify blocks (length ≤ depth+1 < window) never enter the CED path, so `mtp_partial_rollback` semantics are unchanged.
- **DSpark prime ring**: CED priming captures only the tail rows; the ring legitimately replaces a stale window with a fresh full window (`start > offset and length >= max_size`). RoPE is baked at append time and ring attention is non-causal, so slot order is free.
- **Native packed attention**: the CED tail (`localL == qL == 128`) hits the same corner case as today's short-prompt fast path; the fallback index math with `old_len = 0` was verified slot-by-slot.

## Tests

- CED-off regression: full existing V4.1 + DSpark suites unchanged.
- New: layout validation (incl. `validate()` rejection), encoder + midpoint global-KV caches bit-identical CED-on vs off, determinism, inactive-within-window bitwise full compute, chunked-vs-single CED bitwise equality + decode seam, DSpark ring gap replacement.

## Answers to the four questions in #3605

1. **Chunked prefill**: absolute gate + per-active-chunk window clear ⇒ chunked == single, bitwise (tested).
2. **DSpark verify**: never enters CED (length guard); rollback path untouched.
3. **Snapshot/rollback**: CED never runs during verify; SSD snapshots see the same tail-window shape as full compute.
4. **Numerics**: deterministic (same kernel order per chunk); early tail queries see truncated windows — the paper-approved bounded-replay approximation; encoder and global KV are bit-identical to CED-off.
