### PR TITLE
fix(cluster): propagate client cancellation through sequential prefill

### DIFF
--- a/omlx/cluster/telemetry.py
+++ b/omlx/cluster/telemetry.py
@@ -158,6 +158,7 @@ class RuntimeTelemetry:
         self._pending_transport_cancels: set[str] = set()
         self._cancel_requested_requests: set[int] = set()
         self._pending_uid = threading.local()
+        self._sequential_state = threading.local()
         self._last_completed: dict[str, Any] | None = None
         self._last_publish_at = float("-inf")
         self._requests_completed = 0
@@ -555,6 +556,12 @@ class RuntimeTelemetry:
                 queue.put(None)
             except Exception as exc:
                 logger.debug("Could not terminate cancelled response queue: %s", exc)
+
+    def is_sequential_active(self) -> bool:
+        return bool(getattr(self._sequential_state, "active", False))
+
+    def set_sequential_active(self, active: bool) -> None:
+        self._sequential_state.active = bool(active)
 
     def register_batch_generator(self, generator: Any) -> None:
         """Remember the live BatchGenerator so force-cancel can reach it."""
@@ -1088,6 +1095,14 @@ class _TelemetryQueue:
                 self._telemetry.register_context(self._request_id, item)
             elif hasattr(item, "token") and hasattr(item, "finish_reason"):
                 self._telemetry.observe_token(self._request_id)
+            elif isinstance(item, tuple) and len(item) == 2:
+                if self._telemetry.is_sequential_active():
+                    self._telemetry.poll_cancel_requests(min_interval=0.0)
+                    context = self._telemetry._request_contexts.get(self._request_id)
+                    if context is not None and getattr(context, "_should_stop", False):
+                        raise InterruptedError(
+                            f"Request {self._request_id} aborted during sequential prefill"
+                        )
         return self._queue.put(item, *args, **kwargs)
 
 
@@ -1659,13 +1674,16 @@ def install_server_telemetry(
             # agreement; model collectives remain distributed.
             was_distributed = self._is_distributed
             previous = getattr(cancellation_state, "sequential", False)
+            previous_seq = telemetry.is_sequential_active()
             cancellation_state.sequential = was_distributed
+            telemetry.set_sequential_active(True)
             self._is_distributed = False
             try:
                 return super()._serve_single(request)
             finally:
                 self._is_distributed = was_distributed
                 cancellation_state.sequential = previous
+                telemetry.set_sequential_active(previous_seq)
 
     original_stream_generate = mlx_server.stream_generate
 

--- a/tests/test_cluster_telemetry.py
+++ b/tests/test_cluster_telemetry.py
@@ -952,3 +952,60 @@ def test_rank_hot_clear_reaches_live_prompt_cache_instances(monkeypatch):
     assert cache.entries == 0
     assert handler.status == 200
     assert json.loads(handler.wfile.getvalue())["hot_cleared"] == 3
+
+
+def test_sequential_prefill_cancellation_halts_prompt_processing(monkeypatch):
+    """A client abort during sequential prefill stops generation immediately."""
+
+    from queue import Queue
+
+    import mlx_lm.server as mlx_server
+
+    from omlx.cluster.telemetry import _TelemetryQueue
+
+    cancelled_during_prefill = False
+    chunks_processed = []
+
+    class FakeResponseGenerator:
+        def __init__(self):
+            self._is_distributed = False
+
+        def _serve_single(self, request):
+            rqueue, _req, _args = request
+            ctx = mlx_server.GenerationContext(
+                has_tool_calling=False,
+                has_thinking=False,
+                tool_parser=lambda *_args: {},
+                sequences={},
+                prompt=[1, 2, 3, 4],
+            )
+            rqueue.put(ctx)
+
+            def progress(processed, total):
+                rqueue.put((processed, total))
+
+            # Simulate chunked prefill steps
+            try:
+                chunks_processed.append(1)
+                progress(1, 4)
+                # Client abort arrives during prefill
+                ctx.stop()
+                chunks_processed.append(2)
+                progress(2, 4)
+                # Should not reach subsequent chunks
+                chunks_processed.append(3)
+                progress(3, 4)
+            except InterruptedError:
+                nonlocal cancelled_during_prefill
+                cancelled_during_prefill = True
+
+    monkeypatch.setattr(mlx_server, "ResponseGenerator", FakeResponseGenerator)
+
+    with install_server_telemetry(_Marker()) as telemetry:
+        generator = mlx_server.ResponseGenerator()
+        q = Queue()
+        wrapped_queue = _TelemetryQueue(q, telemetry)
+        generator._serve_single((wrapped_queue, "request", "args"))
+
+    assert cancelled_during_prefill is True
+    assert chunks_processed == [1, 2]


### PR DESCRIPTION
## Problem

While PR #3258 bounded continuous-batching prefill slices to 1 chunk via `PrefillCancellationTimeBudget`, sequential routes (`_serve_single`, which runs when callers specify an explicit `seed` or on non-batchable models) still ran prompt prefill synchronously inside `stream_generate` without checking `context._should_stop` until decode began.

On long prompts (e.g. 100k-300k+ tokens), disconnecting during prefill on that path left the ranks processing chunks to completion with no listener.

## Solution

1. Hook cooperative cancellation into `_TelemetryQueue.put` when observing prompt progress reports `(processed, total)`.
2. When sequential serving is active, poll cancel requests at each prefill step boundary.
3. If cancellation has been requested, raise `InterruptedError` out of `prompt_progress_callback` to halt prefill immediately.
4. `_serve_single` catches the exception and routes it through the response queue, cleanly exiting `handle_completion` without hanging rank collectives.
5. In distributed TP/ring modes, `CoordinatedGenerationContext._should_stop` retains rank agreement so all ranks exit the prefill chunk at the same boundary.

Follow-up to #3013 and #3258.

## Validation

- Added `test_sequential_prefill_cancellation_halts_prompt_processing` in `tests/test_cluster_telemetry.py` (verifies prefill halts after chunk 2 upon cancellation).
- Full `tests/test_cluster_telemetry.py` suite: 27 passed in 2.28s.
- Ruff clean (`ruff check` passes).