### PR TITLE
fix: normalize TurboQuant bit depth across model settings and profiles

### DIFF
--- a/omlx/model_profiles.py
+++ b/omlx/model_profiles.py
@@ -142,9 +142,28 @@ def filter_universal_fields(data: dict[str, Any]) -> dict[str, Any]:
     return _filter_and_sanitize(data, UNIVERSAL_FIELDS_SET)
 
 
+def normalize_turboquant_kv_bits(value: Any) -> Any:
+    """Canonicalize numeric spellings without adding load-time validation.
+
+    Invalid legacy values must not cause the settings loader to discard a
+    model's other settings. Unset markers keep their existing semantics.
+    """
+    if isinstance(value, bool):
+        return value
+    try:
+        return float(value)
+    except (TypeError, ValueError, OverflowError):
+        return value
+
+
 def filter_profile_fields(data: dict[str, Any]) -> dict[str, Any]:
     """Return a new dict of UNIVERSAL + MODEL_SPECIFIC keys with real values."""
-    return _filter_and_sanitize(data, PROFILE_FIELDS_SET)
+    filtered = _filter_and_sanitize(data, PROFILE_FIELDS_SET)
+    if "turboquant_kv_bits" in filtered:
+        filtered["turboquant_kv_bits"] = normalize_turboquant_kv_bits(
+            filtered["turboquant_kv_bits"]
+        )
+    return filtered
 
 
 @dataclass

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -19,6 +19,7 @@ from .model_profiles import (
     UNIVERSAL_FIELDS_SET,
     filter_profile_fields,
     filter_universal_fields,
+    normalize_turboquant_kv_bits,
     slugify_profile_api_name,
     validate_profile_name,
     utcnow,
@@ -467,6 +468,8 @@ class ModelSettings:
     active_profile_name: Optional[str] = None  # Name of the currently-applied profile
 
     def __post_init__(self) -> None:
+        # Profiles retain raw JSON types; engine signatures use repr().
+        self.turboquant_kv_bits = normalize_turboquant_kv_bits(self.turboquant_kv_bits)
         if self.qwen35_oq_a8_enabled and self.qwen35_oq_a8_min_tokens < 1:
             raise ValueError("qwen35_oq_a8_min_tokens must be at least 1")
         # Both accelerate the same Qwen3.5 prefill projections by wrapping
@@ -531,6 +534,8 @@ class ModelSettings:
         result = {}
         for f in fields(self):
             value = getattr(self, f.name)
+            if f.name == "turboquant_kv_bits":
+                value = normalize_turboquant_kv_bits(value)
             if value is not None:
                 result[f.name] = value
         return result
@@ -845,6 +850,11 @@ class ModelSettingsManager:
                 used_api_names: set[str] = set()
                 for name, profile in profiles.items():
                     settings = profile.get("settings")
+                    # Normalize in memory only; the next save writes floats.
+                    if settings and "turboquant_kv_bits" in settings:
+                        settings["turboquant_kv_bits"] = normalize_turboquant_kv_bits(
+                            settings["turboquant_kv_bits"]
+                        )
                     if settings and "ttl_seconds" in settings:
                         del settings["ttl_seconds"]
                         changed = True

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -1362,6 +1362,104 @@ class TestEnginePoolAsync:
         assert refreshed.load_failed is False
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("bits", [8, 8.0, "8", "8.0", 2.5, "2.5", 3.5, "3.5"])
+    async def test_turboquant_profile_numeric_spelling_reuses_engine(
+        self, pool_with_mock_engines, tmp_path, bits
+    ):
+        """Legacy JSON spellings must reuse an engine, even while leased."""
+        from omlx.model_settings import ModelSettingsManager
+
+        (tmp_path / "model_settings.json").write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "models": {
+                        "model-a": {
+                            "model_alias": "alias-a",
+                            "turboquant_kv_enabled": True,
+                            "turboquant_kv_bits": float(bits),
+                        }
+                    },
+                }
+            )
+        )
+        (tmp_path / "model_profiles.json").write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "profiles": {
+                        "model-a": {
+                            "test": {
+                                "name": "test",
+                                "display_name": "Test",
+                                "api_name": "test",
+                                "expose_as_model": True,
+                                "settings": {"turboquant_kv_bits": bits},
+                            }
+                        }
+                    },
+                }
+            )
+        )
+        manager = ModelSettingsManager(tmp_path)
+        pool = pool_with_mock_engines
+        pool._settings_manager = manager
+        engine = MagicMock()
+        engine.start = AsyncMock()
+        engine.stop = AsyncMock()
+
+        with patch("omlx.engine_pool.BatchedEngine", return_value=engine) as factory:
+            assert (
+                await pool.get_engine(pool.resolve_model_id("alias-a", manager))
+                is engine
+            )
+            pool.get_entry("model-a").in_use = 1
+            for alias in ("model-a:test", "alias-a:test"):
+                resolved = manager.get_exposed_profile_runtime_settings_for_request(
+                    alias
+                )
+                assert resolved is not None
+                model_id, settings = resolved
+                assert (
+                    await pool.get_engine(model_id, runtime_settings=settings) is engine
+                )
+            assert await pool.get_engine("model-a") is engine
+
+        factory.assert_called_once()
+        engine.stop.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_turboquant_real_bit_depth_change_reloads_engine(
+        self, pool_with_mock_engines
+    ):
+        from omlx.model_settings import ModelSettings
+
+        pool = pool_with_mock_engines
+        engines = [MagicMock(), MagicMock()]
+        for engine in engines:
+            engine.start = AsyncMock()
+            engine.stop = AsyncMock()
+            engine.has_active_requests.return_value = False
+        with patch("omlx.engine_pool.BatchedEngine", side_effect=engines):
+            first = await pool.get_engine(
+                "model-a",
+                runtime_settings=ModelSettings(
+                    turboquant_kv_enabled=True,
+                    turboquant_kv_bits=3,
+                ),
+            )
+            second = await pool.get_engine(
+                "model-a",
+                runtime_settings=ModelSettings(
+                    turboquant_kv_enabled=True,
+                    turboquant_kv_bits=3.5,
+                ),
+            )
+        assert first is engines[0]
+        assert second is engines[1]
+        first.stop.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_runtime_settings_signature_reload(self, pool_with_mock_engines):
         """A profile runtime variant with engine fields reloads the base engine."""
         from omlx.model_settings import ModelSettings

--- a/tests/test_turboquant_settings_normalization.py
+++ b/tests/test_turboquant_settings_normalization.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+"""TurboQuant settings must not depend on JSON numeric spelling."""
+
+import json
+
+import pytest
+
+from omlx.model_settings import ModelSettings, ModelSettingsManager
+
+
+@pytest.mark.parametrize("value", [8, 8.0, "8", "8.0", 2.5, "2.5", 3.5, "3.5"])
+def test_settings_normalize_turboquant_bits_on_load(tmp_path, value):
+    settings_file = tmp_path / "model_settings.json"
+    original = json.dumps(
+        {"version": 1, "models": {"model-a": {"turboquant_kv_bits": value}}}
+    )
+    settings_file.write_text(original)
+
+    manager = ModelSettingsManager(tmp_path)
+    settings = manager.get_settings("model-a")
+
+    assert type(settings.turboquant_kv_bits) is float
+    assert settings.turboquant_kv_bits == float(value)
+    assert type(ModelSettings(turboquant_kv_bits=value).turboquant_kv_bits) is float
+    assert settings_file.read_text() == original  # Loading is not a migration.
+
+    manager.set_settings("model-a", settings)
+    stored = json.loads(settings_file.read_text())["models"]["model-a"]
+    assert type(stored["turboquant_kv_bits"]) is float
+    assert stored["turboquant_kv_bits"] == float(value)
+
+
+@pytest.mark.parametrize("value", [None, "", "invalid"])
+def test_normalization_does_not_drop_other_model_settings(tmp_path, value):
+    (tmp_path / "model_settings.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "models": {
+                    "model-a": {
+                        "turboquant_kv_bits": value,
+                        "model_alias": "test-alias",
+                        "temperature": 0.7,
+                    }
+                },
+            }
+        )
+    )
+    settings = ModelSettingsManager(tmp_path).get_settings("model-a")
+    assert settings.model_alias == "test-alias"
+    assert settings.temperature == 0.7
+
+
+@pytest.mark.parametrize("value", [8, 8.0, "8", "8.0", 2.5, "2.5", 3.5, "3.5"])
+def test_profile_saves_canonical_turboquant_bits(tmp_path, value):
+    manager = ModelSettingsManager(tmp_path)
+    manager.save_profile("model-a", "test", "Test", None, {"turboquant_kv_bits": value})
+    stored = json.loads(manager.profiles_file.read_text())
+    bits = stored["profiles"]["model-a"]["test"]["settings"]["turboquant_kv_bits"]
+    assert type(bits) is float
+    assert bits == float(value)
+
+    manager.update_profile("model-a", "test", settings={"turboquant_kv_bits": value})
+    stored = json.loads(manager.profiles_file.read_text())
+    bits = stored["profiles"]["model-a"]["test"]["settings"]["turboquant_kv_bits"]
+    assert type(bits) is float
+    assert bits == float(value)
+
+
+@pytest.mark.parametrize("value", [8, "8", "8.0", "2.5"])
+def test_legacy_profile_is_normalized_without_rewriting_on_load(tmp_path, value):
+    profiles_file = tmp_path / "model_profiles.json"
+    original = json.dumps(
+        {
+            "version": 1,
+            "profiles": {
+                "model-a": {
+                    "test": {
+                        "name": "test",
+                        "display_name": "Test",
+                        "api_name": "test",
+                        "settings": {"turboquant_kv_bits": value, "temperature": None},
+                    }
+                }
+            },
+        }
+    )
+    profiles_file.write_text(original)
+    manager = ModelSettingsManager(tmp_path)
+    profile = manager.get_profile("model-a", "test")
+    assert profile is not None
+    assert type(profile["settings"]["turboquant_kv_bits"]) is float
+    assert profiles_file.read_text() == original
+    # A metadata-only save must also canonicalize old settings on disk.
+    manager.update_profile("model-a", "test", display_name="Renamed")
+    stored = json.loads(profiles_file.read_text())
+    settings = stored["profiles"]["model-a"]["test"]["settings"]
+    assert type(settings["turboquant_kv_bits"]) is float
+    assert settings["turboquant_kv_bits"] == float(value)
+    assert settings["temperature"] is None
+
+
+@pytest.mark.parametrize("value", [None, ""])
+def test_profile_unset_bits_remain_absent(tmp_path, value):
+    manager = ModelSettingsManager(tmp_path)
+    profile = manager.save_profile(
+        "model-a", "test", "Test", None, {"turboquant_kv_bits": value}
+    )
+    assert "turboquant_kv_bits" not in profile["settings"]
+
+
+def test_settings_serialization_normalizes_assignment():
+    settings = ModelSettings()
+    settings.turboquant_kv_bits = "8"
+    assert type(settings.to_dict()["turboquant_kv_bits"]) is float
+
+
+def test_default_turboquant_bits_are_float():
+    assert type(ModelSettings().turboquant_kv_bits) is float
+    assert ModelSettings().turboquant_kv_bits == 4.0


### PR DESCRIPTION
## Description

I observed this problem several times and it manifests as the model reloading when client calls a model alias, even though the settings should be the same. I traced it to a difference in how turboquant bits are represented. It's possible there are other keys with the same problem, I didn't encounter those nor does this fix try and fix them all.

## Problem

Saving settings through the dashboard can store `turboquant_kv_bits` as `8.0` in `model_settings.json` and `8` in `model_profiles.json`.

The model-settings API converts the value to a float. The profile API accepts an untyped settings dictionary and preserves the original numeric type.

Engine runtime signatures use `repr()`, which distinguishes `8` from `8.0`. As a result, switching between a model and an otherwise equivalent exposed profile can cause an unnecessary reload. If the engine is in use, the request can fail with `ModelBusyError`.

## Changes

- Normalize numeric bit-depth values when constructing model settings and loading profiles.
- Normalize model-settings serialization and profile create/update operations so future saves use JSON floating-point numbers.
- Treat `8`, `8.0`, `"8"`, and `"8.0"` as the same value.
- Preserve fractional depths such as `2.5` and `3.5`.
- Preserve unset values and unrelated settings.

Profile normalization occurs in memory. It does not trigger a disk rewrite solely to change numeric formatting. The next normal save writes the canonical value.

Invalid legacy values retain their existing behavior. This avoids introducing conversion errors that could cause the settings loader to discard a model's other settings. Input validation is outside this fix; invalid configurations can still fail at runtime.

No UI, engine-signature, or schema-version changes are required. Existing unrelated profile migrations are unchanged.

## Tests

```bash
python -m pytest \
  tests/test_turboquant_settings_normalization.py \
  tests/test_model_settings.py \
  tests/test_model_settings_profiles.py \
  tests/test_admin_profiles_api.py \
  tests/test_engine_pool.py -q
```

**Result: 407 passed** on macOS with Python 3.12.13, including a fresh run before submission.

Regression coverage includes:

- Loading equivalent integer, float, and string representations.
- Consistent persistence on settings and profile saves.
- Metadata-only saves of existing profiles.
- Fractional depths and unset values.
- Reuse of the same engine across equivalent aliases while the engine is in use.
- A real bit-depth change still triggering a reload.

Against unmodified upstream production code, the regression subset produced **21 failures and 15 passes**, including the unwanted `ModelBusyError`.

`git diff --check` passed. Ruff reported no additional findings compared with the baseline (105 existing findings in the checked files).

Tests use synthetic configuration and mocked engines. The full repository suite and real-model inference were not run.

## Attribution

Made under human guidelines with assistance from Qwen and gpt-6-astra.
