### PR TITLE
perf(deepseek_v41): read offloaded experts with positional preads

### DIFF
--- a/benchmarks/deepseek_v41_offload_bench.py
+++ b/benchmarks/deepseek_v41_offload_bench.py
@@ -1,0 +1,233 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DeepSeek V4.1 expert offload on one machine: load, prefill, decode.
+
+Loads a V4.1 checkpoint through the oMLX loader with Engram on SSD and MoE
+expert offload at each requested resident fraction, then runs a chunked
+prefill and a greedy decode directly on the model (no scheduler), reporting
+load time, Metal and process memory, time to first token, decode speed, and
+the expert cache's hit rate and fetch throughput per phase. Prints the
+resident set per fraction from the shard headers and the largest fraction
+that fits the Metal working-set limit first, so a run that cannot fit is
+visible before any weights load::
+
+    python benchmarks/deepseek_v41_offload_bench.py --model /path/to/oQ3e \\
+        --fractions 0.125 0.25 --prompt-tokens 512 --decode-tokens 32
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import time
+from pathlib import Path
+
+import mlx.core as mx
+
+from omlx.utils.proc_memory import get_lifetime_max_phys_footprint, get_phys_footprint
+
+
+def _offload_stats(model) -> dict:
+    hits = misses = fetched = 0
+    for layer in model.language_model.layers:
+        slots = getattr(layer.ffn.experts, "slots", None)
+        if slots is None:
+            continue
+        hits += slots.hits
+        misses += slots.misses
+        fetched += slots.fetched_bytes
+    return {"hits": hits, "misses": misses, "fetched_bytes": fetched}
+
+
+def _delta(after: dict, before: dict, seconds: float) -> dict:
+    misses = after["misses"] - before["misses"]
+    hits = after["hits"] - before["hits"]
+    fetched = after["fetched_bytes"] - before["fetched_bytes"]
+    return {
+        "hits": hits,
+        "misses": misses,
+        "hit_rate": hits / max(1, hits + misses),
+        "fetched_gib": fetched / 2**30,
+        "fetch_gbps": fetched / max(seconds, 1e-9) / 1e9,
+    }
+
+
+def sizing(path: Path, budget: int, engram_ssd: bool) -> dict:
+    from omlx.patches.deepseek_v41.moe_offload import (
+        _plan,
+        admission_bytes,
+        fit_resident_fraction,
+    )
+
+    plan = _plan(path, 1.0)
+    rows = []
+    for fraction in (0.125, 0.25, 1 / 3, 0.375, 0.5, 1.0):
+        capacity = min(plan.count, max(plan.floor, round(plan.count * fraction)))
+        rows.append(
+            {
+                "fraction": fraction,
+                "experts_per_layer": capacity,
+                "admission_gib": admission_bytes(
+                    path, fraction, engram_ssd_offload=engram_ssd
+                )
+                / 2**30,
+            }
+        )
+    fit = fit_resident_fraction(path, budget, engram_ssd_offload=engram_ssd)
+    print(
+        f"experts {plan.full_bytes / 2**30:.1f} GiB, draft {plan.draft_bytes / 2**30:.1f} GiB, "
+        f"budget {budget / 2**30:.1f} GiB"
+    )
+    for row in rows:
+        print(
+            f"  {row['fraction'] * 100:5.1f}%  {row['experts_per_layer']:4d} experts/layer  "
+            f"admission {row['admission_gib']:6.1f} GiB"
+        )
+    print(
+        "largest fraction within budget: "
+        + (
+            "none"
+            if fit is None
+            else f"{fit:.4f} ({round(fit * plan.count)} experts/layer)"
+        )
+    )
+    return {"rows": rows, "fit": fit, "budget": budget}
+
+
+def run(path: Path, fraction: float, args) -> dict:
+    from omlx.patches.deepseek_v41.loading import load
+
+    gc.collect()
+    mx.clear_cache()
+    mx.reset_peak_memory()
+    t0 = time.perf_counter()
+    model, processor = load(
+        path,
+        engram_ssd_offload=args.engram == "ssd",
+        moe_expert_offload_resident_fraction=fraction,
+    )
+    load_s = time.perf_counter() - t0
+    result = {
+        "fraction": fraction,
+        "capacity": model._moe_offload_plan.capacity,
+        "load_s": load_s,
+        "after_load": {
+            "active_gib": mx.get_active_memory() / 2**30,
+            "peak_gib": mx.get_peak_memory() / 2**30,
+            "footprint_gib": get_phys_footprint() / 2**30,
+        },
+    }
+    print(
+        f"[{fraction:.4f}] loaded in {load_s:.1f} s: {result['capacity']} experts/layer, "
+        f"active {result['after_load']['active_gib']:.1f} GiB, "
+        f"peak {result['after_load']['peak_gib']:.1f} GiB, footprint {result['after_load']['footprint_gib']:.1f} GiB"
+    )
+    try:
+        tokenizer = processor.tokenizer
+        text = (args.prompt + " ") * (args.prompt_tokens // 8 + 1)
+        ids = tokenizer.encode(text)[: args.prompt_tokens]
+        cache = model.language_model.make_cache()
+        before = _offload_stats(model)
+        t0 = time.perf_counter()
+        logits = None
+        for start in range(0, len(ids), args.prefill_chunk):
+            chunk = mx.array([ids[start : start + args.prefill_chunk]])
+            logits = model(chunk, cache=cache)
+            mx.eval(logits)
+        ttft = time.perf_counter() - t0
+        result["prefill"] = {
+            "tokens": len(ids),
+            "seconds": ttft,
+            "tok_s": len(ids) / ttft,
+            **_delta(_offload_stats(model), before, ttft),
+        }
+        p = result["prefill"]
+        print(
+            f"[{fraction:.4f}] prefill {p['tokens']} tokens: {ttft:.1f} s "
+            f"({p['tok_s']:.1f} tok/s), hit rate {p['hit_rate']:.2f}, "
+            f"fetched {p['fetched_gib']:.1f} GiB at {p['fetch_gbps']:.2f} GB/s"
+        )
+        token = int(mx.argmax(logits[0, -1]).item())
+        generated = [token]
+        before = _offload_stats(model)
+        t0 = time.perf_counter()
+        for _ in range(args.decode_tokens - 1):
+            logits = model(mx.array([[token]]), cache=cache)
+            token = int(mx.argmax(logits[0, -1]).item())
+            generated.append(token)
+        decode_s = time.perf_counter() - t0
+        result["decode"] = {
+            "tokens": len(generated) - 1,
+            "seconds": decode_s,
+            "tok_s": (len(generated) - 1) / decode_s,
+            **_delta(_offload_stats(model), before, decode_s),
+        }
+        result["generated"] = tokenizer.decode(generated)
+        d = result["decode"]
+        print(
+            f"[{fraction:.4f}] decode {d['tokens']} tokens: {d['tok_s']:.2f} tok/s, "
+            f"hit rate {d['hit_rate']:.2f}, fetched {d['fetched_gib']:.1f} GiB at "
+            f"{d['fetch_gbps']:.2f} GB/s"
+        )
+        print(f"[{fraction:.4f}] text: {result['generated'][:200]!r}")
+        result["after_run"] = {
+            "active_gib": mx.get_active_memory() / 2**30,
+            "peak_gib": mx.get_peak_memory() / 2**30,
+            "footprint_gib": get_phys_footprint() / 2**30,
+            "max_footprint_gib": get_lifetime_max_phys_footprint() / 2**30,
+        }
+        a = result["after_run"]
+        print(
+            f"[{fraction:.4f}] after run: active {a['active_gib']:.1f} GiB, "
+            f"peak {a['peak_gib']:.1f} GiB, footprint {a['footprint_gib']:.1f} GiB, "
+            f"max footprint {a['max_footprint_gib']:.1f} GiB"
+        )
+    finally:
+        model.close()
+        del model, processor
+        gc.collect()
+        mx.clear_cache()
+    return result
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--model", required=True, type=Path)
+    ap.add_argument("--fractions", nargs="+", type=float, default=[0.125])
+    ap.add_argument("--engram", choices=["ssd", "ram"], default="ssd")
+    ap.add_argument("--prompt-tokens", type=int, default=512)
+    ap.add_argument("--prefill-chunk", type=int, default=512)
+    ap.add_argument("--decode-tokens", type=int, default=32)
+    ap.add_argument(
+        "--prompt",
+        default="The expert offload path streams routed experts from the checkpoint on demand.",
+    )
+    ap.add_argument("--budget-gib", type=float, default=None)
+    ap.add_argument("--sizing-only", action="store_true")
+    ap.add_argument("--json", type=Path, default=None)
+    args = ap.parse_args()
+    if args.prompt_tokens <= 0 or args.prefill_chunk <= 0 or args.decode_tokens < 1:
+        ap.error(
+            "--prompt-tokens and --prefill-chunk must be positive, --decode-tokens >= 1"
+        )
+    if any(not 0 < fraction <= 1 for fraction in args.fractions):
+        ap.error("--fractions must be in (0, 1]")
+    budget = (
+        int(args.budget_gib * 2**30)
+        if args.budget_gib is not None
+        else int(mx.device_info()["max_recommended_working_set_size"])
+    )
+    report = {
+        "model": str(args.model),
+        "sizing": sizing(args.model, budget, args.engram == "ssd"),
+    }
+    if not args.sizing_only:
+        report["runs"] = [
+            run(args.model, fraction, args) for fraction in args.fractions
+        ]
+    if args.json:
+        args.json.write_text(json.dumps(report, indent=1))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/MoE_Expert_Offload.md
+++ b/docs/MoE_Expert_Offload.md
@@ -135,10 +135,36 @@ cold reads from the internal SSD of an M5 Max, 12.5% residency:
 | sorted prefill, 256 tokens | 33 token-layers/s | 568 token-layers/s |
 
 These are single runs of adapter-level calls on synthetic weights; they
-exclude attention, Engram, and the rest of the forward. The per-token decode cost
-of the offload path is the sum over the 40 MoE layers, so at 12.5%
-residency expect the expert reads alone to take roughly 0.35 s per token
-on this SSD, with fewer misses at higher residency.
+exclude attention, Engram, and the rest of the forward.
+
+### Measured on a 128 GB Mac
+
+`Jundot/DeepSeek-V4.1-Flash-oQ3e-mtp` on an M5 Max with 128 GB and the
+internal SSD (`iogpu.wired_limit_mb` unset), Engram on SSD, native kernels
+built, run with `benchmarks/deepseek_v41_offload_bench.py` on a 433-token
+prose prompt in one prefill chunk followed by 64 greedy tokens. Single runs:
+
+| residency | experts per layer | load | Metal active | peak footprint | prefill | decode | decode hit rate |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 12.5% | 48 | 3.9 s | 38.0 GiB | 49.6 GiB | 28 tok/s | 5.6 tok/s | 0.69 |
+| 25% | 96 | 4.5 s | 65.7 GiB | 77.4 GiB | 25 tok/s | 4.2 tok/s | 0.78 |
+
+Both settings produce coherent, on-topic continuations. Served through
+`omlx serve` with the same settings (discovered from the HF cache, Engram
+forced to SSD by admission, 12.5% residency, engine load 4.4 s), two
+64-token chat completions ran at 2.7 tok/s on cold expert slots and
+4.1 tok/s after. Prefill reads every
+expert the prompt routes to once per layer (about 226 of 384 per layer for
+this prompt, 130 GiB in total) at 8 to 9 GB/s. Decode is bound by miss
+latency at one to two misses per layer per token. The lower residency
+decodes faster: the RAM the resident slots do not take is used by the page
+cache, which serves repeated misses far faster than the SSD (6.5 GB/s
+effective at 12.5% against 3.4 GB/s at 25%). On a 128 GB machine 12.5% is
+the better default. Expect the page cache to take all remaining RAM during
+a run; it is reclaimable and is not part of the Metal working-set limit.
+Higher residencies fit the limit on paper (`fit_resident_fraction` reports
+41% at 107.5 GiB) but leave no headroom for the KV cache and prefill
+transients, and were not measured.
 
 ### Sizing on a 128 GB Mac
 

--- a/docs/MoE_Expert_Offload.md
+++ b/docs/MoE_Expert_Offload.md
@@ -113,6 +113,33 @@ to the routed experts in each backbone layer, with capacity floored at the
 number selected by one token. Shared experts, attention, and other backbone
 weights remain resident.
 
+Non-resident experts are read with positional `pread` calls on a small
+reader pool of their own, not through the Engram row-gather mapping: an
+expert is megabytes of contiguous bytes, and a faulting `MADV_RANDOM` gather
+reads it one page at a time. A residency update starts the misses' reads
+ahead of the installs, at most 512 MiB of payload in flight, and installs
+them serially in the order the misses were seen, so eviction victims, hit
+and miss counts, and resident bytes are identical to a serial fetch. Sorted
+prefill routes are chunked on expert boundaries (every route of up to
+`capacity` distinct experts per chunk), so a prefill reads each expert once
+per layer and runs one kernel per chunk.
+
+Measured on a synthetic checkpoint with the oQ3e expert geometry (384
+experts, 3-bit affine, 14.8 MiB per expert, 4 layers, random weights),
+cold reads from the internal SSD of an M5 Max, 12.5% residency:
+
+| | mmap gather (before) | positional reads |
+|---|---:|---:|
+| decode, one token, per MoE layer | 362 ms | 9.1 ms |
+| expert fetch throughput | 0.23 GB/s | 9.3 GB/s |
+| sorted prefill, 256 tokens | 33 token-layers/s | 568 token-layers/s |
+
+These are single runs of adapter-level calls on synthetic weights; they
+exclude attention, Engram, and the rest of the forward. The per-token decode cost
+of the offload path is the sum over the 40 MoE layers, so at 12.5%
+residency expect the expert reads alone to take roughly 0.35 s per token
+on this SSD, with fewer misses at higher residency.
+
 For a 384-expert checkpoint, 12.5% keeps 48 experts per layer. The adapter
 preserves V4.1's activation quantization, clamped SwiGLU, and application of
 routing weights before the down projection. Large routed batches are split

--- a/docs/MoE_Expert_Offload.md
+++ b/docs/MoE_Expert_Offload.md
@@ -140,6 +140,28 @@ of the offload path is the sum over the 40 MoE layers, so at 12.5%
 residency expect the expert reads alone to take roughly 0.35 s per token
 on this SSD, with fewer misses at higher residency.
 
+### Sizing on a 128 GB Mac
+
+For `Jundot/DeepSeek-V4.1-Flash-oQ3e-mtp`, the shard headers give 221.5 GiB
+of routed experts, 91.9 GiB of Engram tables, 7.5 GiB of DSpark draft
+weights (not loaded under offload), and 10.1 GiB of everything else. With
+Engram on SSD the resident set is:
+
+| resident fraction | experts per layer | resident weights |
+|---:|---:|---:|
+| 12.5% | 48 | 38 GiB |
+| 25% | 96 | 65 GiB |
+| 33.3% | 128 | 84 GiB |
+| 37.5% | 144 | 93 GiB |
+
+The Metal working-set limit on a 128 GB machine with `iogpu.wired_limit_mb`
+unset is about 107 GiB, and KV cache, prefill transients, and the Engram
+page cache share it. `admission_bytes(path, fraction)` and
+`fit_resident_fraction(path, budget_bytes)` in
+`omlx.patches.deepseek_v41.moe_offload` give the engine pool's admission
+estimate for a fraction and the largest fraction whose estimate fits a byte
+budget.
+
 For a 384-expert checkpoint, 12.5% keeps 48 experts per layer. The adapter
 preserves V4.1's activation quantization, clamped SwiGLU, and application of
 routing weights before the down projection. Large routed batches are split

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -54,8 +54,9 @@ V4.1 expert reads, MXFP4/MXFP8 and mixed-bit affine arithmetic, repeated
 evictions, sorted routes, load/inference thread separation, Engram coexistence,
 draft-weight exclusion, and memory estimates. The load probe rejects whole
 expert reads from shared shards and any expert slab read through the Engram
-mapping. Further cases pin the serial LRU order under concurrent reads and
-expert-boundary chunking of sorted routes. Run alongside `test_deepseek_v41_offload.py`,
+mapping. Further cases pin the serial LRU order under concurrent reads,
+expert-boundary chunking of sorted routes, and the fit-to-budget residency
+helper against the admission arithmetic. Run alongside `test_deepseek_v41_offload.py`,
 `test_moe_expert_offload.py`, and the engine-pool/model-settings suites.
 `node tests/moe_expert_offload_ui.test.cjs` checks the actual dashboard
 save/reopen payload and speculative-decoding toggle exclusion.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -53,7 +53,9 @@ Engram storage and prefetch lifecycle: `python -m pytest tests/test_deepseek_v41
 V4.1 expert reads, MXFP4/MXFP8 and mixed-bit affine arithmetic, repeated
 evictions, sorted routes, load/inference thread separation, Engram coexistence,
 draft-weight exclusion, and memory estimates. The load probe rejects whole
-expert reads from shared shards. Run alongside `test_deepseek_v41_offload.py`,
+expert reads from shared shards and any expert slab read through the Engram
+mapping. Further cases pin the serial LRU order under concurrent reads and
+expert-boundary chunking of sorted routes. Run alongside `test_deepseek_v41_offload.py`,
 `test_moe_expert_offload.py`, and the engine-pool/model-settings suites.
 `node tests/moe_expert_offload_ui.test.cjs` checks the actual dashboard
 save/reopen payload and speculative-decoding toggle exclusion.

--- a/omlx/patches/deepseek_v41/moe_offload.py
+++ b/omlx/patches/deepseek_v41/moe_offload.py
@@ -27,7 +27,11 @@ import numpy as np
 
 from .convert import repack_weight
 from .quantization import QuantizedProjection
-from .residency import checkpoint_signature, header_with_offset
+from .residency import (
+    checkpoint_signature,
+    deepseek_v41_residency_estimate,
+    header_with_offset,
+)
 from .storage import SAFETENSORS_NUMPY_DTYPES, decode_array
 
 _PROJECTIONS = ("w1", "w3", "w2")
@@ -511,3 +515,69 @@ def _estimate_expert_savings(path, fraction, signature):
     plan = _plan(path, fraction)
     # Keep the existing residency estimator's 5% nonexpert safety allowance.
     return plan.full_bytes - plan.resident_bytes + plan.draft_bytes
+
+
+def _admission(plan, capacity, estimate, engram_ssd_offload, file_bytes):
+    """``EnginePool._entry_runtime_resident_size`` for one expert capacity.
+
+    With Engram tables: the header residency estimate for the selected
+    Engram mode, less 1.05 times the expert savings. Without them the pool
+    has no residency estimate and discounts the savings from the discovery
+    size (shard file sizes with a 5% allowance) instead.
+    """
+    saved = plan.full_bytes - plan.resident_bytes_at(capacity) + plan.draft_bytes
+    if estimate.supported:
+        base = estimate.mmap_bytes if engram_ssd_offload else estimate.resident_bytes
+        return max(0, base - int(saved * 1.05))
+    return max(0, file_bytes() - saved)
+
+
+def _file_bytes(path):
+    from ...model_discovery import estimate_model_size
+
+    return lambda: estimate_model_size(Path(path))
+
+
+def admission_bytes(path, fraction, *, engram_ssd_offload=True):
+    """The engine pool's admission estimate for expert offload at ``fraction``."""
+    return _admission_bytes(
+        str(path), float(fraction), bool(engram_ssd_offload), checkpoint_signature(path)
+    )
+
+
+@lru_cache(maxsize=32)
+def _admission_bytes(path, fraction, engram_ssd_offload, signature):
+    plan = _plan(path, fraction)
+    estimate = deepseek_v41_residency_estimate(path)
+    return _admission(
+        plan, plan.capacity, estimate, engram_ssd_offload, _file_bytes(path)
+    )
+
+
+def fit_resident_fraction(path, budget_bytes, *, engram_ssd_offload=True):
+    """Largest resident fraction whose admission estimate fits ``budget_bytes``.
+
+    Returns ``None`` when even the routing floor does not fit. The result is
+    a whole number of experts per layer expressed as a fraction, so passing
+    it back as the setting reproduces the same capacity.
+    """
+    return _fit_resident_fraction(
+        str(path),
+        int(budget_bytes),
+        bool(engram_ssd_offload),
+        checkpoint_signature(path),
+    )
+
+
+@lru_cache(maxsize=32)
+def _fit_resident_fraction(path, budget_bytes, engram_ssd_offload, signature):
+    plan = _plan(path, 1.0)
+    estimate = deepseek_v41_residency_estimate(path)
+    file_bytes = _file_bytes(path)
+    for capacity in range(plan.count, plan.floor - 1, -1):
+        if (
+            _admission(plan, capacity, estimate, engram_ssd_offload, file_bytes)
+            <= budget_bytes
+        ):
+            return capacity / plan.count
+    return None

--- a/omlx/patches/deepseek_v41/moe_offload.py
+++ b/omlx/patches/deepseek_v41/moe_offload.py
@@ -1,21 +1,71 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Bounded expert residency for V4.1, preserving its projection arithmetic."""
+"""Bounded expert residency for V4.1, preserving its projection arithmetic.
 
+Non-resident experts are read from the checkpoint's own safetensors shards
+with positional ``os.preadv`` calls on a small reader pool of their own. An
+expert slab is megabytes of contiguous bytes, the opposite access pattern
+from the sparse Engram row gathers that ``storage.TensorFile`` serves through
+an ``MADV_RANDOM`` mapping: a faulting gather reads one page per fault, while
+a positional read lets the kernel issue large requests. Routing is computed
+exactly as shipped; a miss changes when an expert's weights are read, never
+which expert runs.
+"""
+
+import contextlib
 import json
 import math
-import struct
+import os
+from collections import namedtuple
+from concurrent.futures import ThreadPoolExecutor
 from functools import lru_cache
 from pathlib import Path
+from threading import Lock
 
 import mlx.core as mx
 import mlx.nn as nn
+import numpy as np
 
 from .convert import repack_weight
 from .quantization import QuantizedProjection
-from .storage import TensorFile, decode_array
+from .residency import checkpoint_signature, header_with_offset
+from .storage import SAFETENSORS_NUMPY_DTYPES, decode_array
 
 _PROJECTIONS = ("w1", "w3", "w2")
 _FLOAT_BYTES = {"BF16": 2, "F16": 2, "F32": 4}
+# Host bytes one residency update may hold in flight before the serial slot
+# writes drain them (about 32 oQ3e experts).
+INFLIGHT_BYTES = 512 * 1024 * 1024
+# Expert reads get their own pool: the Engram page pool runs long sequential
+# page touches that would otherwise queue ahead of a layer's misses.
+EXPERT_IO_WORKERS = 24
+_EXPERT_IO_POOL = ThreadPoolExecutor(
+    max_workers=EXPERT_IO_WORKERS, thread_name_prefix="v41-expert-io"
+)
+
+# One positional read: a whole tensor, or one leading-axis row of it.
+Slab = namedtuple("Slab", "key expert fd offset nbytes dtype shape")
+
+
+def _fields(spec):
+    """Tensor fields of a projection: packed weights plus quantization metadata."""
+    if not spec:
+        return ["weight"]
+    return ["weight", "scales"] + (["biases"] if spec["mode"] == "affine" else [])
+
+
+def _to_numpy(slab, raw):
+    return np.frombuffer(raw, dtype=SAFETENSORS_NUMPY_DTYPES[slab.dtype]).reshape(
+        slab.shape
+    )
+
+
+def _to_array(slab, raw):
+    array = _to_numpy(slab, raw)
+    if slab.dtype == "BF16":
+        return mx.array(array).view(mx.bfloat16)
+    if slab.dtype.startswith("F8_"):
+        return decode_array(array, slab.dtype)
+    return mx.array(array)
 
 
 class ExpertOffloadPlan:
@@ -28,15 +78,16 @@ class ExpertOffloadPlan:
         self.mapping = mapping
         self.converted = raw.get("omlx_deepseek_v41")
         self.count = config.n_routed_experts
-        self.capacity = min(
-            self.count, max(config.n_activated_experts, round(self.count * fraction))
-        )
+        self.floor = config.n_activated_experts
+        self.capacity = min(self.count, max(self.floor, round(self.count * fraction)))
         self.layers = {}
+        self.layer_bytes = {}
         self.excluded_keys = set()
-        self.resident_bytes = 0
         self.full_bytes = 0
         self._headers = {}
-        self._readers = {}
+        self._data_start = {}
+        self._fds = {}
+        self._lock = Lock()
         self._closed = False
         self.draft_bytes = 0
         if self.converted is not None:
@@ -49,6 +100,7 @@ class ExpertOffloadPlan:
         for layer in range(config.n_layers):
             prefix = f"language_model.layers.{layer}.ffn.experts"
             specs = {}
+            self.layer_bytes[prefix] = 0
             for proj in _PROJECTIONS:
                 shape = (
                     (config.dim, config.moe_inter_dim)
@@ -57,16 +109,23 @@ class ExpertOffloadPlan:
                 )
                 specs[proj] = self._projection(prefix, proj, shape)
             self.layers[prefix] = specs
+        self.expert_bytes = (
+            self.full_bytes // (self.count * len(self.layers)) if self.layers else 0
+        )
+
+    def _header(self, filename):
+        if filename not in self._headers:
+            full = self.path / filename
+            stat = full.stat()
+            header, start = header_with_offset(
+                str(full), stat.st_size, stat.st_mtime_ns
+            )
+            self._headers[filename] = header
+            self._data_start[filename] = start
+        return self._headers[filename]
 
     def _entry(self, key):
-        filename = self.mapping[key]
-        if filename not in self._headers:
-            path = self.path / filename
-            with path.open("rb") as file:
-                length = struct.unpack("<Q", file.read(8))[0]
-                header = json.loads(file.read(length))
-            self._headers[filename] = header
-        entry = self._headers[filename][key]
+        entry = self._header(self.mapping[key])[key]
         self.excluded_keys.add(key)
         return entry
 
@@ -74,10 +133,7 @@ class ExpertOffloadPlan:
         if self.converted is not None:
             name = f"{prefix}.{proj}"
             spec = self.converted.get("quantized_modules", {}).get(name)
-            fields = ["weight"]
-            if spec:
-                fields += ["scales"] + (["biases"] if spec["mode"] == "affine" else [])
-            entries = {f: self._entry(f"{name}.{f}") for f in fields}
+            entries = {f: self._entry(f"{name}.{f}") for f in _fields(spec)}
             for field, entry in entries.items():
                 shape = (self.count, *logical)
                 dtype = entry["dtype"]
@@ -145,41 +201,113 @@ class ExpertOffloadPlan:
                     raise ValueError(f"Mixed expert formats within {prefix}.{proj}")
                 signature, spec = item, current
         self.full_bytes += size
-        self.resident_bytes += size * self.capacity // self.count
+        self.layer_bytes[prefix] += size
         return spec
 
-    def _read(self, key, expert=None):
-        if self._closed:
-            raise RuntimeError("MoE expert store is closed")
+    def resident_bytes_at(self, capacity):
+        """Expert bytes resident with ``capacity`` slots per layer."""
+        return sum(size * capacity // self.count for size in self.layer_bytes.values())
+
+    @property
+    def resident_bytes(self):
+        return self.resident_bytes_at(self.capacity)
+
+    def _fd(self, filename):
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("MoE expert store is closed")
+            fd = self._fds.get(filename)
+            if fd is None:
+                fd = self._fds[filename] = os.open(self.path / filename, os.O_RDONLY)
+            return fd
+
+    def slab(self, key, expert=None):
+        """Read plan for one tensor, or for one leading-axis row of it."""
         filename = self.mapping[key]
-        if filename not in self._readers:
-            self._readers[filename] = TensorFile(self.path / filename)
-        return self._readers[filename].read(key, rows=expert)
+        entry = self._header(filename)[key]
+        dtype = entry["dtype"]
+        if dtype not in SAFETENSORS_NUMPY_DTYPES:
+            raise ValueError(f"Unsupported source tensor dtype: {dtype}")
+        shape = tuple(entry["shape"])
+        start, end = entry["data_offsets"]
+        nbytes = end - start
+        itemsize = np.dtype(SAFETENSORS_NUMPY_DTYPES[dtype]).itemsize
+        if nbytes != math.prod(shape) * itemsize:
+            raise ValueError(f"Invalid tensor byte length: {key}")
+        if expert is not None:
+            if not shape or not 0 <= expert < shape[0]:
+                raise IndexError(f"Expert {expert} outside {key}")
+            nbytes //= shape[0]
+            start += expert * nbytes
+            shape = shape[1:]
+        return Slab(
+            key,
+            expert,
+            self._fd(filename),
+            self._data_start[filename] + start,
+            nbytes,
+            dtype,
+            shape,
+        )
+
+    @staticmethod
+    def read(slab):
+        """The slab's bytes. Positional reads only, so any thread may call it."""
+        buffer = bytearray(slab.nbytes)
+        view = memoryview(buffer)
+        done = 0
+        while done < slab.nbytes:
+            count = os.preadv(slab.fd, [view[done:]], slab.offset + done)
+            if count <= 0:
+                raise ValueError(f"Truncated tensor data: {slab.key}")
+            done += count
+        return buffer
+
+    def slabs(self, prefix, proj, expert):
+        """Read plans for one expert's projection, in decode order."""
+        if self.converted is not None:
+            return [
+                self.slab(f"{prefix}.{proj}.{field}", expert)
+                for field in _fields(self.layers[prefix][proj])
+            ]
+        name = f"{prefix.removeprefix('language_model.')}.{expert}.{proj}"
+        slabs = [self.slab(name + ".weight")]
+        if name + ".scale" in self.mapping:
+            slabs.append(self.slab(name + ".scale"))
+        return slabs
+
+    def decode(self, slabs, raws):
+        """Projection arrays from the slabs' bytes, keyed by field."""
+        if self.converted is not None:
+            return {
+                slab.key.rsplit(".", 1)[1]: _to_array(slab, raw)
+                for slab, raw in zip(slabs, raws)
+            }
+        scale = _to_numpy(slabs[1], raws[1]) if len(slabs) > 1 else None
+        return repack_weight(
+            _to_numpy(slabs[0], raws[0]),
+            slabs[0].dtype,
+            scale,
+            slabs[1].dtype if scale is not None else None,
+        )[0]
 
     def fetch(self, prefix, proj, expert):
-        if self.converted is not None:
-            spec = self.layers[prefix][proj]
-            fields = ["weight"]
-            if spec:
-                fields += ["scales"] + (["biases"] if spec["mode"] == "affine" else [])
-            return {
-                field: decode_array(*self._read(f"{prefix}.{proj}.{field}", expert))
-                for field in fields
-            }
-        name = f"{prefix.removeprefix('language_model.')}.{expert}.{proj}"
-        raw, dtype = self._read(name + ".weight")
-        scale, scale_dtype = (
-            self._read(name + ".scale")
-            if name + ".scale" in self.mapping
-            else (None, None)
-        )
-        return repack_weight(raw, dtype, scale, scale_dtype)[0]
+        slabs = self.slabs(prefix, proj, expert)
+        return self.decode(slabs, [self.read(slab) for slab in slabs])
 
     def close(self):
-        self._closed = True
-        for reader in self._readers.values():
-            reader.close()
-        self._readers.clear()
+        """Release the shard descriptors.
+
+        Reads in flight must have drained: the engine closes a model after its
+        executor is idle, and ``ensure_ids`` waits for every read it started
+        before it returns or raises.
+        """
+        with self._lock:
+            self._closed = True
+            fds, self._fds = self._fds, {}
+        for fd in fds.values():
+            with contextlib.suppress(OSError):
+                os.close(fd)
 
 
 class _ExpertSlots:
@@ -188,6 +316,7 @@ class _ExpertSlots:
         self.slot_of = {}
         self.free = list(range(plan.capacity))
         self.hits = self.misses = 0
+        self.fetched_bytes = 0
         for proj in _PROJECTIONS:
             sample = plan.fetch(prefix, proj, 0)
             values = {
@@ -203,31 +332,82 @@ class _ExpertSlots:
         expert.eval()
 
     def ensure(self, indices):
-        needed = set(indices.reshape(-1).tolist())
+        slots = self.ensure_ids(indices.reshape(-1).tolist())
+        return mx.array(slots, dtype=mx.int32).reshape(indices.shape)
+
+    def ensure_ids(self, ids):
+        """Make every expert in ``ids`` resident; return their slots in order.
+
+        Two passes. The first starts the misses' reads on the reader pool,
+        at most ``INFLIGHT_BYTES`` of payload ahead of the installs; the
+        second installs them serially in the order the misses were seen, so
+        eviction victims, counters and resident bytes match a serial fetch
+        exactly. A failed read or decode leaves the cache as it was, and
+        every read this call started is drained before it raises.
+        """
+        needed = list(dict.fromkeys(ids))
         if len(needed) > self.plan.capacity:
             raise ValueError("Expert working set exceeds resident capacity")
         # Protect the entire working set, including hits encountered after misses.
+        misses = []
         for expert in needed:
             if expert in self.slot_of:
                 self.hits += 1
                 self.slot_of[expert] = self.slot_of.pop(expert)
-        for expert in needed:
-            if expert in self.slot_of:
-                continue
-            slot = (
-                self.free.pop()
-                if self.free
-                else self.slot_of.pop(next(e for e in self.slot_of if e not in needed))
-            )
-            for proj in _PROJECTIONS:
-                for field, array in self.plan.fetch(self.prefix, proj, expert).items():
-                    lin = getattr(self.expert, proj)
-                    lin[field][slot] = array
-            self.slot_of[expert] = slot
-            self.misses += 1
-        return mx.array(
-            [self.slot_of[e] for e in indices.reshape(-1).tolist()], dtype=mx.int32
-        ).reshape(indices.shape)
+            else:
+                misses.append(expert)
+        protected = set(needed)
+        pending = {}
+        started = []
+        window = max(1, INFLIGHT_BYTES // max(1, self.plan.expert_bytes))
+        submitted = 0
+
+        def submit(limit):
+            nonlocal submitted
+            while submitted < min(limit, len(misses)):
+                expert = misses[submitted]
+                submitted += 1
+                pending[expert] = []
+                for proj in _PROJECTIONS:
+                    slabs = self.plan.slabs(self.prefix, proj, expert)
+                    futures = [_EXPERT_IO_POOL.submit(self.plan.read, s) for s in slabs]
+                    started.extend(futures)
+                    pending[expert].append((proj, slabs, futures))
+
+        try:
+            submit(window)
+            for done, expert in enumerate(misses):
+                # Refill before this expert's writes so at most ``window``
+                # experts' bytes exist at once, counting the one written here.
+                submit(done + window)
+                arrays, nbytes = {}, 0
+                for proj, slabs, futures in pending.pop(expert):
+                    raws = [future.result() for future in futures]
+                    arrays[proj] = self.plan.decode(slabs, raws)
+                    nbytes += sum(slab.nbytes for slab in slabs)
+                slot = (
+                    self.free.pop()
+                    if self.free
+                    else self.slot_of.pop(
+                        next(e for e in self.slot_of if e not in protected)
+                    )
+                )
+                try:
+                    for proj, fields in arrays.items():
+                        lin = getattr(self.expert, proj)
+                        for field, array in fields.items():
+                            lin[field][slot] = array
+                except BaseException:
+                    self.free.append(slot)  # Unmapped, so any partial write is inert.
+                    raise
+                self.slot_of[expert] = slot
+                self.misses += 1
+                self.fetched_bytes += nbytes
+        finally:
+            for future in started:
+                if not future.cancel():
+                    future.exception()
+        return [self.slot_of[e] for e in ids]
 
 
 class OffloadedExpert(nn.Module):
@@ -249,52 +429,69 @@ class OffloadedExpert(nn.Module):
         if indices.size == 0:
             return mx.zeros((*indices.shape, 1, x.shape[-1]), dtype=x.dtype)
         if sorted_indices:
-            flat_i = indices.reshape(-1, 1)
-            flat_x = x.reshape(-1, 1, x.shape[-1])
+            outputs = self._sorted(x, indices, weights, input_quantized)
         else:
-            flat_i = indices.reshape(-1, indices.shape[-1])
-            flat_x = x.reshape(-1, 1, 1, x.shape[-1])
+            outputs = self._routed(x, indices, weights, input_quantized)
+        return mx.concatenate(outputs, axis=0).reshape(*indices.shape, 1, x.shape[-1])
+
+    def _routed(self, x, indices, weights, input_quantized):
+        """Per-token top-k routes: bound each chunk by its route count."""
+        flat_i = indices.reshape(-1, indices.shape[-1])
+        flat_x = x.reshape(-1, 1, 1, x.shape[-1])
         flat_w = None if weights is None else weights.reshape(flat_i.shape)
-        # Bound each chunk by route count without an O(prompt^2) search.
         step = max(1, self.slots.plan.capacity // flat_i.shape[-1])
         outputs = []
         for start in range(0, flat_i.shape[0], step):
             idx = flat_i[start : start + step]
             slots = self.slots.ensure(idx)
-            value = flat_x[start : start + step]
-            scores = None if flat_w is None else flat_w[start : start + step]
-            if sorted_indices:
-                slots = slots.reshape(-1)
-                order = mx.argsort(slots)
-                inverse = mx.argsort(order)
-                value, slots = value[order], slots[order]
-                scores = None if scores is None else scores.reshape(-1)[order]
             out = self.slots.expert(
-                value,
+                flat_x[start : start + step],
                 slots,
-                scores,
-                sorted_indices=sorted_indices,
+                None if flat_w is None else flat_w[start : start + step],
+                sorted_indices=False,
                 input_quantized=input_quantized,
             )
-            if sorted_indices:
-                out = out[inverse]
             mx.eval(out)
             outputs.append(out)
-        return mx.concatenate(outputs, axis=0).reshape(*indices.shape, 1, x.shape[-1])
+        return outputs
+
+    def _sorted(self, x, indices, weights, input_quantized):
+        """Routes sorted by expert: chunk on expert boundaries.
+
+        A chunk holds every route of up to ``capacity`` distinct experts, so a
+        prefill reads each expert once per layer and runs one kernel per
+        chunk instead of one per ``capacity`` routes.
+        """
+        ids = indices.reshape(-1).tolist()
+        rows = x.reshape(-1, 1, x.shape[-1])
+        scores = None if weights is None else weights.reshape(-1)
+        capacity = self.slots.plan.capacity
+        outputs = []
+        start = 0
+        while start < len(ids):
+            end, distinct = start, 0
+            while end < len(ids) and distinct < capacity:
+                run = end + 1
+                while run < len(ids) and ids[run] == ids[end]:
+                    run += 1
+                end, distinct = run, distinct + 1
+            slots = mx.array(self.slots.ensure_ids(ids[start:end]), dtype=mx.int32)
+            order = mx.argsort(slots)
+            inverse = mx.argsort(order)
+            out = self.slots.expert(
+                rows[start:end][order],
+                slots[order],
+                None if scores is None else scores[start:end][order],
+                sorted_indices=True,
+                input_quantized=input_quantized,
+            )[inverse]
+            mx.eval(out)
+            outputs.append(out)
+            start = end
+        return outputs
 
 
-def estimate_expert_savings(path, fraction):
-    path = Path(path)
-    files = [path / "config.json", path / "model.safetensors.index.json"]
-    files.extend(path.glob("*.safetensors"))
-    signature = tuple(
-        (str(p), p.stat().st_size, p.stat().st_mtime_ns) for p in sorted(files)
-    )
-    return _estimate_expert_savings(str(path), fraction, signature)
-
-
-@lru_cache(maxsize=32)
-def _estimate_expert_savings(path, fraction, signature):
+def _plan(path, fraction):
     from .config import ModelConfig
 
     path = Path(path)
@@ -302,6 +499,15 @@ def _estimate_expert_savings(path, fraction, signature):
     mapping = json.loads((path / "model.safetensors.index.json").read_text())[
         "weight_map"
     ]
-    plan = ExpertOffloadPlan(path, raw, mapping, ModelConfig.from_dict(raw), fraction)
+    return ExpertOffloadPlan(path, raw, mapping, ModelConfig.from_dict(raw), fraction)
+
+
+def estimate_expert_savings(path, fraction):
+    return _estimate_expert_savings(str(path), fraction, checkpoint_signature(path))
+
+
+@lru_cache(maxsize=32)
+def _estimate_expert_savings(path, fraction, signature):
+    plan = _plan(path, fraction)
     # Keep the existing residency estimator's 5% nonexpert safety allowance.
     return plan.full_bytes - plan.resident_bytes + plan.draft_bytes

--- a/omlx/patches/deepseek_v41/residency.py
+++ b/omlx/patches/deepseek_v41/residency.py
@@ -24,7 +24,8 @@ class EngramResidencyEstimate:
 
 
 @lru_cache(maxsize=128)
-def _header(filename, size, mtime_ns):
+def header_with_offset(filename, size, mtime_ns):
+    """A shard's safetensors header and the file offset of its tensor data."""
     with open(filename, "rb") as file:
         raw = file.read(8)
         if len(raw) != 8:
@@ -32,20 +33,29 @@ def _header(filename, size, mtime_ns):
         length = struct.unpack("<Q", raw)[0]
         if length > size - 8:
             raise ValueError("Invalid safetensors header length")
-        return json.loads(file.read(length))
+        return json.loads(file.read(length)), 8 + length
 
 
-def deepseek_v41_residency_estimate(model_path):
+def _header(filename, size, mtime_ns):
+    return header_with_offset(filename, size, mtime_ns)[0]
+
+
+def checkpoint_signature(model_path):
+    """Sizes and mtimes of every file a residency estimate depends on."""
     path = Path(model_path).expanduser().resolve()
     files = [path / "config.json", path / "model.safetensors.index.json"]
     files.extend(path.glob("*.safetensors"))
     files.extend((path / "engram").glob("*.safetensors"))
-    signature = tuple(
+    return tuple(
         (str(f), st.st_size, st.st_mtime_ns)
         for f in sorted(files)
         for st in (f.stat(),)
     )
-    return _estimate(str(path), signature)
+
+
+def deepseek_v41_residency_estimate(model_path):
+    path = Path(model_path).expanduser().resolve()
+    return _estimate(str(path), checkpoint_signature(path))
 
 
 @lru_cache(maxsize=128)

--- a/omlx/patches/deepseek_v41/storage.py
+++ b/omlx/patches/deepseek_v41/storage.py
@@ -23,6 +23,19 @@ import mlx.nn as nn
 import numpy as np
 
 RESIDENT_READ_BYTES = 8 * 1024 * 1024
+# safetensors dtype tag -> numpy transport dtype (bf16 travels as raw uint16).
+SAFETENSORS_NUMPY_DTYPES = {
+    "BF16": "<u2",
+    "F16": "<f2",
+    "F32": "<f4",
+    "U32": "<u4",
+    "U8": "u1",
+    "I8": "i1",
+    "F8_E4M3": "u1",
+    "F8_E8M0": "u1",
+    "F8_E4M3FN": "u1",
+    "F8_E8M0FNU": "u1",
+}
 PAGE_SIZE = os.sysconf("SC_PAGE_SIZE")
 PAGE_PREFETCH_MIN_ROWS = 128
 PAGE_IO_WORKERS = 48
@@ -81,21 +94,9 @@ class TensorFile:
                 raise RuntimeError("Engram tensor file is closed")
             entry = self.header[key]
             dtype = entry["dtype"]
-            formats = {
-                "BF16": "<u2",
-                "F16": "<f2",
-                "F32": "<f4",
-                "U32": "<u4",
-                "U8": "u1",
-                "I8": "i1",
-                "F8_E4M3": "u1",
-                "F8_E8M0": "u1",
-                "F8_E4M3FN": "u1",
-                "F8_E8M0FNU": "u1",
-            }
-            if dtype not in formats:
+            if dtype not in SAFETENSORS_NUMPY_DTYPES:
                 raise ValueError(f"Unsupported source tensor dtype: {dtype}")
-            dt = np.dtype(formats[dtype])
+            dt = np.dtype(SAFETENSORS_NUMPY_DTYPES[dtype])
             start, end = entry["data_offsets"]
             if end - start != math.prod(entry["shape"]) * dt.itemsize:
                 raise ValueError(f"Invalid tensor byte length: {key}")

--- a/tests/test_deepseek_v41_moe_offload.py
+++ b/tests/test_deepseek_v41_moe_offload.py
@@ -482,3 +482,58 @@ def test_sorted_routes_chunk_on_expert_boundaries(tmp_path, monkeypatch):
         assert disk.slots.misses == 16 and disk.slots.hits == 0
     finally:
         plan.close()
+
+
+@pytest.mark.parametrize("engram", [False, True])
+def test_admission_and_fit_match_the_engine_pool(tmp_path, engram):
+    from test_engine_pool import _make_pool
+
+    from omlx.engine_pool import EngineEntry
+    from omlx.model_discovery import estimate_model_size
+    from omlx.model_settings import ModelSettings
+    from omlx.patches.deepseek_v41.moe_offload import (
+        admission_bytes,
+        fit_resident_fraction,
+    )
+
+    kwargs = dict(n_routed_experts=8, n_activated_experts=2)
+    if engram:
+        kwargs.update(
+            engram_layer_ids=(1, 3),
+            engram_num_embeddings=(72, 204),
+            engram_vocab_size=5,
+            engram_max_ngram_size=4,
+            engram_n_heads=2,
+            engram_head_dim=32,
+            engram_compressed_vocab_size=64,
+        )
+    source, _ = write_checkpoint(tmp_path, vision=False, **kwargs)
+    target = tmp_path / "converted"
+    convert(source, target)
+    pool = _make_pool(ceiling=1024**3)
+    entry = EngineEntry(
+        model_id="v41",
+        model_path=str(target),
+        model_type="vlm",
+        engine_type="vlm",
+        config_model_type="deepseek_v41",
+        estimated_size=estimate_model_size(target),
+    )
+    assert fit_resident_fraction(target, 1 << 60, engram_ssd_offload=engram) == 1.0
+    assert fit_resident_fraction(target, 0, engram_ssd_offload=engram) is None
+    for capacity in range(2, 9):
+        fraction = capacity / 8
+        settings = ModelSettings(
+            moe_expert_offload_enabled=True,
+            moe_expert_offload_resident_fraction=fraction,
+            deepseek_v41_engram_ssd_offload=engram,
+        )
+        expected = pool._entry_runtime_resident_size(entry, settings)
+        assert expected > 0
+        assert admission_bytes(target, fraction, engram_ssd_offload=engram) == expected
+        assert fit_resident_fraction(target, expected, engram_ssd_offload=engram) == (
+            fraction
+        )
+        assert fit_resident_fraction(
+            target, expected - 1, engram_ssd_offload=engram
+        ) == ((capacity - 1) / 8 if capacity > 2 else None)

--- a/tests/test_deepseek_v41_moe_offload.py
+++ b/tests/test_deepseek_v41_moe_offload.py
@@ -57,7 +57,7 @@ def test_checkpoint_offload_matches_prefill_decode_and_closes(
     finally:
         resident.close()
         disk.close()
-    assert plan._closed and not plan._readers
+    assert plan._closed and not plan._fds
     disk.close()
 
 
@@ -190,21 +190,28 @@ def test_offload_api_rejects_invalid_fraction(fraction):
 
 def test_loader_never_reads_nonresident_stacked_experts(tmp_path, monkeypatch):
     from omlx.patches.deepseek_v41 import loading
+    from omlx.patches.deepseek_v41.moe_offload import ExpertOffloadPlan
     from omlx.patches.deepseek_v41.storage import TensorFile
 
     source, _ = write_checkpoint(tmp_path, vision=False, n_routed_experts=8)
     target = tmp_path / "converted"
     convert(source, target)
     seen = []
-    original = TensorFile.read
+    original_read = ExpertOffloadPlan.read
 
-    def read(self, key, rows=None, **kwargs):
-        if ".ffn.experts." in key:
-            assert rows is not None, "Whole expert tensor materialized"
-            seen.append(rows)
-        return original(self, key, rows, **kwargs)
+    def read(slab):
+        assert slab.expert is not None, "Whole expert tensor materialized"
+        seen.append(slab.expert)
+        return original_read(slab)
 
-    monkeypatch.setattr(TensorFile, "read", read)
+    monkeypatch.setattr(ExpertOffloadPlan, "read", staticmethod(read))
+    original_gather = TensorFile.read
+
+    def gather(self, key, rows=None, **kwargs):
+        assert ".ffn.experts." not in key, "Expert slab read through the mmap"
+        return original_gather(self, key, rows, **kwargs)
+
+    monkeypatch.setattr(TensorFile, "read", gather)
 
     def no_whole_shards(*args, **kwargs):
         raise AssertionError("Shared shard would materialize nonresident experts")
@@ -319,3 +326,159 @@ def test_engram_and_expert_estimates_compose(tmp_path, monkeypatch):
     )
     monkeypatch.setenv("OMLX_MOE_EXPERT_OFFLOAD", "0")
     assert pool._entry_runtime_resident_size(entry, settings) == base.mmap_bytes
+
+
+def _synthetic_affine_experts(tmp_path, fraction, seed=412):
+    """A one-layer stacked affine checkpoint with a resident reference Expert."""
+    from mlx.utils import tree_flatten
+
+    from omlx.patches.deepseek_v41.config import ModelConfig
+    from omlx.patches.deepseek_v41.language import Expert
+    from omlx.patches.deepseek_v41.moe_offload import ExpertOffloadPlan
+    from omlx.patches.deepseek_v41.quantization import QuantizedProjection
+
+    mx.random.seed(seed)
+    config = ModelConfig(
+        dim=64, moe_inter_dim=64, n_layers=1, n_routed_experts=8, n_activated_experts=2
+    )
+    reference = Expert(config, True)
+    specs = {}
+    for proj in ("w1", "w3", "w2"):
+        arrays = mx.quantize(
+            mx.random.normal((8, 64, 64)).astype(mx.bfloat16) * 0.05,
+            bits=4,
+            group_size=32,
+            mode="affine",
+        )
+        setattr(
+            reference,
+            proj,
+            QuantizedProjection(arrays[0], arrays[1], 4, "affine", biases=arrays[2]),
+        )
+        specs[f"language_model.layers.0.ffn.experts.{proj}"] = dict(
+            bits=4, mode="affine"
+        )
+    prefix = "language_model.layers.0.ffn.experts"
+    tensors = {prefix + "." + k: v for k, v in tree_flatten(reference.parameters())}
+    mx.save_safetensors(str(tmp_path / "model.safetensors"), tensors)
+    mapping = {k: "model.safetensors" for k in tensors}
+    raw = {"omlx_deepseek_v41": {"version": 1, "quantized_modules": specs}}
+    plan = ExpertOffloadPlan(tmp_path, raw, mapping, config, fraction)
+    return reference, OffloadedExpert(Expert(config, True), plan, prefix), plan
+
+
+def _lru_reference(sequence, capacity):
+    """The serial residency policy: hits protect, misses evict the LRU expert."""
+    slot_of, free = {}, list(range(capacity))
+    for ids in sequence:
+        needed = list(dict.fromkeys(ids))
+        for e in needed:
+            if e in slot_of:
+                slot_of[e] = slot_of.pop(e)
+        protected = set(needed)
+        for e in needed:
+            if e not in slot_of:
+                slot = (
+                    free.pop()
+                    if free
+                    else slot_of.pop(next(k for k in slot_of if k not in protected))
+                )
+                slot_of[e] = slot
+    return list(slot_of.items())
+
+
+@pytest.mark.parametrize("inflight", [1, 1 << 30])
+def test_parallel_reads_install_in_serial_lru_order(tmp_path, monkeypatch, inflight):
+    from omlx.patches.deepseek_v41 import moe_offload
+
+    monkeypatch.setattr(moe_offload, "INFLIGHT_BYTES", inflight)
+    _, disk, plan = _synthetic_affine_experts(tmp_path, 0.375)
+    try:
+        assert plan.capacity == 3
+        sequence = [[0, 1, 2], [3, 1], [4, 5, 5], [1, 4], [6, 7, 0], [2]]
+        for ids in sequence:
+            slots = disk.slots.ensure_ids(ids)
+            assert slots == [disk.slots.slot_of[e] for e in ids]
+        assert list(disk.slots.slot_of.items()) == _lru_reference(sequence, 3)
+        misses = sum(len(dict.fromkeys(ids)) for ids in sequence) - disk.slots.hits
+        assert disk.slots.misses == misses == 11
+        assert disk.slots.fetched_bytes == misses * plan.expert_bytes
+        assert plan.expert_bytes * plan.count == plan.full_bytes
+    finally:
+        plan.close()
+    assert not plan._fds
+    with pytest.raises(RuntimeError, match="closed"):
+        disk(mx.zeros((1, 1, 64), mx.bfloat16), mx.array([0]), sorted_indices=True)
+
+
+def test_failed_read_leaves_the_cache_intact(tmp_path, monkeypatch):
+    from omlx.patches.deepseek_v41.moe_offload import ExpertOffloadPlan
+
+    _, disk, plan = _synthetic_affine_experts(tmp_path, 0.375)
+    original = ExpertOffloadPlan.read
+    broken = {"expert": None}
+
+    def read(slab):
+        if slab.expert == broken["expert"] and slab.key.endswith("w3.scales"):
+            raise OSError("simulated EIO")
+        return original(slab)
+
+    monkeypatch.setattr(ExpertOffloadPlan, "read", staticmethod(read))
+    try:
+        assert disk.slots.ensure_ids([0, 1, 2]) == [2, 1, 0]
+        broken["expert"] = 4
+        with pytest.raises(OSError, match="EIO"):
+            disk.slots.ensure_ids([3, 4])
+        # The failing expert and everything queued behind it left no trace:
+        # the slot count is intact and only the completed install counts.
+        assert len(disk.slots.free) + len(disk.slots.slot_of) == plan.capacity
+        assert 4 not in disk.slots.slot_of and 3 in disk.slots.slot_of
+        assert disk.slots.misses == 4
+        broken["expert"] = None
+        assert disk.slots.ensure_ids([4, 5, 6]) == [
+            disk.slots.slot_of[e] for e in (4, 5, 6)
+        ]
+        assert disk.slots.misses == 7
+    finally:
+        plan.close()
+    plan.close()  # Idempotent, and never re-closes a released descriptor.
+    assert not plan._fds
+
+
+def test_sorted_routes_chunk_on_expert_boundaries(tmp_path, monkeypatch):
+    from omlx.patches.deepseek_v41.language import Expert
+
+    reference, disk, plan = _synthetic_affine_experts(tmp_path, 0.25)
+    calls = []
+    original = Expert.__call__
+
+    def counted(self, x, indices=None, *args, **kwargs):
+        if self is disk.slots.expert and kwargs.get("sorted_indices"):
+            calls.append(indices.size)
+        return original(self, x, indices, *args, **kwargs)
+
+    monkeypatch.setattr(Expert, "__call__", counted)
+    try:
+        ids = sorted([0, 0, 0, 1, 2, 2, 3, 4, 4, 4, 4, 5, 6, 7, 7])
+        idx = mx.array(ids)
+        x = mx.random.normal((len(ids), 1, 64)).astype(mx.bfloat16)
+        weights = mx.ones(idx.shape) / 2
+        expected = reference(x, idx, weights, sorted_indices=True)
+        actual = disk(x, idx, weights, sorted_indices=True)
+        mx.eval(expected, actual)
+        np.testing.assert_allclose(
+            actual.astype(mx.float32),
+            expected.astype(mx.float32),
+            rtol=0.01,
+            atol=0.002,
+        )
+        # Eight experts at two resident slots: every route of two experts per
+        # chunk, never a chunk cut inside an expert's run.
+        assert calls == [4, 3, 5, 3]
+        assert disk.slots.misses == 8 and disk.slots.hits == 0
+        # A second sweep evicts the last resident pair before reaching it:
+        # sorted routes over more experts than slots thrash by construction.
+        disk(x, idx, weights, sorted_indices=True)
+        assert disk.slots.misses == 16 and disk.slots.hits == 0
+    finally:
+        plan.close()


### PR DESCRIPTION
# perf(deepseek_v41): read offloaded experts with positional preads

Follow-up to #3574 / #986 (V4.1 expert adapter) and #2595 (expert offload primitive). Companion to #3589, which does the same for the common adapter.

## Problem

`omlx/patches/deepseek_v41/moe_offload.py` fetched non-resident experts through `TensorFile.read(key, rows=expert)`, the Engram row-gather path: an mmap under `MADV_RANDOM`, read by NumPy advanced indexing. That is the right shape for Engram (many scattered rows, each smaller than a page). An expert is the opposite: 14.8 MiB of contiguous bytes per expert at the oQ3e geometry, faulted in one 16 KiB page at a time with readahead disabled.

Measured on an M5 Max internal SSD with a synthetic checkpoint at the oQ3e expert geometry (384 experts, 3-bit affine gs64, 4 layers, random weights written with `F_NOCACHE` so the first pass is cold), 12.5% residency:

| | before | after |
|---|---:|---:|
| decode, one token, per MoE layer | 362 ms | 9.1 ms |
| expert fetch throughput (cold) | 0.23 GB/s | 9.3 GB/s |
| sorted prefill, 256 tokens | 33 token-layers/s | 568 token-layers/s |

Summed over 40 layers, the before path spends about 14 s per decoded token on expert reads at 12.5% residency; the after path about 0.35 s. That gap is what decides whether V4.1 is usable on a 128 GB machine, which is the configuration the offload setting exists for.

## Change

- Expert slabs are read with `os.preadv` on per-shard descriptors, submitted to a small reader pool of their own (24 workers) rather than the Engram page pool, whose long sequential page touches would otherwise queue ahead of a layer's misses. No knobs. `TensorFile` stays the Engram path; the header parser and the dtype table are shared with `residency.py` and `storage.py` instead of duplicated, and the tensor byte-length check is kept.
- `_ExpertSlots.ensure_ids` runs two passes: start the misses' reads ahead of the installs (at most `INFLIGHT_BYTES` of host payload in flight), then install serially in the order the misses were seen. Eviction victims, hit and miss counts, and resident bytes are identical to the serial path; the test pins the LRU order against a pure-Python reference at two in-flight windows. A failed read or decode leaves the cache exactly as it was (no slot leak, every started read drained before the error propagates), which the previous serial path did not guarantee either.
- Sorted prefill routes are chunked on expert boundaries: every route of up to `capacity` distinct experts per chunk, instead of `capacity` rows per chunk. A prefill reads each expert once per layer and runs one kernel per chunk (with enough routes for the affine block kernels to engage), where the row-count chunking ran one kernel per 48 rows.
- `admission_bytes(path, fraction)` and `fit_resident_fraction(path, budget_bytes)` give the engine pool's admission estimate for a fraction and the largest fraction whose estimate fits a byte budget. The test pins both to `EnginePool._entry_runtime_resident_size` for every capacity, with and without Engram tables (the pool has two branches there). `docs/MoE_Expert_Offload.md` gets the resident set per fraction for `Jundot/DeepSeek-V4.1-Flash-oQ3e-mtp` on a 128 GB Mac.
- `benchmarks/deepseek_v41_offload_bench.py` loads a checkpoint through the loader with Engram on SSD and offload at each fraction, then runs chunked prefill and greedy decode, reporting memory, TTFT, decode speed, and per-phase hit rate and fetch throughput.

## Validation

- `tests/test_deepseek_v41_moe_offload.py` (46 with `test_moe_offload_compat.py`): existing cases unchanged except the load probe, which now asserts expert reads are single-expert slabs that never touch the Engram mapping; new cases for serial LRU order under concurrent reads, the failure path (cache intact, no slot leak, later reads work, idempotent close), expert-boundary chunking with arithmetic equality against the resident Expert, and admission/fit against the engine pool with and without Engram tables.
- `test_deepseek_v41.py`, `test_deepseek_v41_offload.py`, `test_deepseek_v41_moe.py`, `test_engine_pool.py`, `test_model_settings.py`, `test_moe_expert_offload.py`, `test_admin_model_settings_template.py`: 392 pass.
- Real checkpoint, `Jundot/DeepSeek-V4.1-Flash-oQ3e-mtp` on a 128 GB M5 Max (internal SSD, `iogpu.wired_limit_mb` unset), Engram on SSD, native kernels built, 433-token prose prompt in one prefill chunk plus 64 greedy tokens, single runs:

  | residency | experts/layer | load | Metal active | peak footprint | prefill | decode | decode hit rate |
  |---:|---:|---:|---:|---:|---:|---:|---:|
  | 12.5% | 48 | 3.9 s | 38.0 GiB | 49.6 GiB | 28 tok/s | 5.6 tok/s | 0.69 |
  | 25% | 96 | 4.5 s | 65.7 GiB | 77.4 GiB | 25 tok/s | 4.2 tok/s | 0.78 |

  Coherent continuations at both settings. Prefill reads each routed expert once per layer (about 226 of 384 per layer for this prompt) at 8 to 9 GB/s. Decode is miss-latency bound at one to two misses per layer per token; 12.5% decodes faster than 25% because the RAM the slots do not take becomes page cache, which serves repeated misses at 6.5 GB/s effective against 3.4 GB/s from the SSD. The first, repeated-sentence run at 12.5% gave 4.0 tok/s at a 0.81 hit rate. 33% was not measured: the session's memory guard stopped a run once the page cache had taken all free RAM (macOS itself was not under pressure).
- `omlx serve` end to end on the same machine: the checkpoint is discovered from the HF cache (companion PR), admitted at 39.98 GB against 38.44 GB actual, Engram forced to SSD by admission, VLM engine load 4.4 s; two 64-token chat completions at 2.7 tok/s (cold expert slots) and 4.1 tok/s.

## Not in this PR

DSpark MTP under offload stays excluded. On this path decode is bound by expert reads, and a 5-token verification block touches about 4.6x the experts of a single token at both 12.5% and 25% residency (measured on the synthetic checkpoint: 283 vs 1343 misses per 16 steps at 12.5%, 197 vs 906 at 25%), so DSpark's 1.6 to 2x tokens per step would net roughly 0.4x the throughput. It only pays once residency is high enough that reads stop being the bottleneck, which is not a 128 GB configuration.

The `mlx-community/DeepSeek-V4.1-Flash-MLX-2bit` checkpoint (222 GiB, per-expert affine layout, no `omlx_deepseek_v41` spec) does not load through the V4.1 loader at all. That is a separate loader-side gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
