### PR TITLE
fix(discovery): find DeepSeek V4.1 checkpoints in the HF cache

### DIFF
--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -1408,6 +1408,25 @@ def _is_helper_checkpoint(model_path: Path) -> bool:
     return is_helper_model_config(config)
 
 
+def _is_deepseek_v41_loadable_config(config) -> bool:
+    """True for DeepSeek V4.1 checkpoints the V4.1 loader reads unconverted.
+
+    The loader gates source checkpoints on the model type alone (the FP8/FP4
+    release, or bf16), and reads oMLX conversions by their
+    ``omlx_deepseek_v41`` spec (e.g. ``Jundot/DeepSeek-V4.1-Flash-oQ3e-mtp``).
+    Shards exported before #3583 declare no ``format: mlx`` metadata and the
+    repo names carry no MLX token, so the generic heuristics skip them.
+    MLX affine conversions without the spec (a top-level ``quantization``
+    dict) are not accepted: the loader has no path for them.
+    """
+    if not isinstance(config, dict) or config.get("model_type") != "deepseek_v41":
+        return False
+    spec = config.get("omlx_deepseek_v41")
+    if isinstance(spec, dict):
+        return spec.get("version") == 1
+    return spec is None and "quantization" not in config
+
+
 def _is_hf_cache_mlx_compatible(model_dir: Path, source_repo_id: str) -> bool:
     """Heuristic for HF cache entries that can be loaded without conversion."""
     if not _is_model_dir(model_dir):
@@ -1432,6 +1451,12 @@ def _is_hf_cache_mlx_compatible(model_dir: Path, source_repo_id: str) -> bool:
     if not list(model_dir.glob("model*.safetensors")):
         logger.debug(f"Skipping HF cache model without model*.safetensors: {source_repo_id}")
         return False
+    if _is_deepseek_v41_loadable_config(config):
+        logger.info(
+            "Treating HF cache model as MLX-compatible DeepSeek V4.1 checkpoint: "
+            f"{source_repo_id}"
+        )
+        return True
     if _safetensors_has_mlx_metadata(model_dir):
         return True
 

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -1925,6 +1925,69 @@ class TestHfCacheDiscovery:
         models = discover_models(tmp_path)
         assert models == {}
 
+    @pytest.mark.parametrize(
+        "config, discovered",
+        [
+            (
+                {
+                    "model_type": "deepseek_v41",
+                    "omlx_deepseek_v41": {"version": 1, "preserve_mtp": True},
+                },
+                True,
+            ),
+            (
+                {
+                    "model_type": "deepseek_v41",
+                    "quantization_config": {
+                        "quant_method": "fp8",
+                        "expert_dtype": "fp4",
+                    },
+                },
+                True,
+            ),
+            # The bf16 source layout (the repo's own test fixture) loads too.
+            ({"model_type": "deepseek_v41"}, True),
+            # Unknown conversion version, or an affine conversion without the
+            # oMLX spec: the V4.1 loader has no path for these.
+            (
+                {"model_type": "deepseek_v41", "omlx_deepseek_v41": {"version": 2}},
+                False,
+            ),
+            (
+                {
+                    "model_type": "deepseek_v41",
+                    "quantization": {"bits": 2, "group_size": 64, "mode": "affine"},
+                },
+                False,
+            ),
+            (
+                {
+                    "model_type": "deepseek_v41",
+                    "quantization_config": {"quant_method": "fp8"},
+                    "quantization": {"bits": 4, "group_size": 64, "mode": "affine"},
+                },
+                False,
+            ),
+            (
+                {"model_type": "deepseek_v4", "omlx_deepseek_v41": {"version": 1}},
+                False,
+            ),
+        ],
+    )
+    def test_hf_cache_deepseek_v41_loadable_layouts(self, tmp_path, config, discovered):
+        """oMLX-converted and original V4.1 checkpoints need no MLX metadata."""
+        repo = "Jundot/DeepSeek-V4.1-oQ3e-mtp"
+        _, snapshot = self._make_hf_cache_entry(
+            tmp_path, "Jundot", "DeepSeek-V4.1-oQ3e-mtp"
+        )
+        (snapshot / "config.json").write_text(json.dumps(config))
+        (snapshot / "model-00001-of-00002.safetensors").write_bytes(b"0" * 64)
+        (snapshot / "model-00002-of-00002.safetensors").write_bytes(b"0" * 64)
+        assert _is_hf_cache_mlx_compatible(snapshot, repo) is discovered
+        assert ("Jundot--DeepSeek-V4.1-oQ3e-mtp" in discover_models(tmp_path)) is (
+            discovered
+        )
+
     def test_hf_cache_mlx_metadata_is_discovered(self, tmp_path):
         """HF cache entries with safetensors format=mlx metadata are discovered."""
         np = pytest.importorskip("numpy")


### PR DESCRIPTION
# fix(discovery): find DeepSeek V4.1 checkpoints in the HF cache

Companion to #3583 (which adds `format: mlx` metadata to newly exported oQ shards). Checkpoints already published without it, such as `Jundot/DeepSeek-V4.1-Flash-oQ3e-mtp`, still never appear in the model list after `hf download`: `_is_hf_cache_mlx_compatible` needs shard metadata, an MLX token in the repo name, or a helper checkpoint, and an oQ export has none of the three.

## Change

Accept HF-cache entries with `model_type: deepseek_v41` whose config carries a version-1 `omlx_deepseek_v41` spec (oMLX conversion), or no spec and no top-level `quantization` dict (the FP8/FP4 release and bf16 sources, which the loader gates on the model type alone). MLX affine conversions without the spec (for example `mlx-community/DeepSeek-V4.1-Flash-MLX-2bit`) are not accepted by this rule; the loader has no path for them, so listing them would only move the failure to load time. The `mlx-community/` name rule still lists that repo as before.

## Validation

`tests/test_model_discovery.py`: new parametrized case covering the oMLX spec, the original FP8 config, a bf16 source, an unknown spec version, an affine conversion with and without the FP8 config, and a non-V4.1 model type with the spec; 197 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
