### PR TITLE
fix(cluster): recover quiescence and allow reload when distributed runtime fails

### DIFF
--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -29,6 +29,7 @@ from ..cluster.liveness import (
     check_peers,
     describe_failure,
     marker_age_seconds,
+    marker_owner_is_live,
     read_marker,
 )
 from ..reasoning_effort import _fallback_candidate, _normalized_input
@@ -910,12 +911,17 @@ raise SystemExit(2)
         quiescence evidence an abort or unload should wait for (G5).
         """
 
+        if self.runtime_failed_reason is not None:
+            return 0
+
         marker = read_marker(
             Path(self._supervisor.state_dir).expanduser()
             / f"{self.deployment.deployment_id}-rank-0.json"
         )
         if not isinstance(marker, dict):
             return None
+        if not marker_owner_is_live(marker) or marker.get("error"):
+            return 0
         metrics = marker.get("metrics")
         if not isinstance(metrics, dict):
             return None
@@ -1903,6 +1909,8 @@ raise SystemExit(2)
         return None
 
     def has_active_requests(self) -> bool:
+        if self.runtime_failed_reason is not None:
+            return False
         # Sweep finished-but-abandoned requests first so a leaked generator
         # cannot hold quiescence-gated unload open forever (G4).
         self.reap_orphaned_generators()

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -1287,7 +1287,8 @@ class EnginePool:
             if entry.engine is None:
                 self._clear_load_failure(entry)
                 return
-            self._raise_if_reload_busy(entry, "activate distributed cluster")
+            if not getattr(entry.engine, "runtime_failed_reason", None):
+                self._raise_if_reload_busy(entry, "activate distributed cluster")
             await self._unload_engine(model_id)
             self._clear_load_failure(entry)
 

--- a/tests/test_distributed_engine.py
+++ b/tests/test_distributed_engine.py
@@ -1287,3 +1287,60 @@ async def test_preflight_fails_open_when_the_probe_itself_breaks(monkeypatch):
         await engine.preflight_chat([{"role": "user", "content": "hi"}])
     finally:
         await engine._client.aclose()
+
+
+def test_failed_runtime_quiescence_evidence(tmp_path, monkeypatch):
+    """A failed runtime or dead rank process must report 0 active requests."""
+    engine = _ready_engine(lambda request: httpx.Response(200))
+    engine._supervisor.state_dir = str(tmp_path)
+    marker_path = tmp_path / "engine-test-rank-0.json"
+    marker_path.write_text(
+        json.dumps(
+            {
+                "pid": 99999999,
+                "metrics": {"active_requests": 3},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # Marker exists with active_requests=3, but pid is dead
+    monkeypatch.setattr(distributed, "marker_owner_is_live", lambda m: False)
+    assert engine.rank_side_active_requests() == 0
+
+    # If pid is live, it reports active_requests
+    monkeypatch.setattr(distributed, "marker_owner_is_live", lambda m: True)
+    assert engine.rank_side_active_requests() == 3
+
+    # If marker has an error, it reports 0
+    marker_path.write_text(
+        json.dumps(
+            {
+                "pid": 1234,
+                "error": "Metal GPU watchdog timeout",
+                "metrics": {"active_requests": 3},
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert engine.rank_side_active_requests() == 0
+
+    # If runtime_failed_reason is set on engine, rank_side_active_requests is 0
+    # and has_active_requests is False even if local counter or marker is positive
+    marker_path.write_text(
+        json.dumps(
+            {
+                "pid": 1234,
+                "metrics": {"active_requests": 3},
+            }
+        ),
+        encoding="utf-8",
+    )
+    engine._active_requests = 2
+    assert engine.has_active_requests() is True
+    assert engine.rank_side_active_requests() == 3
+
+    engine._mark_runtime_failed("worker terminated unexpectedly")
+    assert engine.rank_side_active_requests() == 0
+    assert engine.has_active_requests() is False
+

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -4438,3 +4438,31 @@ def test_qwen4_moe_savings_precede_ple_force_decision(
         _, is_forced, _ = pool._qwen4_ple_offload_status(entry, settings)
         assert is_forced is forced
         assert pool._entry_runtime_resident_size(entry, settings) == expected
+
+
+@pytest.mark.asyncio
+async def test_prepare_cluster_reload_unloads_failed_engine_without_busy_error():
+    """A failed distributed engine must reload cleanly even if busy check would otherwise trigger."""
+    pool = _make_pool()
+    engine = MagicMock()
+    engine.runtime_failed_reason = "rank 1 process died unexpectedly"
+    engine.has_active_requests.return_value = True
+
+    entry = EngineEntry(
+        model_id="test-model",
+        model_path="/fake/path",
+        model_type="llm",
+        engine_type="distributed_batched",
+        estimated_size=1000,
+        engine=engine,
+        in_use=1,
+    )
+    pool._entries["test-model"] = entry
+
+    # Because engine has runtime_failed_reason, prepare_cluster_reload must not raise ModelBusyError
+    unloaded = []
+    pool._unload_engine = AsyncMock(side_effect=lambda mid: unloaded.append(mid))
+
+    await pool.prepare_cluster_reload("test-model")
+    assert unloaded == ["test-model"]
+


### PR DESCRIPTION
## Summary

When a distributed worker crashes or terminates unexpectedly (e.g. from an unrecoverable GPU timeout, Metal watchdog kill, or sudden disconnect), the coordinator engine was wedged in an unrecoverable state:
1. Rank zero's runtime marker file (`<deployment_id>-rank-0.json`) remained on disk recording positive `active_requests`.
2. `DistributedBatchedEngine.rank_side_active_requests()` read this stale marker file and continued returning a positive count.
3. `DistributedBatchedEngine.has_active_requests()` could remain positive if internal request state / leases were not drained due to the abrupt termination.
4. When coordinator routes attempted to reload the failed deployment (`await pool.prepare_cluster_reload(model_id)`), `EnginePool._raise_if_reload_busy` rejected the operation with `ModelBusyError(model_id, 'activate distributed cluster')` (HTTP 409), preventing automatic recovery or admin reload without a full server restart.

## Changes

1. **`omlx/engine/distributed.py`**:
   - In `rank_side_active_requests()`: Return `0` if `self.runtime_failed_reason` is set, if the marker owner process is dead (`not marker_owner_is_live(marker)`), or if the marker reports an `error`.
   - In `has_active_requests()`: Return `False` immediately if `self.runtime_failed_reason` is set, allowing quiescence checks to proceed.
2. **`omlx/engine_pool.py`**:
   - In `prepare_cluster_reload()`: Bypass `_raise_if_reload_busy()` when `entry.engine` has an active `runtime_failed_reason`, allowing the pool to force-unload the dead distributed engine and reload cleanly.
3. **Tests**:
   - Added unit test in `tests/test_distributed_engine.py` verifying `rank_side_active_requests()` and `has_active_requests()` report `0` / `False` when the worker process dies or has a runtime failure.
   - Added unit test in `tests/test_engine_pool.py` verifying `prepare_cluster_reload()` successfully unloads a failed distributed engine without raising `ModelBusyError`.

## Verification

- Ran `pytest tests/test_distributed_engine.py tests/test_engine_pool.py tests/test_cluster_routes.py` (all 262 tests passed).
- Deployed and tested live on a dual-Mac cluster serving Qwen3.8.