### PR TITLE
fix(eval): run accuracy benchmark questions through a worker pool

### DIFF
--- a/omlx/admin/accuracy_benchmark.py
+++ b/omlx/admin/accuracy_benchmark.py
@@ -303,7 +303,7 @@ async def _continue_queue(engine_pool: Any, chain_id: int) -> None:
     _current_run_id = run.bench_id
     # Queue-continued runs execute inside this chain's own task; record it
     # so cancel_queue can hard-cancel them instead of waiting for the next
-    # on_progress checkpoint (up to a full generation batch away).
+    # on_progress checkpoint (up to one answered question away).
     run.task = asyncio.current_task()
 
     logger.info(

--- a/omlx/eval/base.py
+++ b/omlx/eval/base.py
@@ -60,6 +60,12 @@ class BaseBenchmark(ABC):
     # Full dataset size, recorded by load_dataset before sampling. Uploaded to
     # omlx.ai so "300 of 14,042" reads correctly on the community leaderboard.
     dataset_total: Optional[int] = None
+    # run() probes the first questions for <think> tags and switches thinking
+    # on when it finds them; code benchmarks keep the caller's setting.
+    auto_detect_thinking: bool = True
+    # Result rendering: fixed "expected" label and a cap on the predicted text.
+    expected_label: Optional[str] = None
+    predicted_max_chars: Optional[int] = None
 
     @abstractmethod
     async def load_dataset(self, sample_size: int = 0) -> list[dict]:
@@ -316,115 +322,98 @@ class BaseBenchmark(ABC):
         Args:
             engine: oMLX engine instance with chat() method.
             items: Dataset items to evaluate.
-            on_progress: Callback(current, total) for progress reporting.
-            batch_size: Number of concurrent requests (1 = sequential).
+            on_progress: Callback(current, total), awaited after every
+                answered question.
+            batch_size: Questions in flight at once. A worker pool keeps that
+                many requests running and starts the next question as soon
+                as one finishes (1 = sequential).
             enable_thinking: Enable thinking mode for reasoning models.
-                When False, auto-detects if the model outputs <think> tags
-                and re-runs the first batch with thinking enabled.
+                When False, the first batch_size questions act as a probe:
+                if any of them outputs <think> tags, thinking is switched on
+                and every question answered so far is re-run, so no
+                mixed-mode results remain.
 
         Returns:
             BenchmarkResult with accuracy and per-question details.
         """
-        results: list[QuestionResult] = []
-        correct = 0
-        category_correct: dict[str, int] = {}
-        category_total: dict[str, int] = {}
         start_time = time.time()
-        completed = 0
-
+        total = len(items)
         thinking_used = enable_thinking
-        auto_switched = False
+        probe_count = 0
+        if (
+            self.auto_detect_thinking
+            and not enable_thinking
+            and not getattr(engine, "is_external_api", False)
+        ):
+            probe_count = batch_size
 
-        # Process in batches
-        for batch_start in range(0, len(items), batch_size):
-            batch_end = min(batch_start + batch_size, len(items))
-            batch = items[batch_start:batch_end]
-            batch_start_time = time.time()
+        todo: asyncio.Queue[int] = asyncio.Queue()
+        for idx in range(total):
+            todo.put_nowait(idx)
+        done: asyncio.Queue[Any] = asyncio.Queue()
 
-            # Launch concurrent requests
-            tasks = [
-                self._eval_single(
-                    engine, item, batch_start + j, sampling_kwargs, thinking_used
-                )
-                for j, item in enumerate(batch)
-            ]
-            batch_results = await asyncio.gather(*tasks)
+        async def worker() -> None:
+            while True:
+                idx = await todo.get()
+                thinking = thinking_used
+                started = time.time()
+                try:
+                    outcome = await self._eval_single(
+                        engine, items[idx], idx, sampling_kwargs, thinking
+                    )
+                except Exception as exc:
+                    done.put_nowait(exc)
+                    return
+                done.put_nowait((thinking, time.time() - started, outcome))
 
-            # Auto-detection: check first batch for <think> tags
-            if (
-                not getattr(engine, "is_external_api", False)
-                and not thinking_used
-                and not auto_switched
-                and batch_start == 0
-            ):
-                auto_switched = True
-                has_think_tags = any(
-                    "<think>" in raw for _, _, _, _, raw, _ in batch_results
-                )
-                if has_think_tags:
+        results: dict[int, QuestionResult] = {}
+        workers = [
+            asyncio.create_task(worker()) for _ in range(min(batch_size, total))
+        ]
+        try:
+            while len(results) < total:
+                message = await done.get()
+                if isinstance(message, Exception):
+                    raise message
+                thinking, elapsed, outcome = message
+                idx, item, response_text, prompt_text, raw_text, diagnostics = outcome
+                if thinking != thinking_used:
+                    # Answered under the mode that was current when it
+                    # started; the switch below made that answer stale.
+                    todo.put_nowait(idx)
+                    continue
+                if idx < probe_count and not thinking_used and "<think>" in raw_text:
                     logger.warning(
                         f"{self.name}: model outputs <think> tags with "
                         "enable_thinking=False, auto-switching to thinking mode"
                     )
                     thinking_used = True
-                    # Re-run first batch with increased token budget
-                    tasks = [
-                        self._eval_single(
-                            engine, item, batch_start + j, sampling_kwargs, True
-                        )
-                        for j, item in enumerate(batch)
-                    ]
-                    batch_results = await asyncio.gather(*tasks)
-
-            batch_elapsed = time.time() - batch_start_time
-
-            # Process results in order
-            for (
-                idx,
-                item,
-                response_text,
-                prompt_text,
-                _raw,
-                diagnostics,
-            ) in sorted(batch_results, key=lambda x: x[0]):
-                predicted, is_correct, question_status = self._classify_response(
-                    response_text, item, diagnostics
+                    for stale in sorted([*results, idx]):
+                        todo.put_nowait(stale)
+                    results.clear()
+                    continue
+                results[idx] = self._question_result(
+                    idx, item, response_text, prompt_text, diagnostics, elapsed
                 )
-                result_diagnostics = self._diagnostic_result_fields(diagnostics)
-                result_diagnostics["status"] = question_status
+                if on_progress:
+                    await on_progress(len(results), total)
+        finally:
+            for task in workers:
+                task.cancel()
+            await asyncio.gather(*workers, return_exceptions=True)
 
-                if is_correct:
-                    correct += 1
-
-                cat = self.get_category(item)
-                if cat is not None:
-                    category_total[cat] = category_total.get(cat, 0) + 1
-                    if is_correct:
-                        category_correct[cat] = category_correct.get(cat, 0) + 1
-
-                q_id = item.get("id", str(idx))
-                expected = item.get("answer", "")
-                results.append(
-                    QuestionResult(
-                        question_id=str(q_id),
-                        correct=is_correct,
-                        expected=str(expected),
-                        predicted=predicted,
-                        time_seconds=batch_elapsed / len(batch),
-                        question_text=prompt_text,
-                        raw_response=response_text,
-                        category=cat,
-                        **result_diagnostics,
-                    )
+        ordered = [results[idx] for idx in range(total)]
+        correct = sum(1 for r in ordered if r.correct)
+        category_correct: dict[str, int] = {}
+        category_total: dict[str, int] = {}
+        for r in ordered:
+            if r.category is None:
+                continue
+            category_total[r.category] = category_total.get(r.category, 0) + 1
+            if r.correct:
+                category_correct[r.category] = (
+                    category_correct.get(r.category, 0) + 1
                 )
-
-            completed += len(batch)
-            if on_progress:
-                await on_progress(completed, len(items))
-
-        total_time = time.time() - start_time
-        total = len(items)
-        accuracy = correct / total if total > 0 else 0.0
 
         cat_scores = None
         if category_total:
@@ -438,11 +427,45 @@ class BaseBenchmark(ABC):
 
         return BenchmarkResult(
             benchmark_name=self.name,
-            accuracy=accuracy,
+            accuracy=correct / total if total > 0 else 0.0,
             total_questions=total,
             correct_count=correct,
-            time_seconds=total_time,
-            question_results=results,
+            time_seconds=time.time() - start_time,
+            question_results=ordered,
             category_scores=cat_scores,
             thinking_used=thinking_used,
+        )
+
+    def _question_result(
+        self,
+        idx: int,
+        item: dict,
+        response_text: str,
+        prompt_text: str,
+        diagnostics: dict[str, Any],
+        elapsed: float,
+    ) -> QuestionResult:
+        predicted, is_correct, question_status = self._classify_response(
+            response_text, item, diagnostics
+        )
+        result_diagnostics = self._diagnostic_result_fields(diagnostics)
+        result_diagnostics["status"] = question_status
+
+        expected = self.expected_label
+        if expected is None:
+            expected = str(item.get("answer", ""))
+        limit = self.predicted_max_chars
+        if limit is not None and len(predicted) > limit:
+            predicted = predicted[:limit] + "..."
+
+        return QuestionResult(
+            question_id=str(item.get("id", idx)),
+            correct=is_correct,
+            expected=expected,
+            predicted=predicted,
+            time_seconds=elapsed,
+            question_text=prompt_text,
+            raw_response=response_text,
+            category=self.get_category(item),
+            **result_diagnostics,
         )

--- a/omlx/eval/humaneval.py
+++ b/omlx/eval/humaneval.py
@@ -10,7 +10,6 @@ SECURITY NOTE: This benchmark executes model-generated code on the local
 machine. Mitigations: subprocess with timeout, memory limits, temp file cleanup.
 """
 
-import asyncio
 import json
 import logging
 import os
@@ -18,11 +17,9 @@ import re
 import resource
 import subprocess
 import tempfile
-import time
 from pathlib import Path
-from typing import Any, Callable, Optional
 
-from .base import BaseBenchmark, BenchmarkResult, QuestionResult
+from .base import BaseBenchmark
 from .datasets import deterministic_sample, load_jsonl
 
 logger = logging.getLogger(__name__)
@@ -150,6 +147,9 @@ class HumanEvalBenchmark(BaseBenchmark):
 
     name = "humaneval"
     quick_size = 100
+    auto_detect_thinking = False
+    expected_label = "(unit tests)"
+    predicted_max_chars = 200
 
     async def load_dataset(self, sample_size: int = 0) -> list[dict]:
         """Load HumanEval from bundled data."""
@@ -212,78 +212,3 @@ class HumanEvalBenchmark(BaseBenchmark):
             predicted, item["test"], item["entry_point"]
         )
         return passed
-
-    async def run(
-        self,
-        engine: Any,
-        items: list[dict],
-        on_progress: Optional[Callable[[int, int], Any]] = None,
-        batch_size: int = 1,
-        sampling_kwargs: Optional[dict] = None,
-        enable_thinking: bool = False,
-    ) -> BenchmarkResult:
-        """Override run: generation is batched, code execution is sequential."""
-        results: list[QuestionResult] = []
-        correct = 0
-        start_time = time.time()
-        completed = 0
-
-        for batch_start in range(0, len(items), batch_size):
-            batch_end = min(batch_start + batch_size, len(items))
-            batch = items[batch_start:batch_end]
-            batch_time = time.time()
-
-            gen_tasks = [
-                self._eval_single(engine, item, batch_start + j, sampling_kwargs, enable_thinking)
-                for j, item in enumerate(batch)
-            ]
-            gen_results = await asyncio.gather(*gen_tasks)
-            gen_elapsed = time.time() - batch_time
-
-            for (
-                idx,
-                item,
-                response_text,
-                prompt_text,
-                _raw,
-                diagnostics,
-            ) in sorted(gen_results, key=lambda x: x[0]):
-                code, is_correct, question_status = self._classify_response(
-                    response_text, item, diagnostics
-                )
-                result_diagnostics = self._diagnostic_result_fields(diagnostics)
-                result_diagnostics["status"] = question_status
-
-                if is_correct:
-                    correct += 1
-
-                results.append(
-                    QuestionResult(
-                        question_id=str(item.get("id", idx)),
-                        correct=is_correct,
-                        expected="(unit tests)",
-                        predicted=code[:200] + "..." if len(code) > 200 else code,
-                        time_seconds=gen_elapsed / len(batch),
-                        question_text=prompt_text,
-                        raw_response=response_text,
-                        category=self.get_category(item),
-                        **result_diagnostics,
-                    )
-                )
-
-            completed += len(batch)
-            if on_progress:
-                await on_progress(completed, len(items))
-
-        total_time = time.time() - start_time
-        total = len(items)
-
-        return BenchmarkResult(
-            benchmark_name=self.name,
-            accuracy=correct / total if total > 0 else 0.0,
-            total_questions=total,
-            correct_count=correct,
-            time_seconds=total_time,
-            question_results=results,
-            thinking_used=enable_thinking,
-        )

--- a/omlx/eval/livecodebench.py
+++ b/omlx/eval/livecodebench.py
@@ -10,7 +10,6 @@ machine. Mitigations: subprocess with timeout, memory limits via resource
 module, temp file cleanup. Users are warned in the UI before running.
 """
 
-import asyncio
 import json
 import logging
 import os
@@ -20,9 +19,8 @@ import subprocess
 import tempfile
 import time
 from pathlib import Path
-from typing import Any, Callable, Optional
 
-from .base import BaseBenchmark, BenchmarkResult, QuestionResult
+from .base import BaseBenchmark
 from .datasets import deterministic_sample, load_jsonl
 
 logger = logging.getLogger(__name__)
@@ -124,6 +122,9 @@ class LiveCodeBenchBenchmark(BaseBenchmark):
 
     name = "livecodebench"
     quick_size = 100
+    auto_detect_thinking = False
+    expected_label = "(test cases)"
+    predicted_max_chars = 200
 
     async def load_dataset(self, sample_size: int = 0) -> list[dict]:
         """Load LiveCodeBench from bundled data."""
@@ -210,80 +211,3 @@ class LiveCodeBenchBenchmark(BaseBenchmark):
                 return False
 
         return True
-
-    async def run(
-        self,
-        engine: Any,
-        items: list[dict],
-        on_progress: Optional[Callable[[int, int], Any]] = None,
-        batch_size: int = 1,
-        sampling_kwargs: Optional[dict] = None,
-        enable_thinking: bool = False,
-    ) -> BenchmarkResult:
-        """Override run: generation is batched, code execution is sequential."""
-        results: list[QuestionResult] = []
-        correct = 0
-        start_time = time.time()
-        completed = 0
-
-        for batch_start in range(0, len(items), batch_size):
-            batch_end = min(batch_start + batch_size, len(items))
-            batch = items[batch_start:batch_end]
-            batch_time = time.time()
-
-            # Batch the generation phase
-            gen_tasks = [
-                self._eval_single(engine, item, batch_start + j, sampling_kwargs, enable_thinking)
-                for j, item in enumerate(batch)
-            ]
-            gen_results = await asyncio.gather(*gen_tasks)
-            gen_elapsed = time.time() - batch_time
-
-            # Code execution is sequential (subprocess safety)
-            for (
-                idx,
-                item,
-                response_text,
-                prompt_text,
-                _raw,
-                diagnostics,
-            ) in sorted(gen_results, key=lambda x: x[0]):
-                code, is_correct, question_status = self._classify_response(
-                    response_text, item, diagnostics
-                )
-                result_diagnostics = self._diagnostic_result_fields(diagnostics)
-                result_diagnostics["status"] = question_status
-
-                if is_correct:
-                    correct += 1
-
-                results.append(
-                    QuestionResult(
-                        question_id=str(item.get("id", idx)),
-                        correct=is_correct,
-                        expected="(test cases)",
-                        predicted=code[:200] + "..." if len(code) > 200 else code,
-                        time_seconds=gen_elapsed / len(batch),
-                        question_text=prompt_text,
-                        raw_response=response_text,
-                        category=self.get_category(item),
-                        **result_diagnostics,
-                    )
-                )
-
-            completed += len(batch)
-            if on_progress:
-                await on_progress(completed, len(items))
-
-        total_time = time.time() - start_time
-        total = len(items)
-
-        return BenchmarkResult(
-            benchmark_name=self.name,
-            accuracy=correct / total if total > 0 else 0.0,
-            total_questions=total,
-            correct_count=correct,
-            time_seconds=total_time,
-            question_results=results,
-            thinking_used=enable_thinking,
-        )

--- a/omlx/eval/mbpp.py
+++ b/omlx/eval/mbpp.py
@@ -9,18 +9,15 @@ SECURITY NOTE: This benchmark executes model-generated code on the local
 machine. Mitigations: subprocess with timeout, memory limits, temp file cleanup.
 """
 
-import asyncio
 import logging
 import os
 import re
 import resource
 import subprocess
 import tempfile
-import time
 from pathlib import Path
-from typing import Any, Callable, Optional
 
-from .base import BaseBenchmark, BenchmarkResult, QuestionResult
+from .base import BaseBenchmark
 from .datasets import deterministic_sample, load_jsonl
 
 logger = logging.getLogger(__name__)
@@ -112,6 +109,9 @@ class MBPPBenchmark(BaseBenchmark):
 
     name = "mbpp"
     quick_size = 200
+    auto_detect_thinking = False
+    expected_label = "(test cases)"
+    predicted_max_chars = 200
 
     async def load_dataset(self, sample_size: int = 0) -> list[dict]:
         """Load MBPP from bundled data."""
@@ -168,78 +168,3 @@ class MBPPBenchmark(BaseBenchmark):
             item.get("test_setup_code", ""),
         )
         return passed
-
-    async def run(
-        self,
-        engine: Any,
-        items: list[dict],
-        on_progress: Optional[Callable[[int, int], Any]] = None,
-        batch_size: int = 1,
-        sampling_kwargs: Optional[dict] = None,
-        enable_thinking: bool = False,
-    ) -> BenchmarkResult:
-        """Override run: generation is batched, code execution is sequential."""
-        results: list[QuestionResult] = []
-        correct = 0
-        start_time = time.time()
-        completed = 0
-
-        for batch_start in range(0, len(items), batch_size):
-            batch_end = min(batch_start + batch_size, len(items))
-            batch = items[batch_start:batch_end]
-            batch_time = time.time()
-
-            gen_tasks = [
-                self._eval_single(engine, item, batch_start + j, sampling_kwargs, enable_thinking)
-                for j, item in enumerate(batch)
-            ]
-            gen_results = await asyncio.gather(*gen_tasks)
-            gen_elapsed = time.time() - batch_time
-
-            for (
-                idx,
-                item,
-                response_text,
-                prompt_text,
-                _raw,
-                diagnostics,
-            ) in sorted(gen_results, key=lambda x: x[0]):
-                code, is_correct, question_status = self._classify_response(
-                    response_text, item, diagnostics
-                )
-                result_diagnostics = self._diagnostic_result_fields(diagnostics)
-                result_diagnostics["status"] = question_status
-
-                if is_correct:
-                    correct += 1
-
-                results.append(
-                    QuestionResult(
-                        question_id=str(item.get("id", idx)),
-                        correct=is_correct,
-                        expected="(test cases)",
-                        predicted=code[:200] + "..." if len(code) > 200 else code,
-                        time_seconds=gen_elapsed / len(batch),
-                        question_text=prompt_text,
-                        raw_response=response_text,
-                        category=self.get_category(item),
-                        **result_diagnostics,
-                    )
-                )
-
-            completed += len(batch)
-            if on_progress:
-                await on_progress(completed, len(items))
-
-        total_time = time.time() - start_time
-        total = len(items)
-
-        return BenchmarkResult(
-            benchmark_name=self.name,
-            accuracy=correct / total if total > 0 else 0.0,
-            total_questions=total,
-            correct_count=correct,
-            time_seconds=total_time,
-            question_results=results,
-            thinking_used=enable_thinking,
-        )

--- a/tests/test_eval_worker_pool.py
+++ b/tests/test_eval_worker_pool.py
@@ -1,0 +1,287 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Scheduling tests for BaseBenchmark.run: batch_size is a worker-pool width."""
+
+import asyncio
+import contextlib
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from omlx.eval.base import BaseBenchmark
+from omlx.eval.humaneval import HumanEvalBenchmark
+from omlx.eval.livecodebench import LiveCodeBenchBenchmark
+from omlx.eval.mbpp import MBPPBenchmark
+
+WAIT = 1.0
+
+CODE_BENCHMARKS = [HumanEvalBenchmark, MBPPBenchmark, LiveCodeBenchBenchmark]
+
+
+class _GatedEngine:
+    """Engine whose chat() calls finish only when the test releases them.
+
+    Questions are keyed by the first message's content (the item id).
+    """
+
+    is_external_api = False
+    model_type = None
+
+    def __init__(self, reply: Callable[[str, bool], str] | None = None):
+        self.reply = reply or (lambda qid, thinking: "A")
+        self.calls: list[dict[str, Any]] = []
+        self.in_flight: set[str] = set()
+        self.max_in_flight = 0
+        self.cancelled: list[str] = []
+        self._started: dict[str, asyncio.Event] = {}
+        self._release: dict[str, asyncio.Event] = {}
+
+    @staticmethod
+    def _event(table: dict[str, asyncio.Event], qid: str) -> asyncio.Event:
+        if qid not in table:
+            table[qid] = asyncio.Event()
+        return table[qid]
+
+    def release(self, *qids: str) -> None:
+        for qid in qids:
+            self._event(self._release, qid).set()
+
+    def started(self, qid: str) -> bool:
+        return self._event(self._started, qid).is_set()
+
+    async def wait_started(self, *qids: str) -> None:
+        for qid in qids:
+            await asyncio.wait_for(self._event(self._started, qid).wait(), WAIT)
+
+    async def chat(self, messages, **kwargs):
+        qid = messages[0]["content"]
+        thinking = kwargs["chat_template_kwargs"]["enable_thinking"]
+        self.calls.append({"id": qid, "thinking": thinking})
+        self.in_flight.add(qid)
+        self.max_in_flight = max(self.max_in_flight, len(self.in_flight))
+        self._event(self._started, qid).set()
+        try:
+            await self._event(self._release, qid).wait()
+        except asyncio.CancelledError:
+            self.cancelled.append(qid)
+            raise
+        finally:
+            self.in_flight.discard(qid)
+        return SimpleNamespace(text=self.reply(qid, thinking))
+
+
+class _EchoBenchmark(BaseBenchmark):
+    name = "echo"
+
+    async def load_dataset(self, sample_size: int = 0) -> list[dict]:
+        return []
+
+    def format_prompt(self, item: dict) -> list[dict[str, str]]:
+        return [{"role": "user", "content": item["id"]}]
+
+    def extract_answer(self, response: str, item: dict) -> str:
+        return response.strip()
+
+    def check_answer(self, predicted: str, item: dict) -> bool:
+        return predicted.startswith(item["answer"])
+
+
+def _items(n: int) -> list[dict]:
+    return [{"id": f"q{i}", "answer": "A"} for i in range(n)]
+
+
+def _code_benchmark(cls, monkeypatch) -> BaseBenchmark:
+    bench = cls()
+    monkeypatch.setattr(
+        bench, "format_prompt", lambda item: [{"role": "user", "content": item["id"]}]
+    )
+    monkeypatch.setattr(bench, "extract_answer", lambda response, item: response.strip())
+    monkeypatch.setattr(bench, "check_answer", lambda predicted, item: predicted.startswith("A"))
+    return bench
+
+
+@pytest.fixture(params=["base", "humaneval", "mbpp", "livecodebench"])
+def benchmark(request, monkeypatch) -> BaseBenchmark:
+    if request.param == "base":
+        return _EchoBenchmark()
+    cls = {
+        "humaneval": HumanEvalBenchmark,
+        "mbpp": MBPPBenchmark,
+        "livecodebench": LiveCodeBenchBenchmark,
+    }[request.param]
+    return _code_benchmark(cls, monkeypatch)
+
+
+@contextlib.asynccontextmanager
+async def _running(coro):
+    task = asyncio.create_task(coro)
+    try:
+        yield task
+    finally:
+        if not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
+
+
+async def test_next_question_starts_as_soon_as_a_slot_frees(benchmark):
+    engine = _GatedEngine()
+    async with _running(benchmark.run(engine, _items(4), batch_size=2)) as run:
+        await engine.wait_started("q0", "q1")
+        assert not engine.started("q2")
+
+        engine.release("q1")
+        await engine.wait_started("q2")
+        assert engine.in_flight == {"q0", "q2"}
+
+        engine.release("q2")
+        await engine.wait_started("q3")
+        engine.release("q0", "q3")
+        result = await asyncio.wait_for(run, WAIT)
+
+    assert engine.max_in_flight == 2
+    assert [c["id"] for c in engine.calls] == ["q0", "q1", "q2", "q3"]
+    assert [r.question_id for r in result.question_results] == ["q0", "q1", "q2", "q3"]
+    assert result.correct_count == 4
+
+
+async def test_each_question_reports_its_own_latency():
+    engine = _GatedEngine()
+    async with _running(_EchoBenchmark().run(engine, _items(3), batch_size=3)) as run:
+        await engine.wait_started("q0", "q1", "q2")
+        engine.release("q2")
+        await asyncio.sleep(0.05)
+        engine.release("q1")
+        await asyncio.sleep(0.05)
+        engine.release("q0")
+        result = await asyncio.wait_for(run, WAIT)
+
+    times = {r.question_id: r.time_seconds for r in result.question_results}
+    assert times["q0"] > times["q1"] > times["q2"]
+
+
+async def test_progress_is_reported_after_every_question():
+    engine = _GatedEngine()
+    engine.release("q0", "q1", "q2", "q3")
+    progress: list[tuple[int, int]] = []
+
+    async def on_progress(current: int, total: int) -> None:
+        progress.append((current, total))
+
+    await asyncio.wait_for(
+        _EchoBenchmark().run(engine, _items(4), on_progress, batch_size=4), WAIT
+    )
+
+    assert progress == [(1, 4), (2, 4), (3, 4), (4, 4)]
+
+
+async def test_think_tags_in_probe_rerun_every_non_thinking_result():
+    def reply(qid: str, thinking: bool) -> str:
+        if qid == "q0" and not thinking:
+            return "<think>hmm</think>A"
+        return "A"
+
+    engine = _GatedEngine(reply)
+    async with _running(_EchoBenchmark().run(engine, _items(4), batch_size=2)) as run:
+        await engine.wait_started("q0", "q1")
+        engine.release("q1")  # probe result without think tags, recorded
+        await engine.wait_started("q2")
+        engine.release("q2")  # non-probe result recorded before the switch
+        await engine.wait_started("q3")  # in flight, started without thinking
+        engine.release("q0")  # probe result with think tags: switch
+        engine.release("q3")
+        result = await asyncio.wait_for(run, WAIT)
+
+    assert result.thinking_used is True
+    assert result.correct_count == 4
+    assert [r.question_id for r in result.question_results] == ["q0", "q1", "q2", "q3"]
+    modes: dict[str, list[bool]] = {}
+    for call in engine.calls:
+        modes.setdefault(call["id"], []).append(call["thinking"])
+    assert modes == {qid: [False, True] for qid in ("q0", "q1", "q2", "q3")}
+
+
+async def test_think_tags_outside_the_probe_do_not_switch_mode():
+    engine = _GatedEngine(
+        lambda qid, thinking: "<think>hmm</think>A" if qid == "q2" else "A"
+    )
+    engine.release("q0", "q1", "q2", "q3")
+
+    result = await asyncio.wait_for(
+        _EchoBenchmark().run(engine, _items(4), batch_size=2), WAIT
+    )
+
+    assert result.thinking_used is False
+    assert [c["thinking"] for c in engine.calls] == [False] * 4
+
+
+async def test_cancelling_progress_callback_stops_in_flight_questions():
+    engine = _GatedEngine()
+
+    async def on_progress(current: int, total: int) -> None:
+        raise asyncio.CancelledError()
+
+    async with _running(
+        _EchoBenchmark().run(engine, _items(4), on_progress, batch_size=2)
+    ) as run:
+        await engine.wait_started("q0", "q1")
+        engine.release("q0")
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(run, WAIT)
+
+    # q0's worker may already have picked up q2 before the callback ran.
+    assert "q1" in engine.cancelled
+    assert set(engine.cancelled) <= {"q1", "q2"}
+    assert engine.in_flight == set()
+    assert not engine.started("q3")
+
+
+async def test_hard_cancel_leaves_no_question_in_flight():
+    engine = _GatedEngine()
+    run = asyncio.create_task(_EchoBenchmark().run(engine, _items(4), batch_size=2))
+    await engine.wait_started("q0", "q1")
+
+    run.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(run, WAIT)
+
+    assert sorted(engine.cancelled) == ["q0", "q1"]
+    assert engine.in_flight == set()
+    assert not engine.started("q2")
+
+
+@pytest.mark.parametrize(
+    ("cls", "expected_label"),
+    [
+        (HumanEvalBenchmark, "(unit tests)"),
+        (MBPPBenchmark, "(test cases)"),
+        (LiveCodeBenchBenchmark, "(test cases)"),
+    ],
+)
+async def test_code_benchmarks_keep_test_case_result_format(
+    cls, expected_label, monkeypatch
+):
+    bench = _code_benchmark(cls, monkeypatch)
+    engine = _GatedEngine(lambda qid, thinking: "A" * 300)
+    engine.release("q0")
+
+    result = await asyncio.wait_for(bench.run(engine, _items(1), batch_size=1), WAIT)
+
+    question = result.question_results[0]
+    assert question.correct is True
+    assert question.expected == expected_label
+    assert question.predicted == "A" * 200 + "..."
+
+
+@pytest.mark.parametrize("cls", CODE_BENCHMARKS)
+async def test_code_benchmarks_do_not_auto_switch_thinking(cls, monkeypatch):
+    bench = _code_benchmark(cls, monkeypatch)
+    engine = _GatedEngine(lambda qid, thinking: "<think>x</think>A")
+    engine.release("q0")
+
+    result = await asyncio.wait_for(bench.run(engine, _items(1), batch_size=1), WAIT)
+
+    assert result.thinking_used is False
+    assert [c["thinking"] for c in engine.calls] == [False]
+


### PR DESCRIPTION
### Problem
In benchmarks, “Batch Size” currently refers to the size of the chunk into which tasks are divided for processing, so every chunk waited for its slowest question.

### Fix
Workers now pull questions from a queue and refill a slot as soon as one finishes. Progress and per-question timing are reported per question, and cancellation stops in-flight workers before the run re-raises. The thinking probe covers the first batch_size questions and re-queues every answer produced before the switch, so no mixed-mode results remain.

HumanEval, MBPP and LiveCodeBench drop their copies of the loop in favour of class-level rendering knobs.